### PR TITLE
fix(cli): preserve base64 '=' padding when parsing config-file api_key

### DIFF
--- a/hindsight-cli/src/config.rs
+++ b/hindsight-cli/src/config.rs
@@ -125,21 +125,10 @@ impl Config {
 
         // Simple TOML parsing for api_url and api_key
         for line in content.lines() {
-            let line = line.trim();
-            if line.starts_with("api_url") {
-                if let Some(value) = line.split('=').nth(1) {
-                    let value = value.trim().trim_matches('"').trim_matches('\'');
-                    if !value.is_empty() {
-                        api_url = Some(value.to_string());
-                    }
-                }
-            } else if line.starts_with("api_key") {
-                if let Some(value) = line.split('=').nth(1) {
-                    let value = value.trim().trim_matches('"').trim_matches('\'');
-                    if !value.is_empty() {
-                        api_key = Some(value.to_string());
-                    }
-                }
+            if let Some(v) = parse_config_value(line, "api_url") {
+                api_url = Some(v);
+            } else if let Some(v) = parse_config_value(line, "api_key") {
+                api_key = Some(v);
             }
         }
 
@@ -375,21 +364,21 @@ pub fn generate_doc_id() -> String {
 
 /// Parse a simple TOML-like config line and extract value.
 /// Handles both quoted and unquoted values.
+///
+/// Uses `split_once('=')` so the value keeps any literal `=` characters it
+/// contains (e.g. the trailing padding of a base64 API key).
 pub fn parse_config_value(line: &str, key: &str) -> Option<String> {
     let line = line.trim();
-    if !line.starts_with(key) {
+    let (k, v) = line.split_once('=')?;
+    if k.trim() != key {
         return None;
     }
-    line.split('=')
-        .nth(1)
-        .map(|value| {
-            value
-                .trim()
-                .trim_matches('"')
-                .trim_matches('\'')
-                .to_string()
-        })
-        .filter(|v| !v.is_empty())
+    let value = v.trim().trim_matches('"').trim_matches('\'');
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -611,6 +600,21 @@ mod tests {
     fn test_parse_config_value_empty() {
         assert_eq!(parse_config_value("api_url = ", "api_url"), None);
         assert_eq!(parse_config_value("api_url = \"\"", "api_url"), None);
+    }
+
+    #[test]
+    fn test_parse_config_value_preserves_base64_padding() {
+        let key = "dCcxYDq+Bg0G268UuJIIHvQG4Cp5GnJWR+HIm8WRAIM=";
+        let line = format!("api_key = \"{}\"", key);
+        assert_eq!(parse_config_value(&line, "api_key").as_deref(), Some(key));
+    }
+
+    #[test]
+    fn test_parse_config_value_key_with_equals() {
+        assert_eq!(
+            parse_config_value("api_key = a=b=c", "api_key").as_deref(),
+            Some("a=b=c")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The CLI's config-file parser (`hindsight-cli/src/config.rs`) reads `~/.hindsight/config` using a hand-rolled TOML parse that splits each line with `line.split('=').nth(1)`. That splits on **every** `=` in the line, so any `api_key` value containing literal `=` characters is truncated at the first `=`.

Base64 API keys routinely end with one or two `=` padding characters (e.g. `…WRAIM=`), so the trailing padding was silently stripped. The result: the CLI loaded `api_url` correctly from the config file but sent a corrupted `api_key`, failing authentication whenever it relied on the config file instead of the `HINDSIGHT_API_KEY` environment variable.

## Changes

- Rewrote `parse_config_value()` to use `split_once('=')`, preserving any literal `=` in the value, and to match the exact key name rather than `starts_with`.
- Delegated the config-file loop in `load_from_file()` to `parse_config_value()`, sharing the logic already used by profile loading and removing the duplicated buggy parser.
- Added regression tests:
  - base64 key with trailing `=` padding is preserved
  - value containing multiple `=` characters is preserved

## Verification

- New unit tests pass (`cargo test parse_config_value` → 8 passed).
- Manually confirmed: with `HINDSIGHT_API_URL` / `HINDSIGHT_API_KEY` unset, the CLI now authenticates successfully from `~/.hindsight/config` alone.

## Scope

Single file changed: `hindsight-cli/src/config.rs`. No API or schema changes.