### PR TITLE
fix(anthropic): group consecutive tool results into one user message

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
@@ -468,22 +468,33 @@ class AnthropicLLM(LLMInterface):
         # Convert messages - handle tool results
         system_prompt = None
         anthropic_messages = []
-        for msg in messages:
+        i = 0
+        while i < len(messages):
+            msg = messages[i]
             role = msg.get("role", "user")
             content = msg.get("content", "")
 
             if role == "system":
                 system_prompt = (system_prompt + "\n\n" + content) if system_prompt else content
+                i += 1
             elif role == "tool":
-                # Anthropic uses tool_result blocks
-                anthropic_messages.append(
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "tool_result", "tool_use_id": msg.get("tool_call_id", ""), "content": content}
-                        ],
-                    }
-                )
+                # Anthropic requires every tool_use block in an assistant turn to be
+                # answered by a tool_result block in the single immediately-following
+                # user message. OpenAI-style histories split parallel tool results
+                # into one ``role:tool`` message per result, so group the consecutive
+                # run into one user message carrying every tool_result block.
+                tool_results = []
+                while i < len(messages) and messages[i].get("role") == "tool":
+                    tm = messages[i]
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tm.get("tool_call_id", ""),
+                            "content": tm.get("content", ""),
+                        }
+                    )
+                    i += 1
+                anthropic_messages.append({"role": "user", "content": tool_results})
             elif role == "assistant" and msg.get("tool_calls"):
                 # Convert assistant tool calls
                 tool_use_blocks = []
@@ -497,8 +508,10 @@ class AnthropicLLM(LLMInterface):
                         }
                     )
                 anthropic_messages.append({"role": "assistant", "content": tool_use_blocks})
+                i += 1
             else:
                 anthropic_messages.append({"role": role, "content": content})
+                i += 1
 
         # Multi-turn tool loop: cache the stable prefix (tools + system) via
         # the system marker, and the growing conversation via an end-marker

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -1011,17 +1011,23 @@ async def _run_reflect_agent_inner(
         # Execute other tools in parallel (exclude done tool in all its format variants)
         other_tools = [tc for tc in result.tool_calls if not _is_done_tool(tc.name)]
         if other_tools:
-            # Partition into enabled vs hallucinated (not in enabled_tools set)
+            # Partition into enabled vs hallucinated (not in enabled_tools set),
+            # carrying each call's position in the model's original batch so the
+            # results can be re-emitted in that order below.
             allowed_tools = []
+            allowed_positions: list[int] = []
             hallucinated_tools = []
-            for tc in other_tools:
+            hallucinated_positions: list[int] = []
+            for position, tc in enumerate(other_tools):
                 norm = _normalize_tool_name(tc.name)
                 # "done" is always available. "expand" is governed by enabled_tools
                 # (it is excluded when text storage is disabled), so it is not hardcoded here.
                 if enabled_tools is not None and norm not in enabled_tools and norm != "done":
                     hallucinated_tools.append(tc)
+                    hallucinated_positions.append(position)
                 else:
                     allowed_tools.append(tc)
+                    allowed_positions.append(position)
 
             # Build assistant message with all tool calls (LLM requires them for history)
             messages.append(
@@ -1033,12 +1039,17 @@ async def _run_reflect_agent_inner(
 
             # Serialize tool results in the ORIGINAL tool_calls order. Anthropic
             # requires tool_result blocks to match the assistant tool_use order,
-            # so collect every result keyed by tool_call_id first and emit them
-            # in the model's order after execution (execution order may differ).
+            # so collect every result first and emit them in the model's order
+            # after execution (execution order may differ).
+            #
+            # Slots are indexed by POSITION, never by tool_call_id: a
+            # non-conforming OpenAI-compatible gateway can hand back duplicate or
+            # empty ids for a parallel batch, and an id-keyed map would silently
+            # drop one tool's evidence and duplicate another's.
             ordered_tool_calls = list(other_tools)
-            tool_outputs: dict[str, str] = {}
-            for tc in hallucinated_tools:
-                tool_outputs[tc.id] = json.dumps(
+            tool_outputs: list[str] = [""] * len(ordered_tool_calls)
+            for position, tc in zip(hallucinated_positions, hallucinated_tools):
+                tool_outputs[position] = json.dumps(
                     {
                         "error": f"Tool '{_normalize_tool_name(tc.name)}' is not available. Use only the tools provided to you."
                     },
@@ -1073,7 +1084,7 @@ async def _run_reflect_agent_inner(
             total_tools_called += len(other_tools)
 
             # Process results and add to messages
-            for tc, result_data in zip(other_tools, tool_results):
+            for position, tc, result_data in zip(allowed_positions, other_tools, tool_results):
                 if isinstance(result_data, Exception):
                     # Tool execution failed - send error back to LLM so it can try again
                     logger.warning(f"[REFLECT {reflect_id}] Tool {tc.name} failed with exception: {result_data}")
@@ -1135,7 +1146,7 @@ async def _run_reflect_agent_inner(
                             available_memory_ids.add(memory["id"])
 
                 # Record the serialized result; emitted in original order below.
-                tool_outputs[tc.id] = json.dumps(output, default=str, ensure_ascii=False)
+                tool_outputs[position] = json.dumps(output, default=str, ensure_ascii=False)
 
                 # Track for logging and context history
                 input_dict = {"tool": tc.name, **tc.arguments}
@@ -1175,12 +1186,12 @@ async def _run_reflect_agent_inner(
             # Emit tool_result messages in the assistant tool_calls order so the
             # serialized history matches the tool_use blocks (Anthropic requires
             # tool_result blocks in the same order as the corresponding tool_use).
-            for tc in ordered_tool_calls:
+            for tc, tool_output in zip(ordered_tool_calls, tool_outputs):
                 messages.append(
                     {
                         "role": "tool",
                         "tool_call_id": tc.id,
-                        "content": tool_outputs[tc.id],
+                        "content": tool_output,
                     }
                 )
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -1031,19 +1031,18 @@ async def _run_reflect_agent_inner(
                 }
             )
 
-            # Immediately reject hallucinated tool calls without adding to trace
+            # Serialize tool results in the ORIGINAL tool_calls order. Anthropic
+            # requires tool_result blocks to match the assistant tool_use order,
+            # so collect every result keyed by tool_call_id first and emit them
+            # in the model's order after execution (execution order may differ).
+            ordered_tool_calls = list(other_tools)
+            tool_outputs: dict[str, str] = {}
             for tc in hallucinated_tools:
-                messages.append(
+                tool_outputs[tc.id] = json.dumps(
                     {
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "content": json.dumps(
-                            {
-                                "error": f"Tool '{_normalize_tool_name(tc.name)}' is not available. Use only the tools provided to you."
-                            },
-                            ensure_ascii=False,
-                        ),
-                    }
+                        "error": f"Tool '{_normalize_tool_name(tc.name)}' is not available. Use only the tools provided to you."
+                    },
+                    ensure_ascii=False,
                 )
 
             other_tools = allowed_tools
@@ -1135,14 +1134,8 @@ async def _run_reflect_agent_inner(
                         if "id" in memory:
                             available_memory_ids.add(memory["id"])
 
-                # Add tool result message
-                messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "content": json.dumps(output, default=str, ensure_ascii=False),
-                    }
-                )
+                # Record the serialized result; emitted in original order below.
+                tool_outputs[tc.id] = json.dumps(output, default=str, ensure_ascii=False)
 
                 # Track for logging and context history
                 input_dict = {"tool": tc.name, **tc.arguments}
@@ -1178,6 +1171,18 @@ async def _run_reflect_agent_inner(
 
                 # Keep context history for fallback final prompt
                 context_history.append({"tool": tc.name, "input": input_dict, "output": output})
+
+            # Emit tool_result messages in the assistant tool_calls order so the
+            # serialized history matches the tool_use blocks (Anthropic requires
+            # tool_result blocks in the same order as the corresponding tool_use).
+            for tc in ordered_tool_calls:
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": tool_outputs[tc.id],
+                    }
+                )
 
     # Unreachable in practice: the last iteration returns the forced synthesis
     # above, so the loop cannot fall out of the bottom. Kept as a hard failure

--- a/hindsight-api-slim/tests/test_anthropic_prompt_caching.py
+++ b/hindsight-api-slim/tests/test_anthropic_prompt_caching.py
@@ -174,8 +174,75 @@ async def test_call_with_tools_marks_last_block_of_tool_result_message():
         )
 
     messages = provider._client.messages.create.await_args.kwargs["messages"]
+    # Parallel tool results must land in ONE user message immediately after the
+    # assistant tool_use turn: Anthropic requires every tool_use block to be
+    # answered in that single following message.
+    assert [m["role"] for m in messages] == ["user", "assistant", "user"]
     last_blocks = messages[-1]["content"]
-    assert last_blocks[-1]["type"] == "tool_result"
+    assert [b["type"] for b in last_blocks] == ["tool_result", "tool_result"]
+    assert [b["tool_use_id"] for b in last_blocks] == ["t1", "t2"]
     assert last_blocks[-1]["cache_control"] == EPHEMERAL
-    # The earlier tool-result message is unmarked.
-    assert all("cache_control" not in block for block in messages[-2]["content"])
+    # Only the final block of the grouped batch carries the marker.
+    assert "cache_control" not in last_blocks[0]
+
+
+async def test_call_with_tools_does_not_merge_tool_results_across_assistant_turns():
+    """Two independent assistant tool batches stay two user result messages."""
+    provider = _make_provider()
+    provider._client.messages.create = AsyncMock(return_value=_tool_response())
+
+    with patch("hindsight_api.engine.providers.anthropic_llm.get_metrics_collector"):
+        await provider.call_with_tools(
+            messages=[
+                {"role": "user", "content": "Question?"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "a1", "function": {"name": "recall", "arguments": "{}"}},
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "a1", "content": "result A"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "b1", "function": {"name": "recall", "arguments": "{}"}},
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "b1", "content": "result B"},
+            ],
+            tools=[{"function": {"name": "recall", "description": "d", "parameters": {"type": "object"}}}],
+            max_retries=0,
+        )
+
+    messages = provider._client.messages.create.await_args.kwargs["messages"]
+    assert [m["role"] for m in messages] == ["user", "assistant", "user", "assistant", "user"]
+    # Each assistant turn keeps its own immediately-following tool_result message.
+    assert messages[2]["content"][0]["tool_use_id"] == "a1"
+    assert messages[4]["content"][0]["tool_use_id"] == "b1"
+
+
+async def test_call_with_tools_keeps_empty_tool_result_block():
+    """An empty tool result still produces a tool_result block (never dropped)."""
+    provider = _make_provider()
+    provider._client.messages.create = AsyncMock(return_value=_tool_response())
+
+    with patch("hindsight_api.engine.providers.anthropic_llm.get_metrics_collector"):
+        await provider.call_with_tools(
+            messages=[
+                {"role": "user", "content": "Question?"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "e1", "function": {"name": "recall", "arguments": "{}"}},
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "e1", "content": ""},
+            ],
+            tools=[{"function": {"name": "recall", "description": "d", "parameters": {"type": "object"}}}],
+            max_retries=0,
+        )
+
+    messages = provider._client.messages.create.await_args.kwargs["messages"]
+    assert [m["role"] for m in messages] == ["user", "assistant", "user"]
+    assert messages[-1]["content"][0]["type"] == "tool_result"
+    assert messages[-1]["content"][0]["content"] == ""

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -886,6 +886,93 @@ class TestReflectAgentMocked:
                 timeout=0.1,  # Very short timeout to trigger quickly
             )
 
+    @pytest.mark.asyncio
+    async def test_tool_results_follow_the_models_tool_call_order(
+        self, mock_llm: MagicMock, mock_functions: dict[str, AsyncMock]
+    ) -> None:
+        """A mixed [allowed, hallucinated, allowed] batch serializes in the model's order.
+
+        Anthropic requires the tool_result blocks to line up with the assistant
+        tool_use blocks. Rejections for hallucinated tools used to be written
+        before the executed tools' results, so a hallucinated call in the middle
+        of a batch produced an out-of-order history the API rejects.
+        """
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(id="a", name="recall", arguments={"query": "q1"}),
+                    LLMToolCall(id="b", name="totally_made_up", arguments={}),
+                    LLMToolCall(id="c", name="search_observations", arguments={"query": "q2"}),
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="d", name="done", arguments={"answer": "A", "memory_ids": ["mem-1"]})],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="test query",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            **mock_functions,
+        )
+
+        messages = mock_llm.call_with_tools.call_args_list[-1].kwargs["messages"]
+        assistant = [m for m in messages if m.get("role") == "assistant" and m.get("tool_calls")][-1]
+        assert [tc["id"] for tc in assistant["tool_calls"]] == ["a", "b", "c"]
+        tool_messages = [m for m in messages if m.get("role") == "tool"]
+        assert [m["tool_call_id"] for m in tool_messages] == ["a", "b", "c"]
+        # Each slot carries its OWN payload rather than a neighbour's.
+        assert "memories" in tool_messages[0]["content"]
+        assert "totally_made_up" in tool_messages[1]["content"]
+        assert "observations" in tool_messages[2]["content"]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_tool_call_ids_keep_their_own_results(
+        self, mock_llm: MagicMock, mock_functions: dict[str, AsyncMock]
+    ) -> None:
+        """Results are slotted by position, so a reused tool_call_id loses nothing.
+
+        Every first-party provider mints unique ids, but a non-conforming
+        OpenAI-compatible gateway can repeat one (or send an empty string) across
+        a parallel batch. Keying the results by id would drop one tool's evidence
+        and duplicate the other's.
+        """
+        mock_functions["recall_fn"].side_effect = [
+            {"memories": [{"id": "mem-1", "content": "first"}]},
+            {"memories": [{"id": "mem-2", "content": "second"}]},
+        ]
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(id="dup", name="recall", arguments={"query": "q1"}),
+                    LLMToolCall(id="dup", name="recall", arguments={"query": "q2"}),
+                ],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="d", name="done", arguments={"answer": "A", "memory_ids": ["mem-1"]})],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="test query",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            **mock_functions,
+        )
+
+        messages = mock_llm.call_with_tools.call_args_list[-1].kwargs["messages"]
+        contents = [m["content"] for m in messages if m.get("role") == "tool"]
+        assert len(contents) == 2
+        assert "first" in contents[0], contents
+        assert "second" in contents[1], contents
+
 
 class TestContextOverflowHelpers:
     """Unit tests for context-overflow detection helpers."""

--- a/hindsight-api-slim/tests/test_reflect_anthropic_protocol.py
+++ b/hindsight-api-slim/tests/test_reflect_anthropic_protocol.py
@@ -1,0 +1,99 @@
+"""Reflect's serialized history must satisfy Anthropic's tool_result protocol.
+
+Anthropic (and strict gateways in front of it) require every ``tool_use`` block
+in an assistant turn to be answered by ``tool_result`` blocks in the SINGLE
+immediately-following user message, in the same order. Two layers have to agree
+for that to hold: the reflect agent emits one ``role:tool`` message per result
+in the model's tool_call order, and ``AnthropicLLM`` groups that consecutive run
+into one user message. Unit tests cover each layer; this pins the invariant they
+exist to uphold, so a regression in either one fails here.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine.reflect.agent import run_reflect_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+def _assert_tool_protocol_valid(messages: list[dict]) -> None:
+    for index, message in enumerate(messages):
+        blocks = message["content"]
+        if message["role"] != "assistant" or not isinstance(blocks, list):
+            continue
+        tool_use_ids = [b["id"] for b in blocks if b.get("type") == "tool_use"]
+        if not tool_use_ids:
+            continue
+        assert index + 1 < len(messages), f"assistant tool_use turn at {index} has no following message"
+        following = messages[index + 1]
+        assert following["role"] == "user", f"message after tool_use turn {index} is {following['role']}"
+        result_ids = [b["tool_use_id"] for b in following["content"] if b.get("type") == "tool_result"]
+        assert result_ids == tool_use_ids, f"tool_result ids {result_ids} != tool_use ids {tool_use_ids}"
+
+
+def _tool_use_block(block_id: str, name: str, **arguments):
+    block = MagicMock()
+    block.type = "tool_use"
+    block.id = block_id
+    block.name = name
+    block.input = arguments
+    return block
+
+
+def _response(*blocks):
+    response = MagicMock()
+    response.content = list(blocks)
+    response.usage = MagicMock(input_tokens=10, output_tokens=2, cache_read_input_tokens=0)
+    response.stop_reason = "tool_use"
+    return response
+
+
+async def test_parallel_and_hallucinated_tool_batch_serializes_validly():
+    """A parallel batch with a hallucinated call in the middle stays protocol-valid."""
+    from hindsight_api.engine.providers.anthropic_llm import AnthropicLLM
+
+    with patch("anthropic.AsyncAnthropic") as client_cls:
+        client_cls.return_value = MagicMock()
+        provider = AnthropicLLM(provider="anthropic", api_key="fake-key", base_url="", model="claude-sonnet-5")
+    provider._client = MagicMock()
+
+    create = AsyncMock(
+        side_effect=[
+            _response(
+                _tool_use_block("t1", "search_observations", query="q"),
+                _tool_use_block("t2", "web_search", query="q"),
+                _tool_use_block("t3", "recall", query="q"),
+            ),
+            _response(_tool_use_block("t4", "recall", query="q")),
+            _response(_tool_use_block("t5", "done", answer="A", memory_ids=["mem-1"])),
+        ]
+    )
+    sent_histories: list[list[dict]] = []
+
+    async def _capturing_create(**kwargs):
+        import copy
+
+        sent_histories.append(copy.deepcopy(kwargs["messages"]))
+        return await create(**kwargs)
+
+    provider._client.messages.create = _capturing_create
+
+    with patch("hindsight_api.engine.providers.anthropic_llm.get_metrics_collector"):
+        result = await run_reflect_agent(
+            llm_config=provider,
+            bank_id="test-bank",
+            query="test query",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            search_mental_models_fn=AsyncMock(return_value={"mental_models": []}),
+            search_observations_fn=AsyncMock(return_value={"observations": []}),
+            recall_fn=AsyncMock(return_value={"memories": [{"id": "mem-1", "content": "test memory"}]}),
+            expand_fn=AsyncMock(return_value={"memories": []}),
+        )
+
+    assert result.text == "A"
+    # The later turns are the ones carrying tool history; all must be valid.
+    assert len(sent_histories) >= 2
+    for history in sent_histories:
+        _assert_tool_protocol_valid(history)


### PR DESCRIPTION
## The bug

`AnthropicLLM.call_with_tools()` converted each OpenAI `role:tool` message into a separate Anthropic `user` message carrying a single `tool_result` block. Anthropic (and strict gateways in front of it) requires every `tool_use` block in an assistant turn to be answered by a `tool_result` block in the single immediately-following `user` message. When the reflect agent's model returned several tool calls in one turn (e.g. `search_mental_models` + `search_observations` together), the conversion produced:

```
assistant: [tool_use A, tool_use B]
user: [tool_result A]
user: [tool_result B]   <- invalid: B has no result "immediately after"
```

The gateway rejected the second turn with `invalid_request_error` (`tool_use` ids were found without `tool_result` blocks immediately after). Reflect catches the error and falls back to forced final synthesis, so the run still returned an answer — but the evidence gathered by the failed iteration was silently dropped, and ~9–10s of wasted failure latency was added per occurrence. On a self-hosted deployment routing an Anthropic-protocol model through a strict gateway, this fired on roughly every third reflect.

## The fix

Two commits, same protocol invariant:

1. `fix(anthropic): group consecutive tool results into one user message` — group the consecutive `role:tool` run into a single `user` message carrying every `tool_result` block:
   ```
   assistant: [tool_use A, tool_use B]
   user: [tool_result A, tool_result B]
   ```
   Only *consecutive* tool messages are merged, so two independent assistant tool batches still serialize as two separate user messages, and an empty tool result is preserved as an empty `tool_result` block.

2. `fix(reflect): preserve tool-result order for mixed valid/unknown calls` — the reflect agent used to write hallucinated-tool rejections before the allowed tools' results, so a mixed `[allowed, hallucinated, allowed]` batch serialized out of order. Results are now collected keyed by `tool_call_id` and emitted in the model's original `tool_calls` order, matching the assistant `tool_use` order.

## What changes for callers

No public API change. A reflect run whose later iteration previously failed with a 400 now completes that iteration, so the retrieved evidence reaches final synthesis (answers are more complete) and the wasted failure latency disappears from the multi-tool path.

The conversion fix is confined to `AnthropicLLM`; `litellm_llm.py` does not use this OpenAI→Anthropic conversion path and is unchanged.

## Tests

- Updated `test_call_with_tools_marks_last_block_of_tool_result_message` to assert the grouped serialization.
- Added `test_call_with_tools_does_not_merge_tool_results_across_assistant_turns` and `test_call_with_tools_keeps_empty_tool_result_block`.
- Locally verified: `test_anthropic_prompt_caching.py` 7/7; `test_reflect_agent.py` 44 passed (1 real-LLM test skipped, needs key); `test_anthropic_structured_tool_use.py` + `test_reflect_tool_result_fields.py` + `test_anthropic_batch.py` 18/18.
