### PR TITLE
fix(tests): name the ANN index the plan must use (#3619)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -184,6 +184,7 @@ async def import_documents(
     on_conflict: OnConflict = "skip",
     ops: Any = None,
     outbox_callback_factory: Any = None,
+    restore_bank_scoped_rows: bool = True,
 ) -> ImportResult:
     """Import every document in ``archive_bytes`` into ``bank_id``.
 
@@ -200,6 +201,15 @@ async def import_documents(
             bank — ``skip`` (default), ``replace`` (delete old data and re-import),
             or ``new-id`` (import under a freshly generated id).
         ops: Backend ``DataAccessOps``. Defaults to ``backend.ops``.
+        restore_bank_scoped_rows: Whether to restore the archive's mental models
+            and knowledge pages. True for a documents archive, which merges them
+            into an existing bank. False for a whole-bank restore, which owns
+            those rows: ``import_bank`` carries the same ``mental_models.json``
+            in ``bank_rows``, restores it with the archive's own JSON encoding
+            alongside ``mental_model_history``, and — the reason this switch
+            exists — rewrites the persisted ``based_on`` evidence ids onto the
+            replayed facts first. ``_restore_rows`` is ON CONFLICT DO NOTHING,
+            so a copy inserted here would win and strip that repair (#3833).
 
     Returns:
         An :class:`ImportResult` with per-document counts.
@@ -275,7 +285,7 @@ async def import_documents(
         result.observations_skipped = outcome.skipped
         result.remapped_unit_ids.update(outcome.remapped_unit_ids)
 
-    if parsed.mental_models or parsed.knowledge_pages:
+    if restore_bank_scoped_rows and (parsed.mental_models or parsed.knowledge_pages):
         mm_embeddings = await _regenerate_mental_model_embeddings(embeddings_model, parsed.mental_models)
         async with acquire_with_retry(backend) as conn:
             # Document archives serialize bank-row JSON values directly. Keep
@@ -658,6 +668,9 @@ async def import_bank(
         archive_bytes=archive_bytes,
         ops=ops,
         outbox_callback_factory=None,
+        # The bank path restores mental models and knowledge pages itself, below,
+        # after remapping their evidence ids onto the facts just replayed.
+        restore_bank_scoped_rows=False,
     )
 
     result = BankImportResult(
@@ -1136,16 +1149,26 @@ def _remap_based_on_ids(payload: dict[str, Any] | None, unit_id_map: dict[str, s
 
 
 def _remap_mental_model_evidence(rows: list[dict], unit_id_map: dict[str, str]) -> None:
-    """Repair current and historical mental-model reflect-response evidence."""
+    """Repair current and historical mental-model reflect-response evidence.
+
+    Handles both row shapes. A ``mental_models`` row carries the response in its
+    own ``reflect_response`` column. A ``mental_model_history`` row carries one
+    snapshot as a single JSONB ``content`` blob holding ``previous_content`` and
+    ``previous_reflect_response`` — there is no top-level column of that name, so
+    the nested payload has to be decoded, rewritten and put back.
+    """
     for row in rows:
         reflect_response = _decode_json_object(row.get("reflect_response"))
         if isinstance(reflect_response, dict):
             _remap_based_on_ids(reflect_response, unit_id_map)
             row["reflect_response"] = reflect_response
-        previous = _decode_json_object(row.get("previous_reflect_response"))
-        if isinstance(previous, dict):
-            _remap_based_on_ids(previous, unit_id_map)
-            row["previous_reflect_response"] = previous
+        content = _decode_json_object(row.get("content"))
+        if isinstance(content, dict):
+            previous = _decode_json_object(content.get("previous_reflect_response"))
+            if isinstance(previous, dict):
+                _remap_based_on_ids(previous, unit_id_map)
+                content["previous_reflect_response"] = previous
+                row["content"] = content
 
 
 def _decode_json_object(value: Any) -> Any:

--- a/hindsight-api-slim/tests/test_ann_iterative_scan.py
+++ b/hindsight-api-slim/tests/test_ann_iterative_scan.py
@@ -200,9 +200,18 @@ async def test_the_kill_switch_flips_real_retrieval_depth(memory, request_contex
     index are built directly: the property belongs to the index scan, and going through
     retain would drag in extraction and consolidation.
     """
+    from hindsight_api._vector_index import uses_per_bank_vector_indexes
+    from hindsight_api.config import get_config
     from hindsight_api.engine.search.retrieval import retrieve_semantic_bm25_combined_sql
-    from hindsight_api.engine.retain.bank_utils import get_or_create_bank_profile
+    from hindsight_api.engine.retain.bank_utils import (
+        _bank_index_name,
+        create_bank_vector_indexes,
+        get_or_create_bank_profile,
+    )
     from hindsight_api.engine.task_backend import fq_table
+
+    if not uses_per_bank_vector_indexes(get_config().vector_extension):
+        pytest.skip("backend uses a global vector index, so there is no per-bank ANN index to name")
 
     bank_id = f"test_iter_scan_{uuid.uuid4().hex[:8]}"
     budget = 400  # deliberately above the standing ef_search of 200
@@ -214,6 +223,27 @@ async def test_the_kill_switch_flips_real_retrieval_depth(memory, request_contex
     table = fq_table("memory_units")
     try:
         async with pool.acquire() as conn:
+            internal_id = await conn.fetchval(
+                f"SELECT internal_id FROM {fq_table('banks')} WHERE bank_id = $1", bank_id
+            )
+            assert internal_id is not None, f"bank {bank_id} was created without an internal_id"
+            # The plan is asserted against this exact name below. "Index Scan" alone is
+            # not enough: memory_units carries ~19 btrees, any of which can feed a scan
+            # plus a Sort and satisfy the substring while returning every row regardless
+            # of the candidate list — the very plan this test exists to exclude (#3619).
+            index_name = _bank_index_name("world", str(internal_id))
+            # Unqualified, like the table names above: resolved through the session's
+            # search_path, so it names the same index the query below would plan against.
+            if not await conn.fetchval("SELECT to_regclass($1) IS NOT NULL", index_name):
+                # Only reachable with HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS set, where a
+                # fresh bank has not earned its indexes and vector_index_maintenance owns
+                # them. Build them here so the assertion measures the plan rather than the
+                # threshold. Deliberately not unconditional: at the default of 0 this
+                # branch does not run, so the test still fails if bank creation ever stops
+                # building the index recall depends on.
+                ann_config("vector_index_min_rows", 0)
+                await create_bank_vector_indexes(conn, bank_id, str(internal_id), ops=memory._backend.ops)
+
             await conn.executemany(
                 f"INSERT INTO {table} (bank_id, text, fact_type, embedding) VALUES ($1, $2, 'world', $3::vector)",
                 [(bank_id, f"filler fact {i}", _near_query_vector(i)) for i in range(_ROWS)],
@@ -241,11 +271,10 @@ async def test_the_kill_switch_flips_real_retrieval_depth(memory, request_contex
                         probe,
                     )
                 )
-                # "Index Scan" alone is not enough — a btree scan plus a Sort also
-                # matches, and it returns every row regardless of the candidate list,
-                # which would make this quietly measure nothing. An ANN scan emits rows
-                # already ordered, so the giveaway is the absence of a Sort node.
-                assert "Index Scan" in plan and "Sort" not in plan, f"expected an ANN scan, got:\n{plan}"
+                # An ANN scan emits rows already ordered, so a Sort node means the
+                # planner fell back to a btree plus a top-N sort.
+                assert index_name in plan, f"expected an ANN scan using {index_name}, got:\n{plan}"
+                assert "Sort" not in plan, f"expected an ANN scan without a Sort, got:\n{plan}"
                 result = await retrieve_semantic_bm25_combined_sql(
                     conn, probe, "", bank_id, ["world"], budget, min_semantic=0.0
                 )

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -226,7 +226,13 @@ def test_export_bank_covers_schema():
 
 
 def test_remap_mental_model_evidence_updates_current_and_history():
-    """Transfer remapping changes only known memory-unit ids in both payloads."""
+    """Transfer remapping changes only known memory-unit ids in both payloads.
+
+    The two rows carry the two real shapes. A ``mental_models`` row has its own
+    ``reflect_response`` column; a ``mental_model_history`` row stores the whole
+    snapshot in a JSONB ``content`` blob, so its evidence is nested one level
+    down and there is no top-level ``previous_reflect_response`` to find.
+    """
     from hindsight_api.engine.transfer.importer import _remap_mental_model_evidence
 
     rows = [
@@ -234,14 +240,22 @@ def test_remap_mental_model_evidence_updates_current_and_history():
             "reflect_response": {"based_on": {"world": [{"id": "old", "text": "fact"}]}},
         },
         {
-            "previous_reflect_response": json.dumps({"based_on": {"observation": [{"id": "obs-old"}]}}),
+            "content": json.dumps(
+                {
+                    "previous_content": "an earlier draft",
+                    "previous_reflect_response": {"based_on": {"observation": [{"id": "obs-old"}]}},
+                }
+            ),
         },
     ]
 
     _remap_mental_model_evidence(rows, {"old": "new", "obs-old": "obs-new"})
 
     assert rows[0]["reflect_response"]["based_on"]["world"][0]["id"] == "new"
-    assert rows[1]["previous_reflect_response"]["based_on"]["observation"][0]["id"] == "obs-new"
+    history_content = rows[1]["content"]
+    assert history_content["previous_reflect_response"]["based_on"]["observation"][0]["id"] == "obs-new"
+    # The rest of the snapshot is copied through untouched.
+    assert history_content["previous_content"] == "an earlier draft"
 
 
 def test_topological_page_order_is_parent_first():


### PR DESCRIPTION
Supersedes #3745 (same change, rebased on current `main` with review comments applied and moved into this repo so `test-api` actually runs — it is gated on `has_secrets`, so all three shards skip on a fork PR and the only test this touches got no CI signal there). Original work by @Sanderhoff-alt, kept as `Co-authored-by`.

Fixes #3619.

## The assertion

`test_the_kill_switch_flips_real_retrieval_depth` checked the plan with `"Index Scan" in plan and "Sort" not in plan`. `memory_units` carries ~19 btrees, and any of them can feed a scan plus a top-N sort and satisfy that substring — the exact plan the test exists to exclude, as its own comment said. So a failure named a different index each run, and a pass proved little. It now asserts the bank's own `idx_mu_emb_worl_<uid>` by name, keeping the `Sort` check because an ANN scan emits rows already ordered.

## The precondition

The reported failures were the index not existing at all. #3561 set `HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS=1000000` suite-wide, so a fresh bank stopped earning its partial indexes and no ANN plan was a candidate — the `Disabled: true` on the `Sort` in those plans says exactly that. #3638 removed that override the same day, so **this is not currently failing on `main`**; the precondition the test depended on silently was simply never stated.

This states it: if the bank's index is absent, build it through the production entry point and carry on.

- At the default threshold of `0` the branch does not run, so the test still fails if bank creation ever stops building the index recall depends on — an unconditional create would have healed that regression silently.
- With a threshold set, the test measures the plan rather than the configuration.

It also skips early on a backend using a global vector index, where there is no per-bank index to name.

## Verified locally, against an isolated pg0

| Configuration | Result |
| --- | --- |
| Default (`vector_index_min_rows=0`, index built at bank creation — rescue branch not taken) | `11 passed` for the file |
| `HINDSIGHT_API_VECTOR_INDEX_MIN_ROWS=10000` (rescue branch taken) | `1 passed` |
| `./scripts/hooks/lint.sh` | clean |

https://claude.ai/code/session_01DNWFQn8AUN6SApcswHG3aN


---

## Also in this PR: the transfer bug that was failing `test-api (1/3)`

While verifying CI for the change above, `test_document_transfer.py::test_bank_roundtrip_remaps_mental_model_based_on_ids` failed on shard 1 — twice, same test, so not a flake. It is unrelated to the ANN test, but it is a real regression on `main` that no CI run had caught (`main` last ran CI on 2026-08-19), so it is fixed here.

A whole-bank restore replays facts under fresh ids and then rewrites the persisted reflect-response `based_on` ids onto them (#3833). **Neither half of that repair survived.**

**1. The current response was remapped, then overwritten.** `export_bank` writes every `bank_rows` table as `<table>.json`, so a bank archive contains a `mental_models.json` — the same member a documents archive uses. Since #3855 `import_documents` restores that member itself, and `import_bank` calls `import_documents` *before* doing the remap. The un-remapped copy landed first, and `_restore_rows` is `ON CONFLICT DO NOTHING`, so the remapped rows inserted moments later were silently dropped.

Fix: the bank path takes exclusive ownership of those rows — it already restores mental models and knowledge pages itself, with the archive's own JSON encoding and alongside `mental_model_history`.

**2. The historical response was never remapped at all.** `mental_model_history` stores a snapshot as one JSONB `content` blob holding `previous_content` and `previous_reflect_response`. There is no top-level column of that name, so `row.get("previous_reflect_response")` always missed and every history row was left untouched.

Fix: decode `content`, rewrite the nested response, put it back.

**Why this stayed green.** The unit test covering the remap asserted the invented top-level shape:

```python
{"previous_reflect_response": json.dumps({"based_on": {"observation": [{"id": "obs-old"}]}})}
```

That row shape does not exist in the database, so the test passed while the roundtrip stayed broken. It now uses the real `content` blob and also asserts `previous_content` survives.

### Verified

`tests/test_document_transfer.py` — **48 passed** (was 47 passed / 1 failed). `test_admin_bank_transfer.py`, `test_knowledge_base.py`, `test_mental_models.py` — 127 passed, 1 pre-existing failure (`test_consolidation_only_refreshes_matching_tagged_models`, confirmed failing with this change reverted). `lint.sh` and `ty check` clean.

### Not fixed here

A **documents** archive carrying mental models has the same staleness — its `based_on` ids still point at the source bank's units, and `import_documents` never remaps them. That is a pre-existing gap with a different blast radius; worth its own issue.
