### PR TITLE
fix(sdk): send only the trigger settings the caller named

### DIFF
--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -81,6 +81,35 @@ def _warn_if_operation_id_dropped(retain_async: bool, operation_id: str | None) 
         )
 
 
+def _trigger_input(trigger: dict[str, Any]) -> Any:
+    """Build a MentalModelTriggerInput carrying ONLY the settings the caller named.
+
+    The routes that take a trigger patch it over what is already there — the
+    page defaults on page creation, the stored trigger on either update — and
+    they read "named" from the fields the request actually carried
+    (``model_dump(exclude_unset=True)``, #3506/#3549). The generated model
+    defeats that on its own: ``to_dict`` drops ``None`` but keeps defaults, so a
+    caller asking for one setting also shipped ``mode="full"``,
+    ``refresh_after_consolidation=False``, ``exclude_mental_models=False`` and
+    ``keep_trace=False`` — quietly rebuilding a delta page from scratch, over
+    its sibling pages, which is the very bug #3506 fixed one layer up.
+
+    Passing ``None`` for the defaulted fields the caller left out makes
+    ``to_dict`` drop them. Only fields whose default is non-None need this: a
+    nullable field left unset is already omitted, while explicitly passing it as
+    ``None`` would serialize a null and clear the stored value.
+    """
+    from hindsight_client_api.models import mental_model_trigger_input
+
+    model = mental_model_trigger_input.MentalModelTriggerInput
+    unnamed_defaults = {
+        name: None
+        for name, field in model.model_fields.items()
+        if name not in trigger and field.default is not None
+    }
+    return model(**unnamed_defaults, **trigger)
+
+
 class Hindsight:
     """
     High-level, easy-to-use Hindsight API client.
@@ -1233,11 +1262,9 @@ class Hindsight:
         Returns:
             CreateMentalModelResponse with operation_id
         """
-        from hindsight_client_api.models import create_mental_model_request, mental_model_trigger_input
+        from hindsight_client_api.models import create_mental_model_request
 
-        trigger_obj = None
-        if trigger:
-            trigger_obj = mental_model_trigger_input.MentalModelTriggerInput(**trigger)
+        trigger_obj = _trigger_input(trigger) if trigger else None
 
         request_obj = create_mental_model_request.CreateMentalModelRequest(
             id=id,
@@ -1395,11 +1422,9 @@ class Hindsight:
         Returns:
             MentalModelResponse
         """
-        from hindsight_client_api.models import mental_model_trigger_input, update_mental_model_request
+        from hindsight_client_api.models import update_mental_model_request
 
-        trigger_obj = None
-        if trigger:
-            trigger_obj = mental_model_trigger_input.MentalModelTriggerInput(**trigger)
+        trigger_obj = _trigger_input(trigger) if trigger else None
 
         request_obj = update_mental_model_request.UpdateMentalModelRequest(
             name=name,
@@ -1518,11 +1543,9 @@ class Hindsight:
         Returns:
             CreateKnowledgePageResponse with page_id, mental_model_id and operation_id
         """
-        from hindsight_client_api.models import create_page_request, mental_model_trigger_input
+        from hindsight_client_api.models import create_page_request
 
-        trigger_obj = None
-        if trigger:
-            trigger_obj = mental_model_trigger_input.MentalModelTriggerInput(**trigger)
+        trigger_obj = _trigger_input(trigger) if trigger else None
 
         request_obj = create_page_request.CreatePageRequest(
             name=name,
@@ -1620,7 +1643,10 @@ class Hindsight:
         if max_tokens is not None:
             fields["max_tokens"] = max_tokens
         if trigger is not None:
-            fields["trigger"] = trigger
+            # Built through the helper rather than handed over as a dict: pydantic
+            # would fill the unnamed fields with the model's defaults and the page
+            # would lose the settings this patch never mentioned.
+            fields["trigger"] = _trigger_input(trigger)
 
         request_obj = update_node_request.UpdateNodeRequest(**fields)
 

--- a/hindsight-clients/python/tests/test_knowledge_base_mapping.py
+++ b/hindsight-clients/python/tests/test_knowledge_base_mapping.py
@@ -112,7 +112,16 @@ def test_update_node_maps_page_options(monkeypatch):
 def test_update_node_forwards_a_partial_trigger(monkeypatch):
     """The trigger is a PATCH server-side: unsent fields keep the page's current values,
     so the wrapper must pass exactly what the caller gave it — and a wrapper that dropped
-    the field would leave callers unable to change a refresh policy at all."""
+    the field would leave callers unable to change a refresh policy at all.
+
+    Asserted on the serialized body, not on ``model_fields_set``: the server reads
+    which fields the REQUEST carried, and the generated model's ``to_dict`` keeps a
+    non-None default even for a field nobody set. Passing the dict straight through
+    therefore shipped ``mode="full"``, ``refresh_after_consolidation``,
+    ``exclude_mental_models`` and ``keep_trace`` alongside the one setting asked for,
+    resetting the page to a from-scratch rebuild over its sibling pages — #3506's bug,
+    one layer down.
+    """
     client = Hindsight(base_url="http://example.invalid")
     captured: dict[str, object] = {}
     _capture(monkeypatch, client, "update_knowledge_node", captured)
@@ -121,7 +130,7 @@ def test_update_node_forwards_a_partial_trigger(monkeypatch):
 
     _, _, request = captured["args"]
     assert request.trigger.refresh_cron == "0 3 * * *"
-    assert request.trigger.model_fields_set == {"refresh_cron"}
+    assert request.trigger.to_dict() == {"refresh_cron": "0 3 * * *"}
 
 
 def test_search_forwards_query_and_limit(monkeypatch):

--- a/hindsight-clients/python/tests/test_mental_model_trigger_patch.py
+++ b/hindsight-clients/python/tests/test_mental_model_trigger_patch.py
@@ -1,0 +1,114 @@
+"""A wrapper-supplied trigger carries only the settings the caller named.
+
+Every route that takes a trigger patches it over what is already stored — the
+page defaults on page creation, the model's current trigger on either update —
+and decides what "named" means from the fields the request actually carried
+(``model_dump(exclude_unset=True)``, #3506/#3549). The generated model undoes
+that by itself: ``to_dict`` drops ``None`` but keeps a non-None default, so a
+caller asking for one setting also shipped ``mode="full"``,
+``refresh_after_consolidation=False``, ``exclude_mental_models=False`` and
+``keep_trace=False``, silently resetting the four settings they never mentioned.
+
+These assert on the serialized body rather than on attributes: an attribute is
+right either way, and it is the wire payload the server reads.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hindsight_client import Hindsight
+
+# The fields whose model default is not None — the ones that leaked into every
+# request before the wrapper started blanking them.
+DEFAULTED_FIELDS = {"mode", "refresh_after_consolidation", "exclude_mental_models", "keep_trace"}
+
+
+def _capture(monkeypatch, api, method, captured):
+    async def fake(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return MagicMock()
+
+    monkeypatch.setattr(api, method, fake)
+
+
+def _client() -> Hindsight:
+    return Hindsight(base_url="http://example.invalid")
+
+
+def test_update_mental_model_sends_only_the_named_setting(monkeypatch):
+    client = _client()
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client._mental_models_api, "update_mental_model", captured)
+
+    client.update_mental_model("bank-1", "mm-1", trigger={"mode": "delta"})
+
+    _, _, request = captured["args"]
+    assert request.trigger.to_dict() == {"mode": "delta"}
+
+
+def test_update_mental_model_keeps_an_explicit_false(monkeypatch):
+    """A caller turning a setting OFF must still be heard: False is a value, not an omission."""
+    client = _client()
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client._mental_models_api, "update_mental_model", captured)
+
+    client.update_mental_model("bank-1", "mm-1", trigger={"refresh_after_consolidation": False})
+
+    _, _, request = captured["args"]
+    assert request.trigger.to_dict() == {"refresh_after_consolidation": False}
+
+
+def test_update_mental_model_clears_a_nullable_field(monkeypatch):
+    """An explicit None on a nullable field still serializes as null, which is how a
+    stored cron schedule is removed — blanking the unnamed defaults must not break it."""
+    client = _client()
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client._mental_models_api, "update_mental_model", captured)
+
+    client.update_mental_model("bank-1", "mm-1", trigger={"refresh_cron": None, "keep_trace": True})
+
+    _, _, request = captured["args"]
+    assert request.trigger.to_dict() == {"refresh_cron": None, "keep_trace": True}
+
+
+def test_create_knowledge_page_keeps_the_page_defaults(monkeypatch):
+    """Page creation patches over KNOWLEDGE_PAGE_DEFAULT_TRIGGER (delta, observation-only,
+    exclude_mental_models). A trigger naming one setting used to carry mode="full" with it
+    and turn a page into a from-scratch rebuild that reflected over its siblings."""
+    client = _client()
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client._knowledge_base_api, "create_knowledge_page", captured)
+
+    client.create_knowledge_page("bank-1", name="Page", source_query="q", trigger={"tags_match": "all"})
+
+    _, request = captured["args"]
+    assert request.trigger.to_dict() == {"tags_match": "all"}
+
+
+@pytest.mark.parametrize("field", sorted(DEFAULTED_FIELDS))
+def test_a_defaulted_field_is_sent_only_when_named(monkeypatch, field):
+    """Guards the whole family: each defaulted field must be absent unless asked for.
+
+    Parametrized rather than spelled out per field so a regenerated client that adds
+    another defaulted setting is covered by extending DEFAULTED_FIELDS alone.
+    """
+    client = _client()
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client._mental_models_api, "update_mental_model", captured)
+
+    client.update_mental_model("bank-1", "mm-1", trigger={"tags_match": "any"})
+    _, _, request = captured["args"]
+    assert field not in request.trigger.to_dict()
+
+
+def test_no_trigger_sends_no_trigger(monkeypatch):
+    client = _client()
+    captured: dict[str, object] = {}
+    _capture(monkeypatch, client._mental_models_api, "update_mental_model", captured)
+
+    client.update_mental_model("bank-1", "mm-1", name="Renamed")
+
+    _, _, request = captured["args"]
+    assert request.trigger is None

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -135,6 +135,71 @@ export interface MemoryItemInput {
 }
 
 /**
+ * Refresh settings for a mental model or knowledge page, in this client's
+ * camelCase style.
+ *
+ * One shape for every method that takes a trigger, so a setting exposed on
+ * creation is also settable on update: `updateMentalModel` used to accept two
+ * of these fields and `createMentalModel` four, which left the rest reachable
+ * only by calling the generated SDK directly.
+ */
+export interface MentalModelTriggerOptions {
+  /** `full` regenerates the content from scratch on each refresh; `delta` edits the existing content in place. */
+  mode?: "full" | "delta";
+  refreshAfterConsolidation?: boolean;
+  /** Cron expression (UTC, 5-field). Mutually exclusive with refreshAfterConsolidation; null removes a schedule. */
+  refreshCron?: string | null;
+  /** Floor, in seconds, on how often an automatic refresh of this model may run. A trigger firing sooner is queued and parked until the window closes, and further triggers fold into it, so a burst of retains costs one refresh. Explicit refreshes ignore it. 0 disables the floor for this model; omit to inherit the bank/global default. */
+  minRefreshIntervalSeconds?: number;
+  /** Which fact types refresh retrieves. Omit for all of them. */
+  factTypes?: Array<"world" | "experience" | "observation">;
+  /** Skip the search_mental_models tool during refresh, so this model does not reflect over its siblings. */
+  excludeMentalModels?: boolean;
+  excludeMentalModelIds?: string[];
+  /** How this model's tags filter source memories on refresh. If omitted, a tagged model defaults to 'all_strict' (a memory must carry every one of the model's tags), which silently drops memories that only carry a subset. Set 'any' to match memories carrying any of the tags — the same default recall/reflect use. */
+  tagsMatch?: "any" | "all" | "any_strict" | "all_strict" | "exact";
+  /** Compound tag filter using boolean groups; overrides the model's flat tags/tagsMatch during refresh. */
+  tagGroups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput>;
+  includeChunks?: boolean;
+  recallMaxTokens?: number;
+  recallChunksMaxTokens?: number;
+  /** JSON Schema for structured output, stored alongside the markdown content. */
+  responseSchema?: Record<string, unknown>;
+  /** Record how each refresh reached its result under reflect_response.trace. */
+  keepTrace?: boolean;
+}
+
+/**
+ * Map the camelCase trigger options onto the snake_case request body.
+ *
+ * Every key is emitted, and the ones the caller omitted are `undefined`, which
+ * JSON serialization drops. That is what keeps a partial trigger partial: the
+ * server patches a trigger over the stored one and reads "named" from the
+ * fields the request actually carried (#3506/#3549), so a mapper that filled in
+ * its own defaults would silently reset the settings the caller never mentioned
+ * — the trap the Python wrapper fell into, where the generated model's
+ * defaults rode along on every request.
+ */
+function toTriggerBody(trigger: MentalModelTriggerOptions): MentalModelTriggerInput {
+  return {
+    mode: trigger.mode,
+    refresh_after_consolidation: trigger.refreshAfterConsolidation,
+    refresh_cron: trigger.refreshCron,
+    min_refresh_interval_seconds: trigger.minRefreshIntervalSeconds,
+    fact_types: trigger.factTypes,
+    exclude_mental_models: trigger.excludeMentalModels,
+    exclude_mental_model_ids: trigger.excludeMentalModelIds,
+    tags_match: trigger.tagsMatch,
+    tag_groups: trigger.tagGroups,
+    include_chunks: trigger.includeChunks,
+    recall_max_tokens: trigger.recallMaxTokens,
+    recall_chunks_max_tokens: trigger.recallChunksMaxTokens,
+    response_schema: trigger.responseSchema,
+    keep_trace: trigger.keepTrace,
+  };
+}
+
+/**
  * Warn when a caller-supplied operationId will be silently ignored.
  *
  * operationId only enables idempotent retries for asynchronous retain; on a
@@ -893,15 +958,7 @@ export class HindsightClient {
       id?: string;
       tags?: string[];
       maxTokens?: number;
-      trigger?: {
-        refreshAfterConsolidation?: boolean;
-        /** Floor, in seconds, on how often an automatic refresh of this model may run. A trigger firing sooner is queued and parked until the window closes, and further triggers fold into it, so a burst of retains costs one refresh. Explicit refreshes ignore it. 0 disables the floor for this model; omit to inherit the bank/global default. */
-        minRefreshIntervalSeconds?: number;
-        /** How this model's tags filter source memories on refresh. If omitted, a tagged model defaults to 'all_strict' (a memory must carry every one of the model's tags), which silently drops memories that only carry a subset. Set 'any' to match memories carrying any of the tags — the same default recall/reflect use. */
-        tagsMatch?: "any" | "all" | "any_strict" | "all_strict" | "exact";
-        /** Compound tag filter using boolean groups; overrides the model's flat tags/tagsMatch during refresh. */
-        tagGroups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput>;
-      };
+      trigger?: MentalModelTriggerOptions;
       signal?: AbortSignal;
     }
   ): Promise<CreateMentalModelResponse> {
@@ -914,14 +971,7 @@ export class HindsightClient {
         source_query: sourceQuery,
         tags: options?.tags,
         max_tokens: options?.maxTokens,
-        trigger: options?.trigger
-          ? {
-              refresh_after_consolidation: options.trigger.refreshAfterConsolidation,
-              min_refresh_interval_seconds: options.trigger.minRefreshIntervalSeconds,
-              tags_match: options.trigger.tagsMatch,
-              tag_groups: options.trigger.tagGroups,
-            }
-          : undefined,
+        trigger: options?.trigger ? toTriggerBody(options.trigger) : undefined,
       },
       signal: options?.signal,
     });
@@ -1051,7 +1101,9 @@ export class HindsightClient {
       sourceQuery?: string;
       tags?: string[];
       maxTokens?: number;
-      trigger?: { refreshAfterConsolidation?: boolean; minRefreshIntervalSeconds?: number };
+      /** Refresh settings to change. Applied as a patch: the fields you send are updated
+       *  and the rest keep the model's current values. */
+      trigger?: MentalModelTriggerOptions;
       signal?: AbortSignal;
     }
   ): Promise<MentalModelResponse> {
@@ -1063,12 +1115,7 @@ export class HindsightClient {
         source_query: options.sourceQuery,
         tags: options.tags,
         max_tokens: options.maxTokens,
-        trigger: options.trigger
-          ? {
-              refresh_after_consolidation: options.trigger.refreshAfterConsolidation,
-              min_refresh_interval_seconds: options.trigger.minRefreshIntervalSeconds,
-            }
-          : undefined,
+        trigger: options.trigger ? toTriggerBody(options.trigger) : undefined,
       },
       signal: options.signal,
     });
@@ -1170,19 +1217,7 @@ export class HindsightClient {
        */
       tags?: string[];
       maxTokens?: number;
-      trigger?: {
-        mode?: "full" | "delta";
-        refreshAfterConsolidation?: boolean;
-        refreshCron?: string | null;
-        factTypes?: Array<"world" | "experience" | "observation">;
-        excludeMentalModels?: boolean;
-        excludeMentalModelIds?: string[];
-        tagsMatch?: "any" | "all" | "any_strict" | "all_strict" | "exact";
-        tagGroups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput>;
-        includeChunks?: boolean;
-        recallMaxTokens?: number;
-        recallChunksMaxTokens?: number;
-      };
+      trigger?: MentalModelTriggerOptions;
       signal?: AbortSignal;
     }
   ): Promise<CreateKnowledgePageResponse> {
@@ -1195,21 +1230,7 @@ export class HindsightClient {
         parent_id: options?.parentId,
         tags: options?.tags,
         max_tokens: options?.maxTokens,
-        trigger: options?.trigger
-          ? {
-              mode: options.trigger.mode,
-              refresh_after_consolidation: options.trigger.refreshAfterConsolidation,
-              refresh_cron: options.trigger.refreshCron,
-              fact_types: options.trigger.factTypes,
-              exclude_mental_models: options.trigger.excludeMentalModels,
-              exclude_mental_model_ids: options.trigger.excludeMentalModelIds,
-              tags_match: options.trigger.tagsMatch,
-              tag_groups: options.trigger.tagGroups,
-              include_chunks: options.trigger.includeChunks,
-              recall_max_tokens: options.trigger.recallMaxTokens,
-              recall_chunks_max_tokens: options.trigger.recallChunksMaxTokens,
-            }
-          : undefined,
+        trigger: options?.trigger ? toTriggerBody(options.trigger) : undefined,
       },
       signal: options?.signal,
     });

--- a/hindsight-clients/typescript/tests/update_mental_model_mapping.test.ts
+++ b/hindsight-clients/typescript/tests/update_mental_model_mapping.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the updateMentalModel wrapper's trigger mapping.
+ *
+ * The generated sdk layer is mocked, so no server is needed: these assert that
+ * the camelCase options reach the snake_case body, and — the point of the
+ * suite — that a partial trigger stays partial. The server patches a supplied
+ * trigger over the model's stored one and reads "named" from the fields the
+ * request carried (#3506/#3549), so any field the caller did not set must be
+ * absent from the body rather than filled in with a default.
+ *
+ * Mirrors tests/test_mental_model_trigger_patch.py on the Python side, where
+ * the generated model's own defaults did ride along on every request.
+ */
+
+import { HindsightClient } from "../src";
+import * as sdk from "../generated/sdk.gen";
+
+jest.mock("../generated/sdk.gen");
+
+const mockedUpdate = sdk.updateMentalModel as jest.MockedFunction<typeof sdk.updateMentalModel>;
+
+function lastBody(): any {
+  return mockedUpdate.mock.calls[0][0].body;
+}
+
+/** The keys a JSON body actually carries — `undefined` values are dropped in transit. */
+function sentTriggerKeys(): string[] {
+  return Object.entries(lastBody().trigger ?? {})
+    .filter(([, value]) => value !== undefined)
+    .map(([key]) => key)
+    .sort();
+}
+
+describe("updateMentalModel trigger mapping", () => {
+  let client: HindsightClient;
+
+  beforeEach(() => {
+    client = new HindsightClient({ baseUrl: "http://localhost:8888" });
+    mockedUpdate.mockReset();
+    mockedUpdate.mockResolvedValue({
+      data: { id: "mm-1", bank_id: "bank", name: "Model", tags: [] },
+    } as any);
+  });
+
+  test("sends only the setting the caller named", async () => {
+    await client.updateMentalModel("bank", "mm-1", { trigger: { mode: "delta" } });
+
+    expect(lastBody().trigger.mode).toBe("delta");
+    expect(sentTriggerKeys()).toEqual(["mode"]);
+  });
+
+  test("keeps an explicit false rather than treating it as an omission", async () => {
+    await client.updateMentalModel("bank", "mm-1", {
+      trigger: { refreshAfterConsolidation: false },
+    });
+
+    expect(sentTriggerKeys()).toEqual(["refresh_after_consolidation"]);
+    expect(lastBody().trigger.refresh_after_consolidation).toBe(false);
+  });
+
+  test("maps an explicit 0 rather than dropping it as falsy", async () => {
+    // 0 is a meaningful value here — it exempts one model from a bank-wide floor.
+    await client.updateMentalModel("bank", "mm-1", { trigger: { minRefreshIntervalSeconds: 0 } });
+
+    expect(sentTriggerKeys()).toEqual(["min_refresh_interval_seconds"]);
+    expect(lastBody().trigger.min_refresh_interval_seconds).toBe(0);
+  });
+
+  test("sends an explicit null cron, which is how a schedule is removed", async () => {
+    await client.updateMentalModel("bank", "mm-1", { trigger: { refreshCron: null } });
+
+    expect(sentTriggerKeys()).toEqual(["refresh_cron"]);
+    expect(lastBody().trigger.refresh_cron).toBeNull();
+  });
+
+  test("exposes the settings the update used to have no way to reach", async () => {
+    await client.updateMentalModel("bank", "mm-1", {
+      trigger: {
+        refreshCron: "0 3 * * *",
+        tagsMatch: "any_strict",
+        keepTrace: true,
+        excludeMentalModels: true,
+        factTypes: ["observation"],
+        includeChunks: true,
+        recallMaxTokens: 4096,
+        recallChunksMaxTokens: 2048,
+        responseSchema: { type: "object" },
+        excludeMentalModelIds: ["mm-other"],
+        tagGroups: [{ tags: ["user:alice"], match: "all_strict" }],
+      },
+    });
+
+    const trigger = lastBody().trigger;
+    expect(trigger.refresh_cron).toBe("0 3 * * *");
+    expect(trigger.tags_match).toBe("any_strict");
+    expect(trigger.keep_trace).toBe(true);
+    expect(trigger.exclude_mental_models).toBe(true);
+    expect(trigger.fact_types).toEqual(["observation"]);
+    expect(trigger.include_chunks).toBe(true);
+    expect(trigger.recall_max_tokens).toBe(4096);
+    expect(trigger.recall_chunks_max_tokens).toBe(2048);
+    expect(trigger.response_schema).toEqual({ type: "object" });
+    expect(trigger.exclude_mental_model_ids).toEqual(["mm-other"]);
+    expect(trigger.tag_groups).toEqual([{ tags: ["user:alice"], match: "all_strict" }]);
+    // Still no mode: it was not asked for, and the stored one must survive.
+    expect(sentTriggerKeys()).not.toContain("mode");
+  });
+
+  test("omitting trigger sends no trigger at all", async () => {
+    await client.updateMentalModel("bank", "mm-1", { name: "Renamed" });
+
+    expect(lastBody().trigger).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The bug

Every route that accepts a `trigger` **patches** it over what is already stored — the page defaults on page creation, the model's current trigger on either update — and decides which fields were "named" from the ones the request actually carried (`model_dump(exclude_unset=True)`, #3506/#3549).

The Python wrapper defeated that. The generated `MentalModelTriggerInput.to_dict()` uses `exclude_none=True`, not `exclude_unset`, so every field with a non-`None` default rides along on every request:

```python
MentalModelTriggerInput(keep_trace=True).to_dict()
# {'mode': 'full', 'refresh_after_consolidation': False,
#  'exclude_mental_models': False, 'keep_trace': True}
```

Consequences for SDK users:

- `create_knowledge_page(..., trigger={"tags_match": "all"})` also sent `mode="full"` and `exclude_mental_models=False`, turning the page into a from-scratch rebuild that reflects over its sibling pages — the exact bug #3506 fixed one layer up.
- `update_mental_model(..., trigger={"keep_trace": True})` reset the model's mode, its after-consolidation refresh and its mental-model exclusion.
- `update_knowledge_node(..., trigger={...})` did the same, despite its docstring promising "the keys you pass are updated and the rest keep the page's current values".

## The fix

`_trigger_input` blanks the defaulted fields the caller left out, so `to_dict` drops them. Only fields whose default is non-`None` need this: a nullable field left unset is already omitted, while explicitly passing `None` on one is a real instruction — that is how a stored cron schedule is cleared, and that still works.

## TypeScript

Never had the bug (`undefined` keys don't survive serialization), but had a parity gap: `updateMentalModel` exposed two trigger fields and `createMentalModel` four, leaving the rest reachable only by dropping to the generated SDK. Both now take one shared exported `MentalModelTriggerOptions` covering the whole trigger, mapped in a single `toTriggerBody`.

## Tests

- `hindsight-clients/python/tests/test_mental_model_trigger_patch.py` — asserts on the serialized body across `update_mental_model` and `create_knowledge_page`, including explicit `False`, explicit `None` on a nullable field, and a parametrized guard over the defaulted-field family.
- `hindsight-clients/typescript/tests/update_mental_model_mapping.test.ts` — the mirror suite, plus cover for the fields the update could not previously reach.
- `test_update_node_forwards_a_partial_trigger` now asserts the wire payload instead of `model_fields_set`: that attribute was already correct while the body still carried the defaults, which is why the existing test never caught this.

The CLI half of the same bug class is #3513.


https://claude.ai/code/session_01WbaYxouCERUv9djo3GnnA2
