### PR TITLE
fix(kb): apply a knowledge-node patch in one transaction

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -169,6 +169,7 @@ def FieldWithDefault(default_factory: Callable, **kwargs) -> Any:
 from hindsight_api.config import HindsightConfig, StaticConfigProxy, get_config
 from hindsight_api.engine.interface import BankTemplateImportWrite
 from hindsight_api.engine.memory_engine import (
+    KEEP_PARENT,
     Budget,
     RetainOperationConflictError,
     _current_schema,
@@ -6084,51 +6085,45 @@ def _register_routes(app: FastAPI):
     ):
         """Rename/move a node and/or update a page's options."""
         try:
-            updated: dict[str, Any] | None = None
-            did_change = False
-            if body.name is not None:
-                did_change = True
-                updated = await app.state.memory.rename_knowledge_node(
-                    bank_id=bank_id, node_id=node_id, name=body.name, request_context=request_context
-                )
             # parent_id is applied only when present in the body, so passing null
-            # moves the node to the root (distinct from "not provided").
-            if "parent_id" in body.model_fields_set:
-                did_change = True
-                updated = await app.state.memory.move_knowledge_node(
-                    bank_id=bank_id, node_id=node_id, new_parent_id=body.parent_id, request_context=request_context
-                )
-            # Page options live on the backing mental model; each applies only when
-            # present in the body (so tags=[] clears, distinct from "not provided").
+            # moves the node to the root (distinct from "not provided"), which is
+            # what KEEP_PARENT stands in for. Page options live on the backing
+            # mental model and each applies only when supplied (so tags=[] clears,
+            # distinct from "not provided").
             page_fields = {"source_query", "tags", "max_tokens", "trigger"} & body.model_fields_set
-            if page_fields:
-                did_change = True
-                updated = await app.state.memory.update_knowledge_page(
-                    bank_id=bank_id,
-                    page_id=node_id,
-                    source_query=body.source_query if "source_query" in page_fields else None,
-                    tags=body.tags if "tags" in page_fields else None,
-                    max_tokens=body.max_tokens if "max_tokens" in page_fields else None,
-                    # Only the trigger fields the client stated: the engine patches them over
-                    # the page's current trigger, and a full dump would carry this model's own
-                    # defaults (mode="full", exclude_mental_models=False) into every update.
-                    trigger=(body.trigger.model_dump(exclude_unset=True) if body.trigger else None),
-                    request_context=request_context,
-                )
-                # A new source query means the content is stale — rebuild it.
-                if updated is not None and "source_query" in page_fields and updated.get("mental_model_id"):
-                    await app.state.memory.submit_async_refresh_mental_model(
-                        bank_id=bank_id,
-                        mental_model_id=updated["mental_model_id"],
-                        request_context=request_context,
-                    )
-            if not did_change:
+            if body.name is None and "parent_id" not in body.model_fields_set and not page_fields:
                 raise HTTPException(
                     status_code=400,
                     detail="Provide name, parent_id, source_query, tags, max_tokens, and/or trigger to update",
                 )
+            # One call, one transaction: a rename must not survive the move that
+            # fails after it, which is what left clients retrying against a tree
+            # they never asked for.
+            updated = await app.state.memory.update_knowledge_node(
+                bank_id=bank_id,
+                node_id=node_id,
+                name=body.name,
+                parent_id=body.parent_id if "parent_id" in body.model_fields_set else KEEP_PARENT,
+                source_query=body.source_query if "source_query" in page_fields else None,
+                tags=body.tags if "tags" in page_fields else None,
+                max_tokens=body.max_tokens if "max_tokens" in page_fields else None,
+                # Only the trigger fields the client stated: the engine patches them over
+                # the page's current trigger, and a full dump would carry this model's own
+                # defaults (mode="full", exclude_mental_models=False) into every update.
+                trigger=(body.trigger.model_dump(exclude_unset=True) if body.trigger else None),
+                request_context=request_context,
+            )
             if updated is None:
                 raise HTTPException(status_code=404, detail=f"Knowledge node '{node_id}' not found")
+            # A new source query means the content is stale — rebuild it. Scheduled
+            # only once the patch has committed, so a refresh is never queued for a
+            # change that rolled back.
+            if "source_query" in page_fields and body.source_query is not None and updated.get("mental_model_id"):
+                await app.state.memory.submit_async_refresh_mental_model(
+                    bank_id=bank_id,
+                    mental_model_id=updated["mental_model_id"],
+                    request_context=request_context,
+                )
             return _knowledge_node_model(updated)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))

--- a/hindsight-api-slim/hindsight_api/engine/db_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/db_utils.py
@@ -192,3 +192,24 @@ async def acquire_with_retry(backend_or_pool: Any, max_retries: int = DEFAULT_MA
             yield conn
         finally:
             await pool.release(conn)
+
+
+@asynccontextmanager
+async def use_or_acquire(backend_or_pool: Any, conn: Any | None) -> AsyncIterator[Any]:
+    """Reuse the caller's connection, or acquire one when there isn't one.
+
+    Lets a method that normally manages its own connection also run as one step
+    of a caller's transaction: pass ``conn`` and its writes commit or roll back
+    with everything else in that transaction, rather than landing on a separate
+    connection that a later failure cannot undo. A borrowed connection is left
+    open here — the caller that opened it closes it.
+
+    Usage:
+        async with use_or_acquire(backend, conn) as c:
+            await c.execute(...)
+    """
+    if conn is not None:
+        yield conn
+        return
+    async with acquire_with_retry(backend_or_pool) as owned:
+        yield owned

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1348,7 +1348,7 @@ def _recall_scoring_now(question_date: datetime | None) -> datetime:
 # Logger for memory system
 logger = logging.getLogger(__name__)
 
-from .db_utils import acquire_with_retry, retry_with_backoff
+from .db_utils import acquire_with_retry, retry_with_backoff, use_or_acquire
 
 
 def _truncate_query_to_token_limit(query: str, max_query_tokens: int, log_prefix: str = "") -> str:
@@ -1849,6 +1849,19 @@ class KnowledgeBaseExport:
 
     nodes: list[dict[str, Any]]
     pages: list[KnowledgeBaseExportPage]
+
+
+class KeepParentSentinel:
+    """Type of :data:`KEEP_PARENT`."""
+
+
+KEEP_PARENT = KeepParentSentinel()
+""""Leave the parent alone" for :meth:`MemoryEngine.update_knowledge_node`.
+
+Every other field of that patch reads ``None`` as "not supplied", but a null
+``parent_id`` is a real destination — the tree root — so it needs a value
+outside ``str | None`` to say the caller isn't moving anything.
+"""
 
 
 class MemoryEngine(MemoryEngineInterface):
@@ -13875,8 +13888,9 @@ class MemoryEngine(MemoryEngineInterface):
         # types deduced for parameter $3: text versus character varying". Casting
         # the column assignment pins the parameter to text; VARCHAR accepts a text
         # value on assignment. Every write that feeds mental_models.name into
-        # pg_search_vector_expr needs the same cast (see update_mental_model and
-        # rename_knowledge_node).
+        # pg_search_vector_expr needs the same cast (see update_mental_model,
+        # which is now the only other one — the knowledge-base rename goes through
+        # it rather than writing mental_models itself).
         sv_expr = pg_search_vector_expr(
             get_config(), text_col="$3", context_col="$5", signals_col=None, native_inline=False
         )
@@ -15100,6 +15114,7 @@ class MemoryEngine(MemoryEngineInterface):
         refresh_watermark: datetime | None = None,
         refresh_completed: bool = False,
         structured_content: dict[str, Any] | None = None,
+        conn: Any | None = None,
         request_context: "RequestContext",
     ) -> dict[str, Any] | None:
         """Update a pinned mental model.
@@ -15125,6 +15140,10 @@ class MemoryEngine(MemoryEngineInterface):
                 which stamps ``last_refreshed_at = NOW()`` even if the refresh preserved
                 the existing content. A refresh that failed leaves it False, so the
                 timestamp keeps pointing at the last refresh that actually finished.
+            conn: Run on this connection instead of acquiring one, so the write joins
+                the caller's open transaction and rolls back with it. Used by the
+                knowledge-base patch, where the backing model and its node row have to
+                move together.
             request_context: Request context for authentication
 
         Returns:
@@ -15170,7 +15189,7 @@ class MemoryEngine(MemoryEngineInterface):
             if embedding:
                 new_embedding_str = str(embedding[0])
 
-        async with acquire_with_retry(backend) as conn:
+        async with use_or_acquire(backend, conn) as conn:
             # If content is changing, fetch current content + reflect_response to record history
             previous_content: str | None = None
             previous_reflect_response: dict[str, Any] | None = None
@@ -16060,189 +16079,168 @@ class MemoryEngine(MemoryEngineInterface):
             for r in rows
         ]
 
-    async def rename_knowledge_node(
-        self, bank_id: str, node_id: str, name: str, *, request_context: "RequestContext"
-    ) -> dict[str, Any] | None:
-        """Rename a folder or page node."""
-        await self._authenticate_tenant(request_context)
-        if self._operation_validator and not _nested_operation_authorized.get():
-            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
-
-            ctx = BankWriteContext(
-                bank_id=bank_id,
-                operation=BankWriteOperation.RENAME_KNOWLEDGE_NODE,
-                request_context=request_context,
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
-        backend = await self._get_backend()
-        # A page's searchable document is its backing mental model's name + content,
-        # so the rename must also update mental_models.name — and re-tokenize its
-        # search_vector for vchord (native is a generated column, the other backends
-        # index base columns; same helper as create/update/clear_mental_model). Both
-        # writes share one transaction, so a knowledge_pages name-uniqueness
-        # violation rolls the mental-model name back with it. Folders carry no
-        # backing model (mental_model_id is NULL), so only the node row is touched.
-        # The mental-model write casts $3 to text because the same bind feeds
-        # sv_expr; see _insert_pinned_mental_model. knowledge_pages.name is already
-        # TEXT, so the node write needs no cast.
-        sv_expr = pg_search_vector_expr(
-            get_config(), text_col="$3", context_col="content", signals_col=None, native_inline=False
-        )
-        sv_clause = f", search_vector = {sv_expr}" if sv_expr else ""
-        async with acquire_with_retry(backend) as conn:
-            async with conn.transaction():
-                row = await conn.fetchrow(
-                    f"""
-                    UPDATE {fq_table("knowledge_pages")}
-                    SET name = $3, updated_at = now()
-                    WHERE bank_id = $1 AND id = $2
-                    RETURNING {self._KP_COLUMNS}
-                    """,
-                    bank_id,
-                    node_id,
-                    name,
-                )
-                if row is not None and row["mental_model_id"] is not None:
-                    await conn.execute(
-                        f"""
-                        UPDATE {fq_table("mental_models")}
-                        SET name = $3::text{sv_clause}
-                        WHERE bank_id = $1 AND id = $2
-                        """,
-                        bank_id,
-                        row["mental_model_id"],
-                        name,
-                    )
-        return self._row_to_knowledge_node(row) if row else None
-
-    async def update_knowledge_page(
+    async def update_knowledge_node(
         self,
         bank_id: str,
-        page_id: str,
+        node_id: str,
         *,
+        name: str | None = None,
+        parent_id: str | None | KeepParentSentinel = KEEP_PARENT,
         source_query: str | None = None,
         tags: list[str] | None = None,
         max_tokens: int | None = None,
         trigger: dict[str, Any] | None = None,
         request_context: "RequestContext",
     ) -> dict[str, Any] | None:
-        """Update a page's editable options on its backing mental model.
+        """Rename, re-parent, and/or update a page's options in ONE transaction.
 
-        Covers the source query (the question that rebuilds the page), tags,
-        token budget, and refresh trigger — each applied only when provided.
-        Returns the refreshed node (carrying ``mental_model_id``) or ``None`` when
-        the page doesn't exist. Changing the source query does not rebuild content
-        here; the API layer schedules an async refresh so the page re-synthesizes
-        against the new question.
+        Every field applies only when supplied, and the whole patch commits or
+        rolls back together. Splitting it across a call per field is what let a
+        rename survive the move that failed after it, so a client retrying the
+        same PATCH saw a tree it never asked for (a node renamed but not moved).
+
+        ``name`` and the page options use ``None`` for "not supplied" — a null in
+        the request body means the client is not changing that field, which is
+        the contract the HTTP and MCP layers have always exposed. ``parent_id``
+        cannot: null there is a real destination (the tree root), so it takes the
+        ``KEEP_PARENT`` sentinel for "not supplied" instead.
+
+        Page options live on the backing mental model. Returns the updated node,
+        or ``None`` when the node doesn't exist — or when page options were asked
+        for on something that is not a page, in which case nothing is written.
+        Changing the source query does not rebuild content here; the API layer
+        schedules an async refresh so the page re-synthesizes against the new
+        question.
         """
         await self._authenticate_tenant(request_context)
+        # Bind the destination once, so the rest of the method reads a plain
+        # `str | None` and never has to re-narrow the sentinel out of it.
+        moving = not isinstance(parent_id, KeepParentSentinel)
+        new_parent: str | None = parent_id if not isinstance(parent_id, KeepParentSentinel) else None
+        page_options = source_query is not None or tags is not None or max_tokens is not None or trigger is not None
         if self._operation_validator and not _nested_operation_authorized.get():
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
 
-            ctx = BankWriteContext(
-                bank_id=bank_id,
-                operation=BankWriteOperation.UPDATE_KNOWLEDGE_PAGE,
-                request_context=request_context,
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
-        backend = await self._get_backend()
-        async with acquire_with_retry(backend) as conn:
-            # The page's CURRENT trigger comes back with it: a supplied trigger patches
-            # that rather than replacing it (see _merge_trigger).
-            row = await conn.fetchrow(
-                f"SELECT kp.mental_model_id, mm.trigger FROM {fq_table('knowledge_pages')} kp "
-                f"LEFT JOIN {fq_table('mental_models')} mm "
-                f"ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id "
-                f"WHERE kp.bank_id = $1 AND kp.id = $2 AND kp.kind = 'page'",
-                bank_id,
-                page_id,
-            )
-        if row is None or row["mental_model_id"] is None:
-            return None
-        effective_trigger = (
-            self._merge_trigger(trigger, base=self._stored_trigger(row["trigger"])) if trigger is not None else None
-        )
-        # The write is already authorized above; the backing mental-model update
-        # runs without re-invoking the validator.
-        with _authorize_nested_operations():
-            await self.update_mental_model(
-                bank_id=bank_id,
-                mental_model_id=row["mental_model_id"],
-                source_query=source_query,
-                tags=tags,
-                max_tokens=max_tokens,
-                trigger=effective_trigger,
-                request_context=request_context,
-            )
-        async with acquire_with_retry(backend) as conn:
-            node_row = await conn.fetchrow(
-                f"SELECT {self._KP_PAGE_SELECT} FROM {self._kp_join()} "
-                f"WHERE kp.bank_id = $1 AND kp.id = $2 AND kp.kind = 'page'",
-                bank_id,
-                page_id,
-            )
-        return self._row_to_knowledge_node(node_row) if node_row else None
-
-    async def move_knowledge_node(
-        self, bank_id: str, node_id: str, new_parent_id: str | None, *, request_context: "RequestContext"
-    ) -> dict[str, Any] | None:
-        """Re-parent a node, rejecting self-parenting and cycles."""
-        await self._authenticate_tenant(request_context)
-        if self._operation_validator and not _nested_operation_authorized.get():
-            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
-
-            ctx = BankWriteContext(
-                bank_id=bank_id,
-                operation=BankWriteOperation.MOVE_KNOWLEDGE_NODE,
-                request_context=request_context,
-            )
-            await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
-        if new_parent_id == node_id:
+            # One gate per operation the patch actually performs, so an extension
+            # that allows renames but not moves still sees both decisions. All of
+            # them run before the transaction opens: a denial must not leave a
+            # half-applied patch behind.
+            operations = []
+            if name is not None:
+                operations.append(BankWriteOperation.RENAME_KNOWLEDGE_NODE)
+            if moving:
+                operations.append(BankWriteOperation.MOVE_KNOWLEDGE_NODE)
+            if page_options:
+                operations.append(BankWriteOperation.UPDATE_KNOWLEDGE_PAGE)
+            for operation in operations:
+                ctx = BankWriteContext(
+                    bank_id=bank_id,
+                    operation=operation,
+                    request_context=request_context,
+                )
+                await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+        if moving and new_parent == node_id:
             raise ValueError("A node cannot be its own parent")
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
-                # Structural tree writers lock this bank row before reading or
-                # changing the hierarchy, serializing moves with creates/deletes.
-                await self._kp_lock_bank(conn, bank_id)
-                await self._kp_assert_folder_parent(conn, bank_id, new_parent_id)
-                # Cycle guard: walk up from the new parent; if we reach node_id,
-                # the move would create a loop. Done in Python so the check stays
-                # dialect-agnostic (no recursive CTE).
-                if new_parent_id is not None:
-                    parents = {
-                        r["id"]: r["parent_id"]
-                        for r in await conn.fetch(
-                            f"SELECT id, parent_id FROM {fq_table('knowledge_pages')} WHERE bank_id = $1",
-                            bank_id,
-                        )
-                    }
-                    # `seen` bounds the walk. The lock above stops this process
-                    # from creating a loop, but a tree corrupted before the lock
-                    # existed (or restored from such an export) would otherwise
-                    # spin here forever, holding a connection and an open
-                    # transaction. Refuse the move instead of hanging.
-                    seen: set[str] = set()
-                    cursor: str | None = new_parent_id
-                    while cursor is not None:
-                        if cursor == node_id:
-                            raise ValueError("Cannot move a node into its own subtree")
-                        if cursor in seen:
-                            raise ValueError(f"Knowledge tree for bank '{bank_id}' contains a parent cycle")
-                        seen.add(cursor)
-                        cursor = parents.get(cursor)
+                if moving:
+                    # Structural tree writers lock this bank row before reading or
+                    # changing the hierarchy, serializing moves with creates/deletes.
+                    # A patch that only renames or only edits page options changes no
+                    # parent link and so takes no tree lock.
+                    await self._kp_lock_bank(conn, bank_id)
                 row = await conn.fetchrow(
-                    f"""
-                    UPDATE {fq_table("knowledge_pages")}
-                    SET parent_id = $3, updated_at = now()
-                    WHERE bank_id = $1 AND id = $2
-                    RETURNING {self._KP_COLUMNS}
-                    """,
+                    f"SELECT kind, mental_model_id FROM {fq_table('knowledge_pages')} WHERE bank_id = $1 AND id = $2",
                     bank_id,
                     node_id,
-                    new_parent_id,
                 )
-        return self._row_to_knowledge_node(row) if row else None
+                if row is None:
+                    return None
+                mental_model_id = row["mental_model_id"]
+                # Page options only exist on a page's backing model. Reporting this
+                # as "not found" is what the dedicated endpoint always did; the part
+                # that changes here is that the rename alongside it rolls back too.
+                if page_options and (row["kind"] != "page" or mental_model_id is None):
+                    return None
+
+                if moving:
+                    await self._kp_assert_folder_parent(conn, bank_id, new_parent)
+                    # Cycle guard: walk up from the new parent; if we reach node_id,
+                    # the move would create a loop. Done in Python so the check stays
+                    # dialect-agnostic (no recursive CTE).
+                    if new_parent is not None:
+                        parents = {
+                            r["id"]: r["parent_id"]
+                            for r in await conn.fetch(
+                                f"SELECT id, parent_id FROM {fq_table('knowledge_pages')} WHERE bank_id = $1",
+                                bank_id,
+                            )
+                        }
+                        # `seen` bounds the walk. The lock above stops this process
+                        # from creating a loop, but a tree corrupted before the lock
+                        # existed (or restored from such an export) would otherwise
+                        # spin here forever, holding a connection and an open
+                        # transaction. Refuse the move instead of hanging.
+                        seen: set[str] = set()
+                        cursor: str | None = new_parent
+                        while cursor is not None:
+                            if cursor == node_id:
+                                raise ValueError("Cannot move a node into its own subtree")
+                            if cursor in seen:
+                                raise ValueError(f"Knowledge tree for bank '{bank_id}' contains a parent cycle")
+                            seen.add(cursor)
+                            cursor = parents.get(cursor)
+
+                node_updates: list[str] = []
+                node_params: list[Any] = [bank_id, node_id]
+                if name is not None:
+                    node_updates.append(f"name = ${len(node_params) + 1}")
+                    node_params.append(name)
+                if moving:
+                    node_updates.append(f"parent_id = ${len(node_params) + 1}")
+                    node_params.append(new_parent)
+                if node_updates:
+                    await conn.execute(
+                        f"UPDATE {fq_table('knowledge_pages')} "
+                        f"SET {', '.join(node_updates)}, updated_at = now() "
+                        f"WHERE bank_id = $1 AND id = $2",
+                        *node_params,
+                    )
+
+                if mental_model_id is not None and (name is not None or page_options):
+                    # A page's searchable document is its backing mental model's name +
+                    # content, so a rename has to reach the model too (which also
+                    # re-tokenizes its search_vector). Written on the SAME connection
+                    # and transaction as the node row, so a knowledge_pages
+                    # name-uniqueness violation rolls this back with it. Folders carry
+                    # no backing model (mental_model_id is NULL) and skip this.
+                    #
+                    # update_mental_model owns these columns — including patching a
+                    # partial trigger over the stored one — so this reuses it rather
+                    # than restating its SQL, which would be free to drift.
+                    #
+                    # Already authorized above; the nested write must not re-invoke
+                    # the validator.
+                    with _authorize_nested_operations():
+                        await self.update_mental_model(
+                            bank_id=bank_id,
+                            mental_model_id=mental_model_id,
+                            name=name,
+                            source_query=source_query,
+                            tags=tags,
+                            max_tokens=max_tokens,
+                            trigger=trigger,
+                            conn=conn,
+                            request_context=request_context,
+                        )
+
+                node_row = await conn.fetchrow(
+                    f"SELECT {self._KP_PAGE_SELECT} FROM {self._kp_join()} WHERE kp.bank_id = $1 AND kp.id = $2",
+                    bank_id,
+                    node_id,
+                )
+        return self._row_to_knowledge_node(node_row) if node_row else None
 
     async def delete_knowledge_node(self, bank_id: str, node_id: str, *, request_context: "RequestContext") -> bool:
         """Delete a node and its whole subtree, including each page's mental model.

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -22,7 +22,7 @@ from hindsight_api.config import (
     DEFAULT_MCP_RETAIN_DESCRIPTION,
 )
 from hindsight_api.engine.audit import AuditEntry, AuditLogger
-from hindsight_api.engine.memory_engine import Budget
+from hindsight_api.engine.memory_engine import KEEP_PARENT, Budget
 from hindsight_api.engine.response_models import VALID_RECALL_FACT_TYPES, MinScores, TemporalWindow
 from hindsight_api.engine.search.tags import TagGroup, TagsMatch
 from hindsight_api.extensions import OperationValidationError
@@ -2297,35 +2297,28 @@ async def _do_update_knowledge_node(
             "and/or refresh_after_consolidation to update"
         }
 
-    updated: dict[str, Any] | None = None
-    if name is not None:
-        updated = await memory.rename_knowledge_node(
-            bank_id=target_bank, node_id=node_id, name=name, request_context=request_context
-        )
-    if parent_id is not None:
-        updated = await memory.move_knowledge_node(
-            bank_id=target_bank,
-            node_id=node_id,
-            new_parent_id=None if parent_id == KNOWLEDGE_ROOT_PARENT else parent_id,
-            request_context=request_context,
-        )
-    if page_update:
-        updated = await memory.update_knowledge_page(
-            bank_id=target_bank,
-            page_id=node_id,
-            source_query=source_query,
-            tags=tags,
-            max_tokens=max_tokens,
-            trigger=trigger,
-            request_context=request_context,
-        )
-        # A new source query means the page's content no longer answers it — rebuild.
-        if updated is not None and source_query is not None and updated.get("mental_model_id"):
-            await memory.submit_async_refresh_mental_model(
-                bank_id=target_bank, mental_model_id=updated["mental_model_id"], request_context=request_context
-            )
+    # One call, one transaction: a rename must not survive the move that fails
+    # after it. This tool is driven by agents that retry on error, and a partly
+    # applied patch made the retry read a tree nobody asked for.
+    updated = await memory.update_knowledge_node(
+        bank_id=target_bank,
+        node_id=node_id,
+        name=name,
+        parent_id=(None if parent_id == KNOWLEDGE_ROOT_PARENT else parent_id) if parent_id is not None else KEEP_PARENT,
+        source_query=source_query,
+        tags=tags,
+        max_tokens=max_tokens,
+        trigger=trigger,
+        request_context=request_context,
+    )
     if updated is None:
         return {"error": f"Knowledge node '{node_id}' not found in bank '{target_bank}'"}
+    # A new source query means the page's content no longer answers it — rebuild.
+    # Scheduled only once the patch has committed.
+    if source_query is not None and updated.get("mental_model_id"):
+        await memory.submit_async_refresh_mental_model(
+            bank_id=target_bank, mental_model_id=updated["mental_model_id"], request_context=request_context
+        )
     return _knowledge_node_json(updated)
 
 

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -282,7 +282,7 @@ class TestTree:
         which is the same policy stated a different way.)
         """
         bank_id, ids = kb_bank
-        await memory.update_knowledge_page(
+        await memory.update_knowledge_node(
             bank_id, ids.loose, trigger={"refresh_cron": "0 3 * * *"}, request_context=request_context
         )
         resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/tree")
@@ -574,7 +574,7 @@ class TestPageDefaults:
         """
         bank_id = f"test-kb-upd-{uuid.uuid4().hex[:8]}"
         page = await memory.create_knowledge_page(bank_id, "P", "What is P?", "seed", request_context=request_context)
-        await memory.update_knowledge_page(
+        await memory.update_knowledge_node(
             bank_id,
             page["id"],
             trigger={"refresh_cron": "0 3 * * *"},
@@ -590,7 +590,7 @@ class TestPageDefaults:
         assert "refresh_after_consolidation" not in mm["trigger"]
 
         # ...and back again: the stated auto-refresh clears the stored cron.
-        await memory.update_knowledge_page(
+        await memory.update_knowledge_node(
             bank_id,
             page["id"],
             trigger={"refresh_after_consolidation": True},
@@ -612,7 +612,7 @@ class TestPageDefaults:
             trigger={"refresh_cron": "0 3 * * *"},
             request_context=request_context,
         )
-        await memory.update_knowledge_page(bank_id, page["id"], max_tokens=2048, request_context=request_context)
+        await memory.update_knowledge_node(bank_id, page["id"], max_tokens=2048, request_context=request_context)
         mm = await memory.get_mental_model(bank_id, page["mental_model_id"], request_context=request_context)
         assert mm["max_tokens"] == 2048
         assert mm["trigger"]["refresh_cron"] == "0 3 * * *"
@@ -635,7 +635,7 @@ class TestPageDefaults:
             captured.update(kwargs)
             return {"id": ids.orders, "kind": "page", "name": "Orders", "mental_model_id": ids.orders_mm}
 
-        monkeypatch.setattr(memory, "update_knowledge_page", fake_update)
+        monkeypatch.setattr(memory, "update_knowledge_node", fake_update)
         resp = await api_client.patch(
             f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
             json={"trigger": {"refresh_cron": "0 4 * * *"}},
@@ -930,12 +930,16 @@ class TestMoveRenameDelete:
         pauser.install(monkeypatch)
         try:
             first = asyncio.create_task(
-                memory.move_knowledge_node(bank_id, folder_a["id"], folder_b["id"], request_context=request_context)
+                memory.update_knowledge_node(
+                    bank_id, folder_a["id"], parent_id=folder_b["id"], request_context=request_context
+                )
             )
             await asyncio.wait_for(pauser.first_holds_lock.wait(), timeout=5)
 
             second = asyncio.create_task(
-                memory.move_knowledge_node(bank_id, folder_b["id"], folder_a["id"], request_context=request_context)
+                memory.update_knowledge_node(
+                    bank_id, folder_b["id"], parent_id=folder_a["id"], request_context=request_context
+                )
             )
             await asyncio.wait_for(pauser.second_reached_lock.wait(), timeout=5)
             await _assert_blocked(second, "the second move")
@@ -969,7 +973,9 @@ class TestMoveRenameDelete:
             await asyncio.wait_for(pauser.first_holds_lock.wait(), timeout=5)
 
             moving = asyncio.create_task(
-                memory.move_knowledge_node(bank_id, folder_a["id"], folder_b["id"], request_context=request_context)
+                memory.update_knowledge_node(
+                    bank_id, folder_a["id"], parent_id=folder_b["id"], request_context=request_context
+                )
             )
             await asyncio.wait_for(pauser.second_reached_lock.wait(), timeout=5)
             await _assert_blocked(moving, "the move")
@@ -1050,8 +1056,8 @@ class TestMoveRenameDelete:
             # The ancestor walk never reaches C, so only the cycle guard ends it.
             with pytest.raises(ValueError, match="cycle"):
                 await asyncio.wait_for(
-                    memory.move_knowledge_node(
-                        bank_id, folder_c["id"], folder_a["id"], request_context=request_context
+                    memory.update_knowledge_node(
+                        bank_id, folder_c["id"], parent_id=folder_a["id"], request_context=request_context
                     ),
                     timeout=10,
                 )
@@ -1068,6 +1074,129 @@ class TestMoveRenameDelete:
             assert remaining == {folder_c["id"]}
         finally:
             await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_patch_rolls_back_the_rename_when_the_move_fails(self, api_client, kb_bank, memory, request_context):
+        """One PATCH is one transaction.
+
+        A rename used to commit on its own connection before the move was even
+        attempted, so a bad parent left the node renamed but not moved: state the
+        client never asked for, and one its retry of the same PATCH could not undo.
+        """
+        bank_id, ids = kb_bank
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"name": "Renamed Orders", "parent_id": "kf-does-not-exist"},
+        )
+        assert resp.status_code == 400, resp.text
+
+        node = next(
+            n
+            for n in await memory.list_knowledge_nodes(bank_id, request_context=request_context)
+            if n["id"] == ids.orders
+        )
+        assert node["name"] == "Orders"
+        assert node["parent_id"] == ids.runbooks
+        # The backing mental model is written in the same transaction, so it has to
+        # roll back with the node rather than keep a name nothing points at.
+        mm = await memory.get_mental_model(bank_id, ids.orders_mm, request_context=request_context)
+        assert mm["name"] == "Orders"
+
+    async def test_patch_rolls_back_the_rename_when_the_page_options_do_not_apply(
+        self, api_client, kb_bank, memory, request_context
+    ):
+        """Same guarantee on the other ordering: page options are rejected last.
+
+        A folder has no backing mental model, so page options cannot apply to it.
+        That verdict used to arrive after the rename had already committed.
+        """
+        bank_id, ids = kb_bank
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.policies}",
+            json={"name": "Renamed Policies", "tags": ["type:policy"]},
+        )
+        assert resp.status_code == 404, resp.text
+
+        node = next(
+            n
+            for n in await memory.list_knowledge_nodes(bank_id, request_context=request_context)
+            if n["id"] == ids.policies
+        )
+        assert node["name"] == "Policies"
+
+    async def test_patch_rolls_back_the_move_when_it_would_make_a_cycle(
+        self, api_client, kb_bank, memory, request_context
+    ):
+        """The cycle guard fires mid-transaction; the rename beside it must not survive."""
+        bank_id, ids = kb_bank
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.runbooks}",
+            json={"name": "Renamed Runbooks", "parent_id": ids.sub},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "subtree" in resp.text
+
+        node = next(
+            n
+            for n in await memory.list_knowledge_nodes(bank_id, request_context=request_context)
+            if n["id"] == ids.runbooks
+        )
+        assert node["name"] == "Runbooks"
+        assert node["parent_id"] is None
+
+    async def test_patch_applies_rename_move_and_page_options_together(
+        self, api_client, kb_bank, memory, request_context
+    ):
+        """The whole patch commits as one, and each field still lands where it lives."""
+        bank_id, ids = kb_bank
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.loose}",
+            json={
+                "name": "Compliance Rules",
+                "parent_id": ids.policies,
+                "source_query": "what are the compliance rules?",
+                "tags": ["type:policy", "compliance"],
+                "max_tokens": 1024,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        node = resp.json()
+        assert node["name"] == "Compliance Rules"
+        assert node["parent_id"] == ids.policies
+        assert set(node["tags"]) == {"type:policy", "compliance"}
+
+        mm = await memory.get_mental_model(bank_id, node["mental_model_id"], request_context=request_context)
+        assert mm["name"] == "Compliance Rules"
+        assert mm["source_query"] == "what are the compliance rules?"
+        assert set(mm["tags"]) == {"type:policy", "compliance"}
+        assert mm["max_tokens"] == 1024
+
+    async def test_patch_does_not_schedule_a_refresh_it_rolled_back(self, api_client, kb_bank, memory, monkeypatch):
+        """A new source query rebuilds the page — but only if the patch committed.
+
+        The refresh is submitted after the transaction, so a move that fails beside
+        it leaves no job queued against a source query the page never took on.
+        """
+        bank_id, ids = kb_bank
+        submitted: list[str] = []
+
+        async def fake_submit(*, bank_id: str, mental_model_id: str, request_context):
+            submitted.append(mental_model_id)
+
+        monkeypatch.setattr(memory, "submit_async_refresh_mental_model", fake_submit)
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"source_query": "a question the page never adopts", "parent_id": "kf-does-not-exist"},
+        )
+        assert resp.status_code == 400, resp.text
+        assert submitted == []
+
+        # The committing case still queues exactly one rebuild.
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"source_query": "a question the page does adopt"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert submitted == [ids.orders_mm]
 
     async def test_delete_folder_cascades(self, api_client, kb_bank, memory, request_context):
         bank_id, ids = kb_bank

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from hindsight_api.engine.memory_engine import DirectivePage, MentalModelPage
+from hindsight_api.engine.memory_engine import KEEP_PARENT, DirectivePage, MentalModelPage
 from hindsight_api.mcp_tools import (
     KNOWLEDGE_ROOT_PARENT,
     MCPToolsConfig,
@@ -277,9 +277,7 @@ def mock_memory():
     )
     memory.create_knowledge_folder = AsyncMock(return_value=dict(_KNOWLEDGE_FOLDER))
     memory.create_knowledge_page = AsyncMock(return_value=dict(_KNOWLEDGE_PAGE_NODE))
-    memory.rename_knowledge_node = AsyncMock(return_value=dict(_KNOWLEDGE_PAGE_NODE))
-    memory.move_knowledge_node = AsyncMock(return_value=dict(_KNOWLEDGE_PAGE_NODE))
-    memory.update_knowledge_page = AsyncMock(return_value=dict(_KNOWLEDGE_PAGE_NODE))
+    memory.update_knowledge_node = AsyncMock(return_value=dict(_KNOWLEDGE_PAGE_NODE))
     memory.delete_knowledge_node = AsyncMock(return_value=True)
 
     return memory
@@ -2110,41 +2108,46 @@ class TestKnowledgeBaseTools:
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         result = json.loads(await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1", name="Deployments"))
         assert result["id"] == "kp-1"
-        assert mock_memory.rename_knowledge_node.call_args.kwargs["name"] == "Deployments"
-        mock_memory.update_knowledge_page.assert_not_called()
-        mock_memory.move_knowledge_node.assert_not_called()
+        kwargs = mock_memory.update_knowledge_node.call_args.kwargs
+        assert kwargs["name"] == "Deployments"
+        # The one call carries the whole patch, so the fields the client left out
+        # have to reach the engine as "not supplied" or a rename would reset them.
+        assert kwargs["parent_id"] is KEEP_PARENT
+        assert kwargs["source_query"] is None
+        assert kwargs["tags"] is None
+        assert kwargs["max_tokens"] is None
+        assert kwargs["trigger"] is None
 
     async def test_update_move_to_folder(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1", parent_id="kf-2")
-        assert mock_memory.move_knowledge_node.call_args.kwargs["new_parent_id"] == "kf-2"
+        assert mock_memory.update_knowledge_node.call_args.kwargs["parent_id"] == "kf-2"
 
     async def test_update_move_to_root(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1", parent_id=KNOWLEDGE_ROOT_PARENT)
-        assert mock_memory.move_knowledge_node.call_args.kwargs["new_parent_id"] is None
+        assert mock_memory.update_knowledge_node.call_args.kwargs["parent_id"] is None
 
     async def test_update_source_query_triggers_refresh(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1", source_query="new question?")
-        assert mock_memory.update_knowledge_page.call_args.kwargs["source_query"] == "new question?"
+        assert mock_memory.update_knowledge_node.call_args.kwargs["source_query"] == "new question?"
         assert mock_memory.submit_async_refresh_mental_model.call_args.kwargs["mental_model_id"] == "mm-page"
 
     async def test_update_tags_only_does_not_refresh(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1", tags=[])
-        assert mock_memory.update_knowledge_page.call_args.kwargs["tags"] == []
+        assert mock_memory.update_knowledge_node.call_args.kwargs["tags"] == []
         mock_memory.submit_async_refresh_mental_model.assert_not_called()
 
     async def test_update_requires_a_field(self, mock_memory):
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         result = await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-1")
         assert "Provide name" in result
-        mock_memory.rename_knowledge_node.assert_not_called()
-        mock_memory.update_knowledge_page.assert_not_called()
+        mock_memory.update_knowledge_node.assert_not_called()
 
     async def test_update_not_found(self, mock_memory):
-        mock_memory.rename_knowledge_node.return_value = None
+        mock_memory.update_knowledge_node.return_value = None
         mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
         result = await _tools(mcp)["update_knowledge_node"].fn(node_id="kp-missing", name="x")
         assert "not found" in result


### PR DESCRIPTION
## Problem

A `PATCH /knowledge-base/nodes/{node_id}` — and the `update_knowledge_node` MCP tool — applied its parts one at a time, each on its own connection and its own transaction: `rename_knowledge_node`, then `move_knowledge_node`, then `update_knowledge_page`.

Anything that failed partway left the earlier steps committed. `{"name": "X", "parent_id": "<missing folder>"}` renamed the node and then returned 400, so the tree ended up in a state the client never asked for and its retry of the same request could not undo. Page options on a folder did the same: the rename committed, and the page-only half then reported 404.

## Fix

One engine method, `MemoryEngine.update_knowledge_node()`, applies the whole patch inside a single transaction. Validation (bad parent, self-parent, cycle, page-only options on a folder) runs before any write, and anything that raises rolls the rest back with it. The async page rebuild is submitted only after the transaction commits, so no refresh is ever queued for a change that rolled back.

`update_mental_model()` gained an optional `conn`, so the backing model is written on the caller's connection and inside the caller's transaction instead of restating its SQL — the trigger patch, the tag/token columns and the `search_vector` re-tokenization all stay in the one place that owns them.

`rename_knowledge_node`, `move_knowledge_node` and `update_knowledge_page` are removed; the HTTP and MCP handlers were their only callers.

## Compatibility

**No API behaviour changes.** Every request that worked before works the same way, with the same status code and the same body:

- `null` on any optional field still means "not changing this field", not "set it to null" — including `{"name": "X", "tags": null}`, which many clients emit when they serialize a whole model.
- `parent_id: null` still means "move to the root", which is why it (and only it) needs the `KEEP_PARENT` sentinel to say "not supplied".
- Empty and blank values (`source_query: ""`, `name: "   "`) are still accepted.
- 400 when no field is supplied; 404 for a missing node, and for page options on a node that isn't a page.
- The `BankWriteOperation` values (`rename_knowledge_node` / `move_knowledge_node` / `update_knowledge_page`) are unchanged, and the same one fires per operation the patch performs, so extension validators see exactly what they saw before.

The tree lock is taken only when the patch actually moves a node, so renames and page-option edits stay lock-free as they are today.

## Tests

Five regression tests in `test_knowledge_base.py`, each asserting the *whole* patch rolled back:

- rename + non-existent parent
- rename + page options on a folder
- rename + a move that would create a cycle
- rename + move + page options applied together (the committing case)
- no refresh queued for a source query whose patch rolled back — and exactly one for the patch that committed

Verified locally on an isolated pg0: `test_knowledge_base.py` and `test_mcp_tools.py` pass (295), `ruff` and `ty` clean.

## Supersedes

Closes #3663, which fixed the same bug but turned `null` on every optional field into a hard 400 — a silent break of the documented request contract that `check-openapi-compatibility` could not see, since the schema still declares those fields nullable.


https://claude.ai/code/session_012gXUp1i7YrWmLJVUYki53g
