### PR TITLE
fix(mental-models): accept id-bearing blocks in section operations

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/delta_ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/delta_ops.py
@@ -38,9 +38,10 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Mapping
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError, field_validator
 
 from hindsight_api.engine.llm_wrapper import parse_llm_json
 
@@ -62,6 +63,20 @@ logger = logging.getLogger(__name__)
 
 class _OpBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+
+def _coerce_block_texts(value: Any) -> Any:
+    """Accept id-bearing block objects where an operation expects markdown strings.
+
+    The current document is shown to the model with block ids alongside their
+    text, so some providers echo that shape for newly-created blocks.  Operation
+    payloads only persist the markdown text; discard the display-only id before
+    normal Pydantic validation.  Values without a string ``text`` stay untouched
+    so malformed blocks are still rejected rather than silently dropped.
+    """
+    if not isinstance(value, list):
+        return value
+    return [item["text"] if isinstance(item, Mapping) and isinstance(item.get("text"), str) else item for item in value]
 
 
 class AppendBlockOp(_OpBase):
@@ -117,6 +132,11 @@ class AddSectionOp(_OpBase):
     after_section_id: str | None = None
     new_id: str | None = None
 
+    @field_validator("blocks", mode="before")
+    @classmethod
+    def coerce_block_objects(cls, value: Any) -> Any:
+        return _coerce_block_texts(value)
+
 
 class RemoveSectionOp(_OpBase):
     """Remove an entire section by id."""
@@ -136,6 +156,11 @@ class ReplaceSectionBlocksOp(_OpBase):
     op: Literal["replace_section_blocks"] = "replace_section_blocks"
     section_id: str
     blocks: list[str] = Field(default_factory=list)
+
+    @field_validator("blocks", mode="before")
+    @classmethod
+    def coerce_block_objects(cls, value: Any) -> Any:
+        return _coerce_block_texts(value)
 
 
 class RenameSectionOp(_OpBase):

--- a/hindsight-api-slim/tests/test_delta_operation_parse.py
+++ b/hindsight-api-slim/tests/test_delta_operation_parse.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import pytest
 
 from hindsight_api.engine.reflect.delta_ops import (
+    AddSectionOp,
     AppendBlockOp,
     DeltaAllOpsInvalidError,
     DeltaOperationList,
+    ReplaceSectionBlocksOp,
     parse_delta_operation_list,
 )
 
@@ -70,6 +72,42 @@ def test_parse_delta_operation_list_skips_invalid_op_keeps_valid():
     op_list = parse_delta_operation_list(raw)
     assert len(op_list.operations) == 2
     assert all(isinstance(o, AppendBlockOp) for o in op_list.operations)
+
+
+def test_parse_delta_operation_list_coerces_add_section_block_objects():
+    """Models may echo the id-bearing document shape for newly-created blocks (#3901)."""
+    raw = (
+        '{"operations": [{"op": "add_section", "heading": "Example Heading", "blocks": ['
+        '{"id": "b12a001", "text": "First paragraph of the new section."}, '
+        '{"id": "b12a002", "text": "Second paragraph of the new section."}'
+        "]}]}"
+    )
+    op = parse_delta_operation_list(raw).operations[0]
+    assert isinstance(op, AddSectionOp)
+    assert op.blocks == ["First paragraph of the new section.", "Second paragraph of the new section."]
+
+
+def test_parse_delta_operation_list_coerces_replace_section_block_objects():
+    """Every operation field typed as list[str] accepts the same provider variation."""
+    raw = {
+        "operations": [
+            {
+                "op": "replace_section_blocks",
+                "section_id": "example",
+                "blocks": ["Unchanged string shape.", {"id": "b12a003", "text": "Object shape."}],
+            }
+        ]
+    }
+    op = parse_delta_operation_list(raw).operations[0]
+    assert isinstance(op, ReplaceSectionBlocksOp)
+    assert op.blocks == ["Unchanged string shape.", "Object shape."]
+
+
+def test_parse_delta_operation_list_rejects_block_object_without_text():
+    """Compatibility coercion must not turn malformed blocks into silent data loss."""
+    raw = {"operations": [{"op": "add_section", "heading": "Broken", "blocks": [{"id": "b12a004"}]}]}
+    with pytest.raises(DeltaAllOpsInvalidError):
+        parse_delta_operation_list(raw)
 
 
 def test_parse_delta_operation_list_rejects_v1_block_payloads():


### PR DESCRIPTION
Fixes #3901

## Summary

Mental-model delta models can echo the current document's `{id, text}` block shape when creating or replacing section blocks. The operation schema stores markdown as `list[str]`, so those operations were previously rejected and an entire refresh could fail.

This adds narrow Pydantic input coercion for `add_section.blocks` and `replace_section_blocks.blocks`:

- Retains string `text` values.
- Discards display-only `id` fields.
- Continues rejecting malformed entries.

## Validation

```text
uv run pytest -n 0 tests/test_delta_operation_parse.py tests/test_structured_doc.py tests/test_delta_prompt_schema_parity.py -q
./scripts/hooks/lint.sh
uv run ty check hindsight_api
```