### PR TITLE
ci: verify #3739 (do not merge)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -23,7 +23,7 @@ import sys
 import time
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import AsyncExitStack, asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, ParamSpec, TypeVar, cast, overload
@@ -15317,7 +15317,9 @@ class MemoryEngine(MemoryEngineInterface):
             if embedding:
                 new_embedding_str = str(embedding[0])
 
-        async with use_or_acquire(backend, conn) as conn:
+        # The exit stack carries the row lock a trigger patch takes below; it stays
+        # empty (and free) on every other update.
+        async with use_or_acquire(backend, conn) as conn, AsyncExitStack() as stack:
             # If content is changing, fetch current content + reflect_response to record history
             previous_content: str | None = None
             previous_reflect_response: dict[str, Any] | None = None
@@ -15338,15 +15340,22 @@ class MemoryEngine(MemoryEngineInterface):
             # A supplied trigger PATCHES the stored one (see _merge_trigger): callers
             # send only the fields they set, so the rest have to be read back rather
             # than defaulted. Only paid for when a trigger is actually being changed.
+            #
+            # Read-modify-write, so the row is locked for the rest of the statement:
+            # two concurrent patches (an agent setting a cron while another flips
+            # fact_types) would otherwise both merge onto the same pre-image and the
+            # later write would drop the earlier one. Only this path takes the lock —
+            # a refresh passes no trigger and stays lock-free.
             if trigger is not None:
+                await stack.enter_async_context(conn.transaction())
                 trigger_row = await conn.fetchrow(
-                    f"SELECT trigger FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                    f"SELECT trigger FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2 FOR UPDATE",
                     bank_id,
                     mental_model_id,
                 )
-                trigger = self._merge_trigger(
-                    trigger, base=self._stored_trigger(trigger_row["trigger"]) if trigger_row else {}
-                )
+                if trigger_row is None:
+                    return None
+                trigger = self._merge_trigger(trigger, base=self._stored_trigger(trigger_row["trigger"]))
 
             # Build dynamic update
             updates = []
@@ -15723,9 +15732,15 @@ class MemoryEngine(MemoryEngineInterface):
         producing a combination no request could have expressed. That matters in
         both directions on update — moving a page onto a cron schedule has to clear
         the auto-refresh it was created with, and moving it back has to clear the
-        cron.
+        cron. A patch that states BOTH is not a merge question but a contradictory
+        request, and is rejected rather than stored as a pair the API itself refuses.
         """
         supplied = trigger or {}
+        if supplied.get("refresh_after_consolidation") and supplied.get("refresh_cron"):
+            raise ValueError(
+                "refresh_after_consolidation and refresh_cron are mutually exclusive: "
+                "a mental model refreshes either after consolidation or on a cron schedule, not both."
+            )
         merged = {**(self.KNOWLEDGE_PAGE_DEFAULT_TRIGGER if base is None else base), **supplied}
         if supplied.get("refresh_cron") and "refresh_after_consolidation" not in supplied:
             merged.pop("refresh_after_consolidation", None)

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -9,11 +9,11 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, get_args
+from typing import Any, Callable, Literal, get_args
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
-from pydantic import TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator, model_validator
 
 from hindsight_api import MemoryEngine
 from hindsight_api.api import page_markdown
@@ -77,6 +77,173 @@ _ALL_TOOLS: frozenset[str] = frozenset(
 )
 
 logger = logging.getLogger(__name__)
+
+
+class MentalModelTriggerInput(BaseModel):
+    """The refresh policy of a mental model or knowledge page, as an MCP tool input.
+
+    Mirrors the HTTP ``MentalModelTrigger`` field for field — an agent that read
+    the API docs must not have a call rejected for naming a setting that exists.
+    ``tests/test_mcp_tools.py::test_trigger_input_covers_every_http_trigger_field``
+    fails if the two drift apart.
+
+    The one deliberate difference is that every field is optional with no default:
+    the HTTP model fills unset fields with its own defaults, which makes a partial
+    trigger silently reset the rest, while these tools send only what the caller
+    actually set (``model_dump(exclude_unset=True)``) and the engine merges that
+    over the stored trigger. Passing an explicit ``null`` still clears a setting.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["full", "delta"] | None = Field(
+        default=None,
+        description=(
+            "Refresh mode. 'full' regenerates the content from scratch on each refresh; 'delta' makes "
+            "surgical edits to the existing content, preserving unchanged sections byte-for-byte. Delta "
+            "falls back to a full regeneration when there is no existing content or the source_query changed."
+        ),
+    )
+    refresh_after_consolidation: bool | None = Field(
+        default=None,
+        description="Refresh automatically after observations are consolidated. Mutually exclusive with refresh_cron.",
+    )
+    refresh_cron: str | None = Field(
+        default=None,
+        description=(
+            "UTC five-field cron schedule, e.g. '0 3 * * *' for daily at 03:00 UTC. A scheduled refresh runs "
+            "only when the model is stale, so an unchanged scope costs no LLM call. Mutually exclusive with "
+            "refresh_after_consolidation. null = no schedule."
+        ),
+    )
+    min_refresh_interval_seconds: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Minimum seconds between two AUTOMATIC refreshes. A trigger that arrives sooner is queued and "
+            "parked until the window expires, and further triggers fold into that one queued refresh, so a "
+            "burst of retains costs one refresh. Explicit refreshes ignore it. 0 disables the floor; null "
+            "falls back to the bank/global setting."
+        ),
+    )
+    fact_types: list[Literal["world", "experience", "observation"]] | None = Field(
+        default=None,
+        description="Fact types to retrieve during refresh; null includes all of world, experience and observation.",
+    )
+    exclude_mental_models: bool | None = Field(
+        default=None,
+        description="Exclude ALL mental models from the refresh's reflect loop, so a model never reflects on its siblings.",
+    )
+    exclude_mental_model_ids: list[str] | None = Field(
+        default=None, description="Exclude specific mental models from the refresh's reflect loop, by ID."
+    )
+    tags_match: TagsMatch | None = Field(
+        default=None,
+        description=(
+            "How this model's tags select memories during refresh: any, all, any_strict, all_strict, or exact. "
+            "Unset means 'all_strict' for a tagged model and 'any' for an untagged one."
+        ),
+    )
+    tag_groups: list[TagGroup] | None = Field(
+        default=None,
+        description=(
+            "Compound boolean tag expressions (nested and/or/not) used during refresh INSTEAD of the model's "
+            "flat tags. When set, the model's own tags are not used for filtering."
+        ),
+    )
+    include_chunks: bool | None = Field(
+        default=None,
+        description="Override whether the refresh's internal recall returns raw chunk text. null = bank/global default.",
+    )
+    recall_max_tokens: int | None = Field(
+        default=None,
+        description="Override the token budget for facts from the refresh's internal recall. null = bank/global default.",
+    )
+    recall_chunks_max_tokens: int | None = Field(
+        default=None,
+        description="Override the token budget for raw chunks from the refresh's internal recall. null = bank/global default.",
+    )
+    response_schema: dict | None = Field(
+        default=None,
+        description=(
+            "JSON Schema for structured output. Each refresh then also stores a parsed result under "
+            "reflect_response.structured_output, alongside the markdown content."
+        ),
+    )
+    keep_trace: bool | None = Field(
+        default=None,
+        description=(
+            "Record how each refresh reached its result under reflect_response.trace (mode and why, resolved "
+            "scope and window, facts retrieved vs used, tool and LLM calls, delta operations). Only the latest "
+            "refresh's trace is kept. This is the only way to diagnose a cron- or consolidation-driven refresh, "
+            "since nobody watches those run."
+        ),
+    )
+
+    @field_validator("refresh_cron")
+    @classmethod
+    def validate_refresh_cron(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        from croniter import croniter
+
+        # An empty string reads as "no schedule", not as a malformed one — same
+        # normalisation the HTTP model does, so the two accept the same input.
+        value = value.strip()
+        if not value:
+            return None
+        if not croniter.is_valid(value):
+            raise ValueError(f"refresh_cron is not a valid cron expression: {value!r}")
+        return value
+
+    @field_validator("fact_types")
+    @classmethod
+    def validate_fact_types(cls, value: list[str] | None) -> list[str] | None:
+        if value is not None and not value:
+            raise ValueError("fact_types must not be empty; use null to include all fact types")
+        return value
+
+    @model_validator(mode="after")
+    def validate_refresh_exclusivity(self) -> "MentalModelTriggerInput":
+        if self.refresh_after_consolidation and self.refresh_cron:
+            raise ValueError(
+                "refresh_after_consolidation and refresh_cron are mutually exclusive: "
+                "a mental model refreshes either after consolidation or on a cron schedule, not both."
+            )
+        return self
+
+
+def _mental_model_trigger_patch(
+    trigger: MentalModelTriggerInput | None,
+    *,
+    tags_match: str | None = None,
+    refresh_after_consolidation: bool | None = None,
+) -> dict[str, Any] | None:
+    """The trigger patch to send down, folding in the legacy flat MCP arguments.
+
+    ``tags_match`` and ``trigger_refresh_after_consolidation`` predate the trigger
+    object and stay accepted as shorthands. Passing a shorthand AND the same field
+    inside ``trigger`` is a contradiction the caller has to resolve rather than one
+    of the two silently winning.
+    """
+    patch = trigger.model_dump(exclude_unset=True) if trigger is not None else {}
+    for field, param, legacy_value in (
+        ("tags_match", "tags_match", tags_match),
+        ("refresh_after_consolidation", "trigger_refresh_after_consolidation", refresh_after_consolidation),
+    ):
+        if legacy_value is None:
+            continue
+        if field in patch and patch[field] != legacy_value:
+            raise ValueError(
+                f"trigger.{field}={patch[field]!r} conflicts with {param}={legacy_value!r}; set it in one place"
+            )
+        patch[field] = legacy_value
+    if patch.get("refresh_after_consolidation") and patch.get("refresh_cron"):
+        raise ValueError(
+            "refresh_after_consolidation and refresh_cron are mutually exclusive: "
+            "a mental model refreshes either after consolidation or on a cron schedule, not both."
+        )
+    return patch or None
 
 
 @dataclass
@@ -1571,9 +1738,10 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
             source_query: str,
             mental_model_id: str | None = None,
             tags: list[str] | None = None,
+            trigger: MentalModelTriggerInput | None = None,
             tags_match: str | None = None,
             max_tokens: int = 2048,
-            trigger_refresh_after_consolidation: bool = False,
+            trigger_refresh_after_consolidation: bool | None = None,
             bank_id: str | None = None,
         ) -> str:
             """
@@ -1599,6 +1767,12 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     model defaults to 'all_strict' — a memory must carry EVERY one of the model's
                     tags to be included, which silently filters out memories that only carry a
                     subset. Pass 'any' when your memories use narrow single-topic tags.
+                trigger: Refresh policy for this model — when it rebuilds itself (mode,
+                    refresh_after_consolidation, refresh_cron) and what it rebuilds from
+                    (fact_types, tags_match, tag_groups, exclude_mental_models,
+                    recall_max_tokens, ...). Omitted fields use engine defaults. Prefer
+                    this over the flat tags_match/trigger_refresh_after_consolidation
+                    shorthands, which are kept only for existing integrations.
                 max_tokens: Maximum tokens for generated content (256-8192, default: 2048)
                 trigger_refresh_after_consolidation: If True, automatically refresh this model after memory consolidation. Default: False
                 bank_id: Optional bank (defaults to session bank). Use for cross-bank operations.
@@ -1615,9 +1789,13 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     return json.dumps({"error": validation_error})
 
                 request_context = _get_request_context(config)
-                trigger: dict[str, Any] = {"refresh_after_consolidation": trigger_refresh_after_consolidation}
-                if tags_match is not None:
-                    trigger["tags_match"] = tags_match
+                trigger_patch = _mental_model_trigger_patch(
+                    trigger,
+                    tags_match=tags_match,
+                    refresh_after_consolidation=trigger_refresh_after_consolidation,
+                )
+                if trigger_patch is None and trigger is None:
+                    trigger_patch = {"refresh_after_consolidation": False}
 
                 # Create with placeholder content
                 model = await memory.create_mental_model(
@@ -1628,7 +1806,7 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     mental_model_id=mental_model_id,
                     tags=tags,
                     max_tokens=max_tokens,
-                    trigger=trigger,
+                    trigger=trigger_patch,
                     request_context=request_context,
                 )
 
@@ -1664,9 +1842,10 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
             source_query: str,
             mental_model_id: str | None = None,
             tags: list[str] | None = None,
+            trigger: MentalModelTriggerInput | None = None,
             tags_match: str | None = None,
             max_tokens: int = 2048,
-            trigger_refresh_after_consolidation: bool = False,
+            trigger_refresh_after_consolidation: bool | None = None,
         ) -> dict:
             """
             Create a new mental model (pinned reflection).
@@ -1691,6 +1870,12 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     model defaults to 'all_strict' — a memory must carry EVERY one of the model's
                     tags to be included, which silently filters out memories that only carry a
                     subset. Pass 'any' when your memories use narrow single-topic tags.
+                trigger: Refresh policy for this model — when it rebuilds itself (mode,
+                    refresh_after_consolidation, refresh_cron) and what it rebuilds from
+                    (fact_types, tags_match, tag_groups, exclude_mental_models,
+                    recall_max_tokens, ...). Omitted fields use engine defaults. Prefer
+                    this over the flat tags_match/trigger_refresh_after_consolidation
+                    shorthands, which are kept only for existing integrations.
                 max_tokens: Maximum tokens for generated content (256-8192, default: 2048)
                 trigger_refresh_after_consolidation: If True, automatically refresh this model after memory consolidation. Default: False
             """
@@ -1706,9 +1891,13 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     return {"error": validation_error}
 
                 request_context = _get_request_context(config)
-                trigger: dict[str, Any] = {"refresh_after_consolidation": trigger_refresh_after_consolidation}
-                if tags_match is not None:
-                    trigger["tags_match"] = tags_match
+                trigger_patch = _mental_model_trigger_patch(
+                    trigger,
+                    tags_match=tags_match,
+                    refresh_after_consolidation=trigger_refresh_after_consolidation,
+                )
+                if trigger_patch is None and trigger is None:
+                    trigger_patch = {"refresh_after_consolidation": False}
 
                 model = await memory.create_mental_model(
                     bank_id=target_bank,
@@ -1718,7 +1907,7 @@ def _register_create_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     mental_model_id=mental_model_id,
                     tags=tags,
                     max_tokens=max_tokens,
-                    trigger=trigger,
+                    trigger=trigger_patch,
                     request_context=request_context,
                 )
 
@@ -1756,6 +1945,8 @@ def _register_update_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
             source_query: str | None = None,
             max_tokens: int | None = None,
             tags: list[str] | None = None,
+            trigger: MentalModelTriggerInput | None = None,
+            tags_match: str | None = None,
             trigger_refresh_after_consolidation: bool | None = None,
             bank_id: str | None = None,
         ) -> str:
@@ -1771,6 +1962,12 @@ def _register_update_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                 source_query: New source query (leave None to keep current)
                 max_tokens: New max tokens for content generation (256-8192, leave None to keep current)
                 tags: New tags (leave None to keep current)
+                trigger: Refresh policy fields to change — mode, refresh_after_consolidation,
+                    refresh_cron, fact_types, tags_match, tag_groups, exclude_mental_models,
+                    recall_max_tokens, and so on. This is a PATCH: fields you omit keep their
+                    current values, so setting a cron schedule does not reset the model's
+                    fact_types. Pass an explicit null to clear a setting.
+                tags_match: Legacy shorthand for trigger.tags_match
                 trigger_refresh_after_consolidation: If set, update whether this model auto-refreshes after consolidation
                 bank_id: Optional bank (defaults to session bank). Use for cross-bank operations.
             """
@@ -1780,10 +1977,16 @@ def _register_update_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     return '{"error": "No bank_id configured"}'
 
                 validation_error = _validate_mental_model_inputs(
-                    name=name, source_query=source_query, max_tokens=max_tokens
+                    name=name, source_query=source_query, max_tokens=max_tokens, tags_match=tags_match
                 )
                 if validation_error:
                     return json.dumps({"error": validation_error})
+
+                trigger_patch = _mental_model_trigger_patch(
+                    trigger,
+                    tags_match=tags_match,
+                    refresh_after_consolidation=trigger_refresh_after_consolidation,
+                )
 
                 update_kwargs: dict[str, Any] = {
                     "bank_id": target_bank,
@@ -1794,8 +1997,8 @@ def _register_update_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     "tags": tags,
                     "request_context": _get_request_context(config),
                 }
-                if trigger_refresh_after_consolidation is not None:
-                    update_kwargs["trigger"] = {"refresh_after_consolidation": trigger_refresh_after_consolidation}
+                if trigger_patch is not None:
+                    update_kwargs["trigger"] = trigger_patch
 
                 model = await memory.update_mental_model(**update_kwargs)
                 if model is None:
@@ -1817,6 +2020,8 @@ def _register_update_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
             source_query: str | None = None,
             max_tokens: int | None = None,
             tags: list[str] | None = None,
+            trigger: MentalModelTriggerInput | None = None,
+            tags_match: str | None = None,
             trigger_refresh_after_consolidation: bool | None = None,
         ) -> dict:
             """
@@ -1831,6 +2036,12 @@ def _register_update_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                 source_query: New source query (leave None to keep current)
                 max_tokens: New max tokens for content generation (256-8192, leave None to keep current)
                 tags: New tags (leave None to keep current)
+                trigger: Refresh policy fields to change — mode, refresh_after_consolidation,
+                    refresh_cron, fact_types, tags_match, tag_groups, exclude_mental_models,
+                    recall_max_tokens, and so on. This is a PATCH: fields you omit keep their
+                    current values, so setting a cron schedule does not reset the model's
+                    fact_types. Pass an explicit null to clear a setting.
+                tags_match: Legacy shorthand for trigger.tags_match
                 trigger_refresh_after_consolidation: If set, update whether this model auto-refreshes after consolidation
             """
             try:
@@ -1839,10 +2050,16 @@ def _register_update_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     return {"error": "No bank_id configured"}
 
                 validation_error = _validate_mental_model_inputs(
-                    name=name, source_query=source_query, max_tokens=max_tokens
+                    name=name, source_query=source_query, max_tokens=max_tokens, tags_match=tags_match
                 )
                 if validation_error:
                     return {"error": validation_error}
+
+                trigger_patch = _mental_model_trigger_patch(
+                    trigger,
+                    tags_match=tags_match,
+                    refresh_after_consolidation=trigger_refresh_after_consolidation,
+                )
 
                 update_kwargs: dict[str, Any] = {
                     "bank_id": target_bank,
@@ -1853,8 +2070,8 @@ def _register_update_mental_model(mcp: FastMCP, memory: MemoryEngine, config: MC
                     "tags": tags,
                     "request_context": _get_request_context(config),
                 }
-                if trigger_refresh_after_consolidation is not None:
-                    update_kwargs["trigger"] = {"refresh_after_consolidation": trigger_refresh_after_consolidation}
+                if trigger_patch is not None:
+                    update_kwargs["trigger"] = trigger_patch
 
                 model = await memory.update_mental_model(**update_kwargs)
                 if model is None:
@@ -2183,18 +2400,6 @@ def _knowledge_tree_json(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return roots
 
 
-def _page_trigger_patch(refresh_after_consolidation: bool | None) -> dict[str, Any] | None:
-    """Build the trigger patch for the one refresh setting exposed over MCP.
-
-    The engine merges a patch over the page's defaults (create) or its current
-    trigger (update), so sending only this field leaves the rest — delta mode,
-    observation-only facts — as they were.
-    """
-    if refresh_after_consolidation is None:
-        return None
-    return {"refresh_after_consolidation": refresh_after_consolidation}
-
-
 async def _do_get_knowledge_base_tree(
     memory: MemoryEngine, target_bank: str, request_context: RequestContext
 ) -> dict[str, Any]:
@@ -2259,6 +2464,7 @@ async def _do_create_knowledge_page(
     parent_id: str | None,
     tags: list[str] | None,
     max_tokens: int | None,
+    trigger: MentalModelTriggerInput | None,
     refresh_after_consolidation: bool | None,
 ) -> dict[str, Any]:
     """Shared implementation for the create_knowledge_page MCP tool variants."""
@@ -2270,7 +2476,10 @@ async def _do_create_knowledge_page(
         parent_id=parent_id,
         tags=tags or None,
         max_tokens=max_tokens,
-        trigger=_page_trigger_patch(refresh_after_consolidation),
+        # Only the fields the caller stated: the engine merges them over
+        # KNOWLEDGE_PAGE_DEFAULT_TRIGGER, so an unmentioned setting keeps the page
+        # contract (delta mode, observation-only facts, sibling pages excluded).
+        trigger=_mental_model_trigger_patch(trigger, refresh_after_consolidation=refresh_after_consolidation),
         request_context=request_context,
     )
     if node is None:
@@ -2298,6 +2507,7 @@ async def _do_update_knowledge_node(
     source_query: str | None,
     tags: list[str] | None,
     max_tokens: int | None,
+    trigger: MentalModelTriggerInput | None,
     refresh_after_consolidation: bool | None,
 ) -> dict[str, Any]:
     """Shared implementation for the update_knowledge_node MCP tool variants.
@@ -2305,12 +2515,14 @@ async def _do_update_knowledge_node(
     Each field is applied only when provided, so a rename never resets a page's
     query and moving a page never drops its tags.
     """
-    trigger = _page_trigger_patch(refresh_after_consolidation)
-    page_update = source_query is not None or tags is not None or max_tokens is not None or trigger is not None
+    # A patch, merged over the page's CURRENT trigger by the engine, so putting a
+    # page on a cron schedule does not reset how or from what it rebuilds.
+    trigger_patch = _mental_model_trigger_patch(trigger, refresh_after_consolidation=refresh_after_consolidation)
+    page_update = source_query is not None or tags is not None or max_tokens is not None or trigger_patch is not None
     if name is None and parent_id is None and not page_update:
         return {
             "error": "Provide name, parent_id, source_query, tags, max_tokens, "
-            "and/or refresh_after_consolidation to update"
+            "trigger, and/or refresh_after_consolidation to update"
         }
 
     # One call, one transaction: a rename must not survive the move that fails
@@ -2324,7 +2536,7 @@ async def _do_update_knowledge_node(
         source_query=source_query,
         tags=tags,
         max_tokens=max_tokens,
-        trigger=trigger,
+        trigger=trigger_patch,
         request_context=request_context,
     )
     if updated is None:
@@ -2639,6 +2851,7 @@ def _register_create_knowledge_page(mcp: FastMCP, memory: MemoryEngine, config: 
             parent_id: str | None = None,
             tags: list[str] | None = None,
             max_tokens: int | None = None,
+            trigger: MentalModelTriggerInput | None = None,
             refresh_after_consolidation: bool | None = None,
             bank_id: str | None = None,
         ) -> str:
@@ -2660,8 +2873,14 @@ def _register_create_knowledge_page(mcp: FastMCP, memory: MemoryEngine, config: 
                 parent_id: Optional parent folder id (a `kf-...` node id). Omit to create at the top level.
                 tags: Optional tags scoping which memories the page is built from
                 max_tokens: Maximum tokens for the generated content (default: 4096)
-                refresh_after_consolidation: Whether the page rebuilds itself after each memory
-                    consolidation. Omit to keep the knowledge-page default (True).
+                trigger: Refresh policy for this page — when it rebuilds itself (mode,
+                    refresh_after_consolidation, refresh_cron) and what it rebuilds from
+                    (fact_types, tags_match, tag_groups, exclude_mental_models,
+                    recall_max_tokens, ...). Omitted fields keep the knowledge-page
+                    defaults: incremental (delta) rebuilds from consolidated observations
+                    after each consolidation, ignoring sibling pages. Set refresh_cron
+                    instead to move the page onto a fixed UTC schedule.
+                refresh_after_consolidation: Legacy shorthand for trigger.refresh_after_consolidation.
                 bank_id: Optional bank (defaults to session bank). Use for cross-bank operations.
             """
             try:
@@ -2678,6 +2897,7 @@ def _register_create_knowledge_page(mcp: FastMCP, memory: MemoryEngine, config: 
                     parent_id=parent_id,
                     tags=tags,
                     max_tokens=max_tokens,
+                    trigger=trigger,
                     refresh_after_consolidation=refresh_after_consolidation,
                 )
                 return json.dumps(result, indent=2, default=str)
@@ -2699,6 +2919,7 @@ def _register_create_knowledge_page(mcp: FastMCP, memory: MemoryEngine, config: 
             parent_id: str | None = None,
             tags: list[str] | None = None,
             max_tokens: int | None = None,
+            trigger: MentalModelTriggerInput | None = None,
             refresh_after_consolidation: bool | None = None,
         ) -> dict:
             """
@@ -2719,8 +2940,14 @@ def _register_create_knowledge_page(mcp: FastMCP, memory: MemoryEngine, config: 
                 parent_id: Optional parent folder id (a `kf-...` node id). Omit to create at the top level.
                 tags: Optional tags scoping which memories the page is built from
                 max_tokens: Maximum tokens for the generated content (default: 4096)
-                refresh_after_consolidation: Whether the page rebuilds itself after each memory
-                    consolidation. Omit to keep the knowledge-page default (True).
+                trigger: Refresh policy for this page — when it rebuilds itself (mode,
+                    refresh_after_consolidation, refresh_cron) and what it rebuilds from
+                    (fact_types, tags_match, tag_groups, exclude_mental_models,
+                    recall_max_tokens, ...). Omitted fields keep the knowledge-page
+                    defaults: incremental (delta) rebuilds from consolidated observations
+                    after each consolidation, ignoring sibling pages. Set refresh_cron
+                    instead to move the page onto a fixed UTC schedule.
+                refresh_after_consolidation: Legacy shorthand for trigger.refresh_after_consolidation.
             """
             try:
                 target_bank = config.bank_id_resolver()
@@ -2736,6 +2963,7 @@ def _register_create_knowledge_page(mcp: FastMCP, memory: MemoryEngine, config: 
                     parent_id=parent_id,
                     tags=tags,
                     max_tokens=max_tokens,
+                    trigger=trigger,
                     refresh_after_consolidation=refresh_after_consolidation,
                 )
             except OperationValidationError as e:
@@ -2761,6 +2989,7 @@ def _register_update_knowledge_node(mcp: FastMCP, memory: MemoryEngine, config: 
             source_query: str | None = None,
             tags: list[str] | None = None,
             max_tokens: int | None = None,
+            trigger: MentalModelTriggerInput | None = None,
             refresh_after_consolidation: bool | None = None,
             bank_id: str | None = None,
         ) -> str:
@@ -2778,8 +3007,14 @@ def _register_update_knowledge_node(mcp: FastMCP, memory: MemoryEngine, config: 
                 source_query: Pages only — the new question the page answers
                 tags: Pages only — replacement tag list (pass [] to clear)
                 max_tokens: Pages only — new maximum tokens for the generated content
-                refresh_after_consolidation: Pages only — whether the page rebuilds itself
-                    after each memory consolidation
+                trigger: Pages only — refresh policy fields to change: mode,
+                    refresh_after_consolidation, refresh_cron, fact_types, tags_match,
+                    tag_groups, exclude_mental_models, recall_max_tokens, and so on. This
+                    is a PATCH: fields you omit keep their current values, so putting a
+                    page on a cron schedule does not reset its delta mode or its
+                    observation-only scope.
+                refresh_after_consolidation: Pages only — legacy shorthand for
+                    trigger.refresh_after_consolidation
                 bank_id: Optional bank (defaults to session bank). Use for cross-bank operations.
             """
             try:
@@ -2797,6 +3032,7 @@ def _register_update_knowledge_node(mcp: FastMCP, memory: MemoryEngine, config: 
                     source_query=source_query,
                     tags=tags,
                     max_tokens=max_tokens,
+                    trigger=trigger,
                     refresh_after_consolidation=refresh_after_consolidation,
                 )
                 return json.dumps(result, indent=2, default=str)
@@ -2819,6 +3055,7 @@ def _register_update_knowledge_node(mcp: FastMCP, memory: MemoryEngine, config: 
             source_query: str | None = None,
             tags: list[str] | None = None,
             max_tokens: int | None = None,
+            trigger: MentalModelTriggerInput | None = None,
             refresh_after_consolidation: bool | None = None,
         ) -> dict:
             """
@@ -2835,8 +3072,14 @@ def _register_update_knowledge_node(mcp: FastMCP, memory: MemoryEngine, config: 
                 source_query: Pages only — the new question the page answers
                 tags: Pages only — replacement tag list (pass [] to clear)
                 max_tokens: Pages only — new maximum tokens for the generated content
-                refresh_after_consolidation: Pages only — whether the page rebuilds itself
-                    after each memory consolidation
+                trigger: Pages only — refresh policy fields to change: mode,
+                    refresh_after_consolidation, refresh_cron, fact_types, tags_match,
+                    tag_groups, exclude_mental_models, recall_max_tokens, and so on. This
+                    is a PATCH: fields you omit keep their current values, so putting a
+                    page on a cron schedule does not reset its delta mode or its
+                    observation-only scope.
+                refresh_after_consolidation: Pages only — legacy shorthand for
+                    trigger.refresh_after_consolidation
             """
             try:
                 target_bank = config.bank_id_resolver()
@@ -2853,6 +3096,7 @@ def _register_update_knowledge_node(mcp: FastMCP, memory: MemoryEngine, config: 
                     source_query=source_query,
                     tags=tags,
                     max_tokens=max_tokens,
+                    trigger=trigger,
                     refresh_after_consolidation=refresh_after_consolidation,
                 )
             except OperationValidationError as e:

--- a/hindsight-api-slim/tests/test_mcp_tools.py
+++ b/hindsight-api-slim/tests/test_mcp_tools.py
@@ -6,12 +6,15 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from hindsight_api.engine.memory_engine import KEEP_PARENT, DirectivePage, MentalModelPage
 from hindsight_api.mcp_tools import (
     KNOWLEDGE_ROOT_PARENT,
     MCPToolsConfig,
+    MentalModelTriggerInput,
     _knowledge_tree_json,
+    _mental_model_trigger_patch,
     _validate_mental_model_inputs,
     build_content_dict,
     parse_timestamp,
@@ -760,6 +763,24 @@ class TestGetMentalModelDetail:
 
 @pytest.mark.asyncio
 class TestCreateMentalModel:
+    async def test_create_accepts_core_trigger_policy(self, mcp_server_with_mental_models, mock_memory):
+        await _tools(mcp_server_with_mental_models)["create_mental_model"].fn(
+            name="Daily observations",
+            source_query="What changed recently?",
+            trigger=MentalModelTriggerInput(
+                mode="delta",
+                refresh_cron="0 3 * * *",
+                fact_types=["observation"],
+                tags_match="any",
+            ),
+        )
+        assert mock_memory.create_mental_model.call_args.kwargs["trigger"] == {
+            "mode": "delta",
+            "refresh_cron": "0 3 * * *",
+            "fact_types": ["observation"],
+            "tags_match": "any",
+        }
+
     async def test_create_multi_bank(self, mcp_server_with_mental_models, mock_memory):
         result = await _tools(mcp_server_with_mental_models)["create_mental_model"].fn(
             name="Test Model",
@@ -865,6 +886,50 @@ class TestCreateMentalModel:
 
 @pytest.mark.asyncio
 class TestUpdateMentalModel:
+    async def test_update_forwards_trigger_patch(self, mcp_server_with_mental_models, mock_memory):
+        await _tools(mcp_server_with_mental_models)["update_mental_model"].fn(
+            mental_model_id="mm-1",
+            trigger=MentalModelTriggerInput(mode="delta", fact_types=["observation"]),
+        )
+        assert mock_memory.update_mental_model.call_args.kwargs["trigger"] == {
+            "mode": "delta",
+            "fact_types": ["observation"],
+        }
+
+    async def test_update_forwards_advanced_trigger_fields(self, mcp_server_with_mental_models, mock_memory):
+        await _tools(mcp_server_with_mental_models)["update_mental_model"].fn(
+            mental_model_id="mm-1",
+            trigger=MentalModelTriggerInput(
+                exclude_mental_models=True,
+                exclude_mental_model_ids=["mm-2"],
+                recall_max_tokens=8000,
+                recall_chunks_max_tokens=4000,
+                include_chunks=True,
+                tag_groups=[{"tags": ["ops", "infra"], "match": "any"}],
+            ),
+        )
+        assert mock_memory.update_mental_model.call_args.kwargs["trigger"] == {
+            "exclude_mental_models": True,
+            "exclude_mental_model_ids": ["mm-2"],
+            "recall_max_tokens": 8000,
+            "recall_chunks_max_tokens": 4000,
+            "include_chunks": True,
+            "tag_groups": [{"tags": ["ops", "infra"], "match": "any"}],
+        }
+
+    async def test_update_sends_only_the_fields_the_caller_set(self, mcp_server_with_mental_models, mock_memory):
+        """An unset field must not reach the engine, or the merge has nothing to preserve."""
+        await _tools(mcp_server_with_mental_models)["update_mental_model"].fn(
+            mental_model_id="mm-1", trigger=MentalModelTriggerInput(mode="delta")
+        )
+        assert mock_memory.update_mental_model.call_args.kwargs["trigger"] == {"mode": "delta"}
+
+    async def test_update_explicit_null_clears_a_setting(self, mcp_server_with_mental_models, mock_memory):
+        await _tools(mcp_server_with_mental_models)["update_mental_model"].fn(
+            mental_model_id="mm-1", trigger=MentalModelTriggerInput(refresh_cron=None)
+        )
+        assert mock_memory.update_mental_model.call_args.kwargs["trigger"] == {"refresh_cron": None}
+
     async def test_update_multi_bank(self, mcp_server_with_mental_models, mock_memory):
         result = await _tools(mcp_server_with_mental_models)["update_mental_model"].fn(
             mental_model_id="mm-1", name="Updated Name"
@@ -1048,6 +1113,25 @@ class TestMentalModelInputValidation:
     async def test_create_empty_source_query_returns_error_multi_bank(self, mcp_server_with_mental_models, mock_memory):
         result = await _tools(mcp_server_with_mental_models)["create_mental_model"].fn(name="Test", source_query="")
         assert "source_query cannot be empty" in result
+        mock_memory.create_mental_model.assert_not_called()
+
+    async def test_update_invalid_tags_match_returns_error_multi_bank(self, mcp_server_with_mental_models, mock_memory):
+        result = await _tools(mcp_server_with_mental_models)["update_mental_model"].fn(
+            mental_model_id="mm-1", tags_match="most"
+        )
+        assert "tags_match" in result
+        mock_memory.update_mental_model.assert_not_called()
+
+    async def test_legacy_refresh_flag_cannot_bypass_trigger_exclusivity(
+        self, mcp_server_with_mental_models, mock_memory
+    ):
+        result = await _tools(mcp_server_with_mental_models)["create_mental_model"].fn(
+            name="Daily observations",
+            source_query="What changed?",
+            trigger=MentalModelTriggerInput(refresh_cron="0 3 * * *"),
+            trigger_refresh_after_consolidation=True,
+        )
+        assert "mutually exclusive" in result
         mock_memory.create_mental_model.assert_not_called()
 
     async def test_create_max_tokens_too_low_multi_bank(self, mcp_server_with_mental_models, mock_memory):
@@ -2097,6 +2181,56 @@ class TestKnowledgeBaseTools:
         assert create_kwargs["tags"] == ["ops"]
         assert create_kwargs["max_tokens"] == 512
 
+    async def test_create_page_with_trigger_policy(self, mock_memory):
+        """A page can be put on a cron schedule at create time, not just HTTP."""
+        mcp = _make_mcp_server(mock_memory, {"create_knowledge_page"}, include_bank_id=True)
+        await _tools(mcp)["create_knowledge_page"].fn(
+            name="Deploys",
+            source_query="q",
+            trigger=MentalModelTriggerInput(
+                refresh_cron="0 3 * * *", fact_types=["world", "observation"], recall_max_tokens=8000
+            ),
+        )
+        # Only the stated fields go down; the engine merges them over the
+        # knowledge-page defaults, so mode/exclude_mental_models survive.
+        assert mock_memory.create_knowledge_page.call_args.kwargs["trigger"] == {
+            "refresh_cron": "0 3 * * *",
+            "fact_types": ["world", "observation"],
+            "recall_max_tokens": 8000,
+        }
+
+    async def test_create_page_rejects_contradictory_refresh_triggers(self, mock_memory):
+        mcp = _make_mcp_server(mock_memory, {"create_knowledge_page"}, include_bank_id=True)
+        result = await _tools(mcp)["create_knowledge_page"].fn(
+            name="Deploys",
+            source_query="q",
+            trigger=MentalModelTriggerInput(refresh_cron="0 3 * * *"),
+            refresh_after_consolidation=True,
+        )
+        assert "mutually exclusive" in result
+        mock_memory.create_knowledge_page.assert_not_called()
+
+    async def test_update_page_trigger_is_a_patch(self, mock_memory):
+        mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
+        await _tools(mcp)["update_knowledge_node"].fn(
+            node_id="kp-1", trigger=MentalModelTriggerInput(mode="full", tags_match="any")
+        )
+        assert mock_memory.update_knowledge_node.call_args.kwargs["trigger"] == {
+            "mode": "full",
+            "tags_match": "any",
+        }
+
+    async def test_update_page_trigger_alone_is_enough_to_update(self, mock_memory):
+        """A trigger-only call must not fall through to the "nothing to update" error."""
+        mcp = _make_mcp_server(mock_memory, {"update_knowledge_node"}, include_bank_id=True)
+        result = await _tools(mcp)["update_knowledge_node"].fn(
+            node_id="kp-1", trigger=MentalModelTriggerInput(refresh_cron="0 4 * * *")
+        )
+        assert "Provide name" not in result
+        mock_memory.update_knowledge_node.assert_called_once()
+        # No source_query change, so no rebuild is scheduled.
+        mock_memory.submit_async_refresh_mental_model.assert_not_called()
+
     async def test_create_page_duplicate_name(self, mock_memory):
         mock_memory.create_knowledge_page.return_value = None
         mcp = _make_mcp_server(mock_memory, {"create_knowledge_page"}, include_bank_id=True)
@@ -2415,3 +2549,56 @@ class TestReflectTraceOmission:
         assert "based_on" in data
         assert "tool_trace" not in data
         assert "directives_applied" not in data
+
+
+class TestMentalModelTriggerInput:
+    """The MCP trigger input contract: HTTP parity, patch shape, merge semantics."""
+
+    def test_trigger_input_covers_every_http_trigger_field(self):
+        """An agent that read the API docs must not be rejected for naming a real setting.
+
+        ``MentalModelTriggerInput`` forbids extra keys, so a field the HTTP
+        ``MentalModelTrigger`` has and this one lacks is not "not exposed yet" — it is
+        a hard validation error on a request the HTTP API would have accepted.
+        """
+        from hindsight_api.api.http import MentalModelTrigger
+
+        assert set(MentalModelTrigger.model_fields) == set(MentalModelTriggerInput.model_fields)
+
+    def test_every_field_is_optional_and_unset_by_default(self):
+        """Defaults would defeat the patch: model_dump(exclude_unset) must stay empty."""
+        assert MentalModelTriggerInput().model_dump(exclude_unset=True) == {}
+
+    def test_rejects_unknown_field(self):
+        with pytest.raises(ValidationError):
+            MentalModelTriggerInput(refresh_evry_hour=True)
+
+    def test_rejects_invalid_cron(self):
+        with pytest.raises(ValidationError):
+            MentalModelTriggerInput(refresh_cron="every tuesday")
+
+    def test_blank_cron_reads_as_no_schedule(self):
+        """Parity with the HTTP model, which normalises a blank cron to null."""
+        assert MentalModelTriggerInput(refresh_cron="   ").refresh_cron is None
+
+    def test_rejects_empty_fact_types(self):
+        with pytest.raises(ValidationError):
+            MentalModelTriggerInput(fact_types=[])
+
+    def test_rejects_both_refresh_triggers(self):
+        with pytest.raises(ValidationError):
+            MentalModelTriggerInput(refresh_after_consolidation=True, refresh_cron="0 3 * * *")
+
+    def test_legacy_shorthand_agreeing_with_trigger_is_accepted(self):
+        patch = _mental_model_trigger_patch(
+            MentalModelTriggerInput(tags_match="any"), tags_match="any", refresh_after_consolidation=True
+        )
+        assert patch == {"tags_match": "any", "refresh_after_consolidation": True}
+
+    def test_legacy_shorthand_contradicting_trigger_is_rejected(self):
+        """One of the two would have to win silently; make the caller resolve it."""
+        with pytest.raises(ValueError, match="conflicts with"):
+            _mental_model_trigger_patch(MentalModelTriggerInput(tags_match="any"), tags_match="all")
+
+    def test_no_trigger_and_no_shorthand_is_no_patch(self):
+        assert _mental_model_trigger_patch(None) is None

--- a/hindsight-api-slim/tests/test_mental_model_trigger_flags.py
+++ b/hindsight-api-slim/tests/test_mental_model_trigger_flags.py
@@ -259,3 +259,113 @@ class TestTriggerRoundTrip:
             assert stored["trigger"].get(key) == value, f"{key} did not survive create"
 
         await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_update_patches_the_trigger_instead_of_replacing_it(self, memory, request_context):
+        """Changing when a model refreshes must not reset how it refreshes.
+
+        ``update_mental_model`` overwrites the whole trigger column, so a caller that
+        sends only the field it wants used to strip every flag it did not mention —
+        the defect #3506 fixed for knowledge pages, on the endpoint every MCP agent
+        goes through.
+        """
+        bank_id = f"test-trigger-patch-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="API Reference",
+            source_query="Document the API",
+            content="## Ops\n\nOriginal.\n",
+            trigger={
+                "mode": "delta",
+                "fact_types": ["observation"],
+                "recall_max_tokens": 1234,
+                "refresh_after_consolidation": True,
+            },
+            request_context=request_context,
+        )
+
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            trigger={"refresh_cron": "0 3 * * *"},
+            request_context=request_context,
+        )
+        stored = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert stored["trigger"]["refresh_cron"] == "0 3 * * *"
+        assert stored["trigger"]["mode"] == "delta"
+        assert stored["trigger"]["fact_types"] == ["observation"]
+        assert stored["trigger"]["recall_max_tokens"] == 1234
+        # Moving onto a schedule clears the auto-refresh: storing both would be a pair
+        # the API itself rejects.
+        assert "refresh_after_consolidation" not in stored["trigger"]
+
+        # ...and back again.
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            trigger={"refresh_after_consolidation": True},
+            request_context=request_context,
+        )
+        stored = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert stored["trigger"]["refresh_after_consolidation"] is True
+        assert "refresh_cron" not in stored["trigger"]
+        assert stored["trigger"]["recall_max_tokens"] == 1234
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_http_style_full_trigger_still_replaces(self, memory, request_context):
+        """The merge must not turn the HTTP contract into a patch by accident.
+
+        HTTP routes serialize the whole ``MentalModelTrigger``, defaults included, so
+        every key is present and the merge is a replacement. A flag cleared through
+        the API has to actually clear.
+        """
+        bank_id = f"test-trigger-replace-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="API Reference",
+            source_query="Document the API",
+            content="## Ops\n\nOriginal.\n",
+            trigger={"mode": "delta", "recall_max_tokens": 1234, "keep_trace": True},
+            request_context=request_context,
+        )
+        from hindsight_api.api.http import MentalModelTrigger
+
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            trigger=MentalModelTrigger(mode="full").model_dump(),
+            request_context=request_context,
+        )
+        stored = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert stored["trigger"]["mode"] == "full"
+        assert stored["trigger"]["recall_max_tokens"] is None
+        assert stored["trigger"]["keep_trace"] is False
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_patch_stating_both_refresh_triggers_is_rejected(self, memory, request_context):
+        bank_id = f"test-trigger-excl-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="API Reference",
+            source_query="Document the API",
+            content="## Ops\n\nOriginal.\n",
+            request_context=request_context,
+        )
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            await memory.update_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mm["id"],
+                trigger={"refresh_after_consolidation": True, "refresh_cron": "0 3 * * *"},
+                request_context=request_context,
+            )
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -278,8 +278,14 @@ Create a mental model — a living document that stays current with your memorie
 | `mental_model_id` | string | No | Custom ID (alphanumeric lowercase with hyphens). Auto-generated if not provided |
 | `tags` | list[string] | No | Tags for organizing and filtering models |
 | `tags_match` | string | No | How the model's tags are matched against memories on refresh: `any`, `all`, `any_strict`, `all_strict`, or `exact`. See the note below on the default |
+| `trigger` | object | No | Refresh policy — see [Trigger settings](#trigger-settings) |
 | `max_tokens` | integer | No | Maximum tokens for model content (default: 2048) |
-| `trigger_refresh_after_consolidation` | boolean | No | Auto-refresh this model after memory consolidation (default: `false`) |
+| `trigger_refresh_after_consolidation` | boolean | No | Legacy shorthand for `trigger.refresh_after_consolidation` |
+
+`trigger` is the preferred form for refresh settings; `tags_match` and
+`trigger_refresh_after_consolidation` remain as shorthands for existing
+integrations. Setting the same field both ways is an error rather than one
+silently winning.
 
 :::warning Tagged models default to `all_strict`
 When a mental model has `tags` but no explicit `tags_match`, its refresh matches memories with **`all_strict`** — a memory must carry **every** one of the model's tags to be included. If your memories use narrow, single-topic tags (e.g. `["project:status"]`) while the model is tagged broadly (e.g. `["projects", "mental-model"]`), the refresh filters out everything and the content comes back empty.
@@ -347,7 +353,59 @@ Update a mental model's metadata or settings.
 | `source_query` | string | No | New source query |
 | `tags` | list[string] | No | New tags |
 | `max_tokens` | integer | No | New max tokens |
+| `trigger` | object | No | Refresh-policy fields to change — see [Trigger settings](#trigger-settings). This is a patch: omitted fields keep their current values |
+| `tags_match` | string | No | Legacy shorthand for `trigger.tags_match` |
 | `trigger_refresh_after_consolidation` | boolean | No | Auto-refresh after consolidation. Only set when you want to change this setting |
+
+---
+
+### Trigger settings
+
+`trigger` carries a mental model's (or knowledge page's) refresh policy: **when**
+it rebuilds itself and **what** it rebuilds from. It accepts every field the HTTP
+API accepts, so anything you can configure through `PATCH /mental_models/{id}`
+you can also configure from an agent over MCP.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | string | `full` regenerates the content from scratch on each refresh; `delta` makes surgical edits, preserving unchanged sections byte-for-byte. Delta falls back to full when there is no existing content or the source query changed |
+| `refresh_after_consolidation` | boolean | Rebuild after each memory consolidation |
+| `refresh_cron` | string | UTC five-field cron, e.g. `0 3 * * *` for daily at 03:00 UTC. Only runs when the model is stale, so an unchanged scope costs no LLM call |
+| `min_refresh_interval_seconds` | integer | Floor between two *automatic* refreshes. Triggers arriving sooner fold into one queued refresh, so a burst of retains costs one rebuild. Explicit refreshes ignore it |
+| `fact_types` | list[string] | Which of `world`, `experience`, `observation` the refresh retrieves. Omit for all three |
+| `exclude_mental_models` | boolean | Exclude **all** mental models from the refresh, so a model never reflects on its siblings |
+| `exclude_mental_model_ids` | list[string] | Exclude specific mental models by ID |
+| `tags_match` | string | How the model's tags select memories: `any`, `all`, `any_strict`, `all_strict`, `exact` |
+| `tag_groups` | list[object] | Compound boolean tag expressions used *instead of* the model's flat tags |
+| `include_chunks` | boolean | Whether the refresh's internal recall returns raw chunk text |
+| `recall_max_tokens` | integer | Token budget for facts from the refresh's internal recall |
+| `recall_chunks_max_tokens` | integer | Token budget for raw chunks from the refresh's internal recall |
+| `response_schema` | object | JSON Schema for structured output, stored alongside the markdown under `reflect_response.structured_output` |
+| `keep_trace` | boolean | Record how each refresh reached its result under `reflect_response.trace`. The only way to diagnose a cron- or consolidation-driven refresh after the fact |
+
+`refresh_after_consolidation` and `refresh_cron` are **mutually exclusive** — a
+model refreshes either after consolidation or on a schedule, never both. Setting
+one clears the other.
+
+**On create**, omitted fields take the engine defaults (`mode: full`, no
+schedule, all fact types); for a knowledge page they take the page defaults
+(`mode: delta`, observation-only, auto-refresh, siblings excluded).
+
+**On update, `trigger` is a patch**: only the fields you send change, so putting
+a model on a cron schedule keeps its `fact_types` and `mode`. Send an explicit
+`null` to clear a nullable setting. Read the current policy back with
+`get_mental_model` (detail `content` or `full`) if you want to inspect before
+changing.
+
+```json
+{
+  "name": "update_mental_model",
+  "arguments": {
+    "mental_model_id": "team-conventions",
+    "trigger": { "refresh_cron": "0 3 * * *", "fact_types": ["observation"] }
+  }
+}
+```
 
 ---
 
@@ -649,7 +707,12 @@ Create a page — a living document whose content is synthesized from the bank's
 | `parent_id` | string | No | Parent folder id (a `kf-...` node id). Omit to create at the top level |
 | `tags` | array | No | Tags scoping which memories the page is built from |
 | `max_tokens` | integer | No | Maximum tokens for the generated content (default: 4096) |
-| `refresh_after_consolidation` | boolean | No | Whether the page rebuilds after each consolidation. Omit to keep the knowledge-page default (`true`) |
+| `trigger` | object | No | Refresh policy — see [Trigger settings](#trigger-settings). Omitted fields keep the knowledge-page defaults: `delta` rebuilds from consolidated observations after each consolidation, ignoring sibling pages |
+| `refresh_after_consolidation` | boolean | No | Legacy shorthand for `trigger.refresh_after_consolidation` |
+
+Set `trigger.refresh_cron` to move a page off consolidation-driven rebuilds and
+onto a fixed UTC schedule — the two are mutually exclusive, so the cron clears
+the auto-refresh while leaving the page's `mode` and `fact_types` alone.
 
 ---
 
@@ -665,7 +728,8 @@ Rename or move a folder/page, and/or update a page's options. Only the arguments
 | `source_query` | string | No | Pages only — the new question the page answers |
 | `tags` | array | No | Pages only — replacement tag list (pass `[]` to clear) |
 | `max_tokens` | integer | No | Pages only — new maximum tokens for the generated content |
-| `refresh_after_consolidation` | boolean | No | Pages only — whether the page rebuilds after each consolidation |
+| `trigger` | object | No | Pages only — refresh-policy fields to change; see [Trigger settings](#trigger-settings). This is a patch: omitted fields keep their current values |
+| `refresh_after_consolidation` | boolean | No | Pages only — legacy shorthand for `trigger.refresh_after_consolidation` |
 
 ---
 

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -278,8 +278,14 @@ Create a mental model — a living document that stays current with your memorie
 | `mental_model_id` | string | No | Custom ID (alphanumeric lowercase with hyphens). Auto-generated if not provided |
 | `tags` | list[string] | No | Tags for organizing and filtering models |
 | `tags_match` | string | No | How the model's tags are matched against memories on refresh: `any`, `all`, `any_strict`, `all_strict`, or `exact`. See the note below on the default |
+| `trigger` | object | No | Refresh policy — see [Trigger settings](#trigger-settings) |
 | `max_tokens` | integer | No | Maximum tokens for model content (default: 2048) |
-| `trigger_refresh_after_consolidation` | boolean | No | Auto-refresh this model after memory consolidation (default: `false`) |
+| `trigger_refresh_after_consolidation` | boolean | No | Legacy shorthand for `trigger.refresh_after_consolidation` |
+
+`trigger` is the preferred form for refresh settings; `tags_match` and
+`trigger_refresh_after_consolidation` remain as shorthands for existing
+integrations. Setting the same field both ways is an error rather than one
+silently winning.
 
 :::warning Tagged models default to `all_strict`
 When a mental model has `tags` but no explicit `tags_match`, its refresh matches memories with **`all_strict`** — a memory must carry **every** one of the model's tags to be included. If your memories use narrow, single-topic tags (e.g. `["project:status"]`) while the model is tagged broadly (e.g. `["projects", "mental-model"]`), the refresh filters out everything and the content comes back empty.
@@ -347,7 +353,59 @@ Update a mental model's metadata or settings.
 | `source_query` | string | No | New source query |
 | `tags` | list[string] | No | New tags |
 | `max_tokens` | integer | No | New max tokens |
+| `trigger` | object | No | Refresh-policy fields to change — see [Trigger settings](#trigger-settings). This is a patch: omitted fields keep their current values |
+| `tags_match` | string | No | Legacy shorthand for `trigger.tags_match` |
 | `trigger_refresh_after_consolidation` | boolean | No | Auto-refresh after consolidation. Only set when you want to change this setting |
+
+---
+
+### Trigger settings
+
+`trigger` carries a mental model's (or knowledge page's) refresh policy: **when**
+it rebuilds itself and **what** it rebuilds from. It accepts every field the HTTP
+API accepts, so anything you can configure through `PATCH /mental_models/{id}`
+you can also configure from an agent over MCP.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | string | `full` regenerates the content from scratch on each refresh; `delta` makes surgical edits, preserving unchanged sections byte-for-byte. Delta falls back to full when there is no existing content or the source query changed |
+| `refresh_after_consolidation` | boolean | Rebuild after each memory consolidation |
+| `refresh_cron` | string | UTC five-field cron, e.g. `0 3 * * *` for daily at 03:00 UTC. Only runs when the model is stale, so an unchanged scope costs no LLM call |
+| `min_refresh_interval_seconds` | integer | Floor between two *automatic* refreshes. Triggers arriving sooner fold into one queued refresh, so a burst of retains costs one rebuild. Explicit refreshes ignore it |
+| `fact_types` | list[string] | Which of `world`, `experience`, `observation` the refresh retrieves. Omit for all three |
+| `exclude_mental_models` | boolean | Exclude **all** mental models from the refresh, so a model never reflects on its siblings |
+| `exclude_mental_model_ids` | list[string] | Exclude specific mental models by ID |
+| `tags_match` | string | How the model's tags select memories: `any`, `all`, `any_strict`, `all_strict`, `exact` |
+| `tag_groups` | list[object] | Compound boolean tag expressions used *instead of* the model's flat tags |
+| `include_chunks` | boolean | Whether the refresh's internal recall returns raw chunk text |
+| `recall_max_tokens` | integer | Token budget for facts from the refresh's internal recall |
+| `recall_chunks_max_tokens` | integer | Token budget for raw chunks from the refresh's internal recall |
+| `response_schema` | object | JSON Schema for structured output, stored alongside the markdown under `reflect_response.structured_output` |
+| `keep_trace` | boolean | Record how each refresh reached its result under `reflect_response.trace`. The only way to diagnose a cron- or consolidation-driven refresh after the fact |
+
+`refresh_after_consolidation` and `refresh_cron` are **mutually exclusive** — a
+model refreshes either after consolidation or on a schedule, never both. Setting
+one clears the other.
+
+**On create**, omitted fields take the engine defaults (`mode: full`, no
+schedule, all fact types); for a knowledge page they take the page defaults
+(`mode: delta`, observation-only, auto-refresh, siblings excluded).
+
+**On update, `trigger` is a patch**: only the fields you send change, so putting
+a model on a cron schedule keeps its `fact_types` and `mode`. Send an explicit
+`null` to clear a nullable setting. Read the current policy back with
+`get_mental_model` (detail `content` or `full`) if you want to inspect before
+changing.
+
+```json
+{
+  "name": "update_mental_model",
+  "arguments": {
+    "mental_model_id": "team-conventions",
+    "trigger": { "refresh_cron": "0 3 * * *", "fact_types": ["observation"] }
+  }
+}
+```
 
 ---
 
@@ -649,7 +707,12 @@ Create a page — a living document whose content is synthesized from the bank's
 | `parent_id` | string | No | Parent folder id (a `kf-...` node id). Omit to create at the top level |
 | `tags` | array | No | Tags scoping which memories the page is built from |
 | `max_tokens` | integer | No | Maximum tokens for the generated content (default: 4096) |
-| `refresh_after_consolidation` | boolean | No | Whether the page rebuilds after each consolidation. Omit to keep the knowledge-page default (`true`) |
+| `trigger` | object | No | Refresh policy — see [Trigger settings](#trigger-settings). Omitted fields keep the knowledge-page defaults: `delta` rebuilds from consolidated observations after each consolidation, ignoring sibling pages |
+| `refresh_after_consolidation` | boolean | No | Legacy shorthand for `trigger.refresh_after_consolidation` |
+
+Set `trigger.refresh_cron` to move a page off consolidation-driven rebuilds and
+onto a fixed UTC schedule — the two are mutually exclusive, so the cron clears
+the auto-refresh while leaving the page's `mode` and `fact_types` alone.
 
 ---
 
@@ -665,7 +728,8 @@ Rename or move a folder/page, and/or update a page's options. Only the arguments
 | `source_query` | string | No | Pages only — the new question the page answers |
 | `tags` | array | No | Pages only — replacement tag list (pass `[]` to clear) |
 | `max_tokens` | integer | No | Pages only — new maximum tokens for the generated content |
-| `refresh_after_consolidation` | boolean | No | Pages only — whether the page rebuilds after each consolidation |
+| `trigger` | object | No | Pages only — refresh-policy fields to change; see [Trigger settings](#trigger-settings). This is a patch: omitted fields keep their current values |
+| `refresh_after_consolidation` | boolean | No | Pages only — legacy shorthand for `trigger.refresh_after_consolidation` |
 
 ---
 


### PR DESCRIPTION
Throwaway branch to run the FULL CI matrix against the exact tree of #3739.

#3739 comes from a fork, so CI runs only 12 of 94 jobs there — `test-api` (all 3 shards) and `test-api-oracle` are skipped and no Python test executes. This PR exists solely so those jobs run against the same commit. Merge #3739, not this; delete this branch afterwards.

Head is identical to `Sanderhoff-alt:feat/mcp-mental-model-trigger`.

https://claude.ai/code/session_018HDqrzHgqZqsGc7EDqoTEu