### PR TITLE
fix(embed): decode control center log tail as UTF-8

### DIFF
--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -104,7 +104,7 @@ def load_config_file():
 
     # Load ONLY this profile's config, never fall back to default
     if config_path.exists():
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if line and not line.startswith("#") and "=" in line:

--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -676,7 +676,7 @@ def do_daemon(args, config: dict, logger):
         else:
             # Show last N lines
             try:
-                with open(daemon_log_path) as f:
+                with open(daemon_log_path, encoding="utf-8", errors="replace") as f:
                     lines = f.readlines()
                     for line in lines[-args.lines :]:
                         print(line, end="")
@@ -838,7 +838,7 @@ def do_ui(args, config: dict, logger):
             return 0
         else:
             try:
-                with open(ui_log_path) as f:
+                with open(ui_log_path, encoding="utf-8", errors="replace") as f:
                     lines = f.readlines()
                     for line in lines[-args.lines :]:
                         print(line, end="")
@@ -1057,7 +1057,7 @@ def do_control(args) -> int:
             except KeyboardInterrupt:
                 pass
             return 0
-        with open(log_path) as f:
+        with open(log_path, encoding="utf-8", errors="replace") as f:
             for line in f.readlines()[-getattr(args, "lines", 50) :]:
                 print(line, end="")
         return 0

--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -255,7 +255,7 @@ def _do_configure_from_env():
 
     from .env_template import render_config
 
-    CONFIG_FILE.write_text(render_config(config_values))
+    CONFIG_FILE.write_text(render_config(config_values), encoding="utf-8")
     CONFIG_FILE.chmod(0o600)
 
     print()
@@ -442,7 +442,7 @@ def _do_configure_interactive(profile_name: str | None = None, port: int | None 
         # Save to default profile
         from .env_template import render_config
 
-        CONFIG_FILE.write_text(render_config(config_dict))
+        CONFIG_FILE.write_text(render_config(config_dict), encoding="utf-8")
         CONFIG_FILE.chmod(0o600)
 
     # Stop existing daemon if running (it needs to pick up new config)
@@ -1216,7 +1216,7 @@ def do_profile_command(args: list[str]) -> int:
                 config_path = CONFIG_FILE
 
             if config_path.exists():
-                for line in config_path.read_text().splitlines():
+                for line in config_path.read_text(encoding="utf-8").splitlines():
                     line = line.strip()
                     if line and not line.startswith("#") and "=" in line:
                         k, v = line.split("=", 1)
@@ -1268,7 +1268,7 @@ def do_profile_command(args: list[str]) -> int:
         # Parse existing config
         config = {}
         if config_path.exists():
-            for line in config_path.read_text().splitlines():
+            for line in config_path.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
                 if line and not line.startswith("#") and "=" in line:
                     k, v = line.split("=", 1)
@@ -1313,7 +1313,7 @@ def do_profile_command(args: list[str]) -> int:
         # Parse existing config
         config = {}
         if config_path.exists():
-            for line in config_path.read_text().splitlines():
+            for line in config_path.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
                 if line and not line.startswith("#") and "=" in line:
                     k, v = line.split("=", 1)

--- a/hindsight-embed/hindsight_embed/control_center/server.py
+++ b/hindsight-embed/hindsight_embed/control_center/server.py
@@ -214,7 +214,7 @@ class ControlCenterHandler(BaseHTTPRequestHandler):
         if not index.exists():
             self._send_html(500, "<h1>Control center UI not found</h1>")
             return
-        self._send_html(200, index.read_text())
+        self._send_html(200, index.read_text(encoding="utf-8"))
 
     _CONTENT_TYPES = {
         ".png": "image/png",

--- a/hindsight-embed/hindsight_embed/control_center/service.py
+++ b/hindsight-embed/hindsight_embed/control_center/service.py
@@ -179,7 +179,7 @@ def _read_raw_env(name: str) -> dict[str, str]:
     env: dict[str, str] = {}
     if not path.exists():
         return env
-    for line in path.read_text().splitlines():
+    for line in path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue
@@ -206,7 +206,7 @@ def _write_raw_env(name: str, env: dict[str, str]) -> None:
     else:
         path = pm.resolve_profile_paths("").config
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("".join(f"{k}={v}\n" for k, v in env.items()))
+        path.write_text("".join(f"{k}={v}\n" for k, v in env.items()), encoding="utf-8")
     # The .env holds the API key — keep it owner-only.
     path.chmod(0o600)
 
@@ -423,7 +423,7 @@ def read_env_file(name: str) -> EnvFileView:
     """
     name = normalize_profile(name)
     path = ProfileManager().resolve_profile_paths(name).config
-    content = path.read_text() if path.exists() else ""
+    content = path.read_text(encoding="utf-8") if path.exists() else ""
     return EnvFileView(
         name=name,
         display_name=_display_name(name),
@@ -441,7 +441,7 @@ def write_env_file(name: str, content: str) -> EnvFileView:
     # Normalize to a trailing newline so the file stays POSIX-clean.
     if content and not content.endswith("\n"):
         content += "\n"
-    path.write_text(content)
+    path.write_text(content, encoding="utf-8")
     path.chmod(0o600)
     return read_env_file(name)
 

--- a/hindsight-embed/hindsight_embed/control_center/service.py
+++ b/hindsight-embed/hindsight_embed/control_center/service.py
@@ -493,7 +493,7 @@ def tail_log(name: str, lines: int = 200, source: str = "daemon") -> LogTailView
         return LogTailView(path=str(path), exists=False, content="")
     # Small logs — reading then slicing is simpler than seeking and is fine for
     # the interactive tail in the UI.
-    tail = path.read_text(errors="replace").splitlines()[-max(lines, 1) :]
+    tail = path.read_text(encoding="utf-8", errors="replace").splitlines()[-max(lines, 1) :]
     return LogTailView(path=str(path), exists=True, content="\n".join(tail))
 
 

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -830,7 +830,7 @@ class DaemonEmbedManager(EmbedManager):
                     # Tail daemon logs
                     if daemon_log.exists():
                         try:
-                            with open(daemon_log, "r") as f:
+                            with open(daemon_log, "r", encoding="utf-8", errors="replace") as f:
                                 f.seek(last_log_position)
                                 new_lines = f.readlines()
                                 last_log_position = f.tell()

--- a/hindsight-embed/hindsight_embed/env_template.py
+++ b/hindsight-embed/hindsight_embed/env_template.py
@@ -21,11 +21,11 @@ def load_template() -> str | None:
     """
     bundled = importlib.resources.files("hindsight_embed").joinpath("env.example")
     if bundled.is_file():
-        return bundled.read_text()
+        return bundled.read_text(encoding="utf-8")
     for parent in Path(__file__).resolve().parents:
         candidate = parent / ".env.example"
         if candidate.is_file():
-            return candidate.read_text()
+            return candidate.read_text(encoding="utf-8")
     return None
 
 

--- a/hindsight-embed/hindsight_embed/profile_manager.py
+++ b/hindsight-embed/hindsight_embed/profile_manager.py
@@ -488,7 +488,7 @@ class ProfileManager:
 
         active_file = self._get_active_profile_file()
         if name:
-            active_file.write_text(name)
+            active_file.write_text(name, encoding="utf-8")
         else:
             # Clear active profile
             if active_file.exists():
@@ -502,7 +502,7 @@ class ProfileManager:
         """
         active_file = self._get_active_profile_file()
         if active_file.exists():
-            return active_file.read_text().strip()
+            return active_file.read_text(encoding="utf-8").strip()
         return ""
 
     def resolve_profile_paths(self, name: str) -> ProfilePaths:

--- a/hindsight-embed/tests/test_control_center.py
+++ b/hindsight-embed/tests/test_control_center.py
@@ -91,6 +91,30 @@ class TestService:
         # raw edit is reflected in the structured view
         assert service.get_profile_config("").provider == "groq"
 
+    def test_raw_env_io_is_utf8_regardless_of_locale(self, temp_hindsight_dir, monkeypatch):
+        """The control center touches the same profile .env as the CLI (#3837).
+
+        The generated template carries em dashes, so on a legacy Windows
+        codepage (cp936/cp1252) a locale-default read raises UnicodeDecodeError
+        and a locale-default write raises or mojibakes the user's edits. Force a
+        narrow codec as the process default and assert the round trip survives.
+        """
+        import io
+
+        real_open = io.open
+
+        def narrow_open(file, mode="r", buffering=-1, encoding=None, errors=None, newline=None, *args, **kwargs):
+            # pathlib passes the sentinel "locale" when the caller gave no encoding.
+            if "b" not in mode and encoding in (None, "locale"):
+                encoding = "ascii"
+            return real_open(file, mode, buffering, encoding, errors, newline, *args, **kwargs)
+
+        monkeypatch.setattr(io, "open", narrow_open)
+
+        service.write_env_file("", "# \u4fdd\u5b58 \u2014 keep this comment\nHINDSIGHT_API_LLM_PROVIDER=groq\n")
+        assert "\u2014" in service.read_env_file("").content
+        assert service._read_raw_env("")["HINDSIGHT_API_LLM_PROVIDER"] == "groq"
+
     def test_write_env_adds_trailing_newline(self, temp_hindsight_dir):
         view = service.write_env_file("", "HINDSIGHT_API_LLM_PROVIDER=openai")
         assert view.content.endswith("\n")

--- a/hindsight-embed/tests/test_control_center.py
+++ b/hindsight-embed/tests/test_control_center.py
@@ -137,6 +137,24 @@ class TestService:
         assert daemon.path.endswith(".log") and not daemon.path.endswith(".ui.log")
         assert ui.path.endswith(".ui.log")
 
+    def test_tail_log_reads_utf8_regardless_of_locale(self, temp_hindsight_dir, monkeypatch):
+        import io
+
+        from hindsight_embed.profile_manager import ProfileManager
+
+        path = ProfileManager().resolve_profile_paths("").log
+        path.write_bytes("retained — 保存\n".encode())
+        real_open = io.open
+
+        def narrow_open(file, mode="r", buffering=-1, encoding=None, errors=None, newline=None, *args, **kwargs):
+            if "b" not in mode and encoding in (None, "locale"):
+                encoding = "ascii"
+            return real_open(file, mode, buffering, encoding, errors, newline, *args, **kwargs)
+
+        monkeypatch.setattr(io, "open", narrow_open)
+
+        assert service.tail_log("", 10).content == "retained — 保存"
+
     def test_delete_named_profile(self, temp_hindsight_dir):
         service.save_llm_config("scratch", "openai", "sk-key1234567890", "", "")
         assert (temp_hindsight_dir / "profiles" / "scratch.env").exists()

--- a/hindsight-embed/tests/test_env_template.py
+++ b/hindsight-embed/tests/test_env_template.py
@@ -65,6 +65,24 @@ def test_template_documents_macos_cpu_workarounds():
     assert "# HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=false" in text
 
 
+def test_load_template_reads_bundled_copy_as_utf8(monkeypatch):
+    class BundledTemplate:
+        def is_file(self):
+            return True
+
+        def read_text(self, *, encoding=None):
+            assert encoding == "utf-8"
+            return "# memory — retained\n"
+
+    class PackageFiles:
+        def joinpath(self, _name):
+            return BundledTemplate()
+
+    monkeypatch.setattr("hindsight_embed.env_template.importlib.resources.files", lambda _package: PackageFiles())
+
+    assert load_template() == "# memory — retained\n"
+
+
 def test_unknown_keys_are_appended():
     text = render_config({"HINDSIGHT_API_LLM_PROVIDER": "openai", "KEY": "value"})
     assert _active_keys(text)["KEY"] == "value"
@@ -84,6 +102,6 @@ def test_bundled_template_matches_repo_root():
     repo_root_example = Path(__file__).resolve().parents[2] / ".env.example"
     if not repo_root_example.is_file():
         return
-    assert bundled == repo_root_example.read_text(), (
+    assert bundled == repo_root_example.read_text(encoding="utf-8"), (
         "hindsight_embed/env.example is out of sync with the repo-root .env.example — re-copy it."
     )

--- a/hindsight-embed/tests/test_env_template.py
+++ b/hindsight-embed/tests/test_env_template.py
@@ -66,13 +66,16 @@ def test_template_documents_macos_cpu_workarounds():
 
 
 def test_load_template_reads_bundled_copy_as_utf8(monkeypatch):
+    raw = "# memory — retained\n".encode("utf-8")
+
     class BundledTemplate:
         def is_file(self):
             return True
 
         def read_text(self, *, encoding=None):
-            assert encoding == "utf-8"
-            return "# memory — retained\n"
+            # Mirrors importlib.resources: no encoding means the process locale,
+            # which is a narrow codepage on a legacy Windows install (#3837).
+            return raw.decode(encoding or "ascii")
 
     class PackageFiles:
         def joinpath(self, _name):

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -165,6 +165,38 @@ def test_load_config_file_uses_correct_profile(temp_home, monkeypatch):
     assert os.environ.get("HINDSIGHT_API_LLM_MODEL") == "llama-3.1-70b", "Should load from named profile, not default"
 
 
+def test_load_config_file_reads_utf8_profile(temp_home, monkeypatch):
+    """Profile templates should load independently of the process locale."""
+    import builtins
+    import os
+
+    from hindsight_embed.cli import load_config_file, set_cli_profile_override
+
+    set_cli_profile_override(None)
+    monkeypatch.delenv("HINDSIGHT_EMBED_PROFILE", raising=False)
+    monkeypatch.delenv("HINDSIGHT_API_LLM_PROVIDER", raising=False)
+
+    config_path = temp_home / ".hindsight" / "embed"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "# memory — retained\nHINDSIGHT_API_LLM_PROVIDER=openai\n",
+        encoding="utf-8",
+    )
+
+    original_open = builtins.open
+
+    def locale_open(file, mode="r", *args, **kwargs):
+        if file == config_path and "b" not in mode and "encoding" not in kwargs:
+            kwargs["encoding"] = "ascii"
+        return original_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", locale_open)
+
+    load_config_file()
+
+    assert os.environ["HINDSIGHT_API_LLM_PROVIDER"] == "openai"
+
+
 def test_get_config_respects_profile(temp_home, monkeypatch):
     """Test that get_config() returns profile-specific values."""
     import os


### PR DESCRIPTION
## What changed

- decode the control-center log tail as UTF-8, matching the CLI and daemon log readers
- add a narrow-locale regression with non-ASCII log output

## Why

The UTF-8 audit merged in #3850 covered the CLI log paths, but `control_center.service.tail_log` still used the process locale. On a legacy Windows codepage this could replace valid UTF-8 output with mojibake in the control-center log view.

## Validation

- `uv run --project hindsight-embed pytest hindsight-embed/tests/test_control_center.py hindsight-embed/tests/test_env_template.py -q` — 54 passed
- Ruff clean on the changed source and test files
- `git diff --check`
