### PR TITLE
fix(llm): derive visible output tokens from total on OpenAI-compatible providers (#3851)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -382,6 +382,63 @@ def _usage_from_openai_response(response: Any) -> LLMResponseUsage:
     )
 
 
+def _visible_token_usage(response: Any) -> TokenUsage:
+    """Normalize an OpenAI-shaped usage block into visible-only output plus reasoning.
+
+    The ``TokenUsage`` contract — and the Gemini provider — treat
+    ``output_tokens``/``total_tokens`` as *visible* output, with reasoning
+    surfaced separately in ``thoughts_tokens``. OpenAI-compatible upstreams do
+    not agree on where reasoning lives in the wire format:
+
+    * folded (OpenAI's own reasoning models): ``total = prompt + completion``
+      and ``completion`` already includes ``reasoning``;
+    * unfolded (several gateways and proxies): ``total = prompt + completion +
+      reasoning`` and ``completion`` is already visible-only.
+
+    Subtracting ``reasoning`` from ``completion`` unconditionally clamps a real,
+    non-empty completion to 0 on the unfolded shape whenever reasoning exceeds
+    visible output — routine for high-effort model variants (#3851). Detecting
+    the shape by comparing ``prompt + completion`` against ``total`` is no
+    better: proxies are a token or two off on ``total``, and near-miss drift on
+    the unfolded shape lands back on the clamp.
+
+    ``total`` reads as ``prompt + visible + reasoning`` under *both* shapes, so
+    visible output is derived from it and never needs the shape to be known.
+    The result is then clamped to the only two admissible readings —
+    ``completion`` (unfolded) and ``completion - reasoning`` (folded) — so an
+    upstream whose ``total`` is drifted or outright unusable degrades to the
+    nearer of those instead of to a bogus count. A missing or zero ``total``
+    leaves nothing to derive from and falls back to the folded reading.
+    """
+    usage = getattr(response, "usage", None)
+    input_tokens = (getattr(usage, "prompt_tokens", 0) or 0) if usage else 0
+    completion_tokens = (getattr(usage, "completion_tokens", 0) or 0) if usage else 0
+    reported_total = (getattr(usage, "total_tokens", 0) or 0) if usage else 0
+    cached_tokens = 0
+    if usage and getattr(usage, "prompt_tokens_details", None):
+        cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
+    thoughts_tokens = 0
+    if usage and getattr(usage, "completion_tokens_details", None):
+        thoughts_tokens = getattr(usage.completion_tokens_details, "reasoning_tokens", 0) or 0
+
+    folded_reading = max(0, completion_tokens - thoughts_tokens)
+    if not thoughts_tokens:
+        output_tokens = completion_tokens
+    elif reported_total > 0:
+        derived = (reported_total - thoughts_tokens) - input_tokens
+        output_tokens = min(completion_tokens, max(folded_reading, derived))
+    else:
+        output_tokens = folded_reading
+
+    return TokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        cached_tokens=cached_tokens,
+        thoughts_tokens=thoughts_tokens,
+    )
+
+
 def _ensure_json_word_in_user_message(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Some OpenAI-compatible gateways require 'json' in a user message for json_object mode."""
 
@@ -1157,23 +1214,15 @@ class OpenAICompatibleLLM(LLMInterface):
                 # Record token usage metrics
                 duration = time.time() - start_time
                 usage = response.usage
-                response_usage = _usage_from_openai_response(response)
-                input_tokens = response_usage.input_tokens
-                output_tokens = response_usage.output_tokens
-                total_tokens = usage.total_tokens or 0 if usage else 0
-                cached_tokens = response_usage.cached_tokens
-                thoughts_tokens = 0
-                if usage and getattr(usage, "completion_tokens_details", None):
-                    thoughts_tokens = getattr(usage.completion_tokens_details, "reasoning_tokens", 0) or 0
-                # OpenAI-compatible providers fold reasoning tokens into
-                # ``completion_tokens`` (and thus ``total_tokens``), but the
-                # TokenUsage contract — and the Gemini provider — treat
-                # ``output_tokens``/``total_tokens`` as visible-only, surfacing
-                # reasoning separately in ``thoughts_tokens``. Subtract so the
-                # two fields don't double-count reasoning (cost over-attribution).
-                if thoughts_tokens:
-                    output_tokens = max(0, output_tokens - thoughts_tokens)
-                    total_tokens = max(0, total_tokens - thoughts_tokens)
+                # ``output_tokens``/``total_tokens`` are visible-only past this
+                # point, with reasoning surfaced separately in
+                # ``thoughts_tokens`` — see ``_visible_token_usage``.
+                token_counts = _visible_token_usage(response)
+                input_tokens = token_counts.input_tokens
+                output_tokens = token_counts.output_tokens
+                total_tokens = token_counts.total_tokens
+                cached_tokens = token_counts.cached_tokens
+                thoughts_tokens = token_counts.thoughts_tokens
 
                 # Record LLM metrics. ``output_tokens`` is visible-only by now, so
                 # ``thoughts_tokens`` has to be recorded alongside it or the reasoning
@@ -1214,21 +1263,18 @@ class OpenAICompatibleLLM(LLMInterface):
                 if duration > 10.0 and usage:
                     ratio = max(1, output_tokens) / max(1, input_tokens)
                     cache_info = f", cached_tokens={cached_tokens}" if cached_tokens > 0 else ""
+                    # Without the reasoning count a high-effort call reads as a
+                    # slow, near-empty completion (#3851).
+                    thoughts_info = f", thoughts_tokens={thoughts_tokens}" if thoughts_tokens > 0 else ""
                     logger.info(
                         f"slow llm call: scope={scope}, model={self.provider}/{self.model}, "
                         f"input_tokens={input_tokens}, output_tokens={output_tokens}, "
-                        f"total_tokens={total_tokens}{cache_info}, time={duration:.3f}s, ratio out/in={ratio:.2f}"
+                        f"total_tokens={total_tokens}{cache_info}{thoughts_info}, "
+                        f"time={duration:.3f}s, ratio out/in={ratio:.2f}"
                     )
 
                 if return_usage:
-                    token_usage = TokenUsage(
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        total_tokens=total_tokens,
-                        cached_tokens=cached_tokens,
-                        thoughts_tokens=thoughts_tokens,
-                    )
-                    return result, token_usage
+                    return result, token_counts
                 return result
 
             except LengthFinishReasonError as e:
@@ -1484,20 +1530,13 @@ class OpenAICompatibleLLM(LLMInterface):
 
                 # Record metrics
                 duration = time.time() - start_time
-                usage = response.usage
-                input_tokens = usage.prompt_tokens or 0 if usage else 0
-                output_tokens = usage.completion_tokens or 0 if usage else 0
-                cached_tokens = 0
-                if usage and getattr(usage, "prompt_tokens_details", None):
-                    cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
-                thoughts_tokens = 0
-                if usage and getattr(usage, "completion_tokens_details", None):
-                    thoughts_tokens = getattr(usage.completion_tokens_details, "reasoning_tokens", 0) or 0
-                # See ``call()``: OpenAI-compatible ``completion_tokens`` includes
-                # reasoning, so make ``output_tokens`` visible-only to avoid
-                # double-counting it against ``thoughts_tokens``.
-                if thoughts_tokens:
-                    output_tokens = max(0, output_tokens - thoughts_tokens)
+                # See ``_visible_token_usage``: ``output_tokens`` is visible-only,
+                # with reasoning surfaced separately in ``thoughts_tokens``.
+                token_counts = _visible_token_usage(response)
+                input_tokens = token_counts.input_tokens
+                output_tokens = token_counts.output_tokens
+                cached_tokens = token_counts.cached_tokens
+                thoughts_tokens = token_counts.thoughts_tokens
 
                 # See ``call()``: record the reasoning and cached counts too, so no
                 # billed token is dropped from the metrics counters.

--- a/hindsight-api-slim/tests/test_token_usage_cached_thoughts.py
+++ b/hindsight-api-slim/tests/test_token_usage_cached_thoughts.py
@@ -377,3 +377,177 @@ async def test_openai_compatible_metrics_account_for_every_billed_output_token()
     assert recorded["output_tokens"] == completion - reasoning  # visible-only
     assert recorded["thoughts_tokens"] == reasoning
     assert recorded["output_tokens"] + recorded["thoughts_tokens"] == completion
+
+
+# --- #3851: folded vs unfolded reasoning on OpenAI-compatible gateways -------
+#
+# Not every OpenAI-compatible upstream folds reasoning into ``completion_tokens``.
+# The gateway in #3851 reported prompt=3110, completion=673, reasoning=909,
+# total=4692 -- ``completion_tokens`` already visible-only -- and the
+# unconditional subtraction clamped a real 673-token completion to 0 on 426 of
+# 565 retain calls. ``total`` reads as prompt + visible + reasoning under both
+# shapes, so these pin that visible output is derived from it rather than from a
+# guess at which shape the upstream used.
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_call_unfolded_reasoning_keeps_visible_output():
+    """#3851: reasoning reported separately from completion_tokens must not be
+    subtracted out of it."""
+    llm = _openai_llm()
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=4692))
+    )
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        _, token_usage = await llm.call(
+            messages=[{"role": "user", "content": "Extract facts"}],
+            response_format=_OkModel,
+            max_retries=0,
+            return_usage=True,
+        )
+    assert token_usage.output_tokens == 673  # was 0: max(0, 673 - 909)
+    assert token_usage.thoughts_tokens == 909
+    assert token_usage.input_tokens == 3110
+    assert token_usage.total_tokens == 3110 + 673  # visible-only, excludes reasoning
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_call_with_tools_unfolded_reasoning_keeps_visible_output():
+    """#3851 carries the same defect on the tool-call path, which reports its own
+    metrics and returns its own LLMToolCallResult."""
+    llm = _openai_llm()
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=4692), content="done")
+    )
+    collector = MagicMock(spec=MetricsCollector)
+    with patch(
+        "hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector",
+        return_value=collector,
+    ):
+        result = await llm.call_with_tools(messages=[{"role": "user", "content": "hi"}], tools=[], max_retries=0)
+
+    assert result.output_tokens == 673
+    assert result.thoughts_tokens == 909
+    recorded = _recorded_llm_call(collector)
+    assert recorded["output_tokens"] == 673
+    assert recorded["thoughts_tokens"] == 909
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_call_unfolded_reasoning_survives_drifted_total():
+    """#3851: a proxy whose ``total`` is a token off the unfolded identity must
+    still not clamp visible output to 0.
+
+    This is what defeats shape *detection*: comparing prompt + completion against
+    total classifies 4691 (one under the true 4692) as the folded shape, and the
+    subtraction that follows puts output straight back to 0. Deriving from total
+    degrades by the same one token instead.
+    """
+    llm = _openai_llm()
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=4691))
+    )
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        _, token_usage = await llm.call(
+            messages=[{"role": "user", "content": "Extract facts"}],
+            response_format=_OkModel,
+            max_retries=0,
+            return_usage=True,
+        )
+    assert token_usage.output_tokens == 672
+    assert token_usage.thoughts_tokens == 909
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_call_folded_reasoning_survives_drifted_total():
+    """#3851: the folded shape (#3851's gpt-5.4 row) with a one-token ``total``
+    drift stays within a token of the folded reading."""
+    llm = _openai_llm()
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=48, prompt=3340, completion=1337, total=4678))
+    )
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        _, token_usage = await llm.call(
+            messages=[{"role": "user", "content": "Query"}],
+            response_format=_OkModel,
+            max_retries=0,
+            return_usage=True,
+        )
+    assert token_usage.output_tokens == (1337 - 48) + 1
+    assert token_usage.thoughts_tokens == 48
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_call_missing_total_falls_back_to_folded_reading():
+    """#3851: nothing to derive from when the upstream omits ``total_tokens``, so
+    keep the folded reading rather than reporting the whole completion twice."""
+    llm = _openai_llm()
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=64, prompt=20, completion=83, total=0))
+    )
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        _, token_usage = await llm.call(
+            messages=[{"role": "user", "content": "Query"}],
+            response_format=_OkModel,
+            max_retries=0,
+            return_usage=True,
+        )
+    assert token_usage.output_tokens == 83 - 64
+    assert token_usage.thoughts_tokens == 64
+    assert token_usage.total_tokens == 20 + (83 - 64)
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_call_clamps_unusable_total_to_an_admissible_reading():
+    """An upstream whose ``total`` fits neither shape must still land on one of the
+    two readings ``completion_tokens`` admits, never on a count derived from the
+    nonsense total.
+
+    ``total=99`` here is below ``prompt`` alone; the derived value is negative, so
+    the folded reading is the floor. The mirror case -- an absurdly large total --
+    is capped at the full completion.
+    """
+    llm = _openai_llm()
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=99))
+    )
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        _, low = await llm.call(
+            messages=[{"role": "user", "content": "Query"}],
+            response_format=_OkModel,
+            max_retries=0,
+            return_usage=True,
+        )
+    assert low.output_tokens == 0  # max(0, 673 - 909), the folded reading
+
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=999_999))
+    )
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        _, high = await llm.call(
+            messages=[{"role": "user", "content": "Query"}],
+            response_format=_OkModel,
+            max_retries=0,
+            return_usage=True,
+        )
+    assert high.output_tokens == 673  # capped at completion_tokens
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_call_without_reasoning_reports_completion_verbatim():
+    """No reasoning tokens means nothing to disentangle: visible output is exactly
+    ``completion_tokens``, whatever ``total`` says."""
+    llm = _openai_llm()
+    llm._client.chat.completions.create = AsyncMock(
+        return_value=_response(usage=_usage(reasoning=0, prompt=120, completion=45, total=165))
+    )
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        _, token_usage = await llm.call(
+            messages=[{"role": "user", "content": "Query"}],
+            response_format=_OkModel,
+            max_retries=0,
+            return_usage=True,
+        )
+    assert token_usage.output_tokens == 45
+    assert token_usage.thoughts_tokens == 0
+    assert token_usage.total_tokens == 165


### PR DESCRIPTION
Fixes #3851.

## The bug

OpenAI-compatible upstreams disagree on where reasoning tokens live in the usage block:

- **folded** (OpenAI's own reasoning models): `total = prompt + completion`, and `completion_tokens` already includes `reasoning_tokens`;
- **unfolded** (several gateways and proxies): `total = prompt + completion + reasoning`, and `completion_tokens` is already visible-only.

Both call sites in `openai_compatible_llm.py` subtracted reasoning from completion unconditionally. On the unfolded shape that clamps a real completion to 0 whenever reasoning exceeds visible output — routine for high-effort model variants, and observed on **426 of 565** `retain_extract_facts` calls in #3851 (`prompt=3110, completion=673, reasoning=909` → `output_tokens=0`).

Retain itself was never affected. The damage was to the metrics counters and to a slow-call log line that reads as an empty extraction, inviting a false "the model returned nothing" diagnosis.

## The fix

Not shape *detection*. Comparing `prompt + completion` against `total` looks like it works, but proxies are a token or two off on `total`, and a near miss on the unfolded shape classifies as folded and lands straight back on the clamp — for the numbers above, a `total` of 4691 instead of 4692 is enough to put `output_tokens` back to 0. The tolerance is widest exactly where reasoning is largest, which is the population this issue is about.

`total` reads as `prompt + visible + reasoning` under **both** shapes, so visible output is derived from it and the shape never has to be known:

```
output = (total - reasoning) - prompt
```

This is the same reasoning `xai_oauth_llm._token_counts` already documents — its docstring points at this file. The derived value is then clamped to the only two readings `completion_tokens` admits (`completion` and `completion - reasoning`), so an upstream whose `total` is drifted or outright unusable degrades to the nearer of those instead of to a bogus count; a missing `total` leaves nothing to derive from and falls back to the folded reading.

Verified against every row in the issue's measurement table:

| model | prompt | completion | reasoning | total | shape | before | after |
|---|---|---|---|---|---|---|---|
| `gemini-3.7-flash-high` | 3110 | 673 | 909 | 4692 | unfolded | **0** | 673 |
| `gpt-5.4` | 3340 | 1337 | 48 | 4677 | folded | 1289 | 1289 |
| `gpt-5.6-luna` | 3340 | 2081 | 407 | 5421 | folded | 1674 | 1674 |

Also in here:

- Both call sites share one `_visible_token_usage` helper instead of two copies of the arithmetic.
- `total_tokens` is visible-only throughout, which is what `TokenUsage` has always documented (*"Total tokens (input + output, excludes thoughts)"*) and what `openai_responses_llm._extract_usage` already does. The old `usage.total_tokens - thoughts` was an approximation of that.
- The slow-call log gains `thoughts_tokens`. Without it, a correctly-counted reasoning-heavy call still reads as slow and near-empty — the log line is what sent #3851 looking for a retain bug in the first place.

## Tests

Seven regression tests in `test_token_usage_cached_thoughts.py`, including the drifted-`total` cases that rule out shape detection and the unusable-`total` clamp. The existing folded-shape assertions are unchanged and still pass.

## Credit

Supersedes #3852 by @Sword-Saint69, who diagnosed the bug, located both call sites, and contributed the unfolded-shape test vectors carried over here.

## Out of scope, noted

- `litellm_llm.py` never reads `reasoning_tokens` at all, so reasoning is unattributed there rather than mis-subtracted — a different defect on a sibling provider.
- `openai_responses_llm._extract_usage` still subtracts unconditionally. That is correct for first-party OpenAI, which is what the provider targets, and no unfolded Responses upstream has been reported.

https://claude.ai/code/session_01F3i5UVdZRK16AZ9oFQqsg4
