### PR TITLE
fix(retain): scrub the whole retain item at the engine ingress, not field by field

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -222,21 +222,27 @@ def sanitize_text(text: str | None) -> str | None:
 sanitize_llm_output = sanitize_text
 
 
-def sanitize_llm_value(value: Any) -> Any:
+def sanitize_value(value: Any) -> Any:
     """
-    Recursively strip UTF-8-hostile characters from every string an LLM produced.
+    Recursively strip UTF-8-hostile characters from every string in a value.
 
-    ``sanitize_text`` guards a single field. This guards a whole response — the
+    ``sanitize_text`` guards a single field. This guards a whole structure — the
     text a provider returned, the dict a structured call parsed, the pydantic
-    model it validated into, the ``LLMCallResult`` ``call`` hands back — so that
-    *every* LLM call is covered at one boundary instead of
-    each consumer remembering to scrub its own fields (see issue #3729).
+    model it validated into, the ``LLMCallResult`` ``call`` hands back, and
+    equally a whole client-supplied retain item — so that *every* such boundary
+    is covered at one place instead of each consumer remembering to scrub its
+    own fields (see issue #3729). It was introduced to scrub LLM output and now
+    also scrubs user input at the retain ingress, hence the broad name.
 
     It matters beyond embeddings. A lone surrogate is legal in a Python ``str``
     but cannot be UTF-8 encoded, so it also breaks the cross-encoder's Rust
     tokenizer at rerank time, asyncpg on the way into a ``text`` column, and
-    stdout logging. Sanitizing where the text enters the process means the
-    downstream stages never have to care which field it landed in.
+    stdout logging. ``U+0000`` is rejected by ``jsonb`` as well as ``text``, so a
+    retain item carrying one aborts the ``async_operations.task_payload`` INSERT
+    no matter which of its fields — content, a tag, a nested ``metadata`` value,
+    even a metadata *key* — happens to hold it. Sanitizing where the text enters
+    the process means the downstream stages never have to care which field it
+    landed in.
 
     Only strings are touched; ints, floats, datetimes and the like pass through
     as-is. Every container returns the *same object* when nothing inside it
@@ -254,7 +260,7 @@ def sanitize_llm_value(value: Any) -> Any:
     if isinstance(value, BaseModel):
         updates = {}
         for name, field_value in value.__dict__.items():
-            cleaned = sanitize_llm_value(field_value)
+            cleaned = sanitize_value(field_value)
             if cleaned is not field_value:
                 updates[name] = cleaned
         # ``model_copy`` skips validation, which is what we want: the values are
@@ -268,8 +274,8 @@ def sanitize_llm_value(value: Any) -> Any:
         for key, item in value.items():
             # Keys are sanitized too: a surrogate in a key is just as fatal once
             # the dict is rendered to text or bound to a query parameter.
-            cleaned_key = sanitize_llm_value(key)
-            cleaned_item = sanitize_llm_value(item)
+            cleaned_key = sanitize_value(key)
+            cleaned_item = sanitize_value(item)
             changed = changed or cleaned_key is not key or cleaned_item is not item
             cleaned_dict[cleaned_key] = cleaned_item
         return cleaned_dict if changed else value
@@ -277,7 +283,7 @@ def sanitize_llm_value(value: Any) -> Any:
     # ``call`` returns an ``LLMCallResult`` now, handled by the BaseModel branch
     # above; ``tuple`` stays because a parsed JSON payload can nest either.
     if isinstance(value, (list, tuple)):
-        cleaned_items = [sanitize_llm_value(item) for item in value]
+        cleaned_items = [sanitize_value(item) for item in value]
         if all(cleaned is original for cleaned, original in zip(cleaned_items, value)):
             return value
         return cleaned_items if isinstance(value, list) else tuple(cleaned_items)
@@ -355,7 +361,7 @@ def parse_llm_json(raw: str) -> Any:
     degenerate-but-valid JSON (repetition loops or leaked scaffolding inside
     string values) parses fine here and is out of scope for this helper.
 
-    Every successful parse is passed through ``sanitize_llm_value``. Decoding is
+    Every successful parse is passed through ``sanitize_value``. Decoding is
     where an un-encodable surrogate is *born*: a model that writes ``"\\ud83d"``
     emits six harmless ASCII characters, and only ``json.loads`` turns them into a
     lone surrogate no downstream stage can UTF-8 encode (#3729). Scrubbing the raw
@@ -382,7 +388,7 @@ def parse_llm_json(raw: str) -> Any:
         text = text.strip()
 
     try:
-        return sanitize_llm_value(json.loads(text))
+        return sanitize_value(json.loads(text))
     except json.JSONDecodeError:
         # Some models (e.g. Gemini) embed raw control characters inside JSON
         # string values. Escape them rather than blank them out: a raw newline
@@ -393,7 +399,7 @@ def parse_llm_json(raw: str) -> Any:
         cleaned = _escape_control_chars_in_json(text)
 
     try:
-        return sanitize_llm_value(json.loads(cleaned))
+        return sanitize_value(json.loads(cleaned))
     except json.JSONDecodeError:
         # Last resort: structural repair of malformed JSON. ``repair_json`` never
         # raises — unrecoverable input yields an empty result ("" / {} / []). Keep
@@ -403,7 +409,7 @@ def parse_llm_json(raw: str) -> Any:
         repaired = repair_json(cleaned, return_objects=True)
         if not repaired:
             raise
-        return sanitize_llm_value(repaired)
+        return sanitize_value(repaired)
 
 
 _PROVIDERS_WITHOUT_API_KEY = frozenset(
@@ -1358,7 +1364,7 @@ class LLMProvider:
         # a model can emit a lone `\udXXX` escape that JSON decoding turns into an
         # un-encodable surrogate, and the field it lands in is not knowable here
         # (#3729). Clean output is returned unchanged, object identity included.
-        return sanitize_llm_value(result)
+        return sanitize_value(result)
 
     async def call_with_tools(
         self,
@@ -1504,7 +1510,7 @@ class LLMProvider:
 
         # Same scrub for the tool-calling path: the agent's text content and every
         # tool-call argument are model-authored and flow on to storage and reranking.
-        return sanitize_llm_value(result)
+        return sanitize_value(result)
 
     def set_response_callback(self, fn: Any) -> None:
         """Set a callback invoked on each call() instead of the fixed mock response."""

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -529,7 +529,14 @@ from enum import Enum
 from ..pg0 import EmbeddedPostgres, parse_pg0_url
 from .entity_resolver import EntityResolver
 from .fact_budget import select_facts_within_budget
-from .llm_wrapper import ConfiguredLLMProvider, LLMConfig, requires_api_key, sanitize_llm_output, sanitize_text
+from .llm_wrapper import (
+    ConfiguredLLMProvider,
+    LLMConfig,
+    requires_api_key,
+    sanitize_llm_output,
+    sanitize_text,
+    sanitize_value,
+)
 from .mental_model_refresh import (
     MentalModelDeltaOperations,
     MentalModelDryRunRefreshResult,
@@ -3003,8 +3010,11 @@ class MemoryEngine(MemoryEngineInterface):
             retain_content["event_date"] = None
         elif file_timestamp:
             retain_content["event_date"] = file_timestamp
-        retain_contents = [retain_content]
-        document_tags = task_dict.get("document_tags")
+        # Same jsonb constraint as `submit_async_retain`: this row's task_payload
+        # carries the item verbatim, and the caller-supplied metadata/tags on a
+        # file upload never passed through that scrub.
+        retain_contents = [sanitize_value(retain_content)]
+        document_tags = sanitize_value(task_dict.get("document_tags"))
 
         retain_task_payload: dict[str, Any] = {"contents": retain_contents}
         if document_tags:
@@ -5261,24 +5271,30 @@ class MemoryEngine(MemoryEngineInterface):
         # those mutations leak back to the caller's dicts.
         contents = cast(list[RetainContentDict], [dict(c) for c in contents])
 
-        # Sanitize content/context at ingress so lone UTF-16 surrogates (e.g. a
-        # half-emoji a client serialized as a `\udXXX` escape) cannot crash the
-        # embedder, cross-encoder, or logging with an HTTP 500 (see issue #1875).
+        # Sanitize the whole item at ingress. A lone UTF-16 surrogate (e.g. a
+        # half-emoji a client serialized as a `\udXXX` escape) crashes the
+        # embedder, cross-encoder or logging with an HTTP 500 (#1875), and U+0000
+        # is storable in neither `text` nor `jsonb`, so a NUL aborts the INSERT
+        # outright. Neither character is confined to `content`: `sanitize_value`
+        # walks the item — context, document_id, tags, entities and nested
+        # metadata, keys included — so no field can be forgotten one at a time.
+        contents = cast(list[RetainContentDict], sanitize_value(contents))
         for item in contents:
+            # Downstream expects a string here even when the item sanitized empty.
             if "content" in item:
-                item["content"] = sanitize_text(item["content"]) or ""
-            if item.get("context"):
-                item["context"] = sanitize_text(item["context"]) or ""
+                item["content"] = item["content"] or ""
             # Client-supplied entity names reach the same places the fact text does:
             # they are appended to the embedded string and joined into `text_signals`
             # for BM25, so an unpaired surrogate here crashes identically (#3729).
-            # Shape is ``[{"text": ..., "type": ...}]``; an entry whose text sanitizes
+            # Shape is ``[{"text": ..., "type": ...}]``; an entry whose text sanitized
             # away entirely is dropped rather than carried as a nameless entity.
             if item.get("entities"):
                 item["entities"] = [
-                    {key: sanitize_text(value) or "" for key, value in entity.items()}
+                    # `RetainContent.entities` is `list[dict[str, str]]`; an omitted
+                    # `type` arrives as None and must not survive as one.
+                    {key: value or "" for key, value in entity.items()}
                     for entity in item["entities"]
-                    if (sanitize_text(entity.get("text")) or "").strip()
+                    if (entity.get("text") or "").strip()
                 ]
 
         # Apply batch-level document_id to contents that don't have their own (backwards compatibility)
@@ -20250,6 +20266,22 @@ class MemoryEngine(MemoryEngineInterface):
             result = await self._validate_operation(self._operation_validator.validate_retain(ctx))
             if result and result.contents is not None:
                 contents = result.contents
+
+        # Sanitize at the same ingress point the synchronous path does, and for a
+        # second reason on top of it: the whole item is serialized into
+        # `async_operations.task_payload::jsonb` below, and PostgreSQL stores
+        # neither U+0000 nor a lone surrogate. One such character anywhere in the
+        # item — content, a tag, a nested metadata value, even a metadata *key* —
+        # aborts that INSERT with UntranslatableCharacterError, the request 500s,
+        # and the memory is never queued. The failure is deterministic for that
+        # payload, so a retrying client re-sends it forever (see PR #3908).
+        #
+        # Scrubbed here rather than in the HTTP model: `mcp_tools.retain` builds a
+        # content dict by hand and calls this method directly, so a validator on
+        # `MemoryItem` would leave the MCP tool 500ing on the same payload.
+        contents = cast(list[dict[str, Any]], sanitize_value(contents))
+        document_tags = sanitize_value(document_tags)
+        strategy = sanitize_value(strategy)
 
         # Idempotency fast path: a caller-supplied id that already resolves to a
         # prior submission is a retried request — return the original operation.

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator
 
 from ..llm_interface import ProviderContentPolicyError, ProviderRateLimitResetError
-from ..llm_wrapper import LLMConfig, OutputTooLongError, parse_llm_json, sanitize_llm_output, sanitize_llm_value
+from ..llm_wrapper import LLMConfig, OutputTooLongError, parse_llm_json, sanitize_llm_output, sanitize_value
 from ..operation_metadata import RetainExtractionErrors
 from ..response_models import TokenUsage
 from ..structured_output import provider_json_schema, strict_json_schema
@@ -2742,7 +2742,7 @@ async def extract_facts_from_contents_batch_api(
     # Batch results are downloaded straight from the provider's output file, so they
     # never pass through ``LLMProvider.call`` and miss the scrub it applies. Sanitize
     # them here so the batch path gets the same guarantee as the sync one (#3729).
-    batch_results = sanitize_llm_value(await batch_impl.retrieve_batch_results(batch_id))
+    batch_results = sanitize_value(await batch_impl.retrieve_batch_results(batch_id))
 
     # Map results by custom_id
     results_by_id = {result["custom_id"]: result for result in batch_results}

--- a/hindsight-api-slim/tests/test_async_batch_retain.py
+++ b/hindsight-api-slim/tests/test_async_batch_retain.py
@@ -1706,3 +1706,77 @@ async def test_multi_document_batch_does_not_misattribute_document_id(memory, re
     # parent nor the child resolves to a single document_id.
     assert ops, "expected operations for the batch"
     assert all(op["document_id"] is None for op in ops)
+
+
+# --- NUL / lone surrogate in a queued item (PR #3908) ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_retain_survives_nul_and_surrogate_in_any_field(memory, request_context, monkeypatch):
+    """A queued item carrying U+0000 must be stored, not 500 on the jsonb INSERT.
+
+    ``submit_async_retain`` serializes the whole item into
+    ``async_operations.task_payload::jsonb``. PostgreSQL stores U+0000 in neither
+    ``text`` nor ``jsonb`` and asyncpg cannot UTF-8-encode a lone surrogate, so
+    before the ingress scrub one such character *anywhere* in the item — content,
+    a tag, a nested metadata value, even a metadata key — aborted that INSERT with
+    ``UntranslatableCharacterError``. The request returned 500 and the memory was
+    never queued; the failure is deterministic for that payload, so a retrying
+    client re-sent it forever.
+    """
+    nul = "\u0000"
+    surrogate = "\ud83d"
+
+    bank_id = f"test_nul_payload_{uuid.uuid4().hex[:8]}"
+    pool = await memory._get_pool()
+    await _ensure_bank(pool, bank_id)
+
+    # Structural assertion on the committed rows — no need to drive the pipeline.
+    async def noop_submit_task(_task_dict):
+        return None
+
+    monkeypatch.setattr(memory._task_backend, "submit_task", noop_submit_task)
+
+    document_id = f"doc-{uuid.uuid4().hex[:8]}"
+    result = await memory.submit_async_retain(
+        bank_id=bank_id,
+        contents=[
+            {
+                "content": f"Alice{nul} joined the {surrogate}team.",
+                "context": f"team{nul} meeting",
+                "document_id": f"{document_id}{nul}",
+                "metadata": {f"so{nul}urce": f"sl{nul}ack", "nested": [f"a{nul}b"]},
+                "tags": [f"te{nul}am"],
+            }
+        ],
+        document_tags=[f"batch{nul}"],
+        request_context=request_context,
+    )
+
+    assert result["operation_id"]
+
+    # Read the committed row directly: the assertion is about what reached the
+    # jsonb column, which no engine read method exposes (the surrounding tests in
+    # this file inspect task_payload the same way).
+    children = await pool.fetch(
+        """
+        SELECT task_payload
+        FROM async_operations
+        WHERE bank_id = $1 AND operation_type = 'retain'
+        """,
+        bank_id,
+    )
+    assert len(children) == 1
+    payload = children[0]["task_payload"]
+    payload = json.loads(payload) if isinstance(payload, str) else payload
+
+    item = payload["contents"][0]
+    assert item["content"] == "Alice joined the team."
+    assert item["context"] == "team meeting"
+    assert item["document_id"] == document_id
+    assert item["metadata"] == {"source": "slack", "nested": ["ab"]}
+    assert item["tags"] == ["team"]
+    assert payload["document_tags"] == ["batch"]
+    # Nothing hostile may remain anywhere in the round-tripped payload.
+    assert nul not in json.dumps(payload)
+    assert surrogate not in json.dumps(payload)

--- a/hindsight-api-slim/tests/test_input_robustness.py
+++ b/hindsight-api-slim/tests/test_input_robustness.py
@@ -17,7 +17,7 @@ from hindsight_api.engine.llm_wrapper import (
     LLMProvider,
     parse_llm_json,
     sanitize_llm_output,
-    sanitize_llm_value,
+    sanitize_value,
     sanitize_text,
 )
 from hindsight_api.engine.reflect.tokenization import count_prompt_tokens
@@ -29,6 +29,9 @@ from hindsight_api.engine.token_encoding import count_tokens, truncate_to_tokens
 # tokenizers behind the local embedder / cross-encoder and uncodable to UTF-8.
 HIGH_SURROGATE = "\ud83d"
 LONE_SURROGATE = f"deploy the {HIGH_SURROGATE} service"
+# U+0000. Legal in JSON, storable in neither a PostgreSQL ``text`` nor a ``jsonb``
+# column, so it aborts an INSERT rather than merely crashing a tokenizer.
+NUL = "\u0000"
 SPECIAL_TOKEN_TEXT = "The fix was to sanitize the <|endoftext|> token before sending."
 
 
@@ -141,17 +144,17 @@ async def test_fact_extraction_sanitizes_surrogates_generated_by_llm():
 # --- Prong C: every LLM response is scrubbed at one boundary (#3729) ------------
 
 
-def test_sanitize_llm_value_returns_clean_input_unchanged():
+def test_sanitize_value_returns_clean_input_unchanged():
     """The common case must not copy: identity is preserved all the way down."""
     payload = {"facts": [{"what": "café 🎉", "n": 3}], "ok": None, "flag": True, "score": 1.5}
-    assert sanitize_llm_value(payload) is payload
+    assert sanitize_value(payload) is payload
     text = "plain text"
-    assert sanitize_llm_value(text) is text
+    assert sanitize_value(text) is text
 
 
-def test_sanitize_llm_value_scrubs_nested_strings_only():
+def test_sanitize_value_scrubs_nested_strings_only():
     payload = {"facts": [{"what": f"a{HIGH_SURROGATE}b", "count": 3, "ratio": 0.5, "missing": None}]}
-    cleaned = sanitize_llm_value(payload)
+    cleaned = sanitize_value(payload)
     assert cleaned["facts"][0]["what"] == "ab"
     # Non-text fields keep their type and value.
     assert cleaned["facts"][0]["count"] == 3
@@ -159,18 +162,18 @@ def test_sanitize_llm_value_scrubs_nested_strings_only():
     assert cleaned["facts"][0]["missing"] is None
 
 
-def test_sanitize_llm_value_scrubs_dict_keys():
-    cleaned = sanitize_llm_value({f"na{HIGH_SURROGATE}me": "Alex"})
+def test_sanitize_value_scrubs_dict_keys():
+    cleaned = sanitize_value({f"na{HIGH_SURROGATE}me": "Alex"})
     assert cleaned == {"name": "Alex"}
 
 
-def test_sanitize_llm_value_scrubs_pydantic_models():
+def test_sanitize_value_scrubs_pydantic_models():
     result = LLMToolCallResult(
         content=f"answer{HIGH_SURROGATE}",
         tool_calls=[LLMToolCall(id="call_1", name="recall", arguments={"query": f"q{HIGH_SURROGATE}"})],
         output_tokens=42,
     )
-    cleaned = sanitize_llm_value(result)
+    cleaned = sanitize_value(result)
     assert isinstance(cleaned, LLMToolCallResult)
     assert cleaned.content == "answer"
     assert cleaned.tool_calls[0].arguments == {"query": "q"}
@@ -178,14 +181,14 @@ def test_sanitize_llm_value_scrubs_pydantic_models():
     assert cleaned.output_tokens == 42
 
 
-def test_sanitize_llm_value_preserves_tuple_shape():
+def test_sanitize_value_preserves_tuple_shape():
     """A tuple reaching the scrubber keeps its shape — both members must survive.
 
     ``call`` returns an ``LLMCallResult`` now (handled by the BaseModel branch), but
     parsed JSON payloads still nest tuples, so the tuple branch has to stay correct.
     """
     usage = TokenUsage()
-    cleaned = sanitize_llm_value(({"text": f"x{HIGH_SURROGATE}"}, usage))
+    cleaned = sanitize_value(({"text": f"x{HIGH_SURROGATE}"}, usage))
     assert isinstance(cleaned, tuple) and len(cleaned) == 2
     assert cleaned[0] == {"text": "x"}
     assert cleaned[1] is usage
@@ -349,6 +352,67 @@ async def test_retain_with_lone_surrogate_entity_name(memory, request_context):
             {
                 "content": "The deploy service ships releases.",
                 "entities": [{"text": f"depl{HIGH_SURROGATE}oy"}, {"text": HIGH_SURROGATE}],
+            }
+        ],
+        request_context=request_context,
+    )
+    assert isinstance(unit_ids, list)
+
+
+# --- Prong D: a retain item is scrubbed as a whole, not field by field ----------
+#
+# U+0000 is the second character PostgreSQL refuses, and unlike a surrogate it is
+# rejected by ``jsonb`` as well as by ``text``. An async retain writes the entire
+# item into ``async_operations.task_payload::jsonb``, so a NUL in *any* field aborts
+# that INSERT — the request 500s and the memory is never queued. The failure is
+# deterministic for that payload, so a retrying client re-sends it forever. JSON
+# permits ``\u0000``, and text scraped from PDFs, log captures and chat exports
+# carries it (see PR #3908).
+
+
+def test_sanitize_value_strips_nul_from_a_whole_retain_item():
+    """Every string in the item, metadata keys and nested values included."""
+    item = {
+        "content": f"Alice{NUL} joined.",
+        "context": f"team{NUL} meeting",
+        "document_id": f"doc{NUL}1",
+        "metadata": {f"so{NUL}urce": f"sl{NUL}ack", "nested": [f"a{NUL}b", {f"k{NUL}": f"v{NUL}"}]},
+        "tags": [f"te{NUL}am"],
+    }
+    cleaned = sanitize_value(item)
+    assert cleaned == {
+        "content": "Alice joined.",
+        "context": "team meeting",
+        "document_id": "doc1",
+        "metadata": {"source": "slack", "nested": ["ab", {"k": "v"}]},
+        "tags": ["team"],
+    }
+    # Nothing may survive anywhere: the whole item is what reaches jsonb.
+    assert NUL not in json.dumps(cleaned)
+
+
+def test_sanitize_value_preserves_non_hostile_text():
+    """Only the uncodable characters go — ordinary unicode is content."""
+    item = {"content": "Über — naïve 🙂 \t newline\n kept", "metadata": {"emoji": "🎉"}}
+    assert sanitize_value(item) is item
+
+
+@pytest.mark.asyncio
+async def test_sync_retain_with_nul_in_metadata(memory, request_context):
+    """The synchronous path is not exempt: metadata lands in a ``jsonb`` column.
+
+    Only ``content``, ``context`` and ``entities`` used to be scrubbed here, so a
+    NUL in ``metadata`` — the field most likely to carry one, since it is copied
+    from whatever produced the document — still aborted the document INSERT.
+    """
+    bank_id = f"test_nul_metadata_{datetime.now(timezone.utc).timestamp()}"
+    unit_ids = await memory.retain_batch_async(
+        bank_id=bank_id,
+        contents=[
+            {
+                "content": f"Alice{NUL} joined the team.",
+                "metadata": {f"so{NUL}urce": f"sl{NUL}ack"},
+                "tags": [f"te{NUL}am"],
             }
         ],
         request_context=request_context,

--- a/hindsight-api-slim/tests/test_named_result_stubs.py
+++ b/hindsight-api-slim/tests/test_named_result_stubs.py
@@ -322,7 +322,7 @@ def test_a_call_result_binding_is_only_read_through_its_fields():
     """
     #: Reading the whole envelope is legitimate here: these hand it onward
     #: unchanged rather than treating it as the payload.
-    PASSTHROUGH = {"sanitize_llm_value", "isinstance_ok"}
+    PASSTHROUGH = {"sanitize_value", "isinstance_ok"}
 
     offenders = []
     for path in _source_files():


### PR DESCRIPTION
## Problem

PostgreSQL cannot store `U+0000` in `text` **or** `jsonb`. A retain item carrying one aborts the INSERT that stores it:

```
asyncpg.exceptions.UntranslatableCharacterError: unsupported Unicode escape sequence
DETAIL:  \u0000 cannot be converted to text.
```

`submit_async_retain` writes the whole item into `async_operations.task_payload::jsonb`, so the request returns 500 and the memory is never queued. The failure is deterministic for that payload, so a retrying client re-sends it forever and never stores it. JSON permits `\u0000`, so clients legitimately send it — text scraped from PDFs, log captures and chat exports all carry stray NULs.

This supersedes #3908, which reported and diagnosed the bug. Two things that PR's placement left open, both verified here by reverting the fix and watching the test fail:

**1. It is not async-only.** #3908 reported that `async: false` succeeds. It does for `content` and `context` — the synchronous ingress has scrubbed those since #1875 — but `metadata` lands in a `jsonb` column too, and nothing scrubbed it:

```
tests/test_input_robustness.py::test_sync_retain_with_nul_in_metadata
E   asyncpg.exceptions.UntranslatableCharacterError: unsupported Unicode escape sequence
```

Scrubbing named fields one at a time is what left that gap; the field most likely to carry a NUL is the one copied verbatim from whatever produced the document.

**2. A validator on `MemoryItem` misses the MCP tool.** `mcp_tools.retain` (`mcp_tools.py:698`, `:753`) builds a content dict by hand and calls `submit_async_retain` directly, never touching the HTTP model, so it would keep 500ing on the same payload.

## Fix

Scrub at the engine ingress, where the synchronous path already does it, using the recursive sanitizer the repo already has rather than a new NUL-only helper.

`sanitize_llm_value` (now `sanitize_value`, `engine/llm_wrapper.py`) already walks a whole structure — strings, dicts including their **keys**, lists, tuples, pydantic models — applying `sanitize_text`, which strips `U+0000` along with the other control characters and lone UTF-16 surrogates, and returns the same object when nothing changed. It was written to scrub LLM *output* (#3729); it is exactly the shape the retain ingress needs, so it is renamed to drop the `llm` and its docstring now covers both callers. The narrower rule matters: a lone surrogate in `metadata` aborts the very same INSERT — asyncpg cannot UTF-8-encode it — so a NUL-only strip would fix one member of a class and leave the rest open.

Three call sites, all at ingress:

- `MemoryEngine.retain_batch_async` — the per-field scrub of `content`/`context`/`entities` becomes one whole-item walk, so `metadata` (nested values and keys), `tags` and `document_id` are covered and no future field can be forgotten. The entity list keeps its two existing rules: drop an entry whose text sanitized away, and coerce an omitted `type` to `""` (`RetainContent.entities` is `list[dict[str, str]]`).
- `MemoryEngine.submit_async_retain` — the reported failure. Covers the HTTP and MCP callers alike.
- `_handle_file_convert_retain` — same `task_payload::jsonb`, and an upload's caller-supplied metadata/tags never passed through either scrub.

Stripping rather than returning 400, as #3908 argued: the character is transport residue, never meaningful content, and a 400 loses the memory just as completely as the 500 does today.

Out of scope: other endpoints that accept a client `metadata` blob (knowledge pages, file upload) have the same latent exposure. This PR fixes the reported retain paths; the rest is a separate sweep.

## Tests

- `test_async_retain_survives_nul_and_surrogate_in_any_field` — the regression. Submits an item with a NUL in content, context, document_id, a metadata **key**, a nested metadata value, a tag and a batch document tag, plus a lone surrogate, then asserts the committed `task_payload` round-trips clean. Reverting the `submit_async_retain` scrub reproduces the reported `UntranslatableCharacterError` exactly.
- `test_sync_retain_with_nul_in_metadata` — the half #3908 believed was already working. Fails the same way with the scrub reverted.
- `test_sanitize_value_strips_nul_from_a_whole_retain_item` / `test_sanitize_value_preserves_non_hostile_text` — unit coverage for the walk, including dict keys; ordinary unicode (accents, em dash, emoji, tab, newline) passes through byte-for-byte and the item is returned by identity.

`tests/test_async_batch_retain.py` (37) and `tests/test_input_robustness.py` (30) pass locally.

Credit to @slayoffer for the report, the reproduction and the diagnosis in #3908.
