### PR TITLE
fix(tests): stop generating webhook parametrize uuids at collection time

### DIFF
--- a/hindsight-api-slim/tests/test_webhooks.py
+++ b/hindsight-api-slim/tests/test_webhooks.py
@@ -525,9 +525,16 @@ class TestWebhookHttpApi:
         [
             ("POST", "/webhooks", {"url": "https://example.com/hook"}, "create_webhook"),
             ("GET", "/webhooks", None, "list_webhooks"),
-            ("DELETE", f"/webhooks/{uuid.uuid4()}", None, "delete_webhook"),
-            ("PATCH", f"/webhooks/{uuid.uuid4()}", {"enabled": False}, "update_webhook"),
-            ("GET", f"/webhooks/{uuid.uuid4()}/deliveries", None, "list_webhook_deliveries"),
+            # Fixed uuids, not uuid.uuid4(): the value is interpolated into the
+            # parameter — and therefore into the test id — at collection time, and
+            # every xdist worker collects independently. Random ids made each
+            # worker's node-id list differ, so the shard aborted with "Different
+            # tests were collected between gw0 and gw2" whenever more than one
+            # worker picked these up. The endpoint never looks the id up (the
+            # validator rejects the call first), so any well-formed uuid does.
+            ("DELETE", "/webhooks/44499a74-6ba1-4c39-bc1e-7ee63635429d", None, "delete_webhook"),
+            ("PATCH", "/webhooks/66935c96-7b4c-417b-8c60-db8f102bafe9", {"enabled": False}, "update_webhook"),
+            ("GET", "/webhooks/75daa3bb-0cb3-4106-9bac-ac003d8f7b23/deliveries", None, "list_webhook_deliveries"),
         ],
     )
     async def test_http_preserves_operation_validation_error(


### PR DESCRIPTION
## Problem

`test_webhooks.py::TestWebhookHttpApi::test_http_preserves_operation_validation_error` builds three of its parametrize values with `uuid.uuid4()`:

```python
("DELETE", f"/webhooks/{uuid.uuid4()}", None, "delete_webhook"),
```

The value — and therefore the test **id** — is generated when the module is imported. Every xdist worker imports and collects independently, so each one ends up with a different node-id list and the whole shard aborts before running a single test:

```
ERROR gw2 - Different tests were collected between gw0 and gw2. The difference is:
-tests/...[DELETE-/webhooks/44499a74-6ba1-4c39-bc1e-7ee63635429d-None-delete_webhook]
+tests/...[DELETE-/webhooks/b410692e-f635-4ab5-a1f9-c2272f73784c-None-delete_webhook]
```

Whether it fires depends on how pytest-split distributes the file across the three shards — it needs two workers in one shard to collect these three params — which is why it has been intermittent since #3832 rather than constant. Any PR that shifts the split turns it on, and then it is deterministic for that branch: it took down `test-api (3/3)` on both the original run and a clean re-run of #3921, whose diff touches nothing related.

## Fix

Fixed uuid literals. The endpoint never looks the id up — the operation validator rejects the call first — so any well-formed uuid tests exactly the same thing, and the ids are now stable across workers. Comment added so the next person doesn't reintroduce it.

Verified: the 8 tests in that class pass locally, and the shard-3 failure on #3921 is this and only this.