### PR TITLE
fix(consolidation): apply one LLM response's writes in one transaction

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -237,7 +237,7 @@ class _TemporalBounds:
     The SQL spelling differs by reach, deliberately. The dedup folds only ever run on PostgreSQL
     (``_dedup_active`` disables dedup on Oracle) and use the plain
     ``LEAST(col, COALESCE(x, col))``, which is enough there because PostgreSQL ignores NULL
-    arguments. ``_execute_update_action`` also runs on Oracle, where LEAST/GREATEST return NULL
+    arguments. ``_apply_update_action`` also runs on Oracle, where LEAST/GREATEST return NULL
     if any argument is NULL, so it wraps the whole expression in one more COALESCE — see the
     comment there.
     """
@@ -363,34 +363,31 @@ async def _dedup_adjudicate(
     return _DedupOutcome(best_id=best_id, merged_text=merged_text, should_merge=True, best_text=best_text)
 
 
-async def _dedup_reconcile_create(
-    pool: DatabaseBackend,
+async def _apply_dedup_create_fold(
+    conn,
     memory_engine: "MemoryEngine",
     bank_id: str,
     config: Any,
-    dedup_llm_config: Any,
-    create_text: str,
+    outcome: _DedupOutcome,
     create_source_ids: list[uuid.UUID],
-    tags: list[str] | None,
     source_bounds: _TemporalBounds,
     txn=None,
 ) -> str | None:
-    """Semantic dedup for a single CREATE (create-time, focused 1-by-1).
+    """Fold a CREATE the adjudicator called a duplicate into its existing twin.
 
-    On "merge", folds the new source facts + the synthesized text into the existing
-    observation and returns its id (caller skips the CREATE). Returns None when there is
-    no near twin or the LLM keeps them distinct.
+    Runs on the caller's connection, inside the caller's transaction: this is one of the
+    writes derived from a single consolidation LLM response, and all of them commit or roll
+    back together (#3876). The slow half — the embed, the semantic probe and the
+    merge-or-keep adjudication that produced ``outcome`` — already ran connection-free in
+    the prepare phase (:func:`_dedup_adjudicate`).
+
+    Returns the twin's id (the caller then skips the CREATE), or None when the fold did not
+    happen and the observation must be inserted after all.
 
     ``source_bounds`` are the dates the skipped CREATE would have been stamped with. They are
     folded into the twin too: this path bypasses the CREATE writer, so without them the twin
     would cite dated source facts while reporting the dates of its original sources only (#3477).
-
-    The probe/embed/LLM adjudication runs with no connection held; the fold takes a
-    short-lived connection and re-checks source liveness inside the fold transaction.
     """
-    outcome = await _dedup_adjudicate(
-        pool, memory_engine, bank_id, config, dedup_llm_config, create_text, None, tags, exclude_id=None
-    )
     if not outcome.should_merge or outcome.best_id is None:
         return None
 
@@ -398,195 +395,171 @@ async def _dedup_reconcile_create(
     # twin's existing embedding (the merged text is >= threshold similar, so it stays
     # representative and avoids a re-embed + a dialect-specific vector UPDATE).
     store = get_memories()
-    async with acquire_with_retry(pool) as conn:
-        async with conn.transaction():
-            # Re-check liveness inside the fold transaction; CREATE performed the slow embed/LLM
-            # work off-connection, so sources may have been deleted since the decision was made.
-            live_source_ids = await _filter_live_source_memories(conn, bank_id, create_source_ids)
-            if not live_source_ids:
-                return None
-            if store.writes_memory_rows_in_sql_for(bank_id):
-                # Oracle-safe: _native_search_vector_update emits the to_tsvector clause only for a
-                # native PG tsvector column, "" otherwise (see #3021 — the raw ::regconfig cast
-                # breaks Oracle). RETURNING-gate on the twin's probe-time text so a concurrent
-                # survivor rewrite during the connection-free LLM window can't be clobbered.
-                search_vector_clause = _native_search_vector_update(config, "$1")
-                folded = await conn.fetchval(
-                    f"""
-                    UPDATE {fq_table("memory_units")}
-                    SET text = $1,
-                        source_memory_ids = (SELECT array_agg(DISTINCT e) FROM unnest(source_memory_ids || $2::uuid[]) e),
-                        proof_count = (SELECT count(DISTINCT e) FROM unnest(source_memory_ids || $2::uuid[]) e),
-                        event_date = LEAST(event_date, COALESCE($5, event_date)),
-                        occurred_start = LEAST(occurred_start, COALESCE($6, occurred_start)),
-                        occurred_end = GREATEST(occurred_end, COALESCE($7, occurred_end)),
-                        mentioned_at = GREATEST(mentioned_at, COALESCE($8, mentioned_at)),
-                        updated_at = now(){search_vector_clause}
-                    WHERE id = $3::uuid AND text = $4
-                    RETURNING id
-                    """,
-                    outcome.merged_text,
-                    live_source_ids,
-                    uuid.UUID(outcome.best_id),
-                    outcome.best_text,
-                    source_bounds.event_date,
-                    source_bounds.occurred_start,
-                    source_bounds.occurred_end,
-                    source_bounds.mentioned_at,
-                )
-                if folded is None:
-                    # The twin vanished (or was rewritten) during the connection-free LLM window.
-                    # Don't skip the CREATE: returning None lets the caller insert the observation
-                    # so nothing is lost.
-                    logger.debug(
-                        "[CONSOLIDATION] dedup-merge target %s vanished before fold; proceeding with CREATE",
-                        outcome.best_id[:8],
-                    )
-                    return None
-            else:
-                await _reconcile_merge_via_store(
-                    store,
-                    conn,
-                    memory_engine,
-                    bank_id,
-                    outcome.best_id,
-                    outcome.merged_text,
-                    live_source_ids,
-                    source_bounds,
-                    txn=txn,
-                )
+    # Re-check liveness inside the write transaction; CREATE performed the slow embed/LLM
+    # work off-connection, so sources may have been deleted since the decision was made.
+    live_source_ids = await _filter_live_source_memories(conn, bank_id, create_source_ids)
+    if not live_source_ids:
+        return None
+    if store.writes_memory_rows_in_sql_for(bank_id):
+        # Oracle-safe: _native_search_vector_update emits the to_tsvector clause only for a
+        # native PG tsvector column, "" otherwise (see #3021 — the raw ::regconfig cast
+        # breaks Oracle). RETURNING-gate on the twin's probe-time text so a concurrent
+        # survivor rewrite during the connection-free LLM window can't be clobbered.
+        search_vector_clause = _native_search_vector_update(config, "$1")
+        folded = await conn.fetchval(
+            f"""
+            UPDATE {fq_table("memory_units")}
+            SET text = $1,
+                source_memory_ids = (SELECT array_agg(DISTINCT e) FROM unnest(source_memory_ids || $2::uuid[]) e),
+                proof_count = (SELECT count(DISTINCT e) FROM unnest(source_memory_ids || $2::uuid[]) e),
+                event_date = LEAST(event_date, COALESCE($5, event_date)),
+                occurred_start = LEAST(occurred_start, COALESCE($6, occurred_start)),
+                occurred_end = GREATEST(occurred_end, COALESCE($7, occurred_end)),
+                mentioned_at = GREATEST(mentioned_at, COALESCE($8, mentioned_at)),
+                updated_at = now(){search_vector_clause}
+            WHERE id = $3::uuid AND text = $4
+            RETURNING id
+            """,
+            outcome.merged_text,
+            live_source_ids,
+            uuid.UUID(outcome.best_id),
+            outcome.best_text,
+            source_bounds.event_date,
+            source_bounds.occurred_start,
+            source_bounds.occurred_end,
+            source_bounds.mentioned_at,
+        )
+        if folded is None:
+            # The twin vanished (or was rewritten) during the connection-free LLM window.
+            # Don't skip the CREATE: returning None lets the caller insert the observation
+            # so nothing is lost.
+            logger.debug(
+                "[CONSOLIDATION] dedup-merge target %s vanished before fold; proceeding with CREATE",
+                outcome.best_id[:8],
+            )
+            return None
+    else:
+        await _reconcile_merge_via_store(
+            store,
+            conn,
+            memory_engine,
+            bank_id,
+            outcome.best_id,
+            outcome.merged_text,
+            live_source_ids,
+            source_bounds,
+            txn=txn,
+        )
     return outcome.best_id
 
 
-async def _dedup_reconcile_update(
-    pool: DatabaseBackend,
+async def _apply_dedup_update_fold(
+    conn,
     memory_engine: "MemoryEngine",
     bank_id: str,
     config: Any,
-    dedup_llm_config: Any,
+    outcome: _DedupOutcome,
     updated_id: str,
     updated_text: str,
-    updated_emb_str: str | None,
-    tags: list[str] | None,
     txn=None,
-) -> None:
-    """Semantic dedup for an UPDATE (after the observation was rewritten + re-embedded).
+) -> bool:
+    """Fold a just-rewritten observation into the twin the adjudicator matched it to.
 
     An UPDATE rewrites an observation's text and re-embeds it, so its vector can drift to
     within threshold of a DIFFERENT existing observation. The create-time guard never sees
     this (it only runs on CREATE), so without this the two persist as a near-duplicate pair —
-    the measured residual-duplicate source. Probe the updated observation's new embedding
-    against the others (excluding itself); on "merge", fold the just-updated observation's
+    the measured residual-duplicate source. On "merge", fold the just-updated observation's
     sources into the twin, persist the merged text, and DELETE the updated row. Unlike the
     CREATE path the row already exists, so reconciliation is a fold-and-delete, not a skip.
-    """
-    outcome = await _dedup_adjudicate(
-        pool,
-        memory_engine,
-        bank_id,
-        config,
-        dedup_llm_config,
-        updated_text,
-        updated_emb_str,
-        tags,
-        exclude_id=updated_id,
-    )
-    if not outcome.should_merge or outcome.best_id is None:
-        return
 
-    # Fold the updated observation's live sources into the twin (keeping the twin's embedding, as
-    # in the create path) then delete the now-redundant updated row. The all_strict/any tag match
-    # guarantees twin and updated share scope, so dropping the updated row's tags loses no
-    # visibility. Temporal fields are the UNION of both rows' bounds: the updated row is about to
-    # be deleted, so anything only it knew about would otherwise be lost with it (#3477).
-    # The fold + delete share one short transaction so the twin gains the sources exactly as the
-    # redundant row is removed; the slow adjudication above already ran connection-free.
+    Like :func:`_apply_dedup_create_fold` this runs on the caller's connection inside the
+    caller's transaction (#3876); ``outcome`` comes from the connection-free prepare phase.
+    Returns True when the updated row was folded away.
+    """
+    if not outcome.should_merge or outcome.best_id is None:
+        return False
+
     store = get_memories()
-    async with acquire_with_retry(pool) as conn:
-        async with conn.transaction():
-            if store.writes_memory_rows_in_sql_for(bank_id):
-                # Snapshot the updated row's sources with a PLAIN read (no FOR UPDATE). Lock order
-                # must be sources-before-observation: _filter_live_source_memories below takes
-                # FOR SHARE on the SOURCE rows first, then the fold UPDATE locks the observation
-                # rows -- the same order as _dedup_reconcile_create and the normal write paths
-                # (_create_observation_directly / _execute_update_action). Locking the observation
-                # here (FOR UPDATE) would invert that against the invalidation path and deadlock.
-                updated_row = await conn.fetchrow(
-                    f"""
-                    SELECT source_memory_ids
-                    FROM {fq_table("memory_units")}
-                    WHERE id = $1::uuid AND text = $2
-                    """,
-                    uuid.UUID(updated_id),
-                    updated_text,
-                )
-                if updated_row is None:
-                    return
-                live_u_sources = await _filter_live_source_memories(
-                    conn, bank_id, list(updated_row["source_memory_ids"] or [])
-                )
-                if not live_u_sources:
-                    return
-                # Oracle-safe search_vector clause (#3021): "" unless a native PG tsvector column.
-                # RETURNING-gate on both rows' probe-time text so a survivor/updated rewrite during
-                # the connection-free LLM window can't be clobbered or fold a stale row.
-                search_vector_clause = _native_search_vector_update(config, "$1")
-                folded = await conn.fetchval(
-                    f"""
-                    UPDATE {fq_table("memory_units")} t
-                    SET text = $1,
-                        source_memory_ids = (
-                            SELECT array_agg(DISTINCT e) FROM unnest(t.source_memory_ids || $6::uuid[]) e
-                        ),
-                        proof_count = (
-                            SELECT count(DISTINCT e) FROM unnest(t.source_memory_ids || $6::uuid[]) e
-                        ),
-                        event_date = LEAST(t.event_date, COALESCE(u.event_date, t.event_date)),
-                        occurred_start = LEAST(t.occurred_start, COALESCE(u.occurred_start, t.occurred_start)),
-                        occurred_end = GREATEST(t.occurred_end, COALESCE(u.occurred_end, t.occurred_end)),
-                        mentioned_at = GREATEST(t.mentioned_at, COALESCE(u.mentioned_at, t.mentioned_at)),
-                        updated_at = now(){search_vector_clause}
-                    FROM {fq_table("memory_units")} u
-                    WHERE t.id = $2::uuid AND u.id = $3::uuid AND t.text = $4 AND u.text = $5
-                    RETURNING t.id
-                    """,
-                    outcome.merged_text,
-                    uuid.UUID(outcome.best_id),
-                    uuid.UUID(updated_id),
-                    outcome.best_text,
-                    updated_text,
-                    live_u_sources,
-                )
-                if folded is None:
-                    # Twin or updated row vanished during the LLM window — keep the updated row
-                    # as a distinct observation instead of deleting it unfolded.
-                    return
-            else:
-                updated_obs = await store.get_memories(
-                    conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[updated_id]
-                )
-                updated_sources = list(updated_obs[0].source_memory_ids or []) if updated_obs else []
-                live_u_sources = await _filter_live_source_memories(conn, bank_id, updated_sources)
-                if not live_u_sources:
-                    return
-                await _reconcile_merge_via_store(
-                    store,
-                    conn,
-                    memory_engine,
-                    bank_id,
-                    outcome.best_id,
-                    outcome.merged_text,
-                    live_u_sources,
-                    _TemporalBounds.of(updated_obs[0]),
-                    txn=txn,
-                )
-            await _execute_delete_action(conn, bank_id, updated_id, txn=txn)
+    if store.writes_memory_rows_in_sql_for(bank_id):
+        # Snapshot the updated row's sources with a PLAIN read (no FOR UPDATE). Lock order
+        # must be sources-before-observation: _filter_live_source_memories below takes
+        # FOR SHARE on the SOURCE rows first, then the fold UPDATE locks the observation
+        # rows -- the same order as _apply_dedup_create_fold and the normal write paths
+        # (_apply_create_observation / _apply_update_action). Locking the observation
+        # here (FOR UPDATE) would invert that against the invalidation path and deadlock.
+        updated_row = await conn.fetchrow(
+            f"""
+            SELECT source_memory_ids
+            FROM {fq_table("memory_units")}
+            WHERE id = $1::uuid AND text = $2
+            """,
+            uuid.UUID(updated_id),
+            updated_text,
+        )
+        if updated_row is None:
+            return False
+        live_u_sources = await _filter_live_source_memories(conn, bank_id, list(updated_row["source_memory_ids"] or []))
+        if not live_u_sources:
+            return False
+        # Oracle-safe search_vector clause (#3021): "" unless a native PG tsvector column.
+        # RETURNING-gate on both rows' probe-time text so a survivor/updated rewrite during
+        # the connection-free LLM window can't be clobbered or fold a stale row.
+        search_vector_clause = _native_search_vector_update(config, "$1")
+        folded = await conn.fetchval(
+            f"""
+            UPDATE {fq_table("memory_units")} t
+            SET text = $1,
+                source_memory_ids = (
+                    SELECT array_agg(DISTINCT e) FROM unnest(t.source_memory_ids || $6::uuid[]) e
+                ),
+                proof_count = (
+                    SELECT count(DISTINCT e) FROM unnest(t.source_memory_ids || $6::uuid[]) e
+                ),
+                event_date = LEAST(t.event_date, COALESCE(u.event_date, t.event_date)),
+                occurred_start = LEAST(t.occurred_start, COALESCE(u.occurred_start, t.occurred_start)),
+                occurred_end = GREATEST(t.occurred_end, COALESCE(u.occurred_end, t.occurred_end)),
+                mentioned_at = GREATEST(t.mentioned_at, COALESCE(u.mentioned_at, t.mentioned_at)),
+                updated_at = now(){search_vector_clause}
+            FROM {fq_table("memory_units")} u
+            WHERE t.id = $2::uuid AND u.id = $3::uuid AND t.text = $4 AND u.text = $5
+            RETURNING t.id
+            """,
+            outcome.merged_text,
+            uuid.UUID(outcome.best_id),
+            uuid.UUID(updated_id),
+            outcome.best_text,
+            updated_text,
+            live_u_sources,
+        )
+        if folded is None:
+            # Twin or updated row vanished during the LLM window — keep the updated row
+            # as a distinct observation instead of deleting it unfolded.
+            return False
+    else:
+        updated_obs = await store.get_memories(conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[updated_id])
+        updated_sources = list(updated_obs[0].source_memory_ids or []) if updated_obs else []
+        live_u_sources = await _filter_live_source_memories(conn, bank_id, updated_sources)
+        if not live_u_sources:
+            return False
+        await _reconcile_merge_via_store(
+            store,
+            conn,
+            memory_engine,
+            bank_id,
+            outcome.best_id,
+            outcome.merged_text,
+            live_u_sources,
+            _TemporalBounds.of(updated_obs[0]),
+            txn=txn,
+        )
+    await _execute_delete_action(conn, bank_id, updated_id, txn=txn)
     logger.info(
         "[CONSOLIDATION] dedup-merged updated observation %s into %s (cosine>=%.2f)",
         updated_id[:8],
         outcome.best_id[:8],
         config.consolidation_dedup_threshold,
     )
+    return True
 
 
 @dataclass
@@ -804,6 +777,47 @@ class _ConsolidationBatchResponse(BaseModel):
     creates: list[_CreateAction] = []
     updates: list[_UpdateAction] = []
     deletes: list[_DeleteAction] = []
+
+
+@dataclass
+class _PreparedUpdate:
+    """One UPDATE from an LLM response, with every slow step already done.
+
+    Consolidation applies all of a response's writes in a single transaction (#3876), and a
+    transaction must never be held open across an embedder or LLM call. So each action is
+    first *prepared* connection-free — the source facts resolved and security-checked, the
+    new text embedded, the semantic-dedup verdict adjudicated — and the resulting value
+    object carries everything the write needs.
+    """
+
+    update: _UpdateAction
+    #: Pre-update snapshot of the observation, from the batch's recall.
+    model: "MemoryFact"
+    source_mems: list[dict[str, Any]]
+    source_memory_ids: list[uuid.UUID]
+    source_fact_tags: list[str]
+    source_bounds: _TemporalBounds
+    embedding_str: str | None
+    #: Fold target for the rewritten observation, when create/update dedup is enabled and
+    #: the re-embed drifted it into a near-twin.
+    dedup: _DedupOutcome | None = None
+
+
+@dataclass
+class _PreparedCreate:
+    """One CREATE from an LLM response, with every slow step already done.
+
+    See :class:`_PreparedUpdate`. ``dedup`` here is a fold into an existing near-twin,
+    which replaces the insert rather than following it.
+    """
+
+    text: str
+    source_mems: list[dict[str, Any]]
+    source_memory_ids: list[uuid.UUID]
+    source_fact_tags: list[str]
+    agg: "_SourceAggregation"
+    embedding_str: str | None
+    dedup: _DedupOutcome | None = None
 
 
 @dataclass
@@ -1504,15 +1518,21 @@ async def _run_consolidation_job(
                     sub_batch = pending.pop(0)
 
                     # No connection is held across the batch: recall, the main LLM call, the
-                    # per-action embeds, and dedup all run connection-free; each helper acquires a
-                    # short-lived connection only around its own SQL.
+                    # per-action embeds, and dedup adjudication all run connection-free. Only then
+                    # does the sub-batch take one connection and write everything that LLM response
+                    # decided — observations and consolidated_at stamps alike — in one transaction.
                     obs_tags_list = _resolve_obs_tags_list(sub_batch[0]) if sub_batch else None
 
                     sub_deleted: int = 0
                     sub_llm_failed = False
+                    sub_ids = [m["id"] for m in sub_batch]
                     if obs_tags_list:
                         sub_results: list[dict[str, Any]] = []
-                        for obs_tags in obs_tags_list:
+                        for pass_index, obs_tags in enumerate(obs_tags_list):
+                            # A memory consolidated at several tag scopes gets one LLM call per
+                            # scope; the ``consolidated_at`` stamp belongs to the last of them, so
+                            # an earlier scope's write and the stamp never commit apart (#3876).
+                            is_final_pass = pass_index == len(obs_tags_list) - 1
                             pass_results, pass_deleted, pass_failed = await _process_memory_batch(
                                 pool=pool,
                                 memory_engine=memory_engine,
@@ -1523,10 +1543,16 @@ async def _run_consolidation_job(
                                 perf=batch_perf,
                                 config=config,
                                 obs_tags_override=obs_tags,
+                                mark_consolidated_ids=sub_ids if is_final_pass else None,
                                 txn=_batch_txn,
                             )
                             sub_deleted += pass_deleted
-                            sub_llm_failed = sub_llm_failed or pass_failed
+                            if pass_failed:
+                                # Stop the remaining scopes: the sub-batch is going to be bisected
+                                # and re-run in full, and every write this pass made is already
+                                # committed. Running the rest would only add writes to discard.
+                                sub_llm_failed = True
+                                break
                             if not sub_results:
                                 sub_results = pass_results
                             else:
@@ -1560,6 +1586,7 @@ async def _run_consolidation_job(
                             request_context=request_context,
                             perf=batch_perf,
                             config=config,
+                            mark_consolidated_ids=sub_ids,
                             txn=_batch_txn,
                         )
 
@@ -1583,23 +1610,17 @@ async def _run_consolidation_job(
                         succeeded_ids.extend(m["id"] for m in sub_batch)
                         all_results.extend(sub_results)
 
-                # Mark through the store so the flag lands wherever the source facts live — tagged
-                # with this batch's txn, so the marks become visible together with the observations
-                # above. Then record the witness row and commit in this ONE short transaction (no LLM
-                # work inside it): its commit is the batch's fate, and `decide` publishes the group.
+                # The successful sub-batches stamped their own ``consolidated_at`` inside the
+                # transaction that wrote their observations (#3876) — a stamp and the writes it
+                # accounts for must never commit apart. What is left here is the failed ids, which
+                # have no writes to share a transaction with, the witness row, and the refresh
+                # tags. Marking goes through the store so the flag lands wherever the source facts
+                # live — tagged with this batch's txn, so it becomes visible with the observations.
+                # The witness commit in this ONE short transaction (no LLM work inside it) is the
+                # batch's fate, and `decide` publishes the group.
                 async with acquire_with_retry(pool) as conn:
                     store = get_memories()
                     now = datetime.now(timezone.utc)
-                    if succeeded_ids:
-                        await store.mark_consolidated(
-                            conn=conn,
-                            fq_table=fq_table,
-                            bank_id=bank_id,
-                            unit_ids=[str(mem_id) for mem_id in succeeded_ids],
-                            when=now,
-                            failed=False,
-                            txn=_batch_txn,
-                        )
                     if failed_ids:
                         await store.mark_consolidated(
                             conn=conn,
@@ -2082,6 +2103,7 @@ async def _process_memory_batch(
     perf: ConsolidationPerfLog | None = None,
     config: Any = None,
     obs_tags_override: list[str] | None = None,
+    mark_consolidated_ids: list[Any] | None = None,
     txn=None,
 ) -> tuple[list[dict[str, Any]], int, bool]:
     """
@@ -2091,7 +2113,7 @@ async def _process_memory_batch(
     1. Parallel recalls — one per fact (read-only; safe to parallelise)
     2. Union of retrieved observations across the batch (deduped by id)
     3. Single LLM call with all N facts + unioned observations
-    4. Sequential action execution (writes remain serial for consistency)
+    4. Prepare every action connection-free, then apply them in ONE transaction
     5. Returns one result dict per memory, in the same order as `memories`
 
     Per-fact security: action execution validates each learning_id against the
@@ -2103,6 +2125,10 @@ async def _process_memory_batch(
             create/update instead of the memory's own tags. This enables multi-pass
             consolidation where a single memory can contribute to observations
             scoped at different tag levels (e.g., user-level vs session-level).
+        mark_consolidated_ids: Source facts to stamp ``consolidated_at`` inside this
+            batch's write transaction, so the stamps share the fate of the observations
+            derived from the same LLM response (#3876). None on a pass that is not the
+            final one for these memories — the caller stamps once, on the last pass.
     """
     # Map the source memories this batch consumes onto the consolidation trace.
     record_source_memory_ids([str(m["id"]) for m in memories])
@@ -2189,9 +2215,21 @@ async def _process_memory_batch(
         perf.record_timing("llm", time.time() - t0)
         perf.record_llm_call(llm_result.obs_count, llm_result.prompt_chars)
 
-    # 4. Sequential execution of deletes / updates / creates
-    # Deletes run first to free observation slots before creates consume them.
-    # Track which memory indices participated so we can build per-memory results for stats
+    # 4. Prepare every action connection-free, then apply them all in ONE transaction.
+    #
+    # Before #3876 each action wrote on its own connection the moment it was decided:
+    # deletes first (to free observation slots), then updates, then creates. A batch whose
+    # DELETE succeeded and whose replacement CREATE then failed — a raising embedder, a
+    # cancelled sibling, a create silently dropped because the model cited a fact id that
+    # was not in this batch — left the observation deleted and nothing in its place, while
+    # the source facts were still stamped ``consolidated_at`` and so were never
+    # re-consolidated. The knowledge was gone with the operation still reporting
+    # ``completed``. The writes derived from one LLM response are now all-or-nothing, and
+    # the ``consolidated_at`` stamps for the facts that response consumed commit with them.
+    #
+    # The transaction must therefore contain no LLM or embedder call: each action is first
+    # prepared (source facts resolved and security-checked, text embedded, semantic-dedup
+    # verdict adjudicated) with no connection held, and only then written.
     per_memory_created: set[str] = set()
     per_memory_updated: set[str] = set()
 
@@ -2211,22 +2249,22 @@ async def _process_memory_batch(
         else None
     )
 
-    # Execute deletes first to free observation slots before creates consume them. Each delete
-    # is a single fast statement, so the whole loop shares one short-lived connection.
-    deleted_count = 0
-    if llm_result.deletes:
-        async with acquire_with_retry(pool) as conn:
-            for delete in llm_result.deletes:
-                # Security: the observation must be present in the unioned recall
-                if not any(str(obs.id) == delete.observation_id for obs in union_observations):
-                    logger.debug(
-                        f"Batch consolidation: rejected delete — observation {delete.observation_id} "
-                        f"not in unioned recall"
-                    )
-                    continue
-                await _execute_delete_action(conn=conn, bank_id=bank_id, observation_id=delete.observation_id, txn=txn)
-                deleted_count += 1
+    # --- Prepare: deletes -----------------------------------------------------
+    # Deletes carry no slow work; validating them here keeps the whole decision set in
+    # one place. They are still applied first inside the transaction, so an observation
+    # slot freed by a delete is available to a create in the same response.
+    prepared_deletes: list[str] = []
+    for delete in llm_result.deletes:
+        # Security: the observation must be present in the unioned recall
+        if not any(str(obs.id) == delete.observation_id for obs in union_observations):
+            logger.debug(
+                f"Batch consolidation: rejected delete — observation {delete.observation_id} not in unioned recall"
+            )
+            continue
+        prepared_deletes.append(delete.observation_id)
 
+    # --- Prepare: updates -----------------------------------------------------
+    prepared_updates: list[_PreparedUpdate] = []
     for update in llm_result.updates:
         source_mems = [mem_by_id[fid] for fid in update.source_fact_ids if fid in mem_by_id]
         if not source_mems:
@@ -2238,39 +2276,49 @@ async def _process_memory_batch(
                 f"not in any source fact's recall"
             )
             continue
+        model = next((m for m in union_observations if str(m.id) == update.observation_id), None)
+        if model is None:
+            logger.debug(f"Update skipped: observation {update.observation_id} not found in recall results")
+            continue
         agg = _aggregate_source_fields(source_mems, tags=fact_tags)
-        updated_emb_str = await _execute_update_action(
-            pool=pool,
-            memory_engine=memory_engine,
-            bank_id=bank_id,
-            source_memory_ids=[m["id"] for m in source_mems],
-            observation_id=update.observation_id,
-            new_text=update.text,
-            observations=union_observations,
+        source_memory_ids = [m["id"] for m in source_mems]
+        # Preflight (non-locking, short-lived conn): if every source memory is already gone,
+        # skip BEFORE the slow embed. The write itself re-checks liveness under FOR SHARE.
+        async with acquire_with_retry(pool) as conn:
+            if not await _any_live_source_memory(conn, bank_id, source_memory_ids):
+                logger.debug(
+                    f"Update skipped: all {len(source_memory_ids)} source memories for observation "
+                    f"{update.observation_id} were deleted before embedding"
+                )
+                continue
+        embedding_str = await _embed_observation_text(memory_engine, update.text, perf)
+        prepared = _PreparedUpdate(
+            update=update,
+            model=model,
+            source_mems=source_mems,
+            source_memory_ids=source_memory_ids,
             source_fact_tags=agg.tags,
             source_bounds=_TemporalBounds.of(agg),
-            perf=perf,
-            txn=txn,
+            embedding_str=embedding_str,
         )
-        for m in source_mems:
-            per_memory_updated.add(str(m["id"]))
         # Reconcile the rewritten observation against its neighbours: the re-embed may have
         # drifted it into a near-twin of another existing observation (the residual-duplicate
-        # source). updated_emb_str is None when the update was skipped — nothing to reconcile.
-        if dedup_enabled and updated_emb_str is not None:
-            await _dedup_reconcile_update(
+        # source). Adjudicated here, folded inside the transaction below.
+        if dedup_enabled and embedding_str is not None:
+            prepared.dedup = await _dedup_adjudicate(
                 pool,
                 memory_engine,
                 bank_id,
                 config,
                 dedup_llm_config,
-                update.observation_id,
                 update.text,
-                updated_emb_str,
+                embedding_str,
                 agg.tags,
-                txn=txn,
+                exclude_id=update.observation_id,
             )
+        prepared_updates.append(prepared)
 
+    # --- Prepare: creates -----------------------------------------------------
     # Deterministic dedup guard: map the observations the LLM was SHOWN by their
     # normalised text. The model intermittently emits a CREATE whose text is identical
     # to an observation already in its context (over-aggregation / incoherence — it even
@@ -2282,6 +2330,7 @@ async def _process_memory_batch(
     # response (the model occasionally UPDATEs the twin to text X and also CREATEs X).
     update_texts = {_norm_obs_text(u.text) for u in llm_result.updates if u.text}
 
+    prepared_creates: list[_PreparedCreate] = []
     for create in llm_result.creates:
         source_mems = [mem_by_id[fid] for fid in create.source_fact_ids if fid in mem_by_id]
         if not source_mems:
@@ -2304,50 +2353,130 @@ async def _process_memory_batch(
             )
             continue
 
+        async with acquire_with_retry(pool) as conn:
+            if not await _any_live_source_memory(conn, bank_id, create_source_ids):
+                logger.debug(
+                    f"Create skipped: all {len(create_source_ids)} source memories were deleted before embedding"
+                )
+                continue
+        embedding_str = await _embed_observation_text(memory_engine, create.text, perf)
+        prepared_create = _PreparedCreate(
+            text=create.text,
+            source_mems=source_mems,
+            source_memory_ids=create_source_ids,
+            source_fact_tags=agg.tags,
+            agg=agg,
+            embedding_str=embedding_str,
+        )
         # Semantic near-duplicate reconciliation: merge this CREATE into an existing
         # near-identical observation (LLM-adjudicated, 1-by-1) instead of inserting a dup.
+        # The probe reads the state the batch started from, so two near-twin CREATEs in ONE
+        # response can both land; the next round's probe sees them and folds them, and the
+        # exact-text guard above already covers the common case.
         if dedup_enabled:
-            merged_into = await _dedup_reconcile_create(
+            prepared_create.dedup = await _dedup_adjudicate(
                 pool,
                 memory_engine,
                 bank_id,
                 config,
                 dedup_llm_config,
                 create.text,
-                create_source_ids,
+                embedding_str,
                 agg.tags,
-                _TemporalBounds.of(agg),
-                txn=txn,
+                exclude_id=None,
             )
-            if merged_into is not None:
-                logger.info(
-                    "[CONSOLIDATION] dedup-merged observation CREATE into %s (cosine>=%.2f)",
-                    merged_into[:8],
-                    config.consolidation_dedup_threshold,
-                )
-                for m in source_mems:
-                    per_memory_created.add(str(m["id"]))
-                continue
+        prepared_creates.append(prepared_create)
 
-        action = await _execute_create_action(
-            pool=pool,
-            memory_engine=memory_engine,
-            bank_id=bank_id,
-            source_memory_ids=create_source_ids,
-            text=create.text,
-            source_fact_tags=agg.tags,
-            event_date=agg.event_date,
-            occurred_start=agg.occurred_start,
-            occurred_end=agg.occurred_end,
-            mentioned_at=agg.mentioned_at,
-            perf=perf,
-            txn=txn,
-        )
-        # Count a memory as created only when an observation was actually written (the
-        # source-liveness recheck inside the write txn can skip it connection-free).
-        if action == "created":
-            for m in source_mems:
-                per_memory_created.add(str(m["id"]))
+    # --- Apply: one transaction for everything this LLM response decided ------
+    deleted_count = 0
+    # A failed LLM call yields no actions, and its memories must NOT be stamped: the caller
+    # bisects and retries them, and a stamp would exclude them from pending consolidation
+    # for good. With neither writes nor stamps there is nothing to open a transaction for.
+    stamp_ids = list(mark_consolidated_ids or []) if not llm_result.failed else []
+    if prepared_deletes or prepared_updates or prepared_creates or stamp_ids:
+        async with acquire_with_retry(pool) as conn:
+            async with conn.transaction():
+                for observation_id in prepared_deletes:
+                    await _execute_delete_action(conn=conn, bank_id=bank_id, observation_id=observation_id, txn=txn)
+                    deleted_count += 1
+
+                for prepared in prepared_updates:
+                    updated_emb_str = await _apply_update_action(
+                        conn=conn,
+                        memory_engine=memory_engine,
+                        bank_id=bank_id,
+                        prepared=prepared,
+                        perf=perf,
+                        txn=txn,
+                    )
+                    if updated_emb_str is None:
+                        # Skipped inside the write (sources or the observation vanished).
+                        continue
+                    for m in prepared.source_mems:
+                        per_memory_updated.add(str(m["id"]))
+                    if prepared.dedup is not None:
+                        await _apply_dedup_update_fold(
+                            conn,
+                            memory_engine,
+                            bank_id,
+                            config,
+                            prepared.dedup,
+                            prepared.update.observation_id,
+                            prepared.update.text,
+                            txn=txn,
+                        )
+
+                for prepared_create in prepared_creates:
+                    if prepared_create.dedup is not None:
+                        merged_into = await _apply_dedup_create_fold(
+                            conn,
+                            memory_engine,
+                            bank_id,
+                            config,
+                            prepared_create.dedup,
+                            prepared_create.source_memory_ids,
+                            _TemporalBounds.of(prepared_create.agg),
+                            txn=txn,
+                        )
+                        if merged_into is not None:
+                            logger.info(
+                                "[CONSOLIDATION] dedup-merged observation CREATE into %s (cosine>=%.2f)",
+                                merged_into[:8],
+                                config.consolidation_dedup_threshold,
+                            )
+                            for m in prepared_create.source_mems:
+                                per_memory_created.add(str(m["id"]))
+                            continue
+
+                    action = await _apply_create_action(
+                        conn=conn,
+                        memory_engine=memory_engine,
+                        bank_id=bank_id,
+                        prepared=prepared_create,
+                        perf=perf,
+                        txn=txn,
+                    )
+                    # Count a memory as created only when an observation was actually written (the
+                    # source-liveness recheck inside the write can skip it).
+                    if action == "created":
+                        for m in prepared_create.source_mems:
+                            per_memory_created.add(str(m["id"]))
+
+                # The facts this response consumed are marked consolidated in the SAME transaction
+                # as the observations that now carry them. Stamping them separately is what let a
+                # half-applied batch orphan its sources forever: the pending-consolidation predicate
+                # excludes a stamped fact, so nothing would ever rebuild what the batch failed to
+                # write (#3876).
+                if stamp_ids:
+                    await get_memories().mark_consolidated(
+                        conn=conn,
+                        fq_table=fq_table,
+                        bank_id=bank_id,
+                        unit_ids=[str(mem_id) for mem_id in stamp_ids],
+                        when=datetime.now(timezone.utc),
+                        failed=False,
+                        txn=txn,
+                    )
 
     # Build per-memory result dicts for the stats tracker in the outer loop
     results: list[dict[str, Any]] = []
@@ -2442,209 +2571,184 @@ async def _append_observation_history(
         )
 
 
-async def _execute_update_action(
-    pool: DatabaseBackend,
+async def _apply_update_action(
+    conn,
     memory_engine: "MemoryEngine",
     bank_id: str,
-    source_memory_ids: list[uuid.UUID],
-    observation_id: str,
-    new_text: str,
-    observations: list["MemoryFact"],
-    source_fact_tags: list[str] | None = None,
-    source_bounds: _TemporalBounds = _TemporalBounds(),
+    prepared: _PreparedUpdate,
     perf: ConsolidationPerfLog | None = None,
     txn=None,
 ) -> str | None:
-    """
-    Update an existing observation.
+    """Write one prepared UPDATE: rewrite the observation and re-attach its sources.
 
     Extends source_memory_ids with all contributing memories, widens the observation's temporal
-    bounds by ``source_bounds`` (see :class:`_TemporalBounds`), and merges tags.
+    bounds by ``prepared.source_bounds`` (see :class:`_TemporalBounds`), and merges tags.
 
-    The embedding is computed off-connection (a slow embedder must never pin a pooled
-    connection); the liveness check + UPDATE + history + observation_sources sync then run
-    in one short transaction so they commit atomically.
+    Runs entirely on the caller's connection inside the caller's transaction. Everything slow —
+    the liveness preflight and the embedding — already happened in the prepare phase, so this
+    write commits or rolls back together with every other write derived from the same LLM
+    response, including the ``consolidated_at`` stamps for its source facts (#3876).
 
-    Returns the observation's freshly-computed embedding (pgvector literal) so the caller can
-    run UPDATE-path dedup without re-embedding, or None when the update was skipped.
+    Returns the observation's embedding (pgvector literal) so the caller can run UPDATE-path
+    dedup without re-embedding, or None when the update was skipped.
     """
-    model = next((m for m in observations if str(m.id) == observation_id), None)
-    if not model:
-        logger.debug(f"Update skipped: observation {observation_id} not found in recall results")
-        return None
-
     from ...config import get_config
 
-    # Preflight (non-locking, separate short-lived conn): if every source memory is already
-    # gone, skip BEFORE the slow embed — restores the pre-refactor short-circuit so a no-op
-    # update doesn't embed and a failing embedder doesn't raise where it used to skip.
-    async with acquire_with_retry(pool) as conn:
-        if not await _any_live_source_memory(conn, bank_id, source_memory_ids):
-            logger.debug(
-                f"Update skipped: all {len(source_memory_ids)} source memories for observation "
-                f"{observation_id} were deleted before embedding"
-            )
-            return None
-
-    # Embed off-connection: the new text is known up front and does not depend on
-    # any DB state, so the (slow) embedder runs before we touch the pool.
-    t0 = time.time()
-    embeddings = await embedding_utils.generate_embeddings_batch(memory_engine.embeddings, [new_text])
-    embedding_str = str(embeddings[0]) if embeddings else None
-    if perf:
-        perf.record_timing("embedding", time.time() - t0)
+    model = prepared.model
+    observation_id = prepared.update.observation_id
+    new_text = prepared.update.text
+    source_memory_ids = prepared.source_memory_ids
+    source_fact_tags = prepared.source_fact_tags
+    source_bounds = prepared.source_bounds
+    embedding_str = prepared.embedding_str
 
     config = get_config()
     search_vector_clause = _native_search_vector_update(config, "$1")
     store = get_memories()
 
-    async with acquire_with_retry(pool) as conn:
-        async with conn.transaction():
-            # FOR SHARE liveness + the write share one tiny transaction so a concurrent
-            # delete cannot remove a source row between the check and the UPDATE.
-            live_source_memory_ids = await _filter_live_source_memories(conn, bank_id, source_memory_ids)
-            if not live_source_memory_ids:
-                logger.debug(
-                    f"Update skipped: all {len(source_memory_ids)} source memories for observation "
-                    f"{observation_id} were deleted concurrently"
-                )
-                return None
-            live_ids = live_source_memory_ids
+    # FOR SHARE liveness + the write share the batch's transaction, so a concurrent
+    # delete cannot remove a source row between the check and the UPDATE.
+    live_source_memory_ids = await _filter_live_source_memories(conn, bank_id, source_memory_ids)
+    if not live_source_memory_ids:
+        logger.debug(
+            f"Update skipped: all {len(source_memory_ids)} source memories for observation "
+            f"{observation_id} were deleted concurrently"
+        )
+        return None
+    live_ids = live_source_memory_ids
 
-            history_entry = _ObservationHistorySnapshot(
-                previous_text=model.text,
-                previous_tags=list(model.tags or []),
-                previous_occurred_start=model.occurred_start,
-                previous_occurred_end=model.occurred_end,
-                previous_mentioned_at=model.mentioned_at,
-                new_source_memory_ids=[str(mid) for mid in live_ids],
+    history_entry = _ObservationHistorySnapshot(
+        previous_text=model.text,
+        previous_tags=list(model.tags or []),
+        previous_occurred_start=model.occurred_start,
+        previous_occurred_end=model.occurred_end,
+        previous_mentioned_at=model.mentioned_at,
+        new_source_memory_ids=[str(mid) for mid in live_ids],
+    )
+
+    source_ids = list(model.source_fact_ids or []) + live_ids
+
+    # SECURITY: Merge source fact's tags into existing observation tags so all contributors can see it
+    existing_tags = set(model.tags or [])
+    source_tags = set(source_fact_tags or [])
+    merged_tags = list(existing_tags | source_tags)
+
+    t0 = time.time()
+    if store.writes_memory_rows_in_sql_for(bank_id):
+        # Unlike the dedup folds this statement also runs on Oracle, where LEAST/GREATEST
+        # return NULL as soon as ANY argument is NULL (PostgreSQL ignores NULL arguments).
+        # The inner COALESCE covers a NULL *parameter*; the outer one covers a NULL
+        # *column* — an observation with no occurred interval yet, which is precisely the
+        # #3477 case. Without it Oracle would compute LEAST(NULL, <source date>) = NULL and
+        # silently drop the date it was told to inherit. Keep the inner
+        # ``COALESCE($n, col)`` spelled exactly like this: the Oracle driver shim keys its
+        # TIMESTAMP-TZ input-size hint off that pattern (db/oracle.py::_apply_clob_input_sizes),
+        # and a NULL parameter binds as VARCHAR2 (ORA-00932) without it.
+        updated_rows = await conn.execute_rows_affected(
+            f"""
+            UPDATE {fq_table("memory_units")}
+            SET text = $1,
+                embedding = $2::vector,
+                source_memory_ids = $3,
+                proof_count = $4,
+                tags = $10,
+                updated_at = now(),
+                event_date = COALESCE(LEAST(event_date, COALESCE($6, event_date)), $6),
+                occurred_start = COALESCE(LEAST(occurred_start, COALESCE($7, occurred_start)), $7),
+                occurred_end = COALESCE(GREATEST(occurred_end, COALESCE($8, occurred_end)), $8),
+                mentioned_at = COALESCE(GREATEST(mentioned_at, COALESCE($9, mentioned_at)), $9){search_vector_clause}
+            WHERE id = $5
+            """,
+            new_text,
+            embedding_str,
+            source_ids,
+            len(source_ids),
+            uuid.UUID(observation_id),
+            source_bounds.event_date,
+            source_bounds.occurred_start,
+            source_bounds.occurred_end,
+            source_bounds.mentioned_at,
+            merged_tags,
+        )
+        # The source-liveness checks above guard the *source* memories; the
+        # observation row itself (WHERE id = $5) can still be invalidated/deleted
+        # concurrently, matching 0 rows. Bail out BEFORE the observation_history
+        # INSERT below — that INSERT carries an observation_id FK onto memory_units,
+        # so appending history for a now-missing row raises ForeignKeyViolationError,
+        # a non-retryable integrity failure that would fail the whole consolidation
+        # op for a row that simply no longer exists.
+        if updated_rows == 0:
+            logger.debug(
+                f"Update skipped: observation {observation_id} no longer exists "
+                "(deleted/invalidated concurrently); not appending history"
+            )
+            return None
+    else:
+        # Upsert overwrites the whole observation, so start from its current state (fetched
+        # from the store) and apply the same merge the SQL does — LEAST/GREATEST on the
+        # times — while preserving fields the update never touches (created_at).
+        current = await store.get_memories(conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[observation_id])
+        cur = current[0] if current else None
+        # Widen the row the store still holds. If it has vanished, fall back to the
+        # pre-update recall snapshot — ISO strings, and no event_date on that model.
+        current_bounds = (
+            _TemporalBounds.of(cur)
+            if cur
+            else _TemporalBounds(
+                occurred_start=_as_dt(model.occurred_start),
+                occurred_end=_as_dt(model.occurred_end),
+                mentioned_at=_as_dt(model.mentioned_at),
+            )
+        )
+        merged_bounds = current_bounds.merged_with(source_bounds)
+        await store.upsert_observation(
+            conn=conn,
+            bank_id=bank_id,
+            txn=txn,
+            record=FactRecord(
+                unit_id=observation_id,
+                text=new_text,
+                embedding=embedding_str,
+                fact_type="observation",
+                tags=merged_tags,
+                proof_count=len(source_ids),
+                source_memory_ids=[str(s) for s in source_ids],
+                event_date=merged_bounds.event_date,
+                occurred_start=merged_bounds.occurred_start,
+                occurred_end=merged_bounds.occurred_end,
+                mentioned_at=merged_bounds.mentioned_at,
+                created_at=cur.created_at if cur else None,
+            ),
+        )
+
+    # Record the pre-update snapshot in the dedicated observation_history table
+    # (one row per change), then trim to the configured cap. History lived in a
+    # single unbounded JSONB column before; an often-reinforced observation grew
+    # it until it crossed Postgres's 256MB jsonb limit and got stuck.
+    if config.enable_observation_history:
+        await _append_observation_history(
+            conn, bank_id, observation_id, history_entry, config.observation_history_max_entries
+        )
+
+    # Sync observation_sources junction table (Oracle only — PG uses native array ops).
+    if memory_engine._backend.ops.uses_observation_sources_table:
+        obs_uuid = uuid.UUID(observation_id)
+        await conn.execute(
+            f"DELETE FROM {fq_table('observation_sources')} WHERE observation_id = $1",
+            obs_uuid,
+        )
+        if source_ids:
+            await conn.executemany(
+                f"""
+                INSERT INTO {fq_table("observation_sources")} (observation_id, source_id)
+                VALUES ($1, $2)
+                ON CONFLICT (observation_id, source_id) DO NOTHING
+                """,
+                [(obs_uuid, sid) for sid in dict.fromkeys(source_ids)],
             )
 
-            source_ids = list(model.source_fact_ids or []) + live_ids
-
-            # SECURITY: Merge source fact's tags into existing observation tags so all contributors can see it
-            existing_tags = set(model.tags or [])
-            source_tags = set(source_fact_tags or [])
-            merged_tags = list(existing_tags | source_tags)
-
-            t0 = time.time()
-            if store.writes_memory_rows_in_sql_for(bank_id):
-                # Unlike the dedup folds this statement also runs on Oracle, where LEAST/GREATEST
-                # return NULL as soon as ANY argument is NULL (PostgreSQL ignores NULL arguments).
-                # The inner COALESCE covers a NULL *parameter*; the outer one covers a NULL
-                # *column* — an observation with no occurred interval yet, which is precisely the
-                # #3477 case. Without it Oracle would compute LEAST(NULL, <source date>) = NULL and
-                # silently drop the date it was told to inherit. Keep the inner
-                # ``COALESCE($n, col)`` spelled exactly like this: the Oracle driver shim keys its
-                # TIMESTAMP-TZ input-size hint off that pattern (db/oracle.py::_apply_clob_input_sizes),
-                # and a NULL parameter binds as VARCHAR2 (ORA-00932) without it.
-                updated_rows = await conn.execute_rows_affected(
-                    f"""
-                    UPDATE {fq_table("memory_units")}
-                    SET text = $1,
-                        embedding = $2::vector,
-                        source_memory_ids = $3,
-                        proof_count = $4,
-                        tags = $10,
-                        updated_at = now(),
-                        event_date = COALESCE(LEAST(event_date, COALESCE($6, event_date)), $6),
-                        occurred_start = COALESCE(LEAST(occurred_start, COALESCE($7, occurred_start)), $7),
-                        occurred_end = COALESCE(GREATEST(occurred_end, COALESCE($8, occurred_end)), $8),
-                        mentioned_at = COALESCE(GREATEST(mentioned_at, COALESCE($9, mentioned_at)), $9){search_vector_clause}
-                    WHERE id = $5
-                    """,
-                    new_text,
-                    embedding_str,
-                    source_ids,
-                    len(source_ids),
-                    uuid.UUID(observation_id),
-                    source_bounds.event_date,
-                    source_bounds.occurred_start,
-                    source_bounds.occurred_end,
-                    source_bounds.mentioned_at,
-                    merged_tags,
-                )
-                # The source-liveness checks above guard the *source* memories; the
-                # observation row itself (WHERE id = $5) can still be invalidated/deleted
-                # concurrently, matching 0 rows. Bail out BEFORE the observation_history
-                # INSERT below — that INSERT carries an observation_id FK onto memory_units,
-                # so appending history for a now-missing row raises ForeignKeyViolationError,
-                # a non-retryable integrity failure that would fail the whole consolidation
-                # op for a row that simply no longer exists.
-                if updated_rows == 0:
-                    logger.debug(
-                        f"Update skipped: observation {observation_id} no longer exists "
-                        "(deleted/invalidated concurrently); not appending history"
-                    )
-                    return None
-            else:
-                # Upsert overwrites the whole observation, so start from its current state (fetched
-                # from the store) and apply the same merge the SQL does — LEAST/GREATEST on the
-                # times — while preserving fields the update never touches (created_at).
-                current = await store.get_memories(
-                    conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[observation_id]
-                )
-                cur = current[0] if current else None
-                # Widen the row the store still holds. If it has vanished, fall back to the
-                # pre-update recall snapshot — ISO strings, and no event_date on that model.
-                current_bounds = (
-                    _TemporalBounds.of(cur)
-                    if cur
-                    else _TemporalBounds(
-                        occurred_start=_as_dt(model.occurred_start),
-                        occurred_end=_as_dt(model.occurred_end),
-                        mentioned_at=_as_dt(model.mentioned_at),
-                    )
-                )
-                merged_bounds = current_bounds.merged_with(source_bounds)
-                await store.upsert_observation(
-                    conn=conn,
-                    bank_id=bank_id,
-                    txn=txn,
-                    record=FactRecord(
-                        unit_id=observation_id,
-                        text=new_text,
-                        embedding=embedding_str,
-                        fact_type="observation",
-                        tags=merged_tags,
-                        proof_count=len(source_ids),
-                        source_memory_ids=[str(s) for s in source_ids],
-                        event_date=merged_bounds.event_date,
-                        occurred_start=merged_bounds.occurred_start,
-                        occurred_end=merged_bounds.occurred_end,
-                        mentioned_at=merged_bounds.mentioned_at,
-                        created_at=cur.created_at if cur else None,
-                    ),
-                )
-
-            # Record the pre-update snapshot in the dedicated observation_history table
-            # (one row per change), then trim to the configured cap. History lived in a
-            # single unbounded JSONB column before; an often-reinforced observation grew
-            # it until it crossed Postgres's 256MB jsonb limit and got stuck.
-            if config.enable_observation_history:
-                await _append_observation_history(
-                    conn, bank_id, observation_id, history_entry, config.observation_history_max_entries
-                )
-
-            # Sync observation_sources junction table (Oracle only — PG uses native array ops).
-            if memory_engine._backend.ops.uses_observation_sources_table:
-                obs_uuid = uuid.UUID(observation_id)
-                await conn.execute(
-                    f"DELETE FROM {fq_table('observation_sources')} WHERE observation_id = $1",
-                    obs_uuid,
-                )
-                if source_ids:
-                    await conn.executemany(
-                        f"""
-                        INSERT INTO {fq_table("observation_sources")} (observation_id, source_id)
-                        VALUES ($1, $2)
-                        ON CONFLICT (observation_id, source_id) DO NOTHING
-                        """,
-                        [(obs_uuid, sid) for sid in dict.fromkeys(source_ids)],
-                    )
-
-            if perf:
-                perf.record_timing("db_write", time.time() - t0)
+    if perf:
+        perf.record_timing("db_write", time.time() - t0)
 
     # Map the updated observation onto the consolidation trace as a produced memory.
     record_created_memory_ids([observation_id])
@@ -2652,17 +2756,11 @@ async def _execute_update_action(
     return embedding_str
 
 
-async def _execute_create_action(
-    pool: DatabaseBackend,
+async def _apply_create_action(
+    conn,
     memory_engine: "MemoryEngine",
     bank_id: str,
-    source_memory_ids: list[uuid.UUID],
-    text: str,
-    source_fact_tags: list[str] | None = None,
-    event_date: datetime | None = None,
-    occurred_start: datetime | None = None,
-    occurred_end: datetime | None = None,
-    mentioned_at: datetime | None = None,
+    prepared: "_PreparedCreate",
     perf: ConsolidationPerfLog | None = None,
     txn=None,
 ) -> str:
@@ -2671,18 +2769,21 @@ async def _execute_create_action(
 
     Tags are inherited from the source facts (determined algorithmically, not by LLM)
     to maintain visibility scope. Returns the write action ("created" or "skipped").
+
+    Runs on the caller's connection inside the caller's transaction (#3876).
     """
-    created = await _create_observation_directly(
-        pool=pool,
+    created = await _apply_create_observation(
+        conn=conn,
         memory_engine=memory_engine,
         bank_id=bank_id,
-        source_memory_ids=source_memory_ids,
-        observation_text=text,
-        tags=source_fact_tags or [],
-        event_date=event_date,
-        occurred_start=occurred_start,
-        occurred_end=occurred_end,
-        mentioned_at=mentioned_at,
+        source_memory_ids=prepared.source_memory_ids,
+        observation_text=prepared.text,
+        embedding_str=prepared.embedding_str,
+        tags=prepared.source_fact_tags or [],
+        event_date=prepared.agg.event_date,
+        occurred_start=prepared.agg.occurred_start,
+        occurred_end=prepared.agg.occurred_end,
+        mentioned_at=prepared.agg.mentioned_at,
         perf=perf,
         txn=txn,
     )
@@ -2690,7 +2791,7 @@ async def _execute_create_action(
     new_id = created.get("observation_id")
     if new_id:
         record_created_memory_ids([new_id])
-    logger.debug(f"Created observation from {len(source_memory_ids)} source memories")
+    logger.debug(f"Created observation from {len(prepared.source_memory_ids)} source memories")
     return created["action"]
 
 
@@ -2720,6 +2821,24 @@ async def _execute_delete_action(
         uuid.UUID(observation_id),
     )
     logger.debug(f"Deleted observation {observation_id}")
+
+
+async def _embed_observation_text(
+    memory_engine: "MemoryEngine",
+    text: str,
+    perf: ConsolidationPerfLog | None = None,
+) -> str | None:
+    """Embed one observation text into a pgvector literal, with no connection held.
+
+    Every caller is in the prepare phase of a batch (#3876): the embedder is the slowest
+    thing consolidation does per action, and it must finish before the batch's single write
+    transaction opens.
+    """
+    t0 = time.time()
+    embeddings = await embedding_utils.generate_embeddings_batch(memory_engine.embeddings, [text])
+    if perf:
+        perf.record_timing("embedding", time.time() - t0)
+    return str(embeddings[0]) if embeddings else None
 
 
 async def _find_related_observations(
@@ -3115,12 +3234,13 @@ async def _consolidate_batch_with_llm(
     )
 
 
-async def _create_observation_directly(
-    pool: DatabaseBackend,
+async def _apply_create_observation(
+    conn,
     memory_engine: "MemoryEngine",
     bank_id: str,
     source_memory_ids: list[uuid.UUID],
     observation_text: str,
+    embedding_str: str | None,
     tags: list[str] | None = None,
     event_date: datetime | None = None,
     occurred_start: datetime | None = None,
@@ -3129,28 +3249,13 @@ async def _create_observation_directly(
     perf: ConsolidationPerfLog | None = None,
     txn=None,
 ) -> dict[str, Any]:
-    """Create an observation from one or more source memories with pre-processed text.
+    """Insert one observation from pre-embedded text.
 
-    The embedding is computed off-connection (a slow embedder must never pin a pooled
-    connection); the liveness check + INSERT + observation_sources insert then run in one
-    short transaction so they commit atomically.
+    Runs on the caller's connection inside the caller's transaction, so it commits together
+    with every other write derived from the same LLM response (#3876). The embedding is
+    computed by the caller's prepare phase — a slow embedder must never pin a pooled
+    connection, let alone one holding an open transaction.
     """
-    # Preflight (non-locking, separate short-lived conn): if every source memory is already
-    # gone, skip BEFORE the slow embed — restores the pre-refactor short-circuit so a no-op
-    # create doesn't embed and a failing embedder doesn't raise where it used to skip.
-    async with acquire_with_retry(pool) as conn:
-        if not await _any_live_source_memory(conn, bank_id, source_memory_ids):
-            logger.debug(f"Create skipped: all {len(source_memory_ids)} source memories were deleted before embedding")
-            return {"action": "skipped", "reason": "sources_deleted"}
-
-    # Generate embedding for the observation (convert to string for pgvector) BEFORE
-    # acquiring a connection so the embedder never holds a pooled connection.
-    t0 = time.time()
-    embeddings = await embedding_utils.generate_embeddings_batch(memory_engine.embeddings, [observation_text])
-    embedding_str = str(embeddings[0]) if embeddings else None
-    if perf:
-        perf.record_timing("embedding", time.time() - t0)
-
     now = datetime.now(timezone.utc)
     obs_event_date = event_date or now
     obs_occurred_start = occurred_start
@@ -3163,107 +3268,105 @@ async def _create_observation_directly(
     # search_vector the configured backend needs); a store that owns its rows takes it through
     # upsert_observation as a normal Observation-type memory carrying all of its own state.
     store = get_memories()
-    async with acquire_with_retry(pool) as conn:
-        async with conn.transaction():
-            # FOR SHARE liveness + INSERT share one tiny transaction so a concurrent
-            # delete cannot orphan the new observation between the check and the insert.
-            live_source_memory_ids = await _filter_live_source_memories(conn, bank_id, source_memory_ids)
-            if not live_source_memory_ids:
-                logger.debug(f"Create skipped: all {len(source_memory_ids)} source memories were deleted concurrently")
-                return {"action": "skipped", "reason": "sources_deleted"}
-            source_memory_ids = live_source_memory_ids
+    # FOR SHARE liveness + INSERT share the batch's transaction, so a concurrent
+    # delete cannot orphan the new observation between the check and the insert.
+    live_source_memory_ids = await _filter_live_source_memories(conn, bank_id, source_memory_ids)
+    if not live_source_memory_ids:
+        logger.debug(f"Create skipped: all {len(source_memory_ids)} source memories were deleted concurrently")
+        return {"action": "skipped", "reason": "sources_deleted"}
+    source_memory_ids = live_source_memory_ids
 
-            t0 = time.time()
-            if store.writes_memory_rows_in_sql_for(bank_id):
-                # Query varies based on text search backend.
-                from ..schema import _is_oracle  # noqa: PLC0415
+    t0 = time.time()
+    if store.writes_memory_rows_in_sql_for(bank_id):
+        # Query varies based on text search backend.
+        from ..schema import _is_oracle  # noqa: PLC0415
 
-                config = get_config()
-                if config.text_search_extension == "vchord":
-                    # VectorChord: manually tokenize and insert search_vector
-                    query = f"""
-                        INSERT INTO {fq_table("memory_units")} (
-                            id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
-                            tags, event_date, occurred_start, occurred_end, mentioned_at, search_vector
-                        )
-                        VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10,
-                                tokenize($3, 'llmlingua2')::bm25_catalog.bm25vector)
-                        RETURNING id
-                    """
-                elif config.text_search_extension == "native" and not _is_oracle():
-                    # Native (PostgreSQL): search_vector is populated with to_tsvector()
-                    # using the configured native language dictionary, matching the batch
-                    # insert path in ops_postgresql.insert_facts_batch. On Oracle this falls
-                    # through to the no-search_vector branch below (Oracle maintains its text
-                    # index separately; to_tsvector/::regconfig is PG-only — see #3021).
-                    query = f"""
-                        INSERT INTO {fq_table("memory_units")} (
-                            id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
-                            tags, event_date, occurred_start, occurred_end, mentioned_at, search_vector
-                        )
-                        VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10,
-                                to_tsvector('{config.text_search_extension_native_language}'::regconfig, COALESCE($3, '')))
-                        RETURNING id
-                    """
-                else:  # pg_textsearch, pgroonga, pg_search, and Oracle: base text columns / separate index
-                    query = f"""
-                        INSERT INTO {fq_table("memory_units")} (
-                            id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
-                            tags, event_date, occurred_start, occurred_end, mentioned_at
-                        )
-                        VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10)
-                        RETURNING id
-                    """
-
-                row = await conn.fetchrow(
-                    query,
-                    observation_id,
-                    bank_id,
-                    observation_text,
-                    embedding_str,
-                    source_memory_ids,
-                    obs_tags,
-                    obs_event_date,
-                    obs_occurred_start,
-                    obs_occurred_end,
-                    obs_mentioned_at,
+        config = get_config()
+        if config.text_search_extension == "vchord":
+            # VectorChord: manually tokenize and insert search_vector
+            query = f"""
+                INSERT INTO {fq_table("memory_units")} (
+                    id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
+                    tags, event_date, occurred_start, occurred_end, mentioned_at, search_vector
                 )
-                created_id = row["id"]
-
-                # Populate observation_sources junction table (Oracle only — PG uses native array ops).
-                if memory_engine._backend.ops.uses_observation_sources_table and source_memory_ids:
-                    await conn.executemany(
-                        f"""
-                        INSERT INTO {fq_table("observation_sources")} (observation_id, source_id)
-                        VALUES ($1, $2)
-                        ON CONFLICT (observation_id, source_id) DO NOTHING
-                        """,
-                        [(observation_id, sid) for sid in dict.fromkeys(source_memory_ids)],
-                    )
-            else:
-                await store.upsert_observation(
-                    conn=conn,
-                    bank_id=bank_id,
-                    txn=txn,
-                    record=FactRecord(
-                        unit_id=str(observation_id),
-                        text=observation_text,
-                        embedding=embedding_str,
-                        fact_type="observation",
-                        tags=list(obs_tags),
-                        proof_count=1,
-                        source_memory_ids=[str(s) for s in source_memory_ids],
-                        event_date=obs_event_date,
-                        occurred_start=obs_occurred_start,
-                        occurred_end=obs_occurred_end,
-                        mentioned_at=obs_mentioned_at,
-                        created_at=now,
-                    ),
+                VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10,
+                        tokenize($3, 'llmlingua2')::bm25_catalog.bm25vector)
+                RETURNING id
+            """
+        elif config.text_search_extension == "native" and not _is_oracle():
+            # Native (PostgreSQL): search_vector is populated with to_tsvector()
+            # using the configured native language dictionary, matching the batch
+            # insert path in ops_postgresql.insert_facts_batch. On Oracle this falls
+            # through to the no-search_vector branch below (Oracle maintains its text
+            # index separately; to_tsvector/::regconfig is PG-only — see #3021).
+            query = f"""
+                INSERT INTO {fq_table("memory_units")} (
+                    id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
+                    tags, event_date, occurred_start, occurred_end, mentioned_at, search_vector
                 )
-                created_id = observation_id
+                VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10,
+                        to_tsvector('{config.text_search_extension_native_language}'::regconfig, COALESCE($3, '')))
+                RETURNING id
+            """
+        else:  # pg_textsearch, pgroonga, pg_search, and Oracle: base text columns / separate index
+            query = f"""
+                INSERT INTO {fq_table("memory_units")} (
+                    id, bank_id, text, fact_type, embedding, proof_count, source_memory_ids,
+                    tags, event_date, occurred_start, occurred_end, mentioned_at
+                )
+                VALUES ($1, $2, $3, 'observation', $4::vector, 1, $5, $6, $7, $8, $9, $10)
+                RETURNING id
+            """
 
-            if perf:
-                perf.record_timing("db_write", time.time() - t0)
+        row = await conn.fetchrow(
+            query,
+            observation_id,
+            bank_id,
+            observation_text,
+            embedding_str,
+            source_memory_ids,
+            obs_tags,
+            obs_event_date,
+            obs_occurred_start,
+            obs_occurred_end,
+            obs_mentioned_at,
+        )
+        created_id = row["id"]
+
+        # Populate observation_sources junction table (Oracle only — PG uses native array ops).
+        if memory_engine._backend.ops.uses_observation_sources_table and source_memory_ids:
+            await conn.executemany(
+                f"""
+                INSERT INTO {fq_table("observation_sources")} (observation_id, source_id)
+                VALUES ($1, $2)
+                ON CONFLICT (observation_id, source_id) DO NOTHING
+                """,
+                [(observation_id, sid) for sid in dict.fromkeys(source_memory_ids)],
+            )
+    else:
+        await store.upsert_observation(
+            conn=conn,
+            bank_id=bank_id,
+            txn=txn,
+            record=FactRecord(
+                unit_id=str(observation_id),
+                text=observation_text,
+                embedding=embedding_str,
+                fact_type="observation",
+                tags=list(obs_tags),
+                proof_count=1,
+                source_memory_ids=[str(s) for s in source_memory_ids],
+                event_date=obs_event_date,
+                occurred_start=obs_occurred_start,
+                occurred_end=obs_occurred_end,
+                mentioned_at=obs_mentioned_at,
+                created_at=now,
+            ),
+        )
+        created_id = observation_id
+
+    if perf:
+        perf.record_timing("db_write", time.time() - t0)
 
     logger.debug(f"Created observation {observation_id} from {len(source_memory_ids)} memories (tags: {obs_tags})")
 

--- a/hindsight-api-slim/tests/consolidation_actions.py
+++ b/hindsight-api-slim/tests/consolidation_actions.py
@@ -1,0 +1,176 @@
+"""Whole consolidation actions, composed from the consolidator's two halves.
+
+Consolidation applies every write derived from one LLM response — deletes, updates,
+creates, dedup folds and the ``consolidated_at`` stamps for the facts consumed — in a
+single transaction (#3876). A transaction must never be held open across an embedder or
+an LLM call, so production splits each action in two: a connection-free *prepare*
+(resolve sources, embed, adjudicate dedup) and an *apply* that runs on the batch's
+connection inside the batch's transaction.
+
+Tests that exercise one action end to end want the pair back together. These helpers do
+exactly what ``_process_memory_batch`` does for a single action, and nothing else — keep
+them that way, so a test asserting on an action still asserts on production behaviour.
+
+Connections are acquired through ``C.acquire_with_retry`` (not the ``db_utils`` symbol) so a
+test that stubs the consolidator's pool acquisition also stubs these helpers'.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from hindsight_api.engine.consolidation import consolidator as C
+
+
+async def create_observation(
+    *,
+    pool,
+    memory_engine,
+    bank_id: str,
+    source_memory_ids: list[uuid.UUID],
+    observation_text: str,
+    tags: list[str] | None = None,
+    event_date=None,
+    occurred_start=None,
+    occurred_end=None,
+    mentioned_at=None,
+    perf=None,
+    txn=None,
+) -> dict[str, Any]:
+    """Preflight + embed off-connection, then insert in one short transaction."""
+    async with C.acquire_with_retry(pool) as conn:
+        if not await C._any_live_source_memory(conn, bank_id, source_memory_ids):
+            return {"action": "skipped", "reason": "sources_deleted"}
+    embedding_str = await C._embed_observation_text(memory_engine, observation_text, perf)
+    async with C.acquire_with_retry(pool) as conn:
+        async with conn.transaction():
+            return await C._apply_create_observation(
+                conn=conn,
+                memory_engine=memory_engine,
+                bank_id=bank_id,
+                source_memory_ids=source_memory_ids,
+                observation_text=observation_text,
+                embedding_str=embedding_str,
+                tags=tags,
+                event_date=event_date,
+                occurred_start=occurred_start,
+                occurred_end=occurred_end,
+                mentioned_at=mentioned_at,
+                perf=perf,
+                txn=txn,
+            )
+
+
+async def execute_create_action(
+    *,
+    pool,
+    memory_engine,
+    bank_id: str,
+    source_memory_ids: list[uuid.UUID],
+    text: str,
+    source_fact_tags: list[str] | None = None,
+    event_date=None,
+    occurred_start=None,
+    occurred_end=None,
+    mentioned_at=None,
+    perf=None,
+    txn=None,
+) -> str:
+    """One CREATE action: returns "created" or "skipped", as the batch executor sees it."""
+    created = await create_observation(
+        pool=pool,
+        memory_engine=memory_engine,
+        bank_id=bank_id,
+        source_memory_ids=source_memory_ids,
+        observation_text=text,
+        tags=source_fact_tags or [],
+        event_date=event_date,
+        occurred_start=occurred_start,
+        occurred_end=occurred_end,
+        mentioned_at=mentioned_at,
+        perf=perf,
+        txn=txn,
+    )
+    new_id = created.get("observation_id")
+    if new_id:
+        C.record_created_memory_ids([new_id])
+    return created["action"]
+
+
+async def execute_update_action(
+    *,
+    pool,
+    memory_engine,
+    bank_id: str,
+    source_memory_ids: list[uuid.UUID],
+    observation_id: str,
+    new_text: str,
+    observations: list,
+    source_fact_tags: list[str] | None = None,
+    source_bounds: C._TemporalBounds = C._TemporalBounds(),
+    perf=None,
+    txn=None,
+) -> str | None:
+    """One UPDATE action: returns the observation's new embedding, or None if skipped."""
+    model = next((m for m in observations if str(m.id) == observation_id), None)
+    if model is None:
+        return None
+    async with C.acquire_with_retry(pool) as conn:
+        if not await C._any_live_source_memory(conn, bank_id, source_memory_ids):
+            return None
+    embedding_str = await C._embed_observation_text(memory_engine, new_text, perf)
+    prepared = C._PreparedUpdate(
+        update=C._UpdateAction(
+            text=new_text,
+            observation_id=observation_id,
+            source_fact_ids=[str(mid) for mid in source_memory_ids],
+        ),
+        model=model,
+        source_mems=[],
+        source_memory_ids=source_memory_ids,
+        source_fact_tags=source_fact_tags or [],
+        source_bounds=source_bounds,
+        embedding_str=embedding_str,
+    )
+    async with C.acquire_with_retry(pool) as conn:
+        async with conn.transaction():
+            return await C._apply_update_action(
+                conn=conn,
+                memory_engine=memory_engine,
+                bank_id=bank_id,
+                prepared=prepared,
+                perf=perf,
+                txn=txn,
+            )
+
+
+async def dedup_reconcile_update(
+    pool,
+    memory_engine,
+    bank_id: str,
+    config,
+    dedup_llm_config,
+    updated_id: str,
+    updated_text: str,
+    updated_emb_str: str | None,
+    tags: list[str] | None,
+    txn=None,
+) -> bool:
+    """UPDATE-path dedup: adjudicate off-connection, then fold in one transaction."""
+    outcome = await C._dedup_adjudicate(
+        pool,
+        memory_engine,
+        bank_id,
+        config,
+        dedup_llm_config,
+        updated_text,
+        updated_emb_str,
+        tags,
+        exclude_id=updated_id,
+    )
+    async with C.acquire_with_retry(pool) as conn:
+        async with conn.transaction():
+            return await C._apply_dedup_update_fold(
+                conn, memory_engine, bank_id, config, outcome, updated_id, updated_text, txn=txn
+            )

--- a/hindsight-api-slim/tests/test_consolidation_batch_atomicity.py
+++ b/hindsight-api-slim/tests/test_consolidation_batch_atomicity.py
@@ -1,0 +1,228 @@
+"""Every write from one consolidation LLM response commits or rolls back together (#3876).
+
+Consolidation used to write each action the moment it was decided, on its own connection:
+deletes first (to free observation slots), then updates, then creates, and the
+``consolidated_at`` stamps for the source facts later still. A batch whose DELETE landed
+and whose replacement CREATE then failed left the observation gone with nothing in its
+place — and the sources stamped consolidated, which is the exclusion predicate for pending
+consolidation, so nothing ever rebuilt it. The operation reported ``completed``.
+
+The reporter of #3876 saw exactly that with a small self-hosted model whose consolidation
+responses intermittently failed schema validation: batches logged success while the bank's
+observations drained away.
+
+These tests pin the contract:
+
+1. A batch that fails partway through applying its actions leaves NOTHING behind — the
+   delete it had already decided is rolled back with the rest.
+2. A batch that fails is not recorded as consolidated, so its facts stay pending and the
+   next round rebuilds what it could not write.
+3. The happy path still commits both the observation writes and the stamps.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.consolidation import consolidator as consolidator_module
+from hindsight_api.engine.consolidation.consolidator import (
+    _ConsolidationBatchResponse,
+    _CreateAction,
+    _DeleteAction,
+    run_consolidation_job,
+)
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.providers.mock_llm import MockLLM
+
+
+@pytest.fixture(autouse=True)
+def enable_observations():
+    config = _get_raw_config()
+    original = config.enable_observations
+    config.enable_observations = True
+    yield
+    config.enable_observations = original
+
+
+def _override_config(memory: MemoryEngine, **overrides):
+    raw = _get_raw_config()
+    fake = type(raw)(**{**{f: getattr(raw, f) for f in raw.__dataclass_fields__}, **overrides})
+    return patch.object(memory._config_resolver, "resolve_full_config", return_value=fake)
+
+
+def _llm(callback):
+    mock_llm = MockLLM(provider="mock", api_key="", base_url="", model="mock-model")
+    mock_llm.set_response_callback(callback)
+    wrapper = MagicMock()
+    wrapper.with_config.return_value = mock_llm
+    return wrapper
+
+
+def _create_one_per_fact(text: str | None = None):
+    """Emit one CREATE per fact id found in the prompt."""
+
+    def callback(messages, scope):
+        if scope != "consolidation":
+            return _ConsolidationBatchResponse()
+        prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+        fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+        return _ConsolidationBatchResponse(
+            creates=[
+                _CreateAction(text=text or f"Observation about fact {fid[:8]}", source_fact_ids=[fid])
+                for fid in fact_ids
+            ]
+        )
+
+    return callback
+
+
+async def _insert_memory(conn, bank_id: str, text: str, tags: list[str]) -> uuid.UUID:
+    mem_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO memory_units (id, bank_id, text, fact_type, tags, observation_scopes, created_at)
+        VALUES ($1, $2, $3, 'experience', $4, $5::jsonb, now())
+        """,
+        mem_id,
+        bank_id,
+        text,
+        tags,
+        json.dumps(None),
+    )
+    return mem_id
+
+
+async def _observations(memory: MemoryEngine, bank_id: str) -> list[str]:
+    async with memory._pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT text FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation' ORDER BY text",
+            bank_id,
+        )
+    return [r["text"] for r in rows]
+
+
+async def _pending_facts(memory: MemoryEngine, bank_id: str) -> list[str]:
+    async with memory._pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT text FROM memory_units WHERE bank_id = $1 AND fact_type = 'experience' "
+            "AND consolidated_at IS NULL AND consolidation_failed_at IS NULL ORDER BY text",
+            bank_id,
+        )
+    return [r["text"] for r in rows]
+
+
+async def _run(memory: MemoryEngine, bank_id: str, request_context, callback):
+    original = memory._consolidation_llm_config
+    memory._consolidation_llm_config = _llm(callback)
+    try:
+        with (
+            _override_config(memory, consolidation_llm_batch_size=4, consolidation_llm_parallelism=1),
+            patch.object(memory, "submit_async_consolidation"),
+        ):
+            return await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+    finally:
+        memory._consolidation_llm_config = original
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_failed_create_rolls_back_the_delete_it_was_replacing(memory: MemoryEngine, request_context):
+    """The classic #3876 shape: DELETE + CREATE in one response, the CREATE blows up.
+
+    Before the fix the delete was already committed on its own connection and the
+    observation was gone for good.
+    """
+    bank_id = f"atomic-del-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice moved to Munich", ["user:alice"])
+
+        def delete_and_create(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[_CreateAction(text="Alice lives in Munich", source_fact_ids=fact_ids)],
+                deletes=[_DeleteAction(observation_id=str(obs_id))],
+            )
+
+        with patch.object(
+            consolidator_module,
+            "_apply_create_observation",
+            new=AsyncMock(side_effect=RuntimeError("write failed mid-batch")),
+        ):
+            with pytest.raises(RuntimeError, match="write failed mid-batch"):
+                await _run(memory, bank_id, request_context, delete_and_create)
+
+        # The delete rolled back with the failed create: the observation is still there.
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+        # And the fact that batch consumed is still pending, so the next round retries it.
+        assert await _pending_facts(memory, bank_id) == ["Alice moved to Munich"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_failed_batch_does_not_stamp_consolidated_at(memory: MemoryEngine, request_context):
+    """``consolidated_at`` commits with the observations, never on its own.
+
+    A stamp written for a batch whose writes were lost would exclude those facts from
+    pending consolidation forever — the silent half of the data loss in #3876.
+    """
+    bank_id = f"atomic-stamp-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            for i in range(3):
+                await _insert_memory(conn, bank_id, f"Alice fact {i}", ["user:alice"])
+
+        with patch.object(
+            consolidator_module,
+            "_apply_create_observation",
+            new=AsyncMock(side_effect=RuntimeError("write failed mid-batch")),
+        ):
+            with pytest.raises(RuntimeError, match="write failed mid-batch"):
+                await _run(memory, bank_id, request_context, _create_one_per_fact())
+
+        assert await _observations(memory, bank_id) == []
+        assert await _pending_facts(memory, bank_id) == ["Alice fact 0", "Alice fact 1", "Alice fact 2"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_successful_batch_commits_observations_and_stamps(memory: MemoryEngine, request_context):
+    """Guard on the rollback tests: the happy path still writes both halves."""
+    bank_id = f"atomic-ok-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        result = await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+
+        assert result["status"] == "completed"
+        assert result["observations_created"] == 1
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+        assert await _pending_facts(memory, bank_id) == []
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -17,15 +17,18 @@ import pytest
 
 from hindsight_api.engine.consolidation.consolidator import (
     _DEDUP_PROMPT,
+    _apply_dedup_create_fold,
+    _apply_dedup_update_fold,
     _dedup_active,
+    _dedup_adjudicate,
     _dedup_decision_from_response,
-    _dedup_reconcile_create,
-    _dedup_reconcile_update,
     _DedupDecision,
+    _DedupOutcome,
     _duplicate_create_target,
     _norm_obs_text,
     _TemporalBounds,
 )
+from hindsight_api.engine.db_utils import acquire_with_retry
 from hindsight_api.engine.memories import RecallArms
 from hindsight_api.engine.search.types import RetrievalResult
 
@@ -36,6 +39,46 @@ _SOURCE_BOUNDS = _TemporalBounds(
     occurred_end=datetime(2024, 1, 3, tzinfo=timezone.utc),
     mentioned_at=datetime(2024, 1, 4, tzinfo=timezone.utc),
 )
+
+
+# Consolidation prepares an action (probe + adjudicate, connection-free) and applies it
+# (the fold) in separate phases, so that every write from one LLM response shares one
+# transaction (#3876). These helpers compose the two halves the way the batch executor
+# does, so the tests below still cover the whole decision -> write path.
+
+
+async def _dedup_reconcile_create(
+    *, pool, memory_engine, bank_id, config, dedup_llm_config, create_text, create_source_ids, tags, source_bounds
+):
+    outcome = await _dedup_adjudicate(
+        pool, memory_engine, bank_id, config, dedup_llm_config, create_text, None, tags, exclude_id=None
+    )
+    async with acquire_with_retry(pool) as conn:
+        async with conn.transaction():
+            return await _apply_dedup_create_fold(
+                conn, memory_engine, bank_id, config, outcome, create_source_ids, source_bounds
+            )
+
+
+async def _dedup_reconcile_update(
+    *, pool, memory_engine, bank_id, config, dedup_llm_config, updated_id, updated_text, updated_emb_str, tags
+):
+    outcome = await _dedup_adjudicate(
+        pool,
+        memory_engine,
+        bank_id,
+        config,
+        dedup_llm_config,
+        updated_text,
+        updated_emb_str,
+        tags,
+        exclude_id=updated_id,
+    )
+    async with acquire_with_retry(pool) as conn:
+        async with conn.transaction():
+            return await _apply_dedup_update_fold(
+                conn, memory_engine, bank_id, config, outcome, updated_id, updated_text
+            )
 
 
 @dataclass
@@ -81,7 +124,7 @@ def test_novel_create_is_not_duplicate() -> None:
     assert _duplicate_create_target("", {}, set()) is None
 
 
-# ── semantic dedup (_dedup_reconcile_create) ──────────────────────────────────
+# ── semantic dedup (create path: adjudicate + fold) ──────────────────────────────────
 #
 # Mocks the embedder, the obs-anchored ANN probe, and the LLM so the decision logic is
 # tested without a DB or a real model.
@@ -187,7 +230,7 @@ def _make_dedup_llm(conn):
 
 
 def _ctx(threshold: float = 0.97):
-    """Return (kwargs, conn_mock, llm_mock) for a _dedup_reconcile_create call."""
+    """Return (kwargs, conn_mock, llm_mock) for a create-path adjudicate + fold."""
     conn = _DedupConn()
     llm = _make_dedup_llm(conn)
     kwargs = dict(
@@ -395,7 +438,7 @@ async def test_dedup_picks_highest_above_threshold_skips_below() -> None:
     assert "near but distinct" not in sent
 
 
-# ── UPDATE-path dedup (_dedup_reconcile_update) ───────────────────────────────
+# ── UPDATE-path dedup (adjudicate + fold) ───────────────────────────────
 #
 # An UPDATE rewrites+re-embeds an observation, which can drift it into a near-twin of a
 # DIFFERENT existing observation. These cover the fold-and-delete reconciliation (unlike
@@ -405,7 +448,7 @@ _UPDATED_ID = "44444444-4444-4444-8444-444444444444"
 
 
 def _update_ctx(threshold: float = 0.97):
-    """Return (kwargs, conn_mock, llm_mock) for a _dedup_reconcile_update call."""
+    """Return (kwargs, conn_mock, llm_mock) for an update-path adjudicate + fold."""
     conn = _DedupConn()
     conn.fetchrow_result = {"source_memory_ids": [uuid.uuid4(), uuid.uuid4()]}
     llm = _make_dedup_llm(conn)
@@ -424,7 +467,7 @@ def _update_ctx(threshold: float = 0.97):
         dedup_llm_config=llm,
         updated_id=_UPDATED_ID,
         updated_text="Uzbek content on YouTube is very rich and growing.",
-        updated_emb_str="[0.1, 0.2, 0.3]",  # already embedded by _execute_update_action
+        updated_emb_str="[0.1, 0.2, 0.3]",  # already embedded by the prepare phase
         tags=["t1"],
     )
     return kwargs, conn, llm
@@ -645,11 +688,19 @@ async def _run_create_batch(create_action_result: str):
         patch.object(C, "_consolidate_batch_with_llm", new=AsyncMock(return_value=llm_result)),
         patch.object(C, "_effective_scope_limit", return_value=-1),
         patch.object(C, "_dedup_active", return_value=True),
-        patch.object(C, "_dedup_reconcile_create", new=AsyncMock(return_value=None)),
-        patch.object(C, "_execute_create_action", new=AsyncMock(return_value=create_action_result)) as create_action,
+        patch.object(C, "_any_live_source_memory", new=AsyncMock(return_value=True)),
+        patch.object(C, "_embed_observation_text", new=AsyncMock(return_value="[0.1, 0.2, 0.3]")),
+        # No twin above threshold: the adjudicator's no-merge verdict is what makes the
+        # batch fall through to the CREATE.
+        patch.object(
+            C,
+            "_dedup_adjudicate",
+            new=AsyncMock(return_value=_DedupOutcome(best_id=None, merged_text="", should_merge=False)),
+        ),
+        patch.object(C, "_apply_create_action", new=AsyncMock(return_value=create_action_result)) as create_action,
     ):
         result = await C._process_memory_batch(
-            pool=object(),
+            pool=_DedupBackend(_DedupConn()),
             memory_engine=_batch_engine(),
             llm_config=object(),
             bank_id="bank1",
@@ -661,23 +712,24 @@ async def _run_create_batch(create_action_result: str):
 
 
 async def test_process_batch_creates_when_dedup_target_vanished() -> None:
-    # Caller contract: when _dedup_reconcile_create returns None (twin vanished mid-window),
-    # _process_memory_batch must still CREATE the observation instead of dropping it.
+    # Caller contract: when the adjudicator finds no twin to fold into, _process_memory_batch
+    # must still CREATE the observation instead of dropping it.
     result, create_action, mem_id = await _run_create_batch("created")
     create_action.assert_awaited_once()
-    assert create_action.await_args.kwargs["text"] == "Uzbek YouTube content is very rich."
-    assert create_action.await_args.kwargs["source_memory_ids"] == [mem_id]
+    prepared = create_action.await_args.kwargs["prepared"]
+    assert prepared.text == "Uzbek YouTube content is very rich."
+    assert prepared.source_memory_ids == [mem_id]
     assert result == ([{"action": "created"}], 0, False)
 
 
 async def test_process_batch_reports_skipped_when_create_skipped() -> None:
-    # _execute_create_action returns "skipped" (all sources deleted in the write txn) ->
+    # _apply_create_action returns "skipped" (all sources deleted in the write txn) ->
     # _process_memory_batch must NOT mark the memory created; it falls through to skipped.
     result, _create_action, _mem_id = await _run_create_batch("skipped")
     assert result == ([{"action": "skipped", "reason": "no_durable_knowledge"}], 0, False)
 
 
 async def test_process_batch_reports_created_when_create_created() -> None:
-    # _execute_create_action returns "created" -> the memory is marked created.
+    # _apply_create_action returns "created" -> the memory is marked created.
     result, _create_action, _mem_id = await _run_create_batch("created")
     assert result == ([{"action": "created"}], 0, False)

--- a/hindsight-api-slim/tests/test_consolidation_embedding_validation.py
+++ b/hindsight-api-slim/tests/test_consolidation_embedding_validation.py
@@ -16,6 +16,7 @@ from contextlib import asynccontextmanager
 import pytest
 
 from hindsight_api.engine.consolidation import consolidator
+from tests import consolidation_actions
 
 
 class _ZeroLengthEmbeddings:
@@ -110,7 +111,7 @@ async def test_create_observation_rejects_zero_length_embedding_before_insert():
     # Preflight passes (fetchval -> live); the real embedder then yields a zero-length vector,
     # which must be rejected before any write. _WriteForbiddenConn fails hard if a write runs.
     with pytest.raises(RuntimeError, match="embedding 0 has dimension 0; expected 384"):
-        await consolidator._create_observation_directly(
+        await consolidation_actions.create_observation(
             pool=_Backend(_WriteForbiddenConn()),
             memory_engine=_FakeMemoryEngine(),
             bank_id="test-bank",
@@ -124,7 +125,7 @@ async def test_create_observation_skips_before_embedding_when_all_sources_dead(m
     # All sources gone -> the create must short-circuit at the preflight, BEFORE the embedder
     # (patched to explode if reached). No write may run.
     _forbid_embedder(monkeypatch)
-    result = await consolidator._create_observation_directly(
+    result = await consolidation_actions.create_observation(
         pool=_Backend(_NoLiveConn()),
         memory_engine=_FakeMemoryEngine(),
         bank_id="test-bank",
@@ -141,7 +142,7 @@ async def test_update_action_skips_before_embedding_when_all_sources_dead(monkey
     # pass even with the embed-first ordering this finding fixed; this pins the embed-skip directly.
     _forbid_embedder(monkeypatch)
     obs_id = str(uuid.uuid4())
-    result = await consolidator._execute_update_action(
+    result = await consolidation_actions.execute_update_action(
         pool=_Backend(_NoLiveConn()),
         memory_engine=_FakeMemoryEngine(),
         bank_id="test-bank",
@@ -163,7 +164,7 @@ async def test_update_action_rejects_zero_length_embedding_before_write():
     # hard if the write transaction is reached.
     obs_id = str(uuid.uuid4())
     with pytest.raises(RuntimeError, match="embedding 0 has dimension 0; expected 384"):
-        await consolidator._execute_update_action(
+        await consolidation_actions.execute_update_action(
             pool=_Backend(_WriteForbiddenConn()),
             memory_engine=_FakeMemoryEngine(),
             bank_id="test-bank",

--- a/hindsight-api-slim/tests/test_consolidation_temporal_merge.py
+++ b/hindsight-api-slim/tests/test_consolidation_temporal_merge.py
@@ -21,12 +21,15 @@ import pytest
 
 from hindsight_api.config import _get_raw_config
 from hindsight_api.engine.consolidation import consolidator
+from tests.consolidation_actions import (
+    dedup_reconcile_update,
+    execute_create_action as _execute_create_action,
+    execute_update_action as _execute_update_action,
+)
 from hindsight_api.engine.consolidation.consolidator import (
     _aggregate_source_fields,
     _DedupDecision,
     _DedupOutcome,
-    _execute_create_action,
-    _execute_update_action,
     _TemporalBounds,
     run_consolidation_job,
 )
@@ -284,7 +287,7 @@ async def test_dedup_update_fold_unions_the_bounds_of_both_rows(
             )
         ),
     ):
-        await consolidator._dedup_reconcile_update(
+        await dedup_reconcile_update(
             await memory._get_backend(),
             memory,
             bank_id,

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -16,7 +16,10 @@ import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
-from hindsight_api.engine.consolidation.consolidator import _create_observation_directly
+from hindsight_api.engine.consolidation.consolidator import (
+    _apply_create_observation,
+    _embed_observation_text,
+)
 from hindsight_api.engine.db_utils import acquire_with_retry
 from hindsight_api.engine.schema import fq_table
 from hindsight_api.engine.transfer import import_documents
@@ -63,6 +66,26 @@ class _RetainResultCapture(OperationValidatorExtension):
 
     async def on_retain_complete(self, result: RetainResult) -> None:
         self.results.append(result)
+
+
+async def _seed_observation(*, pool, memory, bank_id, source_memory_ids, observation_text):
+    """Insert one observation the way consolidation does: embed off-connection, write in a txn.
+
+    The consolidator itself only exposes the two halves — it batches every write from one LLM
+    response into a single transaction (#3876) — so this seeds a fixture observation with the
+    same pair of calls.
+    """
+    embedding_str = await _embed_observation_text(memory, observation_text)
+    async with acquire_with_retry(pool) as conn:
+        async with conn.transaction():
+            return await _apply_create_observation(
+                conn=conn,
+                memory_engine=memory,
+                bank_id=bank_id,
+                source_memory_ids=source_memory_ids,
+                observation_text=observation_text,
+                embedding_str=embedding_str,
+            )
 
 
 @pytest_asyncio.fixture
@@ -597,12 +620,11 @@ async def test_bank_import_preserves_consolidation_lifecycle(memory, request_con
             ]
         assert len(wf_ids) >= 3, "need enough facts to exercise the lineage gap"
 
-        # One surviving observation over the first two facts. The helper now self-acquires a
-        # short-lived connection (the embed runs off-connection), so pass the backend, not a conn.
+        # One surviving observation over the first two facts.
         obs_source_ids = [uuid.UUID(str(i)) for i in wf_ids[:2]]
-        await _create_observation_directly(
+        await _seed_observation(
             pool=backend,
-            memory_engine=memory,
+            memory=memory,
             bank_id=bank,
             source_memory_ids=obs_source_ids,
             observation_text="Alice and Bob are colleagues.",
@@ -1253,9 +1275,9 @@ async def test_export_import_observations(memory, request_context):
         # short-lived connection now (the embed runs off-connection), so pass the backend.
         backend = await memory._get_backend()
         archived_event_date = datetime(2001, 2, 3, 4, 5, 6, tzinfo=timezone.utc)
-        await _create_observation_directly(
+        await _seed_observation(
             pool=backend,
-            memory_engine=memory,
+            memory=memory,
             bank_id=src,
             source_memory_ids=source_ids,
             observation_text="Alice and Bob are colleagues.",

--- a/hindsight-api-slim/tests/test_integrity_violation_not_retried.py
+++ b/hindsight-api-slim/tests/test_integrity_violation_not_retried.py
@@ -22,6 +22,7 @@ import asyncpg
 import pytest
 
 from hindsight_api.worker.exceptions import RetryTaskAt
+from tests import consolidation_actions
 
 
 async def _ensure_bank(pool, bank_id: str) -> None:
@@ -185,7 +186,7 @@ class _AsyncNullCtx:
 
 
 def _fake_config() -> SimpleNamespace:
-    """Minimal config for _execute_update_action: ``text_search_extension='none'``
+    """Minimal config for the update action: ``text_search_extension='none'``
     so no native tsvector clause is emitted, and observation-history enabled so
     the 0-row guard is the only thing preventing the (FK-violating) history INSERT."""
     return SimpleNamespace(
@@ -209,7 +210,7 @@ def _observation_fact(observation_id: str):
 
 
 def _patch_update_action_deps(consolidator, conn, source_ids, append_mock) -> ExitStack:
-    """Enter the common patch set for the two _execute_update_action guard tests
+    """Enter the common patch set for the two update-action guard tests
     and return the live ExitStack (use as ``with _patch_update_action_deps(...):``).
 
     Stubs the pool/transaction acquisition, the (slow) embedder, the source
@@ -240,7 +241,7 @@ def _patch_update_action_deps(consolidator, conn, source_ids, append_mock) -> Ex
 @pytest.mark.asyncio
 async def test_update_action_bails_when_observation_row_missing():
     """
-    Regression: the source-liveness checks in ``_execute_update_action`` guard the
+    Regression: the source-liveness checks in ``execute_update_action`` guard the
     *source* memories, but the observation row itself (``UPDATE ... WHERE id = $5``)
     can be concurrently invalidated/deleted, matching 0 rows. The prior code ignored
     the rowcount and still called ``_append_observation_history``, whose INSERT carries
@@ -262,7 +263,7 @@ async def test_update_action_bails_when_observation_row_missing():
 
     append_mock = AsyncMock()
     with _patch_update_action_deps(consolidator, conn, source_ids, append_mock):
-        result = await consolidator._execute_update_action(
+        result = await consolidation_actions.execute_update_action(
             pool=MagicMock(),
             memory_engine=MagicMock(),
             bank_id="bank-x",
@@ -295,7 +296,7 @@ async def test_update_action_writes_history_when_row_present():
 
     append_mock = AsyncMock()
     with _patch_update_action_deps(consolidator, conn, source_ids, append_mock):
-        result = await consolidator._execute_update_action(
+        result = await consolidation_actions.execute_update_action(
             pool=MagicMock(),
             memory_engine=memory_engine,
             bank_id="bank-x",

--- a/hindsight-api-slim/tests/test_observation_invalidation.py
+++ b/hindsight-api-slim/tests/test_observation_invalidation.py
@@ -1049,7 +1049,7 @@ class TestConsolidationSourceMemoryFiltering:
     async def test_create_observation_filters_deleted_source_memories(
         self, memory: MemoryEngine, request_context: RequestContext
     ):
-        from hindsight_api.engine.consolidation.consolidator import _create_observation_directly
+        from tests.consolidation_actions import create_observation as _create_observation_directly
 
         bank_id = f"test-race-create-filter-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
@@ -1082,7 +1082,7 @@ class TestConsolidationSourceMemoryFiltering:
     async def test_create_observation_skipped_when_all_sources_deleted(
         self, memory: MemoryEngine, request_context: RequestContext
     ):
-        from hindsight_api.engine.consolidation.consolidator import _create_observation_directly
+        from tests.consolidation_actions import create_observation as _create_observation_directly
 
         bank_id = f"test-race-create-skip-{uuid.uuid4().hex[:8]}"
         await _ensure_bank(memory, bank_id, request_context)
@@ -1109,7 +1109,7 @@ class TestConsolidationSourceMemoryFiltering:
     async def test_update_observation_skipped_when_all_new_sources_deleted(
         self, memory: MemoryEngine, request_context: RequestContext
     ):
-        from hindsight_api.engine.consolidation.consolidator import _execute_update_action
+        from tests.consolidation_actions import execute_update_action as _execute_update_action
         from hindsight_api.engine.response_models import MemoryFact
 
         bank_id = f"test-race-update-skip-{uuid.uuid4().hex[:8]}"
@@ -1158,7 +1158,7 @@ class TestConsolidationSourceMemoryFiltering:
         # The preflight sees the source live, but it is deleted while the embedder runs
         # off-connection. The authoritative in-txn FOR SHARE liveness guard (not the preflight) must
         # then skip the update, so a dead source is never written back into the observation.
-        from hindsight_api.engine.consolidation.consolidator import _execute_update_action
+        from tests.consolidation_actions import execute_update_action as _execute_update_action
         from hindsight_api.engine.response_models import MemoryFact
 
         bank_id = f"test-race-update-inflight-{uuid.uuid4().hex[:8]}"

--- a/hindsight-api-slim/tests/test_oracle_integration.py
+++ b/hindsight-api-slim/tests/test_oracle_integration.py
@@ -20,6 +20,7 @@ import pytest_asyncio
 from hindsight_api import MemoryEngine, RequestContext
 from hindsight_api.engine.db import DatabaseConnection
 from hindsight_api.engine.memory_engine import Budget
+from tests import consolidation_actions
 from tests.test_bank_config_atomicity import (
     assert_one_sided_budget_update_sees_stored_state,
     assert_recall_budget_race_is_serialized,
@@ -1223,8 +1224,6 @@ class TestOracleSpecific:
         """
         from hindsight_api.config import _get_raw_config
         from hindsight_api.engine.consolidation.consolidator import (
-            _execute_create_action,
-            _execute_update_action,
             _TemporalBounds,
         )
         from hindsight_api.engine.response_models import MemoryFact
@@ -1253,7 +1252,7 @@ class TestOracleSpecific:
 
             # An observation built from an undated fact: event_date/mentioned_at are stamped at
             # creation time, occurred_start/occurred_end stay NULL.
-            action = await _execute_create_action(
+            action = await consolidation_actions.execute_create_action(
                 pool=backend,
                 memory_engine=oracle_memory,
                 bank_id=bank_id,
@@ -1269,7 +1268,7 @@ class TestOracleSpecific:
                 )
             assert seeded["occurred_start"] is None and seeded["occurred_end"] is None
 
-            await _execute_update_action(
+            await consolidation_actions.execute_update_action(
                 pool=backend,
                 memory_engine=oracle_memory,
                 bank_id=bank_id,


### PR DESCRIPTION
## The bug

Consolidation wrote each action from an LLM response the moment it was decided, each on its own connection — deletes first (to free observation slots), then updates, then creates — and stamped `consolidated_at` on the source facts in a separate statement after the whole batch. Nothing tied those writes together.

So a batch whose DELETE landed and whose replacement CREATE then failed left the observation deleted with nothing in its place, while its sources were stamped consolidated. `consolidated_at` is the exclusion predicate for pending consolidation, so nothing ever rebuilt what the batch failed to write. The operation reported `completed`, `failed_operations: 0`, and nothing reached `audit_log`.

That is #3876: an operator running a small self-hosted model whose consolidation responses intermittently failed schema validation watched a bank's observations drain away while every batch logged success.

I reproduced all three failure shapes on `main` before touching anything:

| shape | outcome on main |
|---|---|
| schema-invalid response (`updates[].observation_id` missing) | every fact stamped `consolidation_failed_at`, job returns `completed` |
| DELETE commits, CREATE then raises | observation gone permanently; source still stamped consolidated |
| DELETE commits, CREATE silently dropped (model cites a fact id not in the batch) | `observations_deleted: 1, observations_created: 0, memories_failed: 0`, status `completed` |

## The fix

Every write derived from **one** LLM response — deletes, updates, creates, dedup folds — now commits or rolls back together, and the `consolidated_at` stamps for the facts that response consumed commit in the same transaction.

A transaction must never be held open across an embedder or an LLM call, so each action is split in two: a connection-free **prepare** (resolve and security-check the source facts, embed the text, adjudicate the semantic-dedup verdict) and an **apply** that runs on the batch's connection inside the batch's transaction.

```
_execute_update_action       -> _apply_update_action      (+ prepare in the batch)
_create_observation_directly -> _apply_create_observation
_execute_create_action       -> _apply_create_action
_dedup_reconcile_create      -> _dedup_adjudicate + _apply_dedup_create_fold
_dedup_reconcile_update      -> _dedup_adjudicate + _apply_dedup_update_fold
```

Every SQL statement is carried over byte-identical (verified by normalising and diffing every statement in the file against `main`) — only *where* it runs changed. Bank scoping, the FOR SHARE liveness rechecks, the RETURNING text guards and the Oracle-safe clauses are all untouched.

## Behaviour changes worth reviewing

- **A failed LLM call stamps nothing.** It produces no actions, so its memories stay pending for the bisection retry. Already the contract; now enforced by the same guard that skips the transaction entirely when a batch has neither writes nor stamps. `test_consolidation_failure_recovery` caught me getting this wrong first time round.
- **Multi-scope passes.** A memory consolidated at several tag scopes gets one LLM call per scope; the stamp belongs to the last of them, and a failed pass now stops the remaining scopes rather than writing observations the bisection retry will redo anyway.
- **Create-path semantic dedup** probes the state the batch started from, so two near-twin CREATEs in a single response can both land. The next round's probe folds them, and the deterministic exact-text guard still covers the common case. Called out in a comment where it happens.

## What this does *not* fix

The third shape above — a DELETE applied while its replacement CREATE is rejected by the per-fact recall guard — still loses the observation, because nothing errors: the response is valid, the delete is authorised, and the create is dropped by design. One transaction cannot help when every statement in it succeeds. Worth a follow-up (don't stamp sources whose actions were all dropped; surface dropped actions in the operation status), and I'd rather keep this PR to the atomicity change.

## Tests

New `tests/test_consolidation_batch_atomicity.py`:
- a failed create rolls back the delete it was replacing, and its fact stays pending
- a failed batch stamps no `consolidated_at`
- the happy path still commits observations and stamps

Tests that drove a whole action through the old pool-based helpers now compose the two halves via `tests/consolidation_actions.py`.

Local runs (isolated pg0): 184 passed across `test_consolidation*`, `test_document_transfer`, `test_integrity_violation_not_retried`, `test_observation_invalidation`; 103 passed across the observation/bank-health sweep. `lint.sh` and `check-unused.sh` clean.

Fixes #3876

https://claude.ai/code/session_01UBcDzagMhuXsYZDp63i7aB
