### PR TITLE
fix(cli): restore default SIGPIPE handling to prevent abort on broken pipe

### DIFF
--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -1357,6 +1357,17 @@ enum DirectiveCommands {
 }
 
 fn main() {
+    // When stdout/stderr is a pipe whose reader closes early (e.g.
+    // `hindsight ... | head`), a write triggers SIGPIPE. Rust's `println!`
+    // panics on the resulting EPIPE error, and with `panic = "abort"` in the
+    // release profile that becomes a silent SIGABRT — which surfaces as a
+    // spurious "fatal error" and kills the process without any message.
+    // Restore the default SIGPIPE disposition so we terminate cleanly on
+    // SIGPIPE, like other Unix CLI tools.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     if let Err(e) = run() {
         ui::print_error(&format!("{:#}", e));
         std::process::exit(1);

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -1357,13 +1357,18 @@ enum DirectiveCommands {
 }
 
 fn main() {
-    // When stdout/stderr is a pipe whose reader closes early (e.g.
-    // `hindsight ... | head`), a write triggers SIGPIPE. Rust's `println!`
-    // panics on the resulting EPIPE error, and with `panic = "abort"` in the
-    // release profile that becomes a silent SIGABRT — which surfaces as a
-    // spurious "fatal error" and kills the process without any message.
-    // Restore the default SIGPIPE disposition so we terminate cleanly on
-    // SIGPIPE, like other Unix CLI tools.
+    // Rust ignores SIGPIPE at startup so that `println!`/`print!` surface a
+    // closed stdout pipe as an `EPIPE` error rather than a signal. But the
+    // release profile sets `panic = "abort"`, so that write error becomes a
+    // silent SIGABRT — a spurious "fatal error" with no message — whenever
+    // the reader closes early (e.g. `hindsight ... | head`).
+    //
+    // Restore the default SIGPIPE disposition on Unix so the CLI terminates
+    // cleanly on a broken pipe, like other Unix CLI tools. Note this also
+    // applies to socket writes: on Linux a peer closing a connection mid-write
+    // surfaces as SIGPIPE rather than an `Err(EPIPE)`. ripgrep and fd accept
+    // the same trade-off, and it is the correct behavior here too.
+    #[cfg(unix)]
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }

--- a/hindsight-cli/tests/integration_test.rs
+++ b/hindsight-cli/tests/integration_test.rs
@@ -197,3 +197,49 @@ fn test_configure_command() {
     // Cleanup
     std::fs::remove_dir_all(&temp_dir).ok();
 }
+
+/// Regression test for the SIGPIPE crash.
+///
+/// Release builds set `panic = "abort"`, and Rust ignores SIGPIPE at startup,
+/// so a write to a closed stdout pipe surfaces as an `EPIPE` panic that becomes
+/// a silent SIGABRT. The fix restores the default SIGPIPE disposition so the
+/// CLI instead terminates with SIGPIPE (signal 13), like other Unix tools.
+///
+/// This test is deterministic: it hands the child a stdout pipe whose read end
+/// is already closed, so the very first write triggers SIGPIPE regardless of
+/// how much output the child produces (no reliance on overflowing the 64 KiB
+/// pipe buffer, which is what makes a plain `--help | head` flaky).
+#[cfg(unix)]
+#[test]
+fn test_sigpipe_terminates_with_signal_not_abort() {
+    use std::os::unix::io::FromRawFd;
+    use std::os::unix::process::ExitStatusExt;
+
+    // Create a pipe and immediately close its read end. There is no reader, so
+    // the child's first write to stdout must hit SIGPIPE (if its default
+    // disposition was restored) rather than an EPIPE panic/abort.
+    let mut fds = [0i32; 2];
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    assert_eq!(rc, 0, "pipe() failed");
+    unsafe {
+        libc::close(fds[0]);
+    }
+
+    let stdout = unsafe { std::process::Stdio::from_raw_fd(fds[1]) };
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_hindsight"))
+        .arg("--help")
+        .stdout(stdout)
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to spawn hindsight");
+
+    let status = child.wait().expect("failed to wait on hindsight");
+    // signal 13 == SIGPIPE. A panic/abort would instead report signal 6 (ABRT)
+    // or a non-zero exit code, neither of which is the desired clean
+    // termination.
+    assert_eq!(
+        status.signal(),
+        Some(13),
+        "expected SIGPIPE termination, got status {status:?}"
+    );
+}


### PR DESCRIPTION
## Problem

When the hindsight CLI's output is piped into a consumer that closes the pipe early (e.g. `hindsight tag list mbn | head -5`), the process crashes with a fatal error (SIGABRT) instead of terminating cleanly.

The release profile sets `panic = "abort"` in `hindsight-cli/Cargo.toml`. Rust's `println!` panics when a write to stdout/stderr hits `EPIPE`, and with abort-panic this becomes a silent `SIGABRT` — no error message, just an abnormal termination (exit 134 = 128 + SIGABRT).

This is especially common for agent/automation workflows that pipe output through `head` or other tools that stop reading early.

## Reproduction

```bash
for i in 1 2 3 4 5; do
  hindsight memory recall mbn "shipping" --tags "domain:stocks" --tags-match any_strict --max-tokens 8000 --output json | head -3 >/dev/null
  echo "exit: ${PIPESTATUS[0]}"
done
# before: exit 134 (SIGABRT) repeatedly
# after:  exit 141 (SIGPIPE, clean)
```

## Fix

Restore the default `SIGPIPE` disposition in `main()` so the CLI terminates cleanly on a broken pipe, matching standard Unix CLI behavior:

```rust
unsafe {
    libc::signal(libc::SIGPIPE, libc::SIG_DFL);
}
```

## Testing

- Reproduced the crash 4/5 times before the fix (exit 134).
- After the fix, the same command consistently exits 141 with no abort.
- Confirmed no `ANOM_ABEND`/SIGABRT entries in the journal afterward.