### PR TITLE
fix(search): embed the whole mental-model document on every write

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -15307,36 +15307,48 @@ class MemoryEngine(MemoryEngineInterface):
             content = document.markdown
             structured_content = document.structure.model_dump()
 
-        # Compute the new embedding BEFORE acquiring a pooled connection: a slow
-        # embedder must never pin a DB connection. The embedding text depends only
-        # on the incoming name/content, never on DB state, so it can be done here.
+        # A model's searchable document is its name AND its content, so half of it
+        # cannot be embedded on its own: a content-only edit that embedded just the
+        # content, and a name-only edit that skipped the embedding altogether, both
+        # left the vector describing text the model no longer holds (#3926). Resolve
+        # the stored half first and embed the whole document. The lexical projection
+        # below already falls back to the untouched column and needs no such read.
+        #
+        # The read happens before the write block so a slow embedder never pins a
+        # pooled connection; when the caller supplied a connection we are inside
+        # their transaction already, so the read joins it rather than racing it.
+        previous_content: str | None = None
+        previous_reflect_response: dict[str, Any] | None = None
         new_embedding_str: str | None = None
-        if content is not None:
-            embedding_text = f"{name or ''} {content}"
-            embedding = await embedding_utils.generate_embeddings_batch(self.embeddings, [embedding_text])
-            if embedding:
-                new_embedding_str = str(embedding[0])
+        document_changed = name is not None or content is not None
+        if document_changed:
+            async with use_or_acquire(backend, conn) as read_conn:
+                current_row = await read_conn.fetchrow(
+                    f"SELECT name, content, reflect_response FROM {fq_table('mental_models')} "
+                    "WHERE bank_id = $1 AND id = $2",
+                    bank_id,
+                    mental_model_id,
+                )
+            if current_row is None:
+                return None
+
+            if content is not None:
+                # Snapshot for history, taken from the same read.
+                previous_content = current_row["content"]
+                raw_rr = current_row["reflect_response"]
+                if isinstance(raw_rr, str):
+                    previous_reflect_response = json.loads(raw_rr) if raw_rr else None
+                else:
+                    previous_reflect_response = raw_rr
+
+            new_embedding_str = await self._generate_mental_model_embedding(
+                name if name is not None else (current_row["name"] or ""),
+                content if content is not None else (current_row["content"] or ""),
+            )
 
         # The exit stack carries the row lock a trigger patch takes below; it stays
         # empty (and free) on every other update.
         async with use_or_acquire(backend, conn) as conn, AsyncExitStack() as stack:
-            # If content is changing, fetch current content + reflect_response to record history
-            previous_content: str | None = None
-            previous_reflect_response: dict[str, Any] | None = None
-            if content is not None:
-                current_row = await conn.fetchrow(
-                    f"SELECT content, reflect_response FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
-                    bank_id,
-                    mental_model_id,
-                )
-                if current_row:
-                    previous_content = current_row["content"]
-                    raw_rr = current_row["reflect_response"]
-                    if isinstance(raw_rr, str):
-                        previous_reflect_response = json.loads(raw_rr) if raw_rr else None
-                    else:
-                        previous_reflect_response = raw_rr
-
             # A supplied trigger PATCHES the stored one (see _merge_trigger): callers
             # send only the fields they set, so the rest have to be read back rather
             # than defaulted. Only paid for when a trigger is actually being changed.
@@ -15407,11 +15419,14 @@ class MemoryEngine(MemoryEngineInterface):
                             slim["trace"] = previous_trace
                         slim_reflect_response = slim or None
                     record_mm_history = True
-                # Apply the embedding computed above (off-connection).
-                if new_embedding_str is not None:
-                    updates.append(f"embedding = ${param_idx}")
-                    params.append(new_embedding_str)
-                    param_idx += 1
+
+            # Apply the embedding computed above (off-connection). Written whenever
+            # either half of the document moved, so the vector and the stored text
+            # never describe different things.
+            if document_changed:
+                updates.append(f"embedding = ${param_idx}")
+                params.append(new_embedding_str)
+                param_idx += 1
 
             # The two timestamps move independently, and conflating them is what made a
             # refresh look like it never ran (#3531): the watermark is clamped so it
@@ -15584,6 +15599,20 @@ class MemoryEngine(MemoryEngineInterface):
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
         backend = await self._get_backend()
 
+        # The dense vector has to be rebuilt from the name alone as well: leaving the
+        # one built from the discarded content behind kept a deliberately cleared
+        # model ranking in semantic recall on a body it no longer has (#3926). Read
+        # the name and embed it before touching a pooled connection for the write.
+        async with acquire_with_retry(backend) as conn:
+            current_row = await conn.fetchrow(
+                f"SELECT name FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                mental_model_id,
+            )
+        if current_row is None:
+            return None
+        embedding_str = await self._generate_mental_model_embedding(current_row["name"] or "", "")
+
         # Content is cleared to '', so re-tokenize search_vector from the name
         # alone — vchord only (see update_mental_model). Non-vchord backends leave
         # the column untouched (generated / base-column indexed).
@@ -15597,7 +15626,8 @@ class MemoryEngine(MemoryEngineInterface):
                 UPDATE {fq_table("mental_models")}
                 SET content = '',
                     structured_content = NULL,
-                    last_refreshed_source_query = NULL{sv_clause}
+                    last_refreshed_source_query = NULL,
+                    embedding = $3{sv_clause}
                 WHERE bank_id = $1 AND id = $2
                 RETURNING id, bank_id, name, source_query, content, tags,
                           last_refreshed_at, last_memory_seen_at, created_at, reflect_response,
@@ -15605,6 +15635,7 @@ class MemoryEngine(MemoryEngineInterface):
                 """,
                 bank_id,
                 mental_model_id,
+                embedding_str,
             )
 
         return self._row_to_mental_model(row) if row else None

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -22,7 +22,9 @@ from hindsight_api.engine.memory_engine import (
     MENTAL_MODEL_PENDING_CONTENT,
     MemoryEngine,
     _may_need_refresh,
+    fq_table,
 )
+from hindsight_api.engine.retain import embedding_utils
 from hindsight_api.extensions import (
     BankReadContext,
     BankReadOperation,
@@ -894,6 +896,45 @@ class TestMoveRenameDelete:
         )
         assert hit.status_code == 200, hit.text
         assert any(r["id"] == ids.orders for r in hit.json()["results"])
+
+    async def test_rename_page_reembeds_backing_model(
+        self, api_client, kb_bank, memory: MemoryEngine, request_context, monkeypatch
+    ):
+        """Regression for #3926: the rename reached the backing model's name and its
+        lexical projection, but not its vector, so semantic recall kept matching the
+        page on its old title."""
+        bank_id, ids = kb_bank
+
+        # No engine read exposes a model's embedding, and the stale column is the
+        # defect under test, so it has to be read directly.
+        async def stored_embedding() -> str:
+            async with memory._pool.acquire() as conn:
+                return await conn.fetchval(
+                    f"SELECT embedding::text FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                    bank_id,
+                    ids.orders_mm,
+                )
+
+        before = await stored_embedding()
+
+        embedded: list[str] = []
+        original_generate = embedding_utils.generate_embeddings_batch
+
+        async def recording_generate(backend, texts, *args, **kwargs):
+            embedded.extend(texts)
+            return await original_generate(backend, texts, *args, **kwargs)
+
+        monkeypatch.setattr(embedding_utils, "generate_embeddings_batch", recording_generate)
+
+        resp = await api_client.patch(
+            f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/nodes/{ids.orders}",
+            json={"name": "Order Operations"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        mm = await memory.get_mental_model(bank_id, ids.orders_mm, request_context=request_context)
+        assert embedded == [f"Order Operations {mm['content']}"]
+        assert await stored_embedding() != before
 
     async def test_update_page_options(self, api_client, kb_bank):
         bank_id, ids = kb_bank

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -2646,6 +2646,53 @@ class TestClearMentalModel:
 
         await memory.delete_bank(bank_id, request_context=request_context)
 
+    async def test_clear_rebuilds_embedding_from_the_name(self, memory: MemoryEngine, request_context, monkeypatch):
+        """Regression for #3926: clearing the content must not leave the vector
+        built from that content behind, or the model keeps ranking in semantic
+        recall on a body it no longer has."""
+        bank_id = f"test-mm-clear-embed-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Test Model",
+            source_query="What do we know?",
+            content="Some existing content",
+            request_context=request_context,
+        )
+
+        # No engine read exposes a model's embedding, and the stale column is the
+        # defect under test, so it has to be read directly.
+        async def stored_embedding() -> str:
+            async with memory._pool.acquire() as conn:
+                return await conn.fetchval(
+                    f"SELECT embedding::text FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                    bank_id,
+                    mm["id"],
+                )
+
+        before = await stored_embedding()
+
+        embedded: list[str] = []
+        original_generate = embedding_utils.generate_embeddings_batch
+
+        async def recording_generate(backend, texts, *args, **kwargs):
+            embedded.extend(texts)
+            return await original_generate(backend, texts, *args, **kwargs)
+
+        monkeypatch.setattr(embedding_utils, "generate_embeddings_batch", recording_generate)
+
+        cleared = await memory.clear_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            request_context=request_context,
+        )
+        assert cleared is not None
+        assert embedded == ["Test Model "]
+        assert await stored_embedding() != before
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
     async def test_clear_nonexistent_returns_none(self, memory: MemoryEngine, request_context):
         """Clearing a non-existent mental model returns None."""
         bank_id = f"test-mm-clear-none-{uuid.uuid4().hex[:8]}"

--- a/hindsight-api-slim/tests/test_reflections.py
+++ b/hindsight-api-slim/tests/test_reflections.py
@@ -7,7 +7,8 @@ import pytest
 import pytest_asyncio
 
 from hindsight_api.api import create_app
-from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.memory_engine import MemoryEngine, fq_table
+from hindsight_api.engine.retain import embedding_utils
 from tests.llm_judge import assert_meets_criteria
 
 
@@ -194,6 +195,75 @@ class TestMentalModelsCRUD:
         assert updated["content"] == "Updated Content\n"
 
         # Cleanup
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_partial_update_embeds_the_whole_stored_document(
+        self, memory: MemoryEngine, request_context, monkeypatch
+    ):
+        """Regression for #3926.
+
+        A model's searchable document is ``name + content``. An update that supplies
+        only one of them must embed the stored other half, and a name-only update
+        must re-embed at all — otherwise the vector keeps describing text the model
+        no longer holds.
+        """
+        bank_id = f"test-mm-partial-embed-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        mental_model = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Original Name",
+            source_query="Original Query",
+            content="Original Content",
+            request_context=request_context,
+        )
+
+        embedded: list[str] = []
+        original_generate = embedding_utils.generate_embeddings_batch
+
+        async def recording_generate(backend, texts, *args, **kwargs):
+            embedded.extend(texts)
+            return await original_generate(backend, texts, *args, **kwargs)
+
+        monkeypatch.setattr(embedding_utils, "generate_embeddings_batch", recording_generate)
+
+        # Read the raw vector: the engine API deliberately never exposes a model's
+        # embedding, and the whole point of the regression is that the column went
+        # stale, so there is no public read that can observe it.
+        async def stored_embedding() -> str:
+            async with memory._pool.acquire() as conn:
+                return await conn.fetchval(
+                    f"SELECT embedding::text FROM {fq_table('mental_models')} WHERE bank_id = $1 AND id = $2",
+                    bank_id,
+                    mental_model["id"],
+                )
+
+        before_content_edit = await stored_embedding()
+
+        # Content-only: the stored name has to be part of the embedded document.
+        updated = await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mental_model["id"],
+            content="Rewritten Content",
+            request_context=request_context,
+        )
+        assert embedded == [f"Original Name {updated['content']}"]
+        after_content_edit = await stored_embedding()
+        assert after_content_edit != before_content_edit
+
+        # Name-only: re-embedded, and against the content still stored.
+        embedded.clear()
+        renamed = await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mental_model["id"],
+            name="Renamed Model",
+            request_context=request_context,
+        )
+        assert renamed["name"] == "Renamed Model"
+        assert embedded == [f"Renamed Model {updated['content']}"]
+        assert await stored_embedding() != after_content_edit
+
         await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #3926.

## Summary

- embed the whole `name + content` document on every mental-model write, resolving whichever half the caller did not supply from the stored row
- re-embed on clear, from the name alone
- three regressions: content-only update, name-only update, Knowledge Page rename, and clear

## Root cause

A mental model's searchable document is its name plus its content — that is what `create` embeds (`_generate_mental_model_embedding`) and what the lexical projection indexes. But `update_mental_model` built the vector from the text a single call happened to pass:

```python
if content is not None:
    embedding_text = f"{name or ''} {content}"
```

So a **content-only** update embedded `" <content>"` with the stored name missing, and a **name-only** update did not re-embed at all. Two callers inherit that:

- **Knowledge Page rename.** `update_knowledge_page` correctly renames the backing model in the same transaction — `mm.name` and `search_vector` move — but it is a name-only update, so the vector kept the old title and semantic recall went on matching the page on the name it no longer has.
- **`clear_mental_model`** reset the content and re-tokenized `search_vector` but never touched `embedding`, leaving a deliberately cleared model ranking on the body it had just discarded.

The lexical half was already correct: it falls back to the untouched column (`name_sql` / `content_sql`), which is why only the dense vector drifted.

## The fix

Resolve the effective document — each half falling back to the stored value — and embed it whenever either half moves. The read runs on the caller's connection when one was supplied, so the Knowledge Page patch keeps its single transaction; otherwise it runs before the write block, so a slow provider still never pins the connection it is about to write on. It replaces the history-snapshot read rather than adding a round trip, except on a name-only update, which previously read nothing.

A refresh (content, no name) now embeds the stored name alongside the new content, matching create.

## Relation to #3313

#3313 reported the same defect. Its Knowledge Page half has since been fixed differently — the KB patch delegates to `update_mental_model` on its own connection rather than writing `mental_models` itself, and `rename_knowledge_node` no longer exists — so that PR no longer applies to this code and is closed in favour of this one.

## Verification

- `./scripts/hooks/lint.sh`: passed
- the three new regressions fail on `origin/main`'s engine and pass here
- `tests/test_knowledge_base.py` (77), `tests/test_reflections.py`, `tests/test_mental_models.py`, `tests/test_mental_model_delta.py`, `tests/test_mental_model_dry_run_refresh.py`, `tests/test_mental_model_trigger_patch_3687.py`, `tests/test_document_transfer.py` (non-LLM selection): all passed

https://claude.ai/code/session_01J52s5Lbg5Lp7KwRyhqg8f3
