### PR TITLE
fix(search): push bm25_min_score to text-search SQL arms and clarify recall score floors (#3882)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -352,9 +352,10 @@ class RecallRequest(BaseModel):
     )
     min_scores: MinScores | None = Field(
         default=None,
-        description="Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are "
-        "retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for "
-        "this request); `reranker` and `final` are post-ranking filters on the scored results. Any field left "
+        description="Optional per-stage score floors (all inclusive >=). `semantic` and `keyword` are "
+        "per-arm retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for "
+        "this request), pruning weak matches within each arm before fusion (without enforcing cross-arm intersection); "
+        "`reranker` and `final` are post-ranking filters applied to the scored results. Any field left "
         "unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use "
         "with care — the reranker's absolute scores are not calibrated across queries (a clearly-relevant match "
         "may score ~0.001 even though it is ranked first).",

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -200,20 +200,48 @@ class RecallScores(BaseModel):
 
 
 class MinScores(BaseModel):
-    """Optional per-stage score floors for recall (all inclusive, AND-ed).
+    """Optional per-stage score floors for recall (all inclusive >=).
 
-    ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL
-    arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``
-    config for this request), so they prune weak matches before fusion. ``reranker``
-    and ``final`` are **post-query** filters applied to the scored results after
-    reranking. Any field left None imposes no floor; all-None (the default) means
-    no score filtering.
+    ``semantic`` and ``keyword`` are **per-arm retrieval-level** cutoffs pushed
+    into the individual SQL query arms (overriding the global
+    ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so
+    they prune weak matches within each arm before fusion. Because recall merges
+    candidates across multiple arms (semantic, keyword, graph, temporal), a result
+    clearing one arm's threshold enters fusion even if absent or below floor in
+    another arm (i.e. not a cross-arm same-result intersection).
+
+    ``reranker`` and ``final`` are **post-ranking filters** applied to all scored
+    candidates after fusion and reranking, filtering out results that do not satisfy
+    the threshold.
+
+    Any field left None imposes no floor; all-None (the default) means no score
+    filtering.
     """
 
-    semantic: float | None = Field(default=None, description="Retrieval-level: minimum vector similarity (0-1).")
-    keyword: float | None = Field(default=None, description="Retrieval-level: minimum keyword/full-text (BM25) score.")
-    reranker: float | None = Field(default=None, description="Post-query: minimum normalized reranker score (0-1).")
-    final: float | None = Field(default=None, description="Post-query: minimum final ranking score.")
+    semantic: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+        description="Retrieval-level: minimum vector similarity (0-1) for the semantic arm.",
+    )
+    keyword: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+        description="Retrieval-level: minimum keyword/full-text (BM25) score for the keyword arm.",
+    )
+    reranker: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+        description="Post-query: minimum normalized reranker score (0-1) for ranked results.",
+    )
+    final: float | None = Field(
+        default=None,
+        ge=0.0,
+        allow_inf_nan=False,
+        description="Post-query: minimum final ranking score for ranked results.",
+    )
 
 
 class TemporalWindow(BaseModel):

--- a/hindsight-api-slim/hindsight_api/engine/sql/oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/oracle.py
@@ -276,6 +276,12 @@ class OracleDialect(SQLDialect):
         # Each arm gets a unique SCORE label (10 + arm_index) to avoid
         # conflicts within the UNION ALL.
         label = 10 + arm_index
+        # CONTAINS already gates to genuine matches; the configurable floor
+        # (default 0) keeps the threshold semantics uniform across backends.
+        # Score 0 in Oracle Text indicates no match, so default (0) uses > 0
+        # while positive user-defined floors use >= for inclusive semantics.
+        effective_min = max(bm25_min_score, 0.0)
+        score_op = ">=" if effective_min > 0 else ">"
         return (
             f"SELECT * FROM (SELECT {cols},"
             f"        NULL AS similarity,"
@@ -284,9 +290,7 @@ class OracleDialect(SQLDialect):
             f" FROM {table}"
             f" WHERE bank_id = {bank_id_param}"
             f"   AND fact_type = '{fact_type}'"
-            # CONTAINS already gates to genuine matches; the configurable floor
-            # (default 0) keeps the threshold semantics uniform across backends.
-            f"   AND CONTAINS(text, {text_param}, {label}) > {bm25_min_score:g}"
+            f"   AND CONTAINS(text, {text_param}, {label}) {score_op} {effective_min:g}"
             f"   {tags_clause}"
             f"   {groups_clause}"
             f"   {extra_where}"

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -313,13 +313,21 @@ class PostgreSQLDialect(SQLDialect):
             bm25_order_by = f"{bm25_score_expr} DESC"
             # Unlike native tsvector (which has a boolean `@@` match gate), the
             # VectorChord operator ranks *every* document, so a bare ORDER BY ...
-            # LIMIT pads the result with zero-score, non-matching rows. Gate on the
-            # score so only genuine term matches survive into fusion/reranking.
-            bm25_where_filter = f"AND -(search_vector <&> to_bm25query('idx_memory_units_text_search', tokenize({text_param}, 'llmlingua2'))) > {bm25_min_score:g}"
+            # LIMIT pads the result with zero-score, non-matching rows.
+            # When bm25_min_score <= 0 (default), gate strictly on > 0 to exclude
+            # zero-score non-matches; when bm25_min_score > 0, use >= for inclusive
+            # score floor semantics aligned with all other stages.
+            effective_min = max(bm25_min_score, 0.0)
+            score_op = ">=" if effective_min > 0 else ">"
+            bm25_where_filter = f"AND -(search_vector <&> to_bm25query('idx_memory_units_text_search', tokenize({text_param}, 'llmlingua2'))) {score_op} {effective_min:g}"
         elif text_search_extension == "pg_textsearch":
             bm25_score_expr = f"-(text <@> to_bm25query({text_param}, 'idx_memory_units_text_search'))"
             bm25_order_by = f"text <@> to_bm25query({text_param}, 'idx_memory_units_text_search') ASC"
-            bm25_where_filter = ""
+            bm25_where_filter = (
+                f"AND -(text <@> to_bm25query({text_param}, 'idx_memory_units_text_search')) >= {bm25_min_score:g}"
+                if bm25_min_score > 0
+                else ""
+            )
         elif text_search_extension == "pgroonga":
             # &@~ accepts pgroonga's query syntax. Tokenize the raw query with
             # pgroonga_tokenize using TokenBigram + NormalizerNFKC150 (the same
@@ -328,6 +336,10 @@ class PostgreSQLDialect(SQLDialect):
             # generation strategy (broadening recall across all scripts); precision
             # is restored downstream via BM25 score ranking, multi-arm RRF fusion,
             # and Cross-Encoder reranking.
+            # NOTE: pgroonga_score() returns a real score only off a PGroonga index
+            # scan and evaluates to 0.0 under sequential scans. The WHERE clause
+            # below matches the expression on idx_memory_units_text_search so the planner
+            # can use the index scan.
             bm25_score_expr = "pgroonga_score(tableoid, ctid)"
             bm25_order_by = f"{bm25_score_expr} DESC"
             query_expr = (
@@ -338,11 +350,16 @@ class PostgreSQLDialect(SQLDialect):
                 f"AND (COALESCE(text, '') || ' ' || COALESCE(context, '') || ' ' || COALESCE(text_signals, '')) "
                 f"&@~ {query_expr}"
             )
+            if bm25_min_score > 0:
+                bm25_where_filter += f" AND pgroonga_score(tableoid, ctid) >= {bm25_min_score:g}"
         elif text_search_extension == "pg_search":
             # ParadeDB pg_search: BM25 index over (id, text, context, text_signals)
             # with key_field='id'. The @@@ operator on the key_field requires a
             # field-qualified query (`text:foo`); to keep the bind-parameter form,
             # we fan the query out across all indexed text fields with paradedb.boolean.
+            # NOTE: Filtering by score in WHERE requires pg_search custom-scan
+            # predicate pushdown support when combined with @@@ and relational filters
+            # (e.g. bank_id, fact_type).
             bm25_score_expr = f"{pg_search_function_schema}.score(id)"
             bm25_order_by = f"{pg_search_function_schema}.score(id) DESC"
             bm25_where_filter = (
@@ -352,12 +369,16 @@ class PostgreSQLDialect(SQLDialect):
                 f"{pg_search_function_schema}.match('text_signals', {text_param})"
                 f"])"
             )
+            if bm25_min_score > 0:
+                bm25_where_filter += f" AND {pg_search_function_schema}.score(id) >= {bm25_min_score:g}"
         else:  # native tsvector
             # bm25_language is validated as a PG identifier in HindsightConfig.validate(),
             # so embedding it as a SQL literal here is safe.
             bm25_score_expr = f"ts_rank_cd(search_vector, to_tsquery('{bm25_language}', {text_param}))"
             bm25_order_by = f"{bm25_score_expr} DESC"
             bm25_where_filter = f"AND search_vector @@ to_tsquery('{bm25_language}', {text_param})"
+            if bm25_min_score > 0:
+                bm25_where_filter += f" AND {bm25_score_expr} >= {bm25_min_score:g}"
 
         return (
             f"(SELECT {cols},"

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -1110,8 +1110,8 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 query_timestamp: Temporal context for the query (ISO format, e.g., '2024-01-15T10:30:00Z').
                     Anchors relative temporal expressions and recency scoring.
                 min_scores: Optional per-stage score floors as an object with any of: "semantic", "keyword"
-                    (retrieval-level cutoffs), "reranker", "final" (post-ranking). E.g. {"reranker": 0.5}.
-                    All inclusive and AND-ed; omit for no score filtering. The reranker's absolute scores are
+                    (per-arm retrieval-level cutoffs), "reranker", "final" (post-ranking). E.g. {"final": 0.5}.
+                    All inclusive (>=); omit for no score filtering. The reranker's absolute scores are
                     not calibrated across queries, so only threshold against scores you've calibrated for your
                     own data.
                 temporal_window: Window for the temporal arm as {"start": ISO, "end": ISO}, used instead of
@@ -1202,8 +1202,8 @@ def _register_recall(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig)
                 query_timestamp: Temporal context for the query (ISO format, e.g., '2024-01-15T10:30:00Z').
                     Anchors relative temporal expressions and recency scoring.
                 min_scores: Optional per-stage score floors as an object with any of: "semantic", "keyword"
-                    (retrieval-level cutoffs), "reranker", "final" (post-ranking). E.g. {"reranker": 0.5}.
-                    All inclusive and AND-ed; omit for no score filtering. The reranker's absolute scores are
+                    (per-arm retrieval-level cutoffs), "reranker", "final" (post-ranking). E.g. {"final": 0.5}.
+                    All inclusive (>=); omit for no score filtering. The reranker's absolute scores are
                     not calibrated across queries, so only threshold against scores you've calibrated for your
                     own data.
                 temporal_window: Window for the temporal arm as {"start": ISO, "end": ISO}, used instead of

--- a/hindsight-api-slim/tests/test_db_abstraction.py
+++ b/hindsight-api-slim/tests/test_db_abstraction.py
@@ -242,6 +242,18 @@ class TestPostgreSQLDialect:
         assert "to_tsquery('french', $4)" in arm
         assert "to_tsquery('english'" not in arm
 
+    def test_build_bm25_arm_native_honors_custom_min_score(self, d):
+        arm = d.build_bm25_arm(
+            table="schema.memory_units",
+            cols="id, text",
+            fact_type="world",
+            bank_id_param="$2",
+            limit_param="$3",
+            text_param="$4",
+            bm25_min_score=0.3,
+        )
+        assert "AND ts_rank_cd(search_vector, to_tsquery('english', $4)) >= 0.3" in arm
+
     def test_build_bm25_arm_vchord(self, d):
         arm = d.build_bm25_arm(
             table="t",
@@ -285,7 +297,22 @@ class TestPostgreSQLDialect:
             text_search_extension="vchord",
             bm25_min_score=2.5,
         )
-        assert "> 2.5" in arm
+        assert ">= 2.5" in arm
+
+    def test_build_bm25_arm_vchord_clamps_negative_min_score(self, d):
+        arm = d.build_bm25_arm(
+            table="t",
+            cols="id",
+            fact_type="world",
+            bank_id_param="$2",
+            limit_param="$3",
+            text_param="$4",
+            text_search_extension="vchord",
+            bm25_min_score=-1.0,
+        )
+        assert (
+            "-(search_vector <&> to_bm25query('idx_memory_units_text_search', tokenize($4, 'llmlingua2'))) > 0" in arm
+        )
 
     def test_build_bm25_arm_pg_textsearch_scores_each_row(self, d):
         arm = d.build_bm25_arm(
@@ -301,6 +328,20 @@ class TestPostgreSQLDialect:
         assert f"-({expected_distance}) AS bm25_score" in arm
         assert f"ORDER BY {expected_distance} ASC" in arm
         assert "$4 <@>" not in arm
+
+    def test_build_bm25_arm_pg_textsearch_honors_custom_min_score(self, d):
+        arm = d.build_bm25_arm(
+            table="schema.memory_units",
+            cols="id, text",
+            fact_type="world",
+            bank_id_param="$2",
+            limit_param="$3",
+            text_param="$4",
+            text_search_extension="pg_textsearch",
+            bm25_min_score=1.5,
+        )
+        expected_distance = "text <@> to_bm25query($4, 'idx_memory_units_text_search')"
+        assert f"AND -({expected_distance}) >= 1.5" in arm
 
     def test_build_bm25_arm_pgroonga(self, d):
         arm = d.build_bm25_arm(
@@ -318,6 +359,19 @@ class TestPostgreSQLDialect:
         assert "pgroonga_tokenize($4, 'tokenizer', 'TokenBigram', 'normalizer', 'NormalizerNFKC150')" in arm
         assert "pgroonga_score(tableoid, ctid)" in arm
         assert "to_tsquery" not in arm
+
+    def test_build_bm25_arm_pgroonga_honors_custom_min_score(self, d):
+        arm = d.build_bm25_arm(
+            table="schema.memory_units",
+            cols="id, text",
+            fact_type="world",
+            bank_id_param="$2",
+            limit_param="$3",
+            text_param="$4",
+            text_search_extension="pgroonga",
+            bm25_min_score=0.8,
+        )
+        assert "AND pgroonga_score(tableoid, ctid) >= 0.8" in arm
 
     def test_build_bm25_arm_pgroonga_ignores_bm25_language(self, d):
         """pgroonga's tokenizer is fixed at index creation; bm25_language must not leak in."""
@@ -353,6 +407,19 @@ class TestPostgreSQLDialect:
         assert "paradedb.score(id) DESC" in arm
         assert "'bm25' AS source" in arm
         assert "LIMIT $3" in arm
+
+    def test_build_bm25_arm_pg_search_honors_custom_min_score(self, d):
+        arm = d.build_bm25_arm(
+            table="schema.memory_units",
+            cols="id, text",
+            fact_type="world",
+            bank_id_param="$2",
+            limit_param="$3",
+            text_param="$4",
+            text_search_extension="pg_search",
+            bm25_min_score=2.0,
+        )
+        assert "AND paradedb.score(id) >= 2" in arm
 
     def test_build_bm25_arm_pg_search_custom_schema(self, d):
         arm = d.build_bm25_arm(
@@ -465,8 +532,35 @@ class TestOracleDialect:
         )
         assert "CONTAINS" in arm
         assert "SCORE(10)" in arm
+        assert "CONTAINS(text, :4, 10) > 0" in arm
         assert "'bm25' AS source" in arm
         assert "FETCH FIRST :3 ROWS ONLY" in arm
+
+    def test_build_bm25_arm_honors_custom_min_score(self, d):
+        arm = d.build_bm25_arm(
+            table="memory_units",
+            cols="id, text",
+            fact_type="world",
+            bank_id_param=":2",
+            limit_param=":3",
+            text_param=":4",
+            arm_index=0,
+            bm25_min_score=2.5,
+        )
+        assert "CONTAINS(text, :4, 10) >= 2.5" in arm
+
+    def test_build_bm25_arm_clamps_negative_min_score(self, d):
+        arm = d.build_bm25_arm(
+            table="memory_units",
+            cols="id, text",
+            fact_type="world",
+            bank_id_param=":2",
+            limit_param=":3",
+            text_param=":4",
+            arm_index=0,
+            bm25_min_score=-1.0,
+        )
+        assert "CONTAINS(text, :4, 10) > 0" in arm
 
     def test_build_bm25_arm_unique_labels(self, d):
         """Each arm_index produces a unique SCORE label to avoid conflicts in UNION ALL."""

--- a/hindsight-api-slim/tests/test_recall_min_score.py
+++ b/hindsight-api-slim/tests/test_recall_min_score.py
@@ -35,8 +35,8 @@ RC = RequestContext(tenant_id="default")
 async def _insert_fact(conn, *, fact_id: str, text: str, bank_id: str, embedding_str: str) -> None:
     await conn.execute(
         """
-        INSERT INTO memory_units (id, bank_id, text, fact_type, embedding)
-        VALUES ($1, $2, $3, 'world', $4::vector)
+        INSERT INTO memory_units (id, bank_id, text, fact_type, embedding, search_vector)
+        VALUES ($1, $2, $3, 'world', $4::vector, to_tsvector('english', $3))
         """,
         fact_id,
         bank_id,
@@ -171,16 +171,73 @@ class TestRetrievalLevelFilters:
         for r in filtered.results:
             assert r.scores.semantic is not None and r.scores.semantic >= floor
 
-    async def test_semantic_floor_above_one_returns_empty(self, seeded_memory):
+    async def test_semantic_floor_above_one_returns_empty_when_no_keyword_match(self, seeded_memory):
         engine, bank_id = seeded_memory
-        filtered = await _recall(engine, bank_id, min_scores=MinScores(semantic=1.1))
+        filtered = await _recall(engine, bank_id, query="philosophy and computers", min_scores=MinScores(semantic=1.1))
+        assert filtered.results == []
+
+    @pytest.mark.memory_backend_incompatible
+    async def test_semantic_floor_prunes_only_semantic_arm_and_keeps_keyword_arm(self, seeded_memory):
+        """A semantic floor above 1.0 prunes all semantic candidates, but keyword matches
+        still survive into fusion since floors operate per retrieval arm."""
+        engine, bank_id = seeded_memory
+        filtered = await _recall(engine, bank_id, query="animals and nature", min_scores=MinScores(semantic=1.1))
+        assert len(filtered.results) > 0
+        for r in filtered.results:
+            assert r.scores.semantic is None
+            assert r.scores.keyword is not None
+
+    @pytest.mark.memory_backend_incompatible
+    async def test_keyword_floor_prunes_in_retrieval(self, seeded_memory):
+        """min_scores.keyword is a SQL-arm cutoff: when keyword search surfaces
+        results, a keyword floor prunes matches below that threshold in the BM25 arm."""
+        engine, bank_id = seeded_memory
+        baseline = await _recall(engine, bank_id, query="cat and dogs")
+        keywords = sorted(r.scores.keyword for r in baseline.results if r.scores.keyword is not None)
+        assert keywords, "keyword arm should have surfaced matched facts"
+        floor = keywords[-1]
+        # Restrict semantic arm to ensure results only come from the keyword arm
+        filtered = await _recall(
+            engine, bank_id, query="cat and dogs", min_scores=MinScores(semantic=1.1, keyword=floor)
+        )
+        assert filtered.results, "Inclusive boundary: result with max score must survive the floor"
+        assert len(filtered.results) <= len(baseline.results)
+        for r in filtered.results:
+            assert r.scores.keyword is not None and r.scores.keyword >= floor
+
+    @pytest.mark.memory_backend_incompatible
+    async def test_keyword_floor_impossibly_high_returns_empty(self, seeded_memory):
+        engine, bank_id = seeded_memory
+        filtered = await _recall(
+            engine, bank_id, query="cat and dogs", min_scores=MinScores(semantic=1.1, keyword=10000.0)
+        )
         assert filtered.results == []
 
 
-class TestRecallRequestDefault:
-    """min_scores is opt-in: the HTTP recall defaults to None (no filtering)."""
+class TestRecallRequestValidation:
+    """Validation tests for RecallRequest and MinScores."""
 
     def test_http_request_defaults_to_none(self):
         from hindsight_api.api.http import RecallRequest
 
         assert RecallRequest(query="hi").min_scores is None
+
+    def test_min_scores_rejects_inf_and_nan(self):
+        from pydantic import ValidationError
+
+        for field in ("semantic", "keyword", "reranker", "final"):
+            with pytest.raises(ValidationError):
+                MinScores(**{field: float("inf")})
+            with pytest.raises(ValidationError):
+                MinScores(**{field: float("-inf")})
+            with pytest.raises(ValidationError):
+                MinScores(**{field: float("nan")})
+
+    def test_min_scores_rejects_negative_scores(self):
+        from pydantic import ValidationError
+
+        for field in ("semantic", "keyword", "reranker", "final"):
+            with pytest.raises(ValidationError):
+                MinScores(**{field: -1.0})
+            with pytest.raises(ValidationError):
+                MinScores(**{field: -0.01})

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -8949,25 +8949,37 @@ components:
       title: MentalModelTrigger
     MinScores:
       description: |-
-        Optional per-stage score floors for recall (all inclusive, AND-ed).
+        Optional per-stage score floors for recall (all inclusive >=).
 
-        ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL
-        arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``
-        config for this request), so they prune weak matches before fusion. ``reranker``
-        and ``final`` are **post-query** filters applied to the scored results after
-        reranking. Any field left None imposes no floor; all-None (the default) means
-        no score filtering.
+        ``semantic`` and ``keyword`` are **per-arm retrieval-level** cutoffs pushed
+        into the individual SQL query arms (overriding the global
+        ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so
+        they prune weak matches within each arm before fusion. Because recall merges
+        candidates across multiple arms (semantic, keyword, graph, temporal), a result
+        clearing one arm's threshold enters fusion even if absent or below floor in
+        another arm (i.e. not a cross-arm same-result intersection).
+
+        ``reranker`` and ``final`` are **post-ranking filters** applied to all scored
+        candidates after fusion and reranking, filtering out results that do not satisfy
+        the threshold.
+
+        Any field left None imposes no floor; all-None (the default) means no score
+        filtering.
       properties:
         semantic:
+          minimum: 0.0
           nullable: true
           type: number
         keyword:
+          minimum: 0.0
           nullable: true
           type: number
         reranker:
+          minimum: 0.0
           nullable: true
           type: number
         final:
+          minimum: 0.0
           nullable: true
           type: number
       title: MinScores

--- a/hindsight-clients/go/model_min_scores.go
+++ b/hindsight-clients/go/model_min_scores.go
@@ -17,7 +17,7 @@ import (
 // checks if the MinScores type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &MinScores{}
 
-// MinScores Optional per-stage score floors for recall (all inclusive, AND-ed).  ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so they prune weak matches before fusion. ``reranker`` and ``final`` are **post-query** filters applied to the scored results after reranking. Any field left None imposes no floor; all-None (the default) means no score filtering.
+// MinScores Optional per-stage score floors for recall (all inclusive >=).  ``semantic`` and ``keyword`` are **per-arm retrieval-level** cutoffs pushed into the individual SQL query arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so they prune weak matches within each arm before fusion. Because recall merges candidates across multiple arms (semantic, keyword, graph, temporal), a result clearing one arm's threshold enters fusion even if absent or below floor in another arm (i.e. not a cross-arm same-result intersection).  ``reranker`` and ``final`` are **post-ranking filters** applied to all scored candidates after fusion and reranking, filtering out results that do not satisfy the threshold.  Any field left None imposes no floor; all-None (the default) means no score filtering.
 type MinScores struct {
 	Semantic NullableFloat32 `json:"semantic,omitempty"`
 	Keyword NullableFloat32 `json:"keyword,omitempty"`

--- a/hindsight-clients/python/hindsight_client_api/models/min_scores.py
+++ b/hindsight-clients/python/hindsight_client_api/models/min_scores.py
@@ -17,19 +17,20 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictFloat, StrictInt
+from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 
 class MinScores(BaseModel):
     """
-    Optional per-stage score floors for recall (all inclusive, AND-ed).  ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so they prune weak matches before fusion. ``reranker`` and ``final`` are **post-query** filters applied to the scored results after reranking. Any field left None imposes no floor; all-None (the default) means no score filtering.
+    Optional per-stage score floors for recall (all inclusive >=).  ``semantic`` and ``keyword`` are **per-arm retrieval-level** cutoffs pushed into the individual SQL query arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so they prune weak matches within each arm before fusion. Because recall merges candidates across multiple arms (semantic, keyword, graph, temporal), a result clearing one arm's threshold enters fusion even if absent or below floor in another arm (i.e. not a cross-arm same-result intersection).  ``reranker`` and ``final`` are **post-ranking filters** applied to all scored candidates after fusion and reranking, filtering out results that do not satisfy the threshold.  Any field left None imposes no floor; all-None (the default) means no score filtering.
     """ # noqa: E501
-    semantic: Optional[Union[StrictFloat, StrictInt]] = None
-    keyword: Optional[Union[StrictFloat, StrictInt]] = None
-    reranker: Optional[Union[StrictFloat, StrictInt]] = None
-    final: Optional[Union[StrictFloat, StrictInt]] = None
+    semantic: Optional[Union[Annotated[float, Field(strict=True, ge=0.0)], Annotated[int, Field(strict=True, ge=0)]]] = None
+    keyword: Optional[Union[Annotated[float, Field(strict=True, ge=0.0)], Annotated[int, Field(strict=True, ge=0)]]] = None
+    reranker: Optional[Union[Annotated[float, Field(strict=True, ge=0.0)], Annotated[int, Field(strict=True, ge=0)]]] = None
+    final: Optional[Union[Annotated[float, Field(strict=True, ge=0.0)], Annotated[int, Field(strict=True, ge=0)]]] = None
     __properties: ClassVar[List[str]] = ["semantic", "keyword", "reranker", "final"]
 
     model_config = ConfigDict(

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -3849,38 +3849,46 @@ export type MentalModelTriggerOutput = {
 /**
  * MinScores
  *
- * Optional per-stage score floors for recall (all inclusive, AND-ed).
+ * Optional per-stage score floors for recall (all inclusive >=).
  *
- * ``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL
- * arms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``
- * config for this request), so they prune weak matches before fusion. ``reranker``
- * and ``final`` are **post-query** filters applied to the scored results after
- * reranking. Any field left None imposes no floor; all-None (the default) means
- * no score filtering.
+ * ``semantic`` and ``keyword`` are **per-arm retrieval-level** cutoffs pushed
+ * into the individual SQL query arms (overriding the global
+ * ``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so
+ * they prune weak matches within each arm before fusion. Because recall merges
+ * candidates across multiple arms (semantic, keyword, graph, temporal), a result
+ * clearing one arm's threshold enters fusion even if absent or below floor in
+ * another arm (i.e. not a cross-arm same-result intersection).
+ *
+ * ``reranker`` and ``final`` are **post-ranking filters** applied to all scored
+ * candidates after fusion and reranking, filtering out results that do not satisfy
+ * the threshold.
+ *
+ * Any field left None imposes no floor; all-None (the default) means no score
+ * filtering.
  */
 export type MinScores = {
   /**
    * Semantic
    *
-   * Retrieval-level: minimum vector similarity (0-1).
+   * Retrieval-level: minimum vector similarity (0-1) for the semantic arm.
    */
   semantic?: number | null;
   /**
    * Keyword
    *
-   * Retrieval-level: minimum keyword/full-text (BM25) score.
+   * Retrieval-level: minimum keyword/full-text (BM25) score for the keyword arm.
    */
   keyword?: number | null;
   /**
    * Reranker
    *
-   * Post-query: minimum normalized reranker score (0-1).
+   * Post-query: minimum normalized reranker score (0-1) for ranked results.
    */
   reranker?: number | null;
   /**
    * Final
    *
-   * Post-query: minimum final ranking score.
+   * Post-query: minimum final ranking score for ranked results.
    */
   final?: number | null;
 };
@@ -4205,7 +4213,7 @@ export type RecallRequest = {
    */
   tag_groups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput> | null;
   /**
-   * Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request); `reranker` and `final` are post-ranking filters on the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care — the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first).
+   * Optional per-stage score floors (all inclusive >=). `semantic` and `keyword` are per-arm retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request), pruning weak matches within each arm before fusion (without enforcing cross-arm intersection); `reranker` and `final` are post-ranking filters applied to the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care — the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first).
    */
   min_scores?: MinScores | null;
   /**

--- a/hindsight-docs/docs/developer/api/recall.mdx
+++ b/hindsight-docs/docs/developer/api/recall.mdx
@@ -404,20 +404,20 @@ When set to `true`, the response includes a detailed debug trace covering the qu
 
 ### min_scores
 
-An optional object of per-stage score floors, each compared **inclusively** (`>=`) against the matching field of a result's [`scores`](#scores) and AND-ed together. Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The four fields operate at **two different levels of the pipeline**:
+An optional object of per-stage score floors, each compared **inclusively** (`>=`). Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The four fields operate at **two different levels of the pipeline**:
 
 | field | level | effect |
 |---|---|---|
-| `semantic` | retrieval | minimum vector similarity, pushed into the SQL — prunes weak vector matches **before** fusion (overrides the global similarity minimum for this request) |
-| `keyword` | retrieval | minimum keyword/full-text (BM25) score, pushed into the SQL — prunes weak keyword matches before fusion |
-| `reranker` | post-query | minimum normalized cross-encoder score, applied to the ranked results |
-| `final` | post-query | minimum final ranking score, applied to the ranked results |
+| `semantic` | retrieval | minimum vector similarity, pushed into the SQL arm — prunes weak vector matches **before** fusion (overrides the global similarity minimum for this request) |
+| `keyword` | retrieval | minimum keyword/full-text (BM25) score, pushed into the SQL arm — prunes weak keyword matches before fusion |
+| `reranker` | post-query | minimum normalized cross-encoder score, applied to all ranked results |
+| `final` | post-query | minimum final ranking score, applied to all ranked results |
 
 ```json
-{ "query": "...", "min_scores": { "reranker": 0.5 } }
+{ "query": "...", "min_scores": { "final": 0.5 } }
 ```
 
-The retrieval-level floors (`semantic`/`keyword`) change *which candidates are considered*, so they can also change the final ordering; the post-query floors (`reranker`/`final`) only drop already-ranked results. Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
+The retrieval-level floors (`semantic`/`keyword`) operate per retrieval arm, changing *which candidates from that arm enter fusion*. Because recall merges candidates from multiple arms (semantic, keyword, graph, temporal), a candidate surfaced by one arm can still be returned even if it lacks or falls below another arm's score. To enforce an abstention or quality gate on the entire returned result set, use the post-query floors (`reranker`/`final`). Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
 
 **Use floors with care.** The reranker's scores are reliable for *ordering* but not as *absolute* values — a clearly-relevant memory can score `~0.001` on one query and `~1.0` on another, so a fixed cutoff risks silently dropping good results. Calibrate any threshold against the scores you actually observe (recall with no `min_scores` first and inspect the [`scores`](#scores) object).
 

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -251,7 +251,14 @@ Hindsight supports five backends for BM25 keyword retrieval:
 - **vchord** — VectorChord BM25 (uses the `llmlingua2` multilingual tokenizer).
 - **pg_textsearch** — Timescale's pg_textsearch extension. English-only.
 - **pgroonga** — pgroonga full-text search. Multilingual / CJK out of the box.
-- **pg_search** — ParadeDB pg_search. True BM25; the only backend that is Citus-compatible.
+- **pg_search** — ParadeDB pg_search. True BM25; the only backend that is Citus-compatible (requires pg_search $\ge$ 0.21.0 when using `min_scores.keyword`).
+
+:::warning[pg_search Version Requirement for Keyword Score Floors]
+When configuring `min_scores.keyword` with `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=pg_search`, ParadeDB **0.21.0 or higher** is recommended (and **0.15.6+** is strictly required):
+- **0.15.6 (Syntax threshold)**: `paradedb.score()` in `WHERE` was introduced in `paradedb#2197`. Versions below 0.15.6 raise a query syntax error when a score floor is configured.
+- **0.17.0 (Direct bugfix)**: Resolved the primary issue where combining `@@@` with standard `AND` filters (`bank_id`, `fact_type`) caused `score()` to return `NULL` (`paradedb#2661`, `paradedb#2740`).
+- **0.21.0 (Conservative safe floor)**: Fully resolved residual outer `WHERE` score-loss defects (`paradedb#3550`, `paradedb#3768`) and planner hook edge cases with `unnest` subqueries (`paradedb#3679`). On self-hosted PostgreSQL instances running versions between 0.15.6 and 0.21.0, complex composite `WHERE` clauses can evaluate `score(id)` to `NULL` or 0, silently pruning matching rows.
+:::
 
 A bank can also use none of them: [`enable_text_search`](#recall-pipeline-stages)
 switches the keyword arm off per bank, leaving pure vector search. Every setting in

--- a/hindsight-docs/docs/developer/mcp-server.md
+++ b/hindsight-docs/docs/developer/mcp-server.md
@@ -205,7 +205,7 @@ Search memories to provide personalized responses.
 | `tags_match` | string | No | `any` (default), `all`, `any_strict`, `all_strict`, or `exact`. With `exact`, pass `tags: []` to select the untagged/global scope |
 | `tag_groups` | list[object] | No | Compound boolean tag filter. Mutually exclusive with `tags`; each leaf has its own `match` value |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
-| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
+| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"final": 0.5}`. Keys: `semantic`/`keyword` (per-arm retrieval cutoffs), `reranker`/`final` (post-ranking). All inclusive (>=); omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
 | `temporal_window` | object | No | An explicit `{"start": ISO, "end": ISO}` period to search over, used instead of reading dates out of the query text. Ranks memories dated inside the window higher; it does not drop the ones outside it, so it can't restrict results to a period |
 
 **Example:**

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -13097,55 +13097,59 @@
           "semantic": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0.0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Semantic",
-            "description": "Retrieval-level: minimum vector similarity (0-1)."
+            "description": "Retrieval-level: minimum vector similarity (0-1) for the semantic arm."
           },
           "keyword": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0.0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Keyword",
-            "description": "Retrieval-level: minimum keyword/full-text (BM25) score."
+            "description": "Retrieval-level: minimum keyword/full-text (BM25) score for the keyword arm."
           },
           "reranker": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0.0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Reranker",
-            "description": "Post-query: minimum normalized reranker score (0-1)."
+            "description": "Post-query: minimum normalized reranker score (0-1) for ranked results."
           },
           "final": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0.0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Final",
-            "description": "Post-query: minimum final ranking score."
+            "description": "Post-query: minimum final ranking score for ranked results."
           }
         },
         "type": "object",
         "title": "MinScores",
-        "description": "Optional per-stage score floors for recall (all inclusive, AND-ed).\n\n``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL\narms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``\nconfig for this request), so they prune weak matches before fusion. ``reranker``\nand ``final`` are **post-query** filters applied to the scored results after\nreranking. Any field left None imposes no floor; all-None (the default) means\nno score filtering."
+        "description": "Optional per-stage score floors for recall (all inclusive >=).\n\n``semantic`` and ``keyword`` are **per-arm retrieval-level** cutoffs pushed\ninto the individual SQL query arms (overriding the global\n``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so\nthey prune weak matches within each arm before fusion. Because recall merges\ncandidates across multiple arms (semantic, keyword, graph, temporal), a result\nclearing one arm's threshold enters fusion even if absent or below floor in\nanother arm (i.e. not a cross-arm same-result intersection).\n\n``reranker`` and ``final`` are **post-ranking filters** applied to all scored\ncandidates after fusion and reranking, filtering out results that do not satisfy\nthe threshold.\n\nAny field left None imposes no floor; all-None (the default) means no score\nfiltering."
       },
       "ObservationScope": {
         "properties": {
@@ -13769,7 +13773,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request); `reranker` and `final` are post-ranking filters on the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care \u2014 the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first)."
+            "description": "Optional per-stage score floors (all inclusive >=). `semantic` and `keyword` are per-arm retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request), pruning weak matches within each arm before fusion (without enforcing cross-arm intersection); `reranker` and `final` are post-ranking filters applied to the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care \u2014 the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first)."
           },
           "temporal_window": {
             "anyOf": [

--- a/hindsight-docs/versioned_docs/version-0.9/developer/api/recall.mdx
+++ b/hindsight-docs/versioned_docs/version-0.9/developer/api/recall.mdx
@@ -404,20 +404,20 @@ When set to `true`, the response includes a detailed debug trace covering the qu
 
 ### min_scores
 
-An optional object of per-stage score floors, each compared **inclusively** (`>=`) against the matching field of a result's [`scores`](#scores) and AND-ed together. Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The four fields operate at **two different levels of the pipeline**:
+An optional object of per-stage score floors, each compared **inclusively** (`>=`). Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The four fields operate at **two different levels of the pipeline**:
 
 | field | level | effect |
 |---|---|---|
-| `semantic` | retrieval | minimum vector similarity, pushed into the SQL — prunes weak vector matches **before** fusion (overrides the global similarity minimum for this request) |
-| `keyword` | retrieval | minimum keyword/full-text (BM25) score, pushed into the SQL — prunes weak keyword matches before fusion |
-| `reranker` | post-query | minimum normalized cross-encoder score, applied to the ranked results |
-| `final` | post-query | minimum final ranking score, applied to the ranked results |
+| `semantic` | retrieval | minimum vector similarity, pushed into the SQL arm — prunes weak vector matches **before** fusion (overrides the global similarity minimum for this request) |
+| `keyword` | retrieval | minimum keyword/full-text (BM25) score, pushed into the SQL arm — prunes weak keyword matches before fusion |
+| `reranker` | post-query | minimum normalized cross-encoder score, applied to all ranked results |
+| `final` | post-query | minimum final ranking score, applied to all ranked results |
 
 ```json
-{ "query": "...", "min_scores": { "reranker": 0.5 } }
+{ "query": "...", "min_scores": { "final": 0.5 } }
 ```
 
-The retrieval-level floors (`semantic`/`keyword`) change *which candidates are considered*, so they can also change the final ordering; the post-query floors (`reranker`/`final`) only drop already-ranked results. Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
+The retrieval-level floors (`semantic`/`keyword`) operate per retrieval arm, changing *which candidates from that arm enter fusion*. Because recall merges candidates from multiple arms (semantic, keyword, graph, temporal), a candidate surfaced by one arm can still be returned even if it lacks or falls below another arm's score. To enforce an abstention or quality gate on the entire returned result set, use the post-query floors (`reranker`/`final`). Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
 
 **Use floors with care.** The reranker's scores are reliable for *ordering* but not as *absolute* values — a clearly-relevant memory can score `~0.001` on one query and `~1.0` on another, so a fixed cutoff risks silently dropping good results. Calibrate any threshold against the scores you actually observe (recall with no `min_scores` first and inspect the [`scores`](#scores) object).
 

--- a/hindsight-docs/versioned_docs/version-0.9/developer/mcp-server.md
+++ b/hindsight-docs/versioned_docs/version-0.9/developer/mcp-server.md
@@ -205,7 +205,7 @@ Search memories to provide personalized responses.
 | `tags_match` | string | No | `any` (default), `all`, `any_strict`, `all_strict`, or `exact`. With `exact`, pass `tags: []` to select the untagged/global scope |
 | `tag_groups` | list[object] | No | Compound boolean tag filter. Mutually exclusive with `tags`; each leaf has its own `match` value |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
-| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
+| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"final": 0.5}`. Keys: `semantic`/`keyword` (per-arm retrieval cutoffs), `reranker`/`final` (post-ranking). All inclusive (>=); omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
 | `temporal_window` | object | No | An explicit `{"start": ISO, "end": ISO}` period to search over, used instead of reading dates out of the query text. Ranks memories dated inside the window higher; it does not drop the ones outside it, so it can't restrict results to a period |
 
 **Example:**

--- a/skills/hindsight-docs/references/developer/api/recall.md
+++ b/skills/hindsight-docs/references/developer/api/recall.md
@@ -646,20 +646,20 @@ When set to `true`, the response includes a detailed debug trace covering the qu
 
 ### min_scores
 
-An optional object of per-stage score floors, each compared **inclusively** (`>=`) against the matching field of a result's [`scores`](#scores) and AND-ed together. Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The four fields operate at **two different levels of the pipeline**:
+An optional object of per-stage score floors, each compared **inclusively** (`>=`). Any field you leave unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering at all. The four fields operate at **two different levels of the pipeline**:
 
 | field | level | effect |
 |---|---|---|
-| `semantic` | retrieval | minimum vector similarity, pushed into the SQL — prunes weak vector matches **before** fusion (overrides the global similarity minimum for this request) |
-| `keyword` | retrieval | minimum keyword/full-text (BM25) score, pushed into the SQL — prunes weak keyword matches before fusion |
-| `reranker` | post-query | minimum normalized cross-encoder score, applied to the ranked results |
-| `final` | post-query | minimum final ranking score, applied to the ranked results |
+| `semantic` | retrieval | minimum vector similarity, pushed into the SQL arm — prunes weak vector matches **before** fusion (overrides the global similarity minimum for this request) |
+| `keyword` | retrieval | minimum keyword/full-text (BM25) score, pushed into the SQL arm — prunes weak keyword matches before fusion |
+| `reranker` | post-query | minimum normalized cross-encoder score, applied to all ranked results |
+| `final` | post-query | minimum final ranking score, applied to all ranked results |
 
 ```json
-{ "query": "...", "min_scores": { "reranker": 0.5 } }
+{ "query": "...", "min_scores": { "final": 0.5 } }
 ```
 
-The retrieval-level floors (`semantic`/`keyword`) change *which candidates are considered*, so they can also change the final ordering; the post-query floors (`reranker`/`final`) only drop already-ranked results. Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
+The retrieval-level floors (`semantic`/`keyword`) operate per retrieval arm, changing *which candidates from that arm enter fusion*. Because recall merges candidates from multiple arms (semantic, keyword, graph, temporal), a candidate surfaced by one arm can still be returned even if it lacks or falls below another arm's score. To enforce an abstention or quality gate on the entire returned result set, use the post-query floors (`reranker`/`final`). Because freed slots are **not** backfilled, any floor can return fewer results than the budget allows.
 
 **Use floors with care.** The reranker's scores are reliable for *ordering* but not as *absolute* values — a clearly-relevant memory can score `~0.001` on one query and `~1.0` on another, so a fixed cutoff risks silently dropping good results. Calibrate any threshold against the scores you actually observe (recall with no `min_scores` first and inspect the [`scores`](#scores) object).
 

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -251,7 +251,14 @@ Hindsight supports five backends for BM25 keyword retrieval:
 - **vchord** — VectorChord BM25 (uses the `llmlingua2` multilingual tokenizer).
 - **pg_textsearch** — Timescale's pg_textsearch extension. English-only.
 - **pgroonga** — pgroonga full-text search. Multilingual / CJK out of the box.
-- **pg_search** — ParadeDB pg_search. True BM25; the only backend that is Citus-compatible.
+- **pg_search** — ParadeDB pg_search. True BM25; the only backend that is Citus-compatible (requires pg_search $\ge$ 0.21.0 when using `min_scores.keyword`).
+
+:::warning[pg_search Version Requirement for Keyword Score Floors]
+When configuring `min_scores.keyword` with `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=pg_search`, ParadeDB **0.21.0 or higher** is recommended (and **0.15.6+** is strictly required):
+- **0.15.6 (Syntax threshold)**: `paradedb.score()` in `WHERE` was introduced in `paradedb#2197`. Versions below 0.15.6 raise a query syntax error when a score floor is configured.
+- **0.17.0 (Direct bugfix)**: Resolved the primary issue where combining `@@@` with standard `AND` filters (`bank_id`, `fact_type`) caused `score()` to return `NULL` (`paradedb#2661`, `paradedb#2740`).
+- **0.21.0 (Conservative safe floor)**: Fully resolved residual outer `WHERE` score-loss defects (`paradedb#3550`, `paradedb#3768`) and planner hook edge cases with `unnest` subqueries (`paradedb#3679`). On self-hosted PostgreSQL instances running versions between 0.15.6 and 0.21.0, complex composite `WHERE` clauses can evaluate `score(id)` to `NULL` or 0, silently pruning matching rows.
+:::
 
 A bank can also use none of them: [`enable_text_search`](#recall-pipeline-stages)
 switches the keyword arm off per bank, leaving pure vector search. Every setting in

--- a/skills/hindsight-docs/references/developer/mcp-server.md
+++ b/skills/hindsight-docs/references/developer/mcp-server.md
@@ -205,7 +205,7 @@ Search memories to provide personalized responses.
 | `tags_match` | string | No | `any` (default), `all`, `any_strict`, `all_strict`, or `exact`. With `exact`, pass `tags: []` to select the untagged/global scope |
 | `tag_groups` | list[object] | No | Compound boolean tag filter. Mutually exclusive with `tags`; each leaf has its own `match` value |
 | `query_timestamp` | string | No | ISO 8601 timestamp — recall as if asking at this point in time; anchors relative temporal expressions and recency scoring |
-| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"reranker": 0.5}`. Keys: `semantic`/`keyword` (retrieval-level cutoffs), `reranker`/`final` (post-ranking). All inclusive and AND-ed; omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
+| `min_scores` | object | No | Optional per-stage score floors, e.g. `{"final": 0.5}`. Keys: `semantic`/`keyword` (per-arm retrieval cutoffs), `reranker`/`final` (post-ranking). All inclusive (>=); omit for no filtering. Reranker scores aren't calibrated across queries — calibrate before use |
 | `temporal_window` | object | No | An explicit `{"start": ISO, "end": ISO}` period to search over, used instead of reading dates out of the query text. Ranks memories dated inside the window higher; it does not drop the ones outside it, so it can't restrict results to a period |
 
 **Example:**

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -13097,55 +13097,59 @@
           "semantic": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0.0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Semantic",
-            "description": "Retrieval-level: minimum vector similarity (0-1)."
+            "description": "Retrieval-level: minimum vector similarity (0-1) for the semantic arm."
           },
           "keyword": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0.0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Keyword",
-            "description": "Retrieval-level: minimum keyword/full-text (BM25) score."
+            "description": "Retrieval-level: minimum keyword/full-text (BM25) score for the keyword arm."
           },
           "reranker": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0.0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Reranker",
-            "description": "Post-query: minimum normalized reranker score (0-1)."
+            "description": "Post-query: minimum normalized reranker score (0-1) for ranked results."
           },
           "final": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0.0
               },
               {
                 "type": "null"
               }
             ],
             "title": "Final",
-            "description": "Post-query: minimum final ranking score."
+            "description": "Post-query: minimum final ranking score for ranked results."
           }
         },
         "type": "object",
         "title": "MinScores",
-        "description": "Optional per-stage score floors for recall (all inclusive, AND-ed).\n\n``semantic`` and ``keyword`` are **retrieval-level** cutoffs pushed into the SQL\narms (overriding the global ``semantic_min_similarity`` / ``bm25_min_score``\nconfig for this request), so they prune weak matches before fusion. ``reranker``\nand ``final`` are **post-query** filters applied to the scored results after\nreranking. Any field left None imposes no floor; all-None (the default) means\nno score filtering."
+        "description": "Optional per-stage score floors for recall (all inclusive >=).\n\n``semantic`` and ``keyword`` are **per-arm retrieval-level** cutoffs pushed\ninto the individual SQL query arms (overriding the global\n``semantic_min_similarity`` / ``bm25_min_score`` config for this request), so\nthey prune weak matches within each arm before fusion. Because recall merges\ncandidates across multiple arms (semantic, keyword, graph, temporal), a result\nclearing one arm's threshold enters fusion even if absent or below floor in\nanother arm (i.e. not a cross-arm same-result intersection).\n\n``reranker`` and ``final`` are **post-ranking filters** applied to all scored\ncandidates after fusion and reranking, filtering out results that do not satisfy\nthe threshold.\n\nAny field left None imposes no floor; all-None (the default) means no score\nfiltering."
       },
       "ObservationScope": {
         "properties": {
@@ -13769,7 +13773,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional per-stage score floors (all inclusive, AND-ed). `semantic` and `keyword` are retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request); `reranker` and `final` are post-ranking filters on the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care \u2014 the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first)."
+            "description": "Optional per-stage score floors (all inclusive >=). `semantic` and `keyword` are per-arm retrieval-level cutoffs pushed into the SQL arms (overriding the global similarity/BM25 minimums for this request), pruning weak matches within each arm before fusion (without enforcing cross-arm intersection); `reranker` and `final` are post-ranking filters applied to the scored results. Any field left unset imposes no floor; omitting `min_scores` entirely (the default) applies no score filtering. Use with care \u2014 the reranker's absolute scores are not calibrated across queries (a clearly-relevant match may score ~0.001 even though it is ranked first)."
           },
           "temporal_window": {
             "anyOf": [


### PR DESCRIPTION
Fixes #3882.

## Overview

In Hindsight recall requests configuring `min_scores.keyword` (`bm25_min_score`), sub-threshold BM25 results were surviving retrieval because text-search SQL query arms across PostgreSQL backends omitted score floor filtering in their `WHERE` clauses. Furthermore, the API documentation and schema docstrings contained ambiguous phrasing (`all inclusive, AND-ed`), leading callers to expect cross-arm intersection semantics rather than per-arm pruning before RRF/Interleave fusion.

This PR:
1. Pushes `bm25_min_score` filtering down into the SQL `WHERE` clauses across all PostgreSQL text-search backends (`native`, `pg_textsearch`, `pgroonga`, `pg_search`) and standardizes Oracle Text comparison semantics.
2. Hardens `MinScores` schema against negative, `NaN`, and `Infinity` inputs (`ge=0.0`, `allow_inf_nan=False`), while clamping backend query builders against negative floors (`effective_min = max(bm25_min_score, 0.0)`).
3. Clarifies the multi-stage recall score floor contracts across schemas, MCP tools, and API documentation.
4. Documents backend-specific version and planner caveats (ParadeDB pg_search version support matrix and PGroonga index scan score prerequisites).
5. Adds comprehensive unit and integration test coverage for per-arm cutoff behavior and inclusive boundary conditions.

---

## Recall Score Floor Architecture

Recall operates as a multi-stage pipeline. The four `min_scores` fields apply at two distinct pipeline stages with different semantics:

```
[ Query ]
   │
   ├──► Semantic Arm (SQL) ───[ WHERE similarity >= min_scores.semantic ]──┐
   ├──► BM25 Arm (SQL)     ───[ WHERE bm25_score >= min_scores.keyword ]──┤ (Per-arm Cutoffs)
   ├──► Graph Arm                                                         ├────────┐
   └──► Temporal Arm                                                      │        │
                                                                                   ▼
                                                                        [ Multi-Arm Fusion ] (RRF / Interleave)
                                                                                   │
                                                                                   ▼
                                                                        [ Cross-Encoder Rerank ]
                                                                                   │
                                                                                   ▼
                                                                        [ Post-Ranking Filters ]
                                                                          • reranker >= min_scores.reranker
                                                                          • final >= min_scores.final
                                                                                   │
                                                                                   ▼
                                                                        [ Final Recalled Facts ]
```

### Stage Comparison

| Score Floor | Execution Stage | Scope | Implementation | Semantic Role |
|---|---|---|---|---|
| `min_scores.semantic` | Retrieval | Semantic SQL Arm | `WHERE (1 - (embedding <=> $1)) >= sem_min` | Prunes weak dense vector matches before fusion |
| `min_scores.keyword` | Retrieval | BM25 SQL Arm | `WHERE ... >= bm25_min` (Backend-specific) | Prunes weak sparse keyword matches before fusion |
| `min_scores.reranker` | Post-Ranking | Fused Candidates | `[sr for sr in scored if sr.cross_encoder_score_normalized >= min_reranker]` | Filters ranked candidates by cross-encoder score |
| `min_scores.final` | Post-Ranking | Fused Candidates | `[sr for sr in scored if sr.weight >= min_final]` | Filters ranked candidates by combined final score (recommended for query abstention) |

---

## Backend Score Pushdown Matrix

Prior to this fix, only `vchord` and `oracle` pushed custom `bm25_min_score` floors into SQL:

| Backend Extension | Index / Operator | Score Floor Pushdown (Before) | Score Floor Pushdown (After) |
|---|---|---|---|
| `native` (PostgreSQL tsvector) | `search_vector @@ to_tsquery()` | ❌ `AND search_vector @@ to_tsquery(...)` | ✅ `AND search_vector @@ to_tsquery(...) AND ts_rank_cd(...) >= bm25_min_score` |
| `pg_textsearch` (Timescale BM25) | `text <@> to_bm25query()` | ❌ None (`bm25_where_filter = ""`) | ✅ `AND -(text <@> to_bm25query(...)) >= bm25_min_score` |
| `pgroonga` (Multilingual) | `&@~` + `pgroonga_score()` | ❌ None (only term match filter) | ✅ `AND pgroonga_score(tableoid, ctid) >= bm25_min_score` |
| `pg_search` (ParadeDB) | `id @@@ boolean()` + `score(id)` | ❌ None (only term match filter) | ✅ `AND paradedb.score(id) >= bm25_min_score` |
| `vchord` (VectorChord) | `<&>` + `to_bm25query()` | ⚠️ `> bm25_min_score` | ✅ `>= bm25_min_score` (when > 0) / `> 0` (when <= 0) |
| `oracle` (Oracle Text) | `CONTAINS()` + `SCORE()` | ⚠️ `> bm25_min_score` | ✅ `>= bm25_min_score` (when > 0) / `> 0` (when <= 0) |

---

## Backend Compatibility Notes

### ParadeDB (`pg_search`) Version Evidence Chain

When using `min_scores.keyword` with `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=pg_search`, the recommended safe version floor is **ParadeDB $\ge$ 0.21.0** (with **0.15.6+** as the absolute syntax minimum):

| pg_search Version | Capability / Bugfix | Impact on Hindsight BM25 Arm |
|---|---|---|
| `< 0.15.6` | Syntax unsupport | Query parser rejects `paradedb.score()` in `WHERE` clause (raises 500 error). |
| `0.15.6 ~ 0.16.x` | Basic predicate pushdown ([paradedb/paradedb#2197](https://github.com/paradedb/paradedb/pull/2197)) | `score()` allowed in `WHERE`, but returns `NULL` when combined with standard relational filters (`bank_id`, `fact_type`). |
| `0.17.0` | AND filter scoring fix ([paradedb/paradedb#2661](https://github.com/paradedb/paradedb/pull/2661), [paradedb/paradedb#2740](https://github.com/paradedb/paradedb/pull/2740)) | Resolves direct `NULL` return on composite `WHERE`, but residual outer query score-loss edge cases remain. |
| `0.21.0` | Comprehensive scoring & planner fix ([paradedb/paradedb#3550](https://github.com/paradedb/paradedb/pull/3550), [paradedb/paradedb#3768](https://github.com/paradedb/paradedb/pull/3768), [paradedb/paradedb#3679](https://github.com/paradedb/paradedb/pull/3679)) | Fully resolves outer `WHERE` score-loss and planner hook crashes (verified in ecosystem trackers like [neondatabase/neon#12853](https://github.com/neondatabase/neon/issues/12853)). |

### PGroonga Index Scan Prerequisite

`pgroonga_score(tableoid, ctid)` computes actual relevance scores only during PGroonga index scans (`&@~`). On sequential scans (e.g. tiny seed tables without planner forcing), `pgroonga_score()` evaluates to `0.0`. The `WHERE` clause preserves the exact indexed expression from `idx_memory_units_text_search` to ensure index scan planning.

---

## Key Changes

### 1. Backend SQL Dialects (`postgresql.py`, `oracle.py`)
- Updated `PostgreSQLDialect.build_bm25_arm` and `OracleDialect.build_bm25_arm` to apply `bm25_min_score` consistently across all backends: strictly `> 0` on default (<= 0) to gate zero-score non-matches, and inclusive `>=` for custom positive score floors.
- Added explanatory documentation on PGroonga index scan score behavior, VectorChord zero-score gating, and ParadeDB custom scan pushdown.

### 2. Documentation & Schema Clarity
- **`MinScores` & `RecallRequest` (`response_models.py`, `http.py`)**: Replaced ambiguous `(all inclusive, AND-ed)` docstrings with explicit descriptions distinguishing per-arm retrieval cutoffs from post-ranking candidate filters. Added `ge=0.0` and `allow_inf_nan=False` to prevent negative and non-numeric floating-point literals in SQL.
- **Configuration & MCP Documentation (`configuration.md`, `recall.mdx`, `mcp-server.md`, `mcp_tools.py`)**: Added detailed backend version requirement warnings and stage cutoff explanations.
- Regenerated SDKs and `static/openapi.json`.

---

## Verification & Test Matrix

### Test Summary

| Test File | Test Case | Target / Assertion |
|---|---|---|
| `test_db_abstraction.py` | `test_build_bm25_arm_native_honors_custom_min_score` | Asserts `AND ts_rank_cd(...) >= 0.3` is present in generated SQL |
| `test_db_abstraction.py` | `test_build_bm25_arm_pg_textsearch_honors_custom_min_score` | Asserts `AND -(text <@> ...) >= 1.5` is present in generated SQL |
| `test_db_abstraction.py` | `test_build_bm25_arm_pgroonga_honors_custom_min_score` | Asserts `AND pgroonga_score(...) >= 0.8` is present in generated SQL |
| `test_db_abstraction.py` | `test_build_bm25_arm_pg_search_honors_custom_min_score` | Asserts `AND paradedb.score(id) >= 2` is present in generated SQL |
| `test_db_abstraction.py` | `test_build_bm25_arm_vchord_honors_custom_min_score` | Asserts `AND -(...) >= 2.5` is present in generated SQL |
| `test_db_abstraction.py` | `test_build_bm25_arm_vchord_clamps_negative_min_score` | Asserts `> 0` gate is preserved when `bm25_min_score = -1.0` |
| `test_db_abstraction.py` | `test_build_bm25_arm_honors_custom_min_score` (Oracle) | Asserts `CONTAINS(...) >= 2.5` is present in generated Oracle SQL |
| `test_db_abstraction.py` | `test_build_bm25_arm_clamps_negative_min_score` (Oracle) | Asserts `CONTAINS(...) > 0` gate is preserved when `bm25_min_score = -1.0` |
| `test_recall_min_score.py` | `test_keyword_floor_prunes_in_retrieval` | End-to-end recall test verifying sub-threshold BM25 results are pruned and max-score boundary survives |
| `test_recall_min_score.py` | `test_semantic_floor_prunes_only_semantic_arm_and_keeps_keyword_arm` | Explicitly validates and documents per-arm union semantics during fusion |
| `test_recall_min_score.py` | `test_min_scores_rejects_inf_and_nan` | Asserts `ValidationError` when passing `Infinity` / `NaN` to `MinScores` |
| `test_recall_min_score.py` | `test_min_scores_rejects_negative_scores` | Asserts `ValidationError` when passing negative floats (`< 0`) to `MinScores` |

All tests passed locally. Code style and formatting validated with `ruff check .` and `ruff format --check .`.
