### PR TITLE
fix(documents): skip the retag cascade when a tags PATCH changes nothing (#3912)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8312,10 +8312,18 @@ class MemoryEngine(MemoryEngineInterface):
         - The document's own units and any co-source memories from other documents
           have consolidated_at reset so they are re-consolidated under the new tags.
 
+        That cascade is required: consolidation scopes a memory by its tags, so an
+        observation built under the old tag set is no longer valid, and deleting it
+        strands every OTHER source that observation carried unless they are requeued
+        too. It only runs when the tag set actually changes — a PATCH re-sending the
+        tags the document already has (an idempotent normalisation sweep) is a no-op.
+
         Args:
             document_id: Document ID to update
             bank_id: Bank ID that owns the document
-            tags: New tags to apply to the document and all its memory units (optional)
+            tags: New tags to apply to the document and all its memory units (optional).
+                Compared as a set against the document's current tags; equal means no
+                retag and no re-consolidation.
             request_context: Request context for authentication.
 
         Returns:
@@ -8333,6 +8341,51 @@ class MemoryEngine(MemoryEngineInterface):
         invalidated_obs = 0
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
+                from .memories import MemoryPatch, get_memories
+
+                _store = get_memories()
+
+                # Read the tags the document already carries BEFORE overwriting them.
+                # A tags array equal to the current one is a semantic no-op, and a bulk
+                # tag-normalisation sweep re-sends an identical array on every run. The
+                # retag cascade below is not cheap enough to pay for that: it deletes
+                # every observation built over this document's memories and then
+                # requeues each of those observations' OTHER sources, so one no-op
+                # PATCH re-consolidates memories reaching well past the document
+                # itself, and a repeated sweep multiplies that by its document count.
+                # Compare as SETS — consolidation scopes a memory by its tag set, never
+                # by the order the array arrived in, so a reordered array changes
+                # nothing that consolidation can observe.
+                _doc_row = await conn.fetchrow(
+                    f"SELECT tags FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
+                    document_id,
+                    bank_id,
+                )
+                _store_record: dict[str, Any] | None = None
+                if _doc_row is not None:
+                    current_tags: list[str] | None = list(_doc_row["tags"] or [])
+                elif _store.owns_document_store_for(bank_id):
+                    # Store-owned bank: no SQL documents row exists, the tags live on
+                    # the store's record. Fetched once here and reused below.
+                    _store_record = await _store.get_document_record(bank_id=bank_id, document_id=document_id)
+                    # A record that does not carry a "tags" key at all is unreadable for
+                    # this purpose, not empty — collapsing it to [] would read a PATCH of
+                    # [] as "unchanged" and skip a real clear-the-tags request.
+                    current_tags = (
+                        list(_store_record["tags"] or [])
+                        if _store_record is not None and "tags" in _store_record
+                        else None
+                    )
+                else:
+                    current_tags = None
+
+                # `None` means "could not read the current tags" (document not found, or
+                # a store record that does not carry them) — never claim unchanged on a
+                # value we did not see, or a real retag would be silently skipped.
+                retag = (
+                    tags if (tags is not None and (current_tags is None or set(current_tags) != set(tags))) else None
+                )
+
                 set_parts: list[str] = ["updated_at = now()"]
                 params: list[Any] = []
                 p = 1
@@ -8352,9 +8405,6 @@ class MemoryEngine(MemoryEngineInterface):
                     """,
                     *params,
                 )
-                from .memories import MemoryPatch, get_memories
-
-                _store = get_memories()
                 if not doc_id_found:
                     # A store-owned bank writes NO Postgres documents row, so the UPDATE above
                     # matched nothing and `doc_id_found` is None for a document that plainly
@@ -8364,13 +8414,13 @@ class MemoryEngine(MemoryEngineInterface):
                     # Drive existence off the STORE instead, the same way document DELETE had to.
                     if not _store.owns_document_store_for(bank_id):
                         return False
-                    if await _store.get_document_record(bank_id=bank_id, document_id=document_id) is None:
+                    if _store_record is None:
                         return False
                     if tags is not None:
                         # The document's OWN tags live on the store's record; the memories are
                         # retagged separately below. Both, or the browser shows one of them stale.
                         await _store.set_document_tags(bank_id=bank_id, document_id=document_id, tags=list(tags))
-                if tags is not None and not _store.writes_memory_rows_in_sql_for(bank_id):
+                if retag is not None and not _store.writes_memory_rows_in_sql_for(bank_id):
                     # A store that keeps memories outside SQL: retag the document's memories, then
                     # invalidate the observations built on them and requeue their sources so the
                     # next consolidation rebuilds them under the new tags (the cascade the SQL
@@ -8381,7 +8431,7 @@ class MemoryEngine(MemoryEngineInterface):
                     _doc_units = _doc_page.memories
                     if _doc_units:
                         await _store.update_memories(
-                            bank_id, [MemoryPatch(unit_id=m.unit_id, tags=list(tags)) for m in _doc_units]
+                            bank_id, [MemoryPatch(unit_id=m.unit_id, tags=list(retag)) for m in _doc_units]
                         )
                     _src_ids = [m.unit_id for m in _doc_units if m.fact_type in ("experience", "world")]
                     if _src_ids:
@@ -8391,7 +8441,7 @@ class MemoryEngine(MemoryEngineInterface):
                         await _store.mark_consolidated(
                             conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=_src_ids, when=None
                         )
-                elif tags is not None:
+                elif retag is not None:
                     unit_rows = await conn.fetch(
                         f"SELECT id FROM {fq_table('memory_units')} WHERE document_id = $1 AND bank_id = $2 AND fact_type IN ('experience', 'world')",
                         document_id,
@@ -8402,7 +8452,7 @@ class MemoryEngine(MemoryEngineInterface):
                     await conn.execute(
                         f"UPDATE {fq_table('memory_units')} SET tags = $1, updated_at = now() "
                         f"WHERE document_id = $2 AND bank_id = $3",
-                        tags,
+                        retag,
                         document_id,
                         bank_id,
                     )

--- a/hindsight-api-slim/tests/test_observation_invalidation.py
+++ b/hindsight-api-slim/tests/test_observation_invalidation.py
@@ -1007,6 +1007,158 @@ class TestUpdateDocumentTagsObservationCleanup:
         await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
+    async def test_repatching_identical_tags_invalidates_nothing(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """A PATCH re-sending the tags the document already has must not run the cascade.
+
+        This is what an idempotent tag-normalisation sweep does on its second run. The
+        retag cascade reaches past the document — it requeues every co-source of every
+        observation it deletes — so paying it for a no-op re-consolidates a large slice
+        of the bank for a write that changes nothing.
+        """
+        bank_id = f"test-tag-update-noop-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            doc_id = f"doc-{uuid.uuid4().hex[:8]}"
+            doc_mem_ids = await _insert_document_with_memories(
+                memory, conn, bank_id, doc_id, [("Alice loves hiking.", "experience")]
+            )
+            other_mem = await _insert_memory(memory, conn, bank_id, "Alice also rock-climbs.")
+
+        # First PATCH is a real change and is expected to invalidate.
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()):
+            await memory.update_document(
+                doc_id, bank_id, tags=["kind:handoff", "pickup"], request_context=request_context
+            )
+
+        # Rebuild the observation the way consolidation would have, then re-send the
+        # SAME tags.
+        async with pool.acquire() as conn:
+            obs_id = await _insert_observation(
+                memory, conn, bank_id, "Alice loves outdoor activities.", doc_mem_ids + [other_mem]
+            )
+            assert await _get_consolidated_at(conn, other_mem, bank_id) is not None
+
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()) as mock_consolidate:
+            result = await memory.update_document(
+                doc_id, bank_id, tags=["kind:handoff", "pickup"], request_context=request_context
+            )
+            assert result is True, "A no-op retag still updates the document and reports success"
+            mock_consolidate.assert_not_awaited()
+
+        async with pool.acquire() as conn:
+            assert str(obs_id) in await _get_observation_ids(conn, bank_id), (
+                "Observation must survive a PATCH that does not change the tag set"
+            )
+            assert await _get_consolidated_at(conn, other_mem, bank_id) is not None, (
+                "Co-source memory must not be requeued by a no-op retag"
+            )
+            for mem_id in doc_mem_ids:
+                assert await _get_consolidated_at(conn, mem_id, bank_id) is not None, (
+                    "Document's own memories must not be requeued by a no-op retag"
+                )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_reordered_tags_are_not_a_change(self, memory: MemoryEngine, request_context: RequestContext):
+        """Tags are compared as a set: a reordered array changes nothing consolidation can see."""
+        bank_id = f"test-tag-update-reorder-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            doc_id = f"doc-{uuid.uuid4().hex[:8]}"
+            doc_mem_ids = await _insert_document_with_memories(
+                memory, conn, bank_id, doc_id, [("Alice loves hiking.", "experience")]
+            )
+
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()):
+            await memory.update_document(doc_id, bank_id, tags=["a", "b", "c"], request_context=request_context)
+
+        async with pool.acquire() as conn:
+            obs_id = await _insert_observation(memory, conn, bank_id, "Alice is outdoorsy.", doc_mem_ids)
+
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()) as mock_consolidate:
+            await memory.update_document(doc_id, bank_id, tags=["c", "a", "b"], request_context=request_context)
+            mock_consolidate.assert_not_awaited()
+
+        async with pool.acquire() as conn:
+            assert str(obs_id) in await _get_observation_ids(conn, bank_id)
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_partial_tag_overlap_still_invalidates(self, memory: MemoryEngine, request_context: RequestContext):
+        """The no-op guard is exact: a tag set that differs at all still runs the cascade."""
+        bank_id = f"test-tag-update-changed-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            doc_id = f"doc-{uuid.uuid4().hex[:8]}"
+            doc_mem_ids = await _insert_document_with_memories(
+                memory, conn, bank_id, doc_id, [("Alice loves hiking.", "experience")]
+            )
+
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()):
+            await memory.update_document(doc_id, bank_id, tags=["a", "b"], request_context=request_context)
+
+        async with pool.acquire() as conn:
+            obs_id = await _insert_observation(memory, conn, bank_id, "Alice is outdoorsy.", doc_mem_ids)
+
+        # Adding one tag to the existing set is a real change.
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()) as mock_consolidate:
+            await memory.update_document(doc_id, bank_id, tags=["a", "b", "c"], request_context=request_context)
+            mock_consolidate.assert_awaited()
+
+        async with pool.acquire() as conn:
+            assert str(obs_id) not in await _get_observation_ids(conn, bank_id)
+            for mem_id in doc_mem_ids:
+                assert await _get_consolidated_at(conn, mem_id, bank_id) is None
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_tag_change_stamps_memory_units_updated_at(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """A real retag stamps the units' ``updated_at``; a no-op retag leaves it alone."""
+        store = get_memories()
+        if not store.writes_memory_rows_in_sql:
+            pytest.skip("updated_at is a SQL memory_units column")
+
+        bank_id = f"test-tag-update-stamp-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            doc_id = f"doc-{uuid.uuid4().hex[:8]}"
+            doc_mem_ids = await _insert_document_with_memories(
+                memory, conn, bank_id, doc_id, [("Alice loves hiking.", "experience")]
+            )
+
+        async def _updated_at():
+            async with pool.acquire() as conn:
+                return await conn.fetchval("SELECT updated_at FROM memory_units WHERE id = $1", doc_mem_ids[0])
+
+        before = await _updated_at()
+
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()):
+            await memory.update_document(doc_id, bank_id, tags=["a"], request_context=request_context)
+        after_change = await _updated_at()
+        assert after_change > before, "A tag change must stamp the memory unit's updated_at"
+
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()):
+            await memory.update_document(doc_id, bank_id, tags=["a"], request_context=request_context)
+        assert await _updated_at() == after_change, "A no-op retag must not restamp updated_at"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
     async def test_update_tags_does_not_affect_unrelated_observations(
         self, memory: MemoryEngine, request_context: RequestContext
     ):

--- a/hindsight-docs/docs/developer/api/documents.mdx
+++ b/hindsight-docs/docs/developer/api/documents.mdx
@@ -146,6 +146,10 @@ hindsight document update-tags my-bank meeting-2024-03-15
 
 :::info Observations are re-consolidated
 When tags change, any consolidated observations derived from the document's memories are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.
+
+This is required for correctness rather than incidental: consolidation scopes a memory by its tag set, so an observation built under the old tags is no longer valid, and deleting it would strand every other memory that observation was consolidated from unless those are requeued too. The size of that requeue is the number of memories co-sourced with this document's — on a densely co-sourced bank it can be many times the document's own memory count.
+
+Tags are compared as a **set** against the document's current tags, and an update that leaves the set unchanged — including one that only reorders the array — performs no retag and queues no re-consolidation. A repeatable tag-normalisation sweep therefore only pays the re-consolidation cost on the run that actually changes something.
 :::
 
 ## Delete Document

--- a/skills/hindsight-docs/references/developer/api/documents.md
+++ b/skills/hindsight-docs/references/developer/api/documents.md
@@ -252,6 +252,10 @@ hindsight document update-tags my-bank meeting-2024-03-15
 > **ℹ️ Observations are re-consolidated**
 >
 When tags change, any consolidated observations derived from the document's memories are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.
+
+This is required for correctness rather than incidental: consolidation scopes a memory by its tag set, so an observation built under the old tags is no longer valid, and deleting it would strand every other memory that observation was consolidated from unless those are requeued too. The size of that requeue is the number of memories co-sourced with this document's — on a densely co-sourced bank it can be many times the document's own memory count.
+
+Tags are compared as a **set** against the document's current tags, and an update that leaves the set unchanged — including one that only reorders the array — performs no retag and queues no re-consolidation. A repeatable tag-normalisation sweep therefore only pays the re-consolidation cost on the run that actually changes something.
 ## Delete Document
 
 Remove a document and all its associated memories:


### PR DESCRIPTION
Follow-up to #3912, which is closed as not-planned: the re-consolidation on a tag change is deliberate and its co-source leg is required. This PR fixes the one real gap that report surfaced.

## The gap

`update_document` never compared the incoming tags to the ones the document already carries — the guard was `if tags is not None:`. A PATCH re-sending an identical tags array, which is exactly what an idempotent tag-normalisation sweep does on every run after its first, paid the full retag cascade for a write that changes nothing.

## Why the cascade itself stays

It deletes every observation built over the document's memories, then resets `consolidated_at` on each of those observations' **other** sources. Both halves are load-bearing:

- Consolidation scopes a memory by its tag set — `_resolve_obs_tags_list` / `_observation_scope_keys` derive an observation's scope from its sources' `tags`, and dedup lookup runs `tags_match="all_strict"`. An observation formed under the old tag set is no longer valid once the tags move.
- Deleting that observation removes the only consolidation output for **all** its sources, not just the ones under the patched document. Without the requeue, the co-sourced memories stay marked consolidated while the observation carrying their content is gone — silently dropped, never rebuilt. Pinned by `test_update_tags_resets_co_source_memories_from_other_documents`.

So the blast radius of one PATCH is the co-source degree of the affected observations, not the document's own memory count — and a sweep multiplies that by its document count. Bounding it (the report's third ask) would reintroduce the hole above; the fix is to not trigger it for free.

## The change

Read the current tags before overwriting them and compare as **sets** — consolidation scopes by tag set, so a reordered array changes nothing it can observe. When the set is unchanged, skip the memory-unit retag, the observation deletion, the source requeue and the consolidation submit.

Guard rails:

- A tag set that differs at all still runs the cascade, unchanged.
- Tags that could not be read (document absent, or a store record that does not carry a `tags` key) are never treated as unchanged — a real retag is never silently skipped.
- Both the SQL and store-owned branches are gated on the same computed value.

Also drops a now-redundant `get_document_record` round-trip on the store-owned path, which the new pre-read already fetched.

`memory_units.updated_at` is stamped on a real tag change (already the case on `main`); this adds the test that pins it, and that a no-op retag does *not* restamp it — otherwise the no-op would still make backfilled documents look recent to anything filtering on `updated_at`.

## One behaviour note

Unit tags are not always identical to the document's: with `entity_labels` tag groups configured, `_apply_label_tags` appends per-fact label tags on top of the document's, so `memory_units.tags` can be a strict superset of `documents.tags`. Because the skip is decided off the document's tags, a PATCH re-sending them no longer force-rewrites unit tags down to that set.

That is the better of the two behaviours — the old force-rewrite silently dropped the entity-label tags on every tags PATCH — and the changed-tags path still overwrites exactly as before. Calling it out because it does narrow `update_document` as an incidental "resync unit tags to the document's" operation, which was never its documented job.

## Tests

Four added to `TestUpdateDocumentTagsObservationCleanup`:

- `test_repatching_identical_tags_invalidates_nothing` — the observation survives and every co-source stays consolidated
- `test_reordered_tags_are_not_a_change`
- `test_partial_tag_overlap_still_invalidates` — the guard is exact
- `test_tag_change_stamps_memory_units_updated_at` — real change stamps, no-op does not

`tests/test_observation_invalidation.py` (33), `test_memory_units_updated_at.py` and `test_bank_stats_cache_invalidation.py` pass locally on an isolated pg0 — 44 total. `ruff` and `ty` clean.

Docs: the re-consolidation callout in `documents.mdx` now states why the cascade exists and that an unchanged tag set is a no-op.

Closes the actionable half of #3912.

https://claude.ai/code/session_018HDqrzHgqZqsGc7EDqoTEu