### PR TITLE
fix(recall): score coarse dates from their period, not its first day (#3893)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -914,6 +914,9 @@ Use "Event Date" from input as reference for relative dates.
   "yesterday" → write the resolved date (e.g. "on November 12, 2024"), NOT the word "yesterday"
   "last night", "this morning", "today", "tonight" → convert to the resolved absolute date
 - For events: set occurred_start AND occurred_end (same for point events)
+- Coarse dates (only a year, or only a month, is stated): span the WHOLE period —
+  "in 2015" → 2015-01-01 to 2015-12-31, "in March 2026" → 2026-03-01 to 2026-03-31.
+  Never collapse to the period's first day or to the Event Date, current year included.
 - For conversation facts: NO occurred dates
 
 ══════════════════════════════════════════════════════════════════════════
@@ -1103,6 +1106,14 @@ For EVENTS (fact_kind="event") - MUST SET BOTH occurred_start AND occurred_end:
 - Always include the day name (Monday, Tuesday, etc.) in the 'when' field
 - Set occurred_start AND occurred_end to WHEN IT HAPPENED (not when mentioned)
 - For single-day/point events: set occurred_end = occurred_start (same timestamp)
+- COARSE DATES (the text states only a year, or only a month): set occurred_start and
+  occurred_end to the FULL SPAN of that period, so the range says how precisely the date
+  is actually known:
+    "in 2015"        → occurred_start="2015-01-01T00:00:00", occurred_end="2015-12-31T23:59:59"
+    "in March 2026"  → occurred_start="2026-03-01T00:00:00", occurred_end="2026-03-31T23:59:59"
+  Do NOT collapse a coarse date to the first day of the period, and do NOT resolve it to the
+  Event Date — even when the period is the current year. A year-only date is not a precise
+  date; recording it as one makes the memory claim a day it never stated.
 
 For CONVERSATIONS (fact_kind="conversation"):
 - General info, preferences, ongoing states → NO occurred dates

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -2,6 +2,7 @@
 Cross-encoder neural reranking for search results.
 """
 
+import calendar
 import math
 from datetime import datetime, timezone
 
@@ -53,6 +54,95 @@ def compute_recency_decay(
     # "linear" (default): straight decay to a 0.1 floor over the window.
     window = linear_window_days if linear_window_days > 0 else _RECENCY_DECAY_LINEAR_WINDOW_DAYS
     return max(0.1, min(1.0, 1.0 - (days_ago / window)))
+
+
+# A memory dated to a *period* rather than an instant carries that period in
+# (occurred_start, occurred_end). Extraction emits a full span for coarse dates —
+# "in 2015" becomes 2015-01-01 → 2015-12-31, "in March 2026" becomes
+# 2026-03-01 → 2026-03-31 — so the granularity is already in the data and does
+# not need to be stored separately.
+#
+# How far a span may deviate from an exact calendar month/year and still be read
+# as that period. Extraction encodes the last instant of a period inconsistently
+# (Dec 31 23:59:59, Dec 31 00:00:00, or Jan 1 of the next year), so allow a day
+# either way rather than matching one spelling.
+_CALENDAR_PERIOD_TOLERANCE_SECONDS: float = 86400.0
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value
+
+
+def _spans_calendar_period(start: datetime, end: datetime) -> bool:
+    """True when [start, end] covers exactly one calendar month or year.
+
+    This distinguishes a *coarse date* — "sometime in 2015", where the whole
+    period is one unit of uncertainty — from a *genuine interval* such as an
+    employment or a multi-day conference, which really did span its whole range.
+    The two are scored differently: see ``_recency_for_unit``.
+
+    Matched on span length rather than on the boundaries lining up with midnight,
+    because ``_add_temporal_offsets`` shifts every fact's timestamps by a
+    sub-second amount to keep them ordered. That shift moves both ends equally,
+    so it preserves the span exactly while destroying absolute alignment.
+    """
+    span = (end - start).total_seconds()
+    if span <= 0:
+        return False
+    month_seconds = calendar.monthrange(start.year, start.month)[1] * 86400.0
+    year_seconds = (366.0 if calendar.isleap(start.year) else 365.0) * 86400.0
+    return any(abs(span - period) <= _CALENDAR_PERIOD_TOLERANCE_SECONDS for period in (month_seconds, year_seconds))
+
+
+def _recency_for_unit(
+    occurred_start: datetime | None,
+    occurred_end: datetime | None,
+    mentioned_at: datetime | None,
+    now: datetime,
+    function: str,
+    linear_window_days: float,
+    halflife_days: float,
+) -> float:
+    """Freshness signal in [0, 1] (neutral 0.5) for one memory unit.
+
+    A unit carrying a *coarse* date — one the text stated only to the year or the
+    month, which extraction records as that whole calendar period — is scored from
+    the END of the period, the latest the event could have happened, instead of
+    from ``occurred_start``. Scoring it from the start invents an age the memory
+    never had: "the 2026 summit" stored as 2026-01-01 reads as eight months stale
+    in August 2026 and loses to any newer but unrelated fact — issue #3893.
+
+    For a coarse date the signal is additionally capped at neutral, because the
+    end of the period is a bound and not an observation. Without the cap a period
+    still in progress ends in the future, ``compute_recency_decay`` clamps it to
+    1.0, and we would swap an invented staleness penalty for an equally invented
+    freshness boost. Capping says "we don't know when in this period" while still
+    letting genuinely old periods decay — a 2015 date reaches the floor either way.
+    """
+    if occurred_start is not None and occurred_end is not None:
+        start, end = _as_utc(occurred_start), _as_utc(occurred_end)
+        if _spans_calendar_period(start, end):
+            recency = compute_recency_decay(
+                (now - end).total_seconds() / 86400,
+                function,
+                linear_window_days,
+                halflife_days,
+            )
+            return min(0.5, recency)
+
+    # Not a coarse date: score the unit's effective instant, unchanged. Note this
+    # deliberately leaves a genuine interval (a multi-day trip, an employment)
+    # aged from occurred_start as it always has been — arguably it should age from
+    # its end too, but that is a separate ranking change and not what #3893 reports.
+    effective = occurred_start or mentioned_at or occurred_end
+    if effective is None:
+        return 0.5
+    return compute_recency_decay(
+        (now - _as_utc(effective)).total_seconds() / 86400,
+        function,
+        linear_window_days,
+        halflife_days,
+    )
 
 
 def apply_combined_scoring(
@@ -146,25 +236,21 @@ def apply_combined_scoring(
 
     for sr in scored_results:
         # Recency: configurable decay (linear default; see compute_recency_decay)
-        # → [0.0, 1.0]; neutral 0.5 if no date.
-        # Use the unit's effective time (occurred_start, then mentioned_at, then
-        # occurred_end) — the same COALESCE order as retrieval._coalesce_date — so a
-        # memory that carries only a mentioned_at / occurred_end (e.g. conversation
-        # facts or ongoing states that intentionally lack occurred_start) still gets
-        # correct recency ordering instead of a flat neutral 0.5.
-        sr.recency = 0.5
-        effective = sr.retrieval.occurred_start or sr.retrieval.mentioned_at or sr.retrieval.occurred_end
-        if effective:
-            occurred = effective
-            if occurred.tzinfo is None:
-                occurred = occurred.replace(tzinfo=UTC)
-            days_ago = (now - occurred).total_seconds() / 86400
-            sr.recency = compute_recency_decay(
-                days_ago,
-                recency_decay_function,
-                recency_decay_linear_window_days,
-                recency_decay_halflife_days,
-            )
+        # → [0.0, 1.0]; neutral 0.5 if no date. Period-dated units are scored from
+        # the end of their period; everything else falls back to the effective
+        # instant (occurred_start, then mentioned_at, then occurred_end — the same
+        # COALESCE order as retrieval._coalesce_date), so a memory carrying only a
+        # mentioned_at / occurred_end still gets correct recency ordering instead
+        # of a flat neutral 0.5. See _recency_for_unit.
+        sr.recency = _recency_for_unit(
+            sr.retrieval.occurred_start,
+            sr.retrieval.occurred_end,
+            sr.retrieval.mentioned_at,
+            now,
+            recency_decay_function,
+            recency_decay_linear_window_days,
+            recency_decay_halflife_days,
+        )
 
         # Temporal proximity: meaningful only for temporal queries; neutral otherwise.
         sr.temporal = sr.retrieval.temporal_proximity if sr.retrieval.temporal_proximity is not None else 0.5

--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -62,10 +62,12 @@ def compute_recency_decay(
 # 2026-03-01 → 2026-03-31 — so the granularity is already in the data and does
 # not need to be stored separately.
 #
-# How far a span may deviate from an exact calendar month/year and still be read
-# as that period. Extraction encodes the last instant of a period inconsistently
-# (Dec 31 23:59:59, Dec 31 00:00:00, or Jan 1 of the next year), so allow a day
-# either way rather than matching one spelling.
+# How far SHORT of an exact calendar month/year a span may fall and still be read
+# as that period. Extraction spells the last instant of a period three ways —
+# Dec 31 23:59:59 (period - 1s), Dec 31 00:00:00 (period - 1 day), or the
+# exclusive Jan 1 of the next year (exactly the period) — so accept that window
+# rather than matching one spelling. The window is deliberately one-sided: a span
+# LONGER than the calendar period is a genuine interval, not a coarse date.
 _CALENDAR_PERIOD_TOLERANCE_SECONDS: float = 86400.0
 
 
@@ -91,7 +93,9 @@ def _spans_calendar_period(start: datetime, end: datetime) -> bool:
         return False
     month_seconds = calendar.monthrange(start.year, start.month)[1] * 86400.0
     year_seconds = (366.0 if calendar.isleap(start.year) else 365.0) * 86400.0
-    return any(abs(span - period) <= _CALENDAR_PERIOD_TOLERANCE_SECONDS for period in (month_seconds, year_seconds))
+    return any(
+        period - _CALENDAR_PERIOD_TOLERANCE_SECONDS <= span <= period for period in (month_seconds, year_seconds)
+    )
 
 
 def _recency_for_unit(

--- a/hindsight-api-slim/tests/test_coarse_date_spans.py
+++ b/hindsight-api-slim/tests/test_coarse_date_spans.py
@@ -1,0 +1,95 @@
+"""Coarse dates are extracted as full period spans (issue #3893).
+
+When the text states only a year or only a month, the extracted fact must carry
+that whole period in ``occurred_start``/``occurred_end`` rather than collapsing
+to a single instant. Recall depends on this: ``_spans_calendar_period`` reads the
+span back to tell a coarse date apart from a precise one, and a collapsed date is
+indistinguishable from an exact one — it then gets aged from the period's first
+day (or, worse, stamped with the ingest date) and the recency boost can outrank a
+strictly more relevant memory.
+
+Real-LLM test: whether the model follows the coarse-date instruction cannot be
+simulated with MockLLM. The assertions are structural rather than judged because
+the contract is a numeric span, and it is asserted through the same production
+helper recall uses, so the two halves of the fix cannot drift apart.
+"""
+
+from datetime import datetime
+
+import pytest
+from dateutil import parser as date_parser
+
+from hindsight_api import LLMConfig
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.retain.fact_extraction import extract_facts_from_text
+from hindsight_api.engine.search.reranking import _spans_calendar_period
+
+pytestmark = pytest.mark.hs_llm_core
+
+# Reference date deliberately inside 2026 so the "current year" case below is a
+# real regression guard: the model used to resolve "in 2026" to this date.
+EVENT_DATE = datetime(2026, 8, 30)
+
+
+async def _dated_spans(text: str) -> list[tuple[datetime, datetime]]:
+    """Extract `text` and return the (start, end) pair of every dated fact."""
+    facts, _, _ = await extract_facts_from_text(
+        text=text,
+        event_date=EVENT_DATE,
+        llm_config=LLMConfig.from_env(),
+        agent_name="user",
+        config=_get_raw_config(),
+    )
+    spans = []
+    for f in facts:
+        if f.occurred_start and f.occurred_end:
+            start = date_parser.isoparse(str(f.occurred_start))
+            end = date_parser.isoparse(str(f.occurred_end))
+            spans.append((start.replace(tzinfo=None), end.replace(tzinfo=None)))
+    return spans
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text,year",
+    [
+        ("The user graduated from university in 2015.", 2015),
+        ("The user visited Japan in 2023.", 2023),
+        # The #3893 case: a coarse date in the *current* year (relative to the
+        # event date) must still span the year instead of collapsing onto it.
+        ("In 2026 the user attended the Hangzhou Open Source Summit.", 2026),
+    ],
+)
+async def test_year_only_date_spans_the_whole_year(text: str, year: int):
+    spans = await _dated_spans(text)
+    assert spans, f"expected a dated fact from: {text}"
+    matching = [(s, e) for s, e in spans if s.year == year and _spans_calendar_period(s, e)]
+    assert matching, (
+        f"expected a fact spanning the whole of {year}, got {spans}. "
+        "A collapsed coarse date reads as an exact date during recall scoring."
+    )
+    start, end = matching[0]
+    assert (start.month, start.day) == (1, 1)
+    assert end.month == 12
+
+
+@pytest.mark.asyncio
+async def test_month_only_date_spans_the_whole_month():
+    spans = await _dated_spans("The user moved to Berlin in March 2026.")
+    assert spans, "expected a dated fact"
+    matching = [(s, e) for s, e in spans if (s.year, s.month) == (2026, 3) and _spans_calendar_period(s, e)]
+    assert matching, f"expected a fact spanning all of March 2026, got {spans}"
+    start, end = matching[0]
+    assert start.day == 1
+    assert end.month == 3
+
+
+@pytest.mark.asyncio
+async def test_exact_date_is_not_widened_into_a_period():
+    """The instruction must not push precise dates into spans — that would make
+    every dated memory look coarse and disable the recency signal wholesale."""
+    spans = await _dated_spans("On August 24, 2026, the user switched the UI to the light theme.")
+    assert spans, "expected a dated fact"
+    same_day = [(s, e) for s, e in spans if s.date() == e.date() == datetime(2026, 8, 24).date()]
+    assert same_day, f"expected a same-day span for an exact date, got {spans}"
+    assert not _spans_calendar_period(*same_day[0])

--- a/hindsight-api-slim/tests/test_combined_scoring.py
+++ b/hindsight-api-slim/tests/test_combined_scoring.py
@@ -252,3 +252,142 @@ class TestRecencyDecayFunction:
         apply_combined_scoring([sr], now=NOW, recency_decay_function="none")
         assert sr.recency == 0.5
         assert abs(sr.weight - 0.5) < 1e-9  # neutral → no recency boost
+
+
+class TestPeriodDatedRecency:
+    """Recency for memories dated to a period rather than an instant (issue #3893).
+
+    Fact extraction emits coarse dates as a full span — "in 2015" becomes
+    2015-01-01 → 2015-12-31 — so the granularity is already in the data. Scoring
+    such a memory from occurred_start invents an age it never had.
+    """
+
+    def test_coarse_current_year_is_neutral_not_stale(self):
+        """A year-coarse date inside the current year scores neutral, not 5 months stale.
+
+        The #3893 regression: 2026-01-01 read as an exact date is ~5 months old and
+        gets a recency *penalty*, even though the event may have happened yesterday.
+        """
+        sr = _make_result(
+            ce_norm=0.5,
+            occurred_start=datetime(2024, 1, 1, tzinfo=UTC),
+            occurred_end=datetime(2024, 12, 31, 23, 59, 59, tzinfo=UTC),
+        )
+        apply_combined_scoring([sr], now=NOW)  # NOW = 2024-06-01, mid-period
+        assert sr.recency == 0.5
+
+    def test_coarse_month_is_neutral(self):
+        """Month-coarse dates get the same treatment as year-coarse ones."""
+        sr = _make_result(
+            ce_norm=0.5,
+            occurred_start=datetime(2024, 5, 1, tzinfo=UTC),
+            occurred_end=datetime(2024, 5, 31, 23, 59, 59, tzinfo=UTC),
+        )
+        apply_combined_scoring([sr], now=NOW)
+        assert sr.recency == 0.5
+
+    def test_old_coarse_dates_still_decay(self):
+        """The neutral cap is a ceiling, not a flattening — old periods still decay.
+
+        Guards the obvious over-correction: returning a flat 0.5 for every coarse
+        date would make a 2015 memory look as fresh as a current-year one.
+        """
+        sr = _make_result(
+            ce_norm=0.5,
+            occurred_start=datetime(2015, 1, 1, tzinfo=UTC),
+            occurred_end=datetime(2015, 12, 31, 23, 59, 59, tzinfo=UTC),
+        )
+        apply_combined_scoring([sr], now=NOW)
+        assert sr.recency == 0.1  # linear floor, ~8 years past the 365d window
+
+    def test_coarse_date_scored_from_end_not_start(self):
+        """The coarse period is aged from its end; its start would look far older."""
+        # A period old enough that BOTH ends decay below the 0.5 cap, so the cap
+        # cannot mask which end was used and the value alone identifies it.
+        start = datetime(2023, 10, 1, tzinfo=UTC)
+        end = datetime(2023, 10, 31, 23, 59, 59, tzinfo=UTC)
+        sr = _make_result(ce_norm=0.5, occurred_start=start, occurred_end=end)
+        apply_combined_scoring([sr], now=NOW)
+
+        days_from_end = (NOW - end).total_seconds() / 86400
+        days_from_start = (NOW - start).total_seconds() / 86400
+        assert sr.recency < 0.5  # uncapped: the cap is not what we are measuring
+        assert abs(sr.recency - compute_recency_decay(days_from_end)) < 1e-9
+        assert sr.recency > compute_recency_decay(days_from_start)
+
+    def test_genuine_interval_keeps_existing_behaviour(self):
+        """A multi-day interval is not a coarse date and is deliberately untouched.
+
+        Its span is not a calendar period, so it stays aged from occurred_start as
+        it always has been. Whether intervals *should* age from their end is a
+        separate ranking question, out of scope for #3893.
+        """
+        sr = _make_result(
+            ce_norm=0.5,
+            occurred_start=NOW - timedelta(days=300),
+            occurred_end=NOW - timedelta(days=5),
+        )
+        apply_combined_scoring([sr], now=NOW)
+        assert sr.recency == compute_recency_decay(300)
+
+    def test_single_day_span_is_an_instant(self):
+        """A day encoded as 00:00:00 → 23:59:59 is a precise date, not a period.
+
+        It must score identically to the same day encoded as a point, or every
+        full-day encoding would silently lose its recency boost.
+        """
+        day = datetime(2024, 5, 30, tzinfo=UTC)
+        spanned = _make_result(ce_norm=0.5, occurred_start=day, occurred_end=day.replace(hour=23, minute=59, second=59))
+        point = _make_result(ce_norm=0.5, occurred_start=day, occurred_end=day)
+        apply_combined_scoring([spanned, point], now=NOW)
+        assert spanned.recency == point.recency
+        assert spanned.recency > 0.9
+
+    def test_point_dates_are_unaffected(self):
+        """Precise dates keep the historical behaviour — recency still ranks them."""
+        recent = _make_result(ce_norm=0.5, occurred_start=NOW - timedelta(days=2))
+        old = _make_result(ce_norm=0.5, occurred_start=NOW - timedelta(days=200))
+        apply_combined_scoring([recent, old], now=NOW)
+        assert recent.recency == compute_recency_decay(2)
+        assert old.recency == compute_recency_decay(200)
+        assert recent.combined_score > old.combined_score
+
+    def test_leap_year_span_is_recognised(self):
+        """A 366-day span is a calendar year too — 2024 must not read as an interval."""
+        sr = _make_result(
+            ce_norm=0.5,
+            occurred_start=datetime(2024, 1, 1, tzinfo=UTC),
+            occurred_end=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        apply_combined_scoring([sr], now=NOW)
+        assert sr.recency == 0.5
+
+    def test_sub_second_ordering_offset_does_not_break_detection(self):
+        """_add_temporal_offsets shifts both ends equally; the span must still match.
+
+        Detection keys on span length rather than midnight alignment precisely so
+        this offset (i * 0.01s, applied at retain) cannot hide a coarse date.
+        """
+        offset = timedelta(milliseconds=430)
+        sr = _make_result(
+            ce_norm=0.5,
+            occurred_start=datetime(2015, 1, 1, tzinfo=UTC) + offset,
+            occurred_end=datetime(2015, 12, 31, 23, 59, 59, tzinfo=UTC) + offset,
+        )
+        apply_combined_scoring([sr], now=NOW)
+        assert sr.recency == 0.1  # still classified coarse, still decayed
+
+    def test_coarse_date_no_longer_loses_to_newer_unrelated_fact(self):
+        """End-to-end #3893: the reranker's preferred result keeps rank 1.
+
+        Before the fix the recency boost on a 6-day-old fact overturned a ~10%
+        cross-encoder lead held by a year-coarse fact from the current year.
+        """
+        relevant_coarse = _make_result(
+            ce_norm=0.999924,
+            occurred_start=datetime(2024, 1, 1, tzinfo=UTC),
+            occurred_end=datetime(2024, 12, 31, 23, 59, 59, tzinfo=UTC),
+        )
+        irrelevant_recent = _make_result(ce_norm=0.900004, occurred_start=NOW - timedelta(days=6))
+        apply_combined_scoring([relevant_coarse, irrelevant_recent], now=NOW)
+        assert relevant_coarse.combined_score > irrelevant_recent.combined_score

--- a/hindsight-api-slim/tests/test_combined_scoring.py
+++ b/hindsight-api-slim/tests/test_combined_scoring.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from hindsight_api.engine.search.reranking import (
     _RECENCY_ALPHA,
     _TEMPORAL_ALPHA,
+    _spans_calendar_period,
     apply_combined_scoring,
     compute_recency_decay,
 )
@@ -361,6 +362,30 @@ class TestPeriodDatedRecency:
         )
         apply_combined_scoring([sr], now=NOW)
         assert sr.recency == 0.5
+
+    def test_all_three_period_end_encodings_are_recognised(self):
+        """Extraction spells a period's last instant three ways; all must match.
+
+        The tolerance exists for exactly this. Dec 31 23:59:59 and the exclusive
+        Jan 1 boundary are covered elsewhere; the midnight-on-the-last-day form
+        is a full day short of the period and is what the window has to absorb.
+        """
+        year_start = datetime(2015, 1, 1, tzinfo=UTC)
+        for year_end in (
+            datetime(2015, 12, 31, 23, 59, 59, tzinfo=UTC),  # period - 1s
+            datetime(2015, 12, 31, tzinfo=UTC),  # period - 1 day
+            datetime(2016, 1, 1, tzinfo=UTC),  # exclusive next boundary
+        ):
+            assert _spans_calendar_period(year_start, year_end), year_end
+
+    def test_span_longer_than_the_period_is_not_coarse(self):
+        """The window is one-sided: overshooting a year is an interval, not a year.
+
+        "worked at Acme from Jan 2015 to Mar 2016" spans more than a calendar year
+        and must keep the interval behaviour rather than being capped as coarse.
+        """
+        assert not _spans_calendar_period(datetime(2015, 1, 1, tzinfo=UTC), datetime(2016, 3, 1, tzinfo=UTC))
+        assert not _spans_calendar_period(datetime(2015, 1, 1, tzinfo=UTC), datetime(2015, 3, 1, tzinfo=UTC))
 
     def test_sub_second_ordering_offset_does_not_break_detection(self):
         """_add_temporal_offsets shifts both ends equally; the span must still match.


### PR DESCRIPTION
Fixes #3893.

## The bug

A memory whose text stated only a year or a month is ranked as if it happened on the **first instant** of that period. "The 2026 summit" stored as `2026-01-01` reads as eight months stale on 2026-08-30, and the recency penalty overturns the cross-encoder — a newer but unrelated fact takes Top-1 from the candidate both semantic retrieval and the reranker preferred.

Reproduced exactly against the production scoring function, matching the issue's table:

```
candidate |  CE_norm |  recency | combined
    wrong | 0.900004 | 0.983562 | 0.987045   <- rank 1
  correct | 0.999924 | 0.339726 | 0.967872

reranker order: ['correct', 'wrong']
final order:    ['wrong', 'correct']   REVERSED
```

This is not a corner case: `recency_boost` spans `[0.92, 1.10]`, so a fresher candidate wins whenever the more relevant one's cross-encoder lead is under **~19.6%**. Here the correct fact led by 11% and lost.

## The fix

Extraction already records a coarse date as its full span, so the granularity is present in the data and needs no new column:

| input | occurred_start | occurred_end |
|---|---|---|
| "graduated … in 2015" | 2015-01-01 00:00:00 | 2015-12-31 23:59:59 |
| "moved to Berlin in March 2026" | 2026-03-01 00:00:00 | 2026-03-31 23:59:59 |

Recall now reads it back (`reranking.py`):

- A unit whose `(occurred_start, occurred_end)` covers exactly one calendar month or year is scored from the **end** of that period — the latest the event could have happened — instead of from its start.
- That signal is **capped at neutral**, because the period's end is a bound, not an observation. Without the cap a period still in progress ends in the future and clamps to full freshness, trading an invented staleness penalty for an equally invented freshness boost. Genuinely old periods still decay — a 2015 date reaches the floor either way.

Detection keys on **span length, not midnight alignment**: `_add_temporal_offsets` shifts both ends of a fact by the same sub-second amount, which preserves the span exactly while destroying absolute alignment.

Extraction had a matching gap (`fact_extraction.py`): with the event date inside the same year, `"In 2026 the user attended …"` resolved to the event date itself, collapsing the period **and** asserting a precise day the text never stated. The prompt now spells out the coarse-date case, current year included. Verified before/after against the real model:

```
before:  start=2026-08-30            end=2026-08-30
after:   start=2026-01-01T00:00:00   end=2026-12-31T23:59:59
```

## Deliberately out of scope

- **Genuine intervals** (a multi-day trip, an employment) stay aged from `occurred_start` as before. Whether they should age from their end is a separate ranking question, not what this issue reports.
- **A year carried only by an event's NAME** ("the 2026 Hangzhou Summit") is still stamped with the event date. Prompt wording for that case was tried and dropped — neither `gemini-2.5-flash-lite` nor `gemini-2.5-flash` honoured it, and shipping prompt text that demonstrably does nothing is worse than the gap.
- **Existing rows** keep the old behaviour. `"2026"` and `"2026-01-01"` were stored identically, so they cannot be told apart after the fact; they correct themselves on re-retain.

## Tests

- `test_combined_scoring.py` — 11 deterministic cases: the reported rank reversal, the neutral cap, old periods still decaying, leap years, the sub-second offset, single-day `00:00:00 → 23:59:59` encodings treated as instants, and precise dates left untouched.
- `test_coarse_date_spans.py` (`hs_llm_core`) — asserts extraction emits real spans, through the same production helper recall uses, so the two halves of the fix cannot drift apart.

51 passed locally; `lint.sh` and `ty check` clean.

https://claude.ai/code/session_0134gt96Tyi2Yi55yDH5s4Rb