### PR TITLE
fix(llm): repair malformed JSON in the openai-compatible provider (#3683)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -52,6 +52,7 @@ from hindsight_api.engine.llm_interface import (
     ProviderRateLimitResetError,
 )
 from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
+from hindsight_api.engine.llm_wrapper import parse_llm_json
 from hindsight_api.engine.providers.llm_debug import dump_request_on_4xx
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.engine.structured_output import strict_json_schema
@@ -273,6 +274,22 @@ def _summarize_provider_error_payload(error: Any, max_len: int = 400) -> str:
     if len(summary) > max_len:
         summary = summary[:max_len] + "...TRUNCATED"
     return summary
+
+
+# Finish reasons that positively say a generation ran to its own end. Repair is
+# gated on one of these because json_repair closes an unterminated string or list
+# by inventing the terminator, so repairing a body that may have been cut turns a
+# loud failure into a short answer reported as a complete one. A missing or
+# unrecognised reason is not evidence of completion.
+#
+# This is deliberately stricter than litellm_llm.py:367, which repairs whatever it
+# has left once the retry budget is spent. An explicit "length" raises before either
+# path reaches repair, so the gate's only remaining effect is to withhold repair from
+# a provider that omits or renames finish_reason — and those are exactly the proxies
+# and gateways this provider fronts. Losing the repair there is the cheaper mistake:
+# a JSONDecodeError is loud and the caller can split, while a silently short answer
+# is indistinguishable from a complete one. Same reasoning as #3827.
+_COMPLETED_FINISH_REASONS = frozenset({"stop", "tool_calls", "function_call", "end_turn"})
 
 
 def _finish_reason_for_choice(choice: Any) -> Any:
@@ -1178,14 +1195,36 @@ class OpenAICompatibleLLM(LLMInterface):
                                 f"  Content preview: {content_preview!r}\n"
                                 f"  Finish reason: {_finish_reason_for_choice(first_choice)}"
                             )
-                            # Retry on JSON parse errors
+                            # Retry on JSON parse errors for the whole
+                            # configured budget. Two identical bodies are not
+                            # proof the next one repeats: temperature is set by
+                            # the caller and not read here, so there is nothing
+                            # on this path that establishes a deterministic
+                            # generation.
                             if attempt < max_retries:
                                 backoff = min(initial_backoff * (2**attempt), max_backoff)
                                 await asyncio.sleep(backoff)
                                 last_exception = json_err
                                 continue
-                            else:
-                                logger.error(f"JSON parse error after {max_retries + 1} attempts, giving up")
+                            # Retry budget spent. Repair structurally as a
+                            # last resort, the way litellm_llm.py has since
+                            # #2547/#2544, but only for a generation that
+                            # reported reaching its own end. Without that,
+                            # a provider that omits finish_reason would have a
+                            # truncated body repaired into schema-valid partial
+                            # data.
+                            if _finish_reason_for_choice(first_choice) not in _COMPLETED_FINISH_REASONS:
+                                logger.error(
+                                    f"JSON parse error after {attempt + 1} attempts and no "
+                                    f"completion signal (finish_reason="
+                                    f"{_finish_reason_for_choice(first_choice)!r}); "
+                                    "not repairing, the body may be truncated"
+                                )
+                                raise
+                            try:
+                                json_data = parse_llm_json(content)
+                            except json.JSONDecodeError:
+                                logger.error(f"JSON parse error after {attempt + 1} attempts, giving up")
                                 raise
 
                     if skip_validation:
@@ -1742,7 +1781,39 @@ class OpenAICompatibleLLM(LLMInterface):
                     response.raise_for_status()
 
                     result = response.json()
+                    # Stash usage before the guards below, which can raise on a
+                    # capped response. Ollama charges for those tokens and the
+                    # capped calls are the expensive ones, so raising first would
+                    # drop exactly the calls worth accounting for.
+                    stash_response_usage(
+                        LLMResponseUsage(
+                            input_tokens=result.get("prompt_eval_count", 0) or 0,
+                            output_tokens=result.get("eval_count", 0) or 0,
+                        )
+                    )
                     content = result.get("message", {}).get("content", "")
+
+                    # Same case as the OpenAI-compatible path, different key: Ollama
+                    # reports a token cap as done_reason "length". Raised ahead of the
+                    # free-form/structured split, and ahead of reading the content, for
+                    # the two reasons _content_or_error gives:
+                    #
+                    #   - a cap that lands on a closing brace still parses and still
+                    #     validates, so the structured path would return a short answer
+                    #     as a complete one;
+                    #   - a cap reached before the first visible token leaves content
+                    #     empty, and the free-form branch below reads that as a
+                    #     *retryable* ProviderResponseError, which re-sends the same
+                    #     request against the same limit (#3811).
+                    #
+                    # Free-form calls raise too, matching the sibling path since #3827:
+                    # a truncated reflect synthesis or mental-model page fails rather
+                    # than being returned as if it were complete.
+                    if result.get("done_reason") == "length":
+                        raise OutputTooLongError(
+                            f"LLM output exceeded token limits (ollama/{self.model}, scope={scope}). "
+                            "Input may need to be split into smaller chunks."
+                        )
 
                     if response_format is None:
                         # Free-form output: no schema, nothing to parse. Reasoning
@@ -1782,7 +1853,21 @@ class OpenAICompatibleLLM(LLMInterface):
                                     await asyncio.sleep(backoff)
                                     last_exception = json_err
                                     continue
-                                else:
+                                # Same last-resort repair as the
+                                # OpenAI-compatible path above, gated the same
+                                # way: only a generation that reported reaching
+                                # its own end gets structurally repaired.
+                                if result.get("done_reason") not in _COMPLETED_FINISH_REASONS:
+                                    logger.error(
+                                        f"Ollama JSON parse error after {attempt + 1} attempts and no "
+                                        f"completion signal (done_reason={result.get('done_reason')!r}); "
+                                        "not repairing, the body may be truncated"
+                                    )
+                                    raise
+                                try:
+                                    json_data = parse_llm_json(content)
+                                except json.JSONDecodeError:
+                                    logger.error(f"Ollama JSON parse error after {attempt + 1} attempts, giving up")
                                     raise
 
                     # Extract token usage from Ollama response
@@ -1871,6 +1956,11 @@ class OpenAICompatibleLLM(LLMInterface):
                     else:
                         logger.error(f"Ollama connection error after {max_retries + 1} attempts: {e}")
                         raise
+
+                except OutputTooLongError:
+                    # Expected and handled upstream by splitting the input, so it
+                    # does not belong in the unexpected-error log below.
+                    raise
 
                 except Exception as e:
                     logger.error(f"Unexpected error during Ollama call: {type(e).__name__}: {e}")

--- a/hindsight-api-slim/tests/test_openai_compatible_response_hardening.py
+++ b/hindsight-api-slim/tests/test_openai_compatible_response_hardening.py
@@ -1,15 +1,23 @@
 import asyncio
+import json
 from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from pydantic import BaseModel
 
+from hindsight_api.engine.llm_trace import (
+    current_response_usage,
+    reset_response_usage,
+    set_response_usage,
+)
 from hindsight_api.engine.providers.openai_compatible_llm import (
     OpenAICompatibleLLM,
+    OutputTooLongError,
     ProviderResponseError,
     _rate_limit_retry_at,
 )
@@ -18,6 +26,12 @@ from hindsight_api.worker.stage import StageHolder, bind_holder, set_stage
 
 class SimpleJsonResponse(BaseModel):
     ok: bool
+
+
+class FactListResponse(BaseModel):
+    """A list is what makes a cap dangerous: repair drops entries and still validates."""
+
+    facts: list[str]
 
 
 def _llm() -> OpenAICompatibleLLM:
@@ -29,14 +43,14 @@ def _llm() -> OpenAICompatibleLLM:
     )
 
 
-def _response(*, content: str | None = '{"ok": true}', choices=None, error=None):
+def _response(*, content: str | None = '{"ok": true}', choices=None, error=None, finish_reason="stop"):
     response = SimpleNamespace(error=error, usage=None)
     if choices is not None:
         response.choices = choices
         return response
 
     choice = SimpleNamespace(
-        finish_reason="stop",
+        finish_reason=finish_reason,
         message=SimpleNamespace(content=content, tool_calls=None, refusal=None),
     )
     response.choices = [choice]
@@ -201,6 +215,272 @@ async def test_missing_choices_are_retryable_provider_response_errors():
     sleep_mock.assert_awaited_once()
 
 
+def _ollama_llm(*, num_ctx: int | None = None) -> OpenAICompatibleLLM:
+    return OpenAICompatibleLLM(
+        provider="ollama",
+        api_key="",
+        base_url="http://localhost:11434/v1",
+        model="qwen3",
+        ollama_num_ctx=num_ctx,
+    )
+
+
+def _ollama_response(content: str, *, done_reason: str | None = None) -> httpx.Response:
+    body = {
+        "model": "qwen3",
+        "message": {"role": "assistant", "content": content},
+        "done": True,
+    }
+    if done_reason is not None:
+        body["done_reason"] = done_reason
+    request = httpx.Request("POST", "http://localhost:11434/api/chat")
+    return httpx.Response(200, json=body, request=request)
+
+
+@pytest.mark.asyncio
+async def test_repairable_json_is_recovered_instead_of_being_dropped():
+    """A malformed but structurally repairable response must not be lost (#3683).
+
+    The trailing comma is what json_repair exists to fix. Before #3683 this
+    provider parsed with bare json.loads and raised once the retries ran out,
+    so the facts in the response never reached the caller.
+    """
+    llm = _llm()
+    create = AsyncMock(return_value=_response(content='{"ok": true,}'))
+    llm._client.chat.completions.create = create
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        result = await llm.call(
+            messages=[{"role": "user", "content": "Return whether this worked."}],
+            response_format=SimpleJsonResponse,
+            max_retries=1,
+            initial_backoff=0,
+        )
+
+    assert result.ok is True
+
+
+@pytest.mark.asyncio
+async def test_repeated_output_does_not_cut_the_retry_budget_short():
+    """Two identical bodies do not establish a deterministic generation (#3683).
+
+    Temperature is set by the caller and never read on this path, so nothing here
+    can tell a deterministic model from a stochastic one that repeated twice. The
+    configured budget is what the caller asked for, and the third attempt is the
+    one that succeeds.
+    """
+    llm = _llm()
+    create = AsyncMock(
+        side_effect=[
+            _response(content='{"ok": true,}'),
+            _response(content='{"ok": true,}'),
+            _response(content='{"ok": true}'),
+        ]
+    )
+    llm._client.chat.completions.create = create
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        result = await llm.call(
+            messages=[{"role": "user", "content": "Return whether this worked."}],
+            response_format=SimpleJsonResponse,
+            max_retries=3,
+            initial_backoff=0,
+        )
+
+    assert result.ok is True
+    assert create.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_a_changed_response_still_earns_a_fresh_generation():
+    """Flaky malformed output keeps its re-rolls (#3683).
+
+    Output that differs each time is the case a fresh generation can actually
+    fix, so the retry ladder must run to the end of the budget.
+    """
+    llm = _llm()
+    create = AsyncMock(
+        side_effect=[
+            _response(content='{"ok": true,}'),
+            _response(content='{"ok": '),
+            _response(content='{"ok": true}'),
+        ]
+    )
+    llm._client.chat.completions.create = create
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        result = await llm.call(
+            messages=[{"role": "user", "content": "Return whether this worked."}],
+            response_format=SimpleJsonResponse,
+            max_retries=3,
+            initial_backoff=0,
+        )
+
+    assert result.ok is True
+    assert create.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_ollama_native_repairs_malformed_json_instead_of_dropping_it():
+    """The native /api/chat path parses the same way and had the same gap (#3683).
+
+    ``done_reason="stop"`` is what real Ollama sends on a completed generation,
+    and repair is gated on it.
+    """
+    llm = _ollama_llm()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _ollama_response('{"ok": true,}', done_reason="stop")
+    mock_client.__aenter__.return_value = mock_client
+
+    with (
+        patch(
+            "hindsight_api.engine.providers.openai_compatible_llm.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        result = await llm.call(
+            messages=[{"role": "user", "content": "Return whether this worked."}],
+            response_format=SimpleJsonResponse,
+            max_retries=1,
+            initial_backoff=0,
+        )
+
+    assert result.ok is True
+
+
+@pytest.mark.asyncio
+async def test_ollama_native_reports_a_truncated_body_rather_than_repairing_it():
+    """The native path carries the same risk under the done_reason key."""
+    llm = _ollama_llm()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _ollama_response('{"facts": ["alpha", "beta", "gam', done_reason="length")
+    mock_client.__aenter__.return_value = mock_client
+
+    with (
+        patch(
+            "hindsight_api.engine.providers.openai_compatible_llm.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        with pytest.raises(OutputTooLongError):
+            await llm.call(
+                messages=[{"role": "user", "content": "List the facts."}],
+                response_format=FactListResponse,
+                max_retries=1,
+                initial_backoff=0,
+            )
+
+
+@pytest.mark.asyncio
+async def test_ollama_native_reports_a_truncated_body_that_still_parses():
+    """The native path has the same quiet case under done_reason."""
+    llm = _ollama_llm()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _ollama_response('{"facts": ["alpha", "beta"]}', done_reason="length")
+    mock_client.__aenter__.return_value = mock_client
+
+    with (
+        patch(
+            "hindsight_api.engine.providers.openai_compatible_llm.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        with pytest.raises(OutputTooLongError):
+            await llm.call(
+                messages=[{"role": "user", "content": "List the facts."}],
+                response_format=FactListResponse,
+                max_retries=3,
+                initial_backoff=0,
+            )
+
+    assert mock_client.post.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ollama_native_reports_a_capped_free_form_answer():
+    """A cap on a free-form native call fails rather than returning the cut text.
+
+    The guard sits ahead of the free-form/structured split, matching what the
+    OpenAI-compatible path has done for every scope since #3827: a truncated
+    reflect synthesis or mental-model page is a failure, not a short success.
+    """
+    # Free-form calls only take the native path once num_ctx is configured.
+    llm = _ollama_llm(num_ctx=8192)
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _ollama_response("The three causes are, first,", done_reason="length")
+    mock_client.__aenter__.return_value = mock_client
+
+    with (
+        patch(
+            "hindsight_api.engine.providers.openai_compatible_llm.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        with pytest.raises(OutputTooLongError):
+            await llm.call(
+                messages=[{"role": "user", "content": "Explain the causes."}],
+                max_retries=3,
+                initial_backoff=0,
+            )
+
+    assert mock_client.post.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ollama_native_does_not_retry_a_capped_empty_free_form_answer():
+    """A cap reached before the first visible token must not be re-sent (#3811).
+
+    Empty content on the free-form branch raises a *retryable*
+    ProviderResponseError, so without the guard ahead of it the identical request
+    goes back out against the identical limit.
+    """
+    llm = _ollama_llm(num_ctx=8192)
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _ollama_response("", done_reason="length")
+    mock_client.__aenter__.return_value = mock_client
+
+    with (
+        patch(
+            "hindsight_api.engine.providers.openai_compatible_llm.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        with pytest.raises(OutputTooLongError):
+            await llm.call(
+                messages=[{"role": "user", "content": "Explain the causes."}],
+                max_retries=3,
+                initial_backoff=0,
+            )
+
+    assert mock_client.post.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_body_that_is_not_truncated_still_gets_repaired():
+    """The guard reads finish_reason, not the shape of the failure.
+
+    Malformed output that was not truncated keeps the repair this PR added.
+    """
+    llm = _llm()
+    create = AsyncMock(return_value=_response(content='{"facts": ["alpha", "beta"],}'))
+    llm._client.chat.completions.create = create
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        result = await llm.call(
+            messages=[{"role": "user", "content": "List the facts."}],
+            response_format=FactListResponse,
+            max_retries=1,
+            initial_backoff=0,
+        )
+
+    assert result.facts == ["alpha", "beta"]
+
+
 @pytest.mark.parametrize(
     ("headers", "message", "expected_seconds"),
     [
@@ -235,3 +515,111 @@ def test_rate_limit_retry_at_uses_latest_header_or_body_reset(
     assert retry_at is not None
     wait = (retry_at - datetime.now(UTC)).total_seconds()
     assert expected_seconds - 1 < wait <= expected_seconds + 1
+
+
+@pytest.mark.asyncio
+async def test_a_truncated_list_is_not_repaired_when_the_provider_omits_finish_reason():
+    """Repair needs positive evidence the generation finished (#3683).
+
+    ``json_repair`` closes an unterminated string and list by inventing the
+    terminators, so ``{"facts": ["alpha", "beta", "gam`` becomes a valid
+    two-and-a-bit-entry answer. A proxy that omits finish_reason gives no
+    evidence either way, and guessing there would turn a truncation into a
+    short result reported as complete.
+    """
+    llm = _llm()
+    truncated = '{"facts": ["alpha", "beta", "gam'
+    create = AsyncMock(return_value=_response(content=truncated, finish_reason=None))
+    llm._client.chat.completions.create = create
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        with pytest.raises(json.JSONDecodeError):
+            await llm.call(
+                messages=[{"role": "user", "content": "List the facts."}],
+                response_format=FactListResponse,
+                max_retries=0,
+                initial_backoff=0,
+            )
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_finish_reason_does_not_earn_a_repair():
+    """An unrecognised reason is not a completion signal either."""
+    llm = _llm()
+    create = AsyncMock(return_value=_response(content='{"facts": ["alpha", "gam', finish_reason="incomplete"))
+    llm._client.chat.completions.create = create
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        with pytest.raises(json.JSONDecodeError):
+            await llm.call(
+                messages=[{"role": "user", "content": "List the facts."}],
+                response_format=FactListResponse,
+                max_retries=0,
+                initial_backoff=0,
+            )
+
+
+@pytest.mark.asyncio
+async def test_ollama_does_not_repair_a_truncated_list_without_done_reason():
+    """The native path is gated the same way."""
+    llm = _ollama_llm()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _ollama_response('{"facts": ["alpha", "beta", "gam')
+    mock_client.__aenter__.return_value = mock_client
+
+    with (
+        patch(
+            "hindsight_api.engine.providers.openai_compatible_llm.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        with pytest.raises(json.JSONDecodeError):
+            await llm.call(
+                messages=[{"role": "user", "content": "List the facts."}],
+                response_format=FactListResponse,
+                max_retries=0,
+                initial_backoff=0,
+            )
+
+
+@pytest.mark.asyncio
+async def test_ollama_records_usage_for_a_capped_response_before_raising():
+    """A capped call still cost tokens, and those are the expensive calls.
+
+    The done_reason guard raises before the usage extraction further down, so
+    without stashing here the most expensive responses would be the ones missing
+    from accounting.
+    """
+    llm = _ollama_llm()
+    mock_client = AsyncMock()
+    body = _ollama_response('{"facts": ["alpha", "beta", "gam', done_reason="length")
+    payload = json.loads(body.content)
+    payload["prompt_eval_count"] = 1234
+    payload["eval_count"] = 567
+    request = httpx.Request("POST", "http://localhost:11434/api/chat")
+    mock_client.post.return_value = httpx.Response(200, json=payload, request=request)
+    mock_client.__aenter__.return_value = mock_client
+
+    token = set_response_usage(None)
+    try:
+        with (
+            patch(
+                "hindsight_api.engine.providers.openai_compatible_llm.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+        ):
+            with pytest.raises(OutputTooLongError):
+                await llm.call(
+                    messages=[{"role": "user", "content": "List the facts."}],
+                    response_format=FactListResponse,
+                    max_retries=0,
+                    initial_backoff=0,
+                )
+        usage = current_response_usage()
+        assert usage is not None
+        assert usage.input_tokens == 1234
+        assert usage.output_tokens == 567
+    finally:
+        reset_response_usage(token)


### PR DESCRIPTION
Fixes #3683. Supersedes #3685 by @chiruu12, who diagnosed the bug and wrote the fix and its tests; carried forward here with credit after `main` moved under it.

## The bug

Both structured-output parse sites in `openai_compatible_llm.py` decoded with a bare `json.loads` and, once the retry budget was spent, gave up. `parse_llm_json` was never reached, so a response `json_repair` could have recovered was dropped — after `max_retries + 1` full generations against a byte-identical request. Both paths now fall back to `parse_llm_json` as a last resort, the way `litellm_llm.py` has since #2547/#2544.

## Repair is gated on a completion signal

`json_repair` closes an unterminated string or list by inventing the terminator, so repairing a body that may have been cut turns a loud failure into a short answer reported as a complete one. Repair therefore requires a `finish_reason` that positively reports completion.

This is stricter than `litellm_llm.py:367`, which repairs whatever it has left. An explicit `"length"` raises before either path reaches repair, so the gate's only remaining effect is to withhold repair from a provider that omits or renames `finish_reason` — exactly the proxies this provider fronts. That trade is deliberate and recorded at the gate: a `JSONDecodeError` is loud and the caller can split, while a silently short answer is indistinguishable from a complete one.

## The native Ollama path gets #3827's truncation guard

Keyed on `done_reason`, and placed **above** the free-form/structured split, for two reasons:

- a cap landing on a closing brace still parses and still validates, so the structured path returned a short answer as a complete one;
- a cap reached before the first visible token leaves content empty, and the free-form branch reads that as a **retryable** `ProviderResponseError` — re-sending the same request against the same limit. That is #3811's exact shape, still live on this path.

Free-form calls raise too, matching the sibling path since #3827: a truncated reflect synthesis or mental-model page fails rather than being returned as if complete.

The native path also stashes provider-reported usage, which it never did (#2387 parity). Recorded before the guards, since a capped call still cost tokens and those are the expensive ones.

## What changed relative to #3685

`main` advanced twice while that PR was open, and #3827 landed the same truncation fix for the OpenAI-compatible path:

- dropped its `finish_reason == "length"` guard in `call()` — `_content_or_error` already raises there since #3827, so the guard was unreachable (verified: removing it left the suite green);
- dropped the three truncation tests that now duplicate `tests/test_openai_compatible_truncation.py`, keeping the Ollama-keyed ones;
- moved the Ollama guard above the free-form branch and added two tests for the cases that exposes;
- rebased onto #3920, which rewrote 119 lines of this file.

Note that native free-form is only reachable with `ollama_num_ctx` configured (`:1039`), which is likely why the free-form half of this gap survived.

## Tests

`tests/test_openai_compatible_response_hardening.py`, all mocked, no network. The two new ones fail with the guard back inside the `else` branch and pass with it moved.

- 43 passed across the hardening, truncation, and Ollama files
- 125 passed / 5 skipped across the 10 provider/LLM test files
- `./scripts/hooks/lint.sh` and `ty check` clean

## Not here

The issue also suggests feeding invalid output back as a repair turn, and a per-document dropped-chunk counter on the retain response. Both change behaviour past parsing; left on the issue.

https://claude.ai/code/session_01DNWFQn8AUN6SApcswHG3aN
