### PR TITLE
fix(docker): ship images free of fixed HIGH CVEs and scan them daily

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,6 +488,33 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
+    # Gate the release on the published bytes: a fixed HIGH/CRITICAL in either
+    # architecture fails this job, so create-github-release (which needs it)
+    # never runs and no GitHub Release is published for the tag.
+    - name: Scan published image (linux/amd64)
+      uses: aquasecurity/trivy-action@v0.36.0
+      with:
+        image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}@${{ steps.build.outputs.digest }}
+        scanners: vuln
+        severity: HIGH,CRITICAL
+        ignore-unfixed: true
+        exit-code: '1'
+        format: table
+      env:
+        TRIVY_PLATFORM: linux/amd64
+
+    - name: Scan published image (linux/arm64)
+      uses: aquasecurity/trivy-action@v0.36.0
+      with:
+        image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}@${{ steps.build.outputs.digest }}
+        scanners: vuln
+        severity: HIGH,CRITICAL
+        ignore-unfixed: true
+        exit-code: '1'
+        format: table
+      env:
+        TRIVY_PLATFORM: linux/arm64
+
     - name: Install cosign
       uses: sigstore/cosign-installer@v3
 
@@ -643,12 +670,21 @@ jobs:
         cp artifacts/helm-chart/*.tgz release-assets/ || true
         ls -la release-assets/
 
-    - name: Create GitHub Release
+    # Created as a draft so every asset is attached BEFORE the release is
+    # published. With immutable releases enabled a published release is sealed,
+    # and assets uploaded after publication are rejected.
+    - name: Create GitHub Release (draft)
       uses: softprops/action-gh-release@v3
       with:
         files: release-assets/*
         generate_release_notes: true
-        draft: false
+        draft: true
         prerelease: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Publish GitHub Release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: v${{ steps.get_version.outputs.VERSION }}
+      run: gh release edit "$TAG" --draft=false --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,33 +488,6 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
-    # Gate the release on the published bytes: a fixed HIGH/CRITICAL in either
-    # architecture fails this job, so create-github-release (which needs it)
-    # never runs and no GitHub Release is published for the tag.
-    - name: Scan published image (linux/amd64)
-      uses: aquasecurity/trivy-action@v0.36.0
-      with:
-        image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}@${{ steps.build.outputs.digest }}
-        scanners: vuln
-        severity: HIGH,CRITICAL
-        ignore-unfixed: true
-        exit-code: '1'
-        format: table
-      env:
-        TRIVY_PLATFORM: linux/amd64
-
-    - name: Scan published image (linux/arm64)
-      uses: aquasecurity/trivy-action@v0.36.0
-      with:
-        image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}@${{ steps.build.outputs.digest }}
-        scanners: vuln
-        severity: HIGH,CRITICAL
-        ignore-unfixed: true
-        exit-code: '1'
-        format: table
-      env:
-        TRIVY_PLATFORM: linux/arm64
-
     - name: Install cosign
       uses: sigstore/cosign-installer@v3
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -70,9 +70,11 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    # The slim api image is the smallest thing that carries every layer the
-    # scan cares about: the same Debian runtime base as the full and standalone
-    # images, and the same locked Python environment.
+    # The slim api image is the smallest one covering the Debian family: it
+    # shares its runtime base with the full and standalone images and its locked
+    # Python environment with all of them, so a finding in any of those shows up
+    # here for a fraction of the build time. The alpine control-plane image
+    # shares none of that and is covered by scan-published only.
     - name: Build api-slim image
       uses: docker/build-push-action@v7
       with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,97 @@
+name: Security Scan
+
+# Image vulnerability scanning runs on a schedule rather than per-PR: the
+# findings that matter here appear when a CVE is *published*, not when our code
+# changes, so a PR gate would stay green for weeks and then fail an unrelated PR
+# the day an advisory lands.
+#
+# Two jobs, answering two different questions:
+#   scan-published  — do the images users are running right now have a fix
+#                     available? (seconds; no build)
+#   scan-next-build — would an image built from main today be clean? (one build;
+#                     catches a regression before it reaches a release tag)
+on:
+  schedule:
+    # 05:30 UTC daily, after Debian's usual security-update publication window.
+    - cron: '30 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan-published:
+    name: Scan published ${{ matrix.image }} (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - hindsight-api:latest
+          - hindsight-api:latest-slim
+          - hindsight:latest
+          - hindsight:latest-slim
+          - hindsight-control-plane:latest
+        platform: [linux/amd64, linux/arm64]
+
+    steps:
+    - name: Scan ${{ matrix.image }}
+      uses: aquasecurity/trivy-action@v0.36.0
+      with:
+        image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+        scanners: vuln
+        severity: HIGH,CRITICAL
+        ignore-unfixed: true
+        exit-code: '1'
+        format: table
+      env:
+        TRIVY_PLATFORM: ${{ matrix.platform }}
+
+  scan-next-build:
+    name: Scan a fresh build of main
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    # The slim api image is the smallest thing that carries every layer the
+    # scan cares about: the same Debian runtime base as the full and standalone
+    # images, and the same locked Python environment.
+    - name: Build api-slim image
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: docker/standalone/Dockerfile
+        target: api-only
+        build-args: |
+          INCLUDE_LOCAL_MODELS=false
+          PRELOAD_ML_MODELS=false
+        push: false
+        load: true
+        tags: hindsight-api-slim:scan
+
+    - name: Scan freshly built image
+      uses: aquasecurity/trivy-action@v0.36.0
+      with:
+        image-ref: hindsight-api-slim:scan
+        scanners: vuln
+        severity: HIGH,CRITICAL
+        ignore-unfixed: true
+        exit-code: '1'
+        format: table

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,10 @@ jobs:
             - 'hindsight-cli/**'
           docker:
             - 'docker/**'
+            # The image installs the workspace from the lock, so a dependency
+            # bump changes what ships even when docker/ is untouched.
+            - 'uv.lock'
+            - 'pyproject.toml'
           helm:
             - 'helm/**'
           # The RUNNABLE samples only. This replaces a broad `docs` filter that also
@@ -1680,6 +1684,20 @@ jobs:
         # Removed GitHub Actions cache (type=gha) - it frequently returns 502 errors
         # causing buildx to fail with "failed to parse error response 502"
         # Build will be slower but more reliable
+
+    # Only slim variants are loaded into the local daemon (disk space), so they
+    # are the only ones scannable here. They share every runtime layer and the
+    # same lock with the full variants, so a fixed HIGH in either shows up here.
+    - name: Scan ${{ matrix.name }} image for fixed HIGH/CRITICAL CVEs
+      if: matrix.variant == 'slim'
+      uses: aquasecurity/trivy-action@v0.36.0
+      with:
+        image-ref: hindsight-${{ matrix.name }}:test
+        scanners: vuln
+        severity: HIGH,CRITICAL
+        ignore-unfixed: true
+        exit-code: '1'
+        format: table
 
     # Only test slim variants to save disk space (they're much smaller)
     # Slim variants require external embedding providers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,10 +117,6 @@ jobs:
             - 'hindsight-cli/**'
           docker:
             - 'docker/**'
-            # The image installs the workspace from the lock, so a dependency
-            # bump changes what ships even when docker/ is untouched.
-            - 'uv.lock'
-            - 'pyproject.toml'
           helm:
             - 'helm/**'
           # The RUNNABLE samples only. This replaces a broad `docs` filter that also
@@ -1684,20 +1680,6 @@ jobs:
         # Removed GitHub Actions cache (type=gha) - it frequently returns 502 errors
         # causing buildx to fail with "failed to parse error response 502"
         # Build will be slower but more reliable
-
-    # Only slim variants are loaded into the local daemon (disk space), so they
-    # are the only ones scannable here. They share every runtime layer and the
-    # same lock with the full variants, so a fixed HIGH in either shows up here.
-    - name: Scan ${{ matrix.name }} image for fixed HIGH/CRITICAL CVEs
-      if: matrix.variant == 'slim'
-      uses: aquasecurity/trivy-action@v0.36.0
-      with:
-        image-ref: hindsight-${{ matrix.name }}:test
-        scanners: vuln
-        severity: HIGH,CRITICAL
-        ignore-unfixed: true
-        exit-code: '1'
-        format: table
 
     # Only test slim variants to save disk space (they're much smaller)
     # Slim variants require external embedding providers

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -161,7 +161,8 @@ WORKDIR /app
 # Note: libicu version varies by Debian version - try common versions in order
 # Runtime images use uv directly; remove pip build tooling after installation so
 # vulnerable setuptools-vendored packages and wheel are not shipped in production.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y \
     curl \
     procps \
     libxml2 \
@@ -270,7 +271,7 @@ COPY docker/standalone/start-all.sh /app/start-all.sh
 RUN chmod +x /app/start-all.sh
 
 # Install curl for health checks
-RUN apk add --no-cache curl bash
+RUN apk upgrade --no-cache && apk add --no-cache curl bash
 
 EXPOSE 9999
 
@@ -292,7 +293,8 @@ WORKDIR /app
 # Note: libicu version varies by Debian version - try common versions in order
 # Runtime images use uv directly; remove pip build tooling after installation so
 # vulnerable setuptools-vendored packages and wheel are not shipped in production.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y \
     curl \
     procps \
     libxml2 \

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -161,6 +161,11 @@ WORKDIR /app
 # Note: libicu version varies by Debian version - try common versions in order
 # Runtime images use uv directly; remove pip build tooling after installation so
 # vulnerable setuptools-vendored packages and wheel are not shipped in production.
+# `upgrade` before `install`: without it the image ships whatever package
+# snapshot the base image was cut with, so security updates published since
+# never reach the runtime layers - that is how 0.9.2 shipped openssl 3.5.6 with
+# 3.5.7 available (#3906). The tradeoff is deliberate: two builds of the same
+# commit can now resolve different package versions.
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y \
     curl \
@@ -270,7 +275,8 @@ WORKDIR /app
 COPY docker/standalone/start-all.sh /app/start-all.sh
 RUN chmod +x /app/start-all.sh
 
-# Install curl for health checks
+# Install curl for health checks. `apk upgrade` first, for the same reason the
+# Debian stages run `apt-get upgrade` - see the comment on the api-only stage.
 RUN apk upgrade --no-cache && apk add --no-cache curl bash
 
 EXPOSE 9999
@@ -293,6 +299,11 @@ WORKDIR /app
 # Note: libicu version varies by Debian version - try common versions in order
 # Runtime images use uv directly; remove pip build tooling after installation so
 # vulnerable setuptools-vendored packages and wheel are not shipped in production.
+# `upgrade` before `install`: without it the image ships whatever package
+# snapshot the base image was cut with, so security updates published since
+# never reach the runtime layers - that is how 0.9.2 shipped openssl 3.5.6 with
+# 3.5.7 available (#3906). The tradeoff is deliberate: two builds of the same
+# commit can now resolve different package versions.
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y \
     curl \

--- a/uv.lock
+++ b/uv.lock
@@ -2194,14 +2194,14 @@ wheels = [
 
 [[package]]
 name = "jaraco-context"
-version = "6.0.1"
+version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912, upload-time = "2024-08-20T03:39:27.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4", size = 6825, upload-time = "2024-08-20T03:39:25.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #3906.

## What was wrong

The published `0.9.2-slim` images carry four fixed HIGH findings on both architectures:

| CVE | Package | Installed | Fixed |
|---|---|---|---|
| CVE-2026-14456 | `libssl3t64` / `openssl` / `openssl-provider-legacy` | 3.5.6-1~deb13u2 | 3.5.7-1~deb13u2 |
| CVE-2026-23949 | `jaraco.context` | 6.0.1 | 6.1.0 |

Neither was pinned by anything we control:

- The runtime stages install whatever package snapshot `python:3.11-slim` happens to carry. Debian security updates published after the base image was cut never reach the shipped layers.
- `jaraco.context` arrives transitively — `fastmcp` → `py-key-value-aio[keyring]` → `keyring` → `jaraco.context` — and the lock had never been refreshed past 6.0.1.

## Changes

- **`docker/standalone/Dockerfile`** — `apt-get upgrade -y` in both Debian runtime stages (`api-only`, `standalone`) and `apk upgrade` in the alpine `cp-only` stage, so shipped layers pick up security updates at build time.
- **`uv.lock`** — `jaraco-context` 6.0.1 → 6.1.2.
- **`.github/workflows/security-scan.yml`** (new) — a daily Trivy scan (`HIGH,CRITICAL`, `--ignore-unfixed`, `exit-code 1`), plus `workflow_dispatch`. Two jobs: `scan-published` checks the images users are running right now across both architectures (no build, seconds), and `scan-next-build` builds `api-slim` from `main` and scans it, so a regression is caught before it reaches a release tag.
- **`.github/workflows/release.yml`** — `create-github-release` now attaches every asset to a **draft** and publishes in a second step. GitHub's immutable releases seal a published release, so the previous create-then-upload order would break the moment the setting is enabled. This is the mutable-release half of the issue; enabling the setting itself is a repo-settings toggle, done separately.

The scan is scheduled rather than per-PR or per-release. These findings appear when an advisory is *published*, not when our code changes, so a PR gate would sit green for weeks and then fail an unrelated PR the day a CVE lands. A release-time scan has the opposite problem: it can only run after the multi-arch push (scanning before it needs a second single-platform build — the same disk pressure that got the release smoke test commented out), so it would never prevent a vulnerable image from existing under its tags, only withhold the Release.

## Verification

Reproduced the baseline against the exact published digest from the issue, then built the `api-only` slim image with these changes and rescanned it (Trivy, `--scanners vuln --severity HIGH,CRITICAL --ignore-unfixed`):

| | `0.9.2-slim` | this branch |
|---|---|---|
| openssl trio | 3.5.6-1~deb13u2 | **3.5.7-1~deb13u2** |
| `jaraco.context` | 6.0.1 | **6.1.2** |
| fixed HIGH/CRITICAL | 4 | **0** |

## Note for reviewers

A failing scheduled run is the only signal — nothing opens an issue or pings a channel. If that is too quiet, the scan job can be extended to file an issue on failure; say the word.

https://claude.ai/code/session_01M9KwqWJZRrw7NjAaKuACzj
