### PR TITLE
fix(server): load .env before importing MemoryEngine to honor concurrency limits

### DIFF
--- a/hindsight-api-slim/hindsight_api/server.py
+++ b/hindsight-api-slim/hindsight_api/server.py
@@ -15,25 +15,28 @@ import warnings
 warnings.filterwarnings("ignore", message="websockets.legacy is deprecated")
 warnings.filterwarnings("ignore", message="websockets.server.WebSocketServerProtocol is deprecated")
 
+# This module IS an entry point: it is the ASGI app targeted by
+# `uvicorn hindsight_api.server:app`, and the import string uvicorn re-imports
+# in each worker process when `hindsight-api` runs with --workers/--reload. Load
+# .env here (like the CLI entry points) so those worker processes see the same
+# configuration. Importing hindsight_api as a library never reaches this module.
+# Note: Must be called BEFORE importing MemoryEngine or create_app, because
+# engine submodules (e.g. llm_wrapper) instantiate semaphores at import time.
+from hindsight_api.config import get_config, load_dotenv_for_entrypoint
+
+load_dotenv_for_entrypoint()
+
+# Disable tokenizers parallelism to avoid warnings
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
 from hindsight_api import MemoryEngine
 from hindsight_api.api import create_app
-from hindsight_api.config import get_config, load_dotenv_for_entrypoint
 from hindsight_api.extensions import (
     DefaultExtensionContext,
     OperationValidatorExtension,
     TenantExtension,
     load_extension,
 )
-
-# This module IS an entry point: it is the ASGI app targeted by
-# `uvicorn hindsight_api.server:app`, and the import string uvicorn re-imports
-# in each worker process when `hindsight-api` runs with --workers/--reload. Load
-# .env here (like the CLI entry points) so those worker processes see the same
-# configuration. Importing hindsight_api as a library never reaches this module.
-load_dotenv_for_entrypoint()
-
-# Disable tokenizers parallelism to avoid warnings
-os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 # Load configuration and configure logging
 config = get_config()

--- a/hindsight-api-slim/tests/test_dotenv_loading.py
+++ b/hindsight-api-slim/tests/test_dotenv_loading.py
@@ -70,3 +70,37 @@ def test_entrypoint_dotenv_loading_is_authoritative(tmp_path: Path, monkeypatch)
     # Don't leak the .env-loaded key into the rest of the session; monkeypatch
     # cannot undo it because load_dotenv set it directly.
     monkeypatch.delenv("HINDSIGHT_TEST_FILLED", raising=False)
+
+
+def test_server_entrypoint_loads_dotenv_before_engine_semaphores(tmp_path: Path) -> None:
+    """Importing hindsight_api.server (the uvicorn ASGI entrypoint) must load .env
+    before engine modules initialize import-time semaphores."""
+    (tmp_path / ".env").write_text(
+        "HINDSIGHT_API_LLM_PROVIDER=none\n"
+        "HINDSIGHT_API_LLM_MAX_CONCURRENT=7\n"
+        "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT=3\n"
+    )
+
+    env = os.environ.copy()
+    env.pop("HINDSIGHT_API_LLM_MAX_CONCURRENT", None)
+    env.pop("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT", None)
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (API_SOURCE, env.get("PYTHONPATH"))))
+
+    code = (
+        "import hindsight_api.server; "
+        "import hindsight_api.engine.llm_wrapper as llm_wrapper; "
+        "print(f'VAL:{llm_wrapper._llm_max_concurrent}'); "
+        "print(f'VAL:{llm_wrapper._global_llm_semaphore._value}'); "
+        "print(f'VAL:{llm_wrapper._per_op_llm_semaphores[\"retain\"]._value}')"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    lines = [line.removeprefix("VAL:") for line in result.stdout.splitlines() if line.startswith("VAL:")]
+    assert lines == ["7", "7", "3"]

--- a/hindsight-api-slim/tests/test_dotenv_loading.py
+++ b/hindsight-api-slim/tests/test_dotenv_loading.py
@@ -90,8 +90,8 @@ def test_server_entrypoint_loads_dotenv_before_engine_semaphores(tmp_path: Path)
         "import hindsight_api.server; "
         "import hindsight_api.engine.llm_wrapper as llm_wrapper; "
         "print(f'VAL:{llm_wrapper._llm_max_concurrent}'); "
-        "print(f'VAL:{llm_wrapper._global_llm_semaphore._value}'); "
-        "print(f'VAL:{llm_wrapper._per_op_llm_semaphores[\"retain\"]._value}')"
+        "print(f'VAL:{llm_wrapper._global_llm_semaphore.capacity}'); "
+        "print(f'VAL:{llm_wrapper._per_op_llm_semaphores[\"retain\"].capacity}')"
     )
 
     result = subprocess.run(


### PR DESCRIPTION
## Overview

When running Hindsight with multi-worker mode (`hindsight-api --workers N`), dev reload (`hindsight-api --reload`), or directly targeting the ASGI app via Uvicorn (`uvicorn hindsight_api.server:app`), `server.py` imported `MemoryEngine` at the top level before calling `load_dotenv_for_entrypoint()`.

Because `MemoryEngine` transitively imports `hindsight_api.engine.llm_wrapper`, and `llm_wrapper` initializes `_global_llm_semaphore` and `_per_op_llm_semaphores` at module import time, the semaphores were constructed before `.env` was parsed. As a result, concurrency settings defined in `.env` (such as `HINDSIGHT_API_LLM_MAX_CONCURRENT`, `HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT`, etc.) were silently ignored and fell back to the defaults (32).

## Execution Flow

```
[BEFORE FIX]
uvicorn worker bootstrap
  │
  ├── 1. import hindsight_api.server
  │     ├── line 18: from hindsight_api import MemoryEngine
  │     │     └── triggers import of hindsight_api.engine.llm_wrapper
  │     │           ├── reads os.getenv("HINDSIGHT_API_LLM_MAX_CONCURRENT") -> None (not in process env yet)
  │     │           └── _global_llm_semaphore = Semaphore(DEFAULT=32) ❌
  │     │
  │     └── line 33: load_dotenv_for_entrypoint()
  │           └── parses .env and populates os.environ (Too late! Semaphore already built)
  │
  └── Result: .env concurrency limits ignored, requests run at default capacity

---------------------------------------------------------------------------------------------

[AFTER FIX]
uvicorn worker bootstrap
  │
  ├── 1. import hindsight_api.server
  │     ├── line 24: from hindsight_api.config import get_config, load_dotenv_for_entrypoint
  │     ├── line 26: load_dotenv_for_entrypoint()
  │     │     └── parses .env and populates os.environ FIRST ✅
  │     │
  │     └── line 31: from hindsight_api import MemoryEngine
  │           └── triggers import of hindsight_api.engine.llm_wrapper
  │                 ├── reads os.getenv("HINDSIGHT_API_LLM_MAX_CONCURRENT") -> configured value ✅
  │                 └── _global_llm_semaphore = Semaphore(configured_value) ✅
  │
  └── Result: .env concurrency limits properly honored across all workers
```

## Impact Matrix

| Mode / Entrypoint | Invocation | Pre-fix Behavior | Post-fix Behavior |
| :--- | :--- | :--- | :--- |
| **Multi-worker CLI** | `hindsight-api --workers N` | `.env` concurrency ignored (default 32) | `.env` concurrency honored |
| **Dev Reload CLI** | `hindsight-api --reload` | `.env` concurrency ignored (default 32) | `.env` concurrency honored |
| **Direct ASGI Server** | `uvicorn hindsight_api.server:app` | `.env` concurrency ignored (default 32) | `.env` concurrency honored |
| **Single-worker CLI** | `hindsight-api` | `.env` concurrency honored (`main.py` flow) | `.env` concurrency honored (unchanged) |

## Changes

1. **`hindsight_api/server.py`**:
   - Reordered imports so that `load_dotenv_for_entrypoint()` executes before importing `MemoryEngine` and `create_app`.
2. **`tests/test_dotenv_loading.py`**:
   - Added `test_server_entrypoint_loads_dotenv_before_engine_semaphores` to verify that importing `hindsight_api.server` in a child process with a `.env` file correctly initializes global and per-op LLM semaphores.

## Verification

- `cd hindsight-api-slim && uv run pytest tests/test_dotenv_loading.py tests/test_server_module.py -v` (9 passed)
- `./scripts/hooks/lint.sh` (All lints passed)
- `cd hindsight-api-slim && uv run ty check hindsight_api/` (All checks passed)