### PR TITLE
docs(hermes): disable Hermes's built-in memory via config flags

### DIFF
--- a/hindsight-docs/blog/2026-03-17-hermes-agent-memory.md
+++ b/hindsight-docs/blog/2026-03-17-hermes-agent-memory.md
@@ -131,13 +131,14 @@ If neither `HINDSIGHT_API_URL` nor `HINDSIGHT_API_KEY` is set, the plugin silent
 
 ### Disable Hermes's built-in memory
 
-This is the step people miss. Hermes has its own `memory` tool that saves to `~/.hermes/`. If both are active, **the LLM defaults to the built-in one** — it's a single tool it already recognizes. Your Hindsight tools will sit unused.
+This is the step people miss. Hermes has its own memory store that saves to `~/.hermes/`. If both are active, **the LLM defaults to the built-in one** — it's a single tool it already recognizes. Your Hindsight tools will sit unused.
 
 ```bash
-hermes tools disable memory
+hermes config set memory.memory_enabled false        # MEMORY.md
+hermes config set memory.user_profile_enabled false  # USER.md (optional)
 ```
 
-This persists across sessions. Re-enable later with `hermes tools enable memory`.
+This persists across sessions. Re-enable later by setting the same flags back to `true`.
 
 ## Using the memory tools
 
@@ -215,7 +216,7 @@ curl -s http://localhost:8888/v1/default/banks/my-agent/memories/recall \
 
 1. **Plugin not in `/tools`.** The most common cause: `hindsight-hermes` is installed in a different Python environment than Hermes. Entry points are per-environment. Run `python -c "import importlib.metadata; print(list(importlib.metadata.entry_points(group='hermes_agent.plugins')))"` from the Hermes venv to verify.
 
-2. **LLM picks built-in memory.** Even with the plugin loaded, if both `memory` and `hindsight_retain` exist, the LLM chooses `memory`. Run `hermes tools disable memory`.
+2. **LLM picks built-in memory.** Even with the plugin loaded, if both `memory` and `hindsight_retain` exist, the LLM chooses `memory`. Run `hermes config set memory.memory_enabled false`.
 
 3. **Retain is asynchronous.** The API returns immediately; fact extraction happens in the background. If you retain and immediately recall in the same turn, the new facts may not be indexed yet. Design so recall happens on subsequent turns.
 

--- a/hindsight-docs/blog/2026-03-18-version-0-4-19.md
+++ b/hindsight-docs/blog/2026-03-18-version-0-4-19.md
@@ -94,10 +94,11 @@ Type `/tools` to verify the plugin loaded:
   * hindsight_retain     - Store information to long-term memory for later retrieval.
 ```
 
-Hermes has its own built-in `memory` tool that writes to local files. Since the LLM will prefer the one it's most familiar with, disable it so Hermes uses Hindsight instead:
+Hermes has its own built-in memory store that writes to local files. Since the LLM will prefer the one it's most familiar with, turn it off so Hermes uses Hindsight instead:
 
 ```bash
-hermes tools disable memory
+hermes config set memory.memory_enabled false        # MEMORY.md
+hermes config set memory.user_profile_enabled false  # USER.md (optional)
 ```
 
 If neither `HINDSIGHT_API_URL` nor `HINDSIGHT_API_KEY` is set, the plugin silently skips registration and Hermes starts normally.

--- a/hindsight-docs/docs-integrations/hermes.md
+++ b/hindsight-docs/docs-integrations/hermes.md
@@ -185,13 +185,17 @@ When using Hermes in gateway mode (multi-platform messaging), the provider works
 
 ## Disabling Hermes's Built-in Memory
 
-Hermes has a built-in `memory` tool that saves to local markdown files. If both are active, the LLM may prefer the built-in one. Disable it:
+Hermes has a built-in memory store that saves to local markdown files (`MEMORY.md`, plus a slimmer `USER.md` profile). If both are active, the LLM may prefer the built-in one. Turn the flat-file stores off:
 
 ```bash
-hermes tools disable memory
+# Turn off the built-in MEMORY.md store
+hermes config set memory.memory_enabled false
+
+# Optional — also turn off the slimmer USER.md profile store
+hermes config set memory.user_profile_enabled false
 ```
 
-Re-enable later with `hermes tools enable memory`.
+Setting both to `false` removes the built-in `memory` tool from the agent entirely. Re-enable later by setting the same flags back to `true`.
 
 ## Troubleshooting
 

--- a/hindsight-docs/guides/2026-04-14-guide-debug-hermes-memory-not-recalling-context.md
+++ b/hindsight-docs/guides/2026-04-14-guide-debug-hermes-memory-not-recalling-context.md
@@ -176,21 +176,18 @@ then hook support is the likely missing piece.
 
 ### 5. Check whether the model is using the wrong memory path
 
-Hermes still has a built-in `memory` tool that writes markdown notes locally. If that tool stays enabled, the model may keep using it instead of Hindsight. The result is confusing because the assistant looks like it is storing memory, but not in the path you are trying to debug.
+Hermes still has a built-in memory store that writes markdown notes locally (`MEMORY.md`, plus a slimmer `USER.md` profile). If those stay enabled, the model may keep using them instead of Hindsight. The result is confusing because the assistant looks like it is storing memory, but not in the path you are trying to debug.
 
-Disable the built-in tool while testing:
+Turn the flat-file stores off while testing:
 
 ```bash
-hermes tools disable memory
+hermes config set memory.memory_enabled false
+hermes config set memory.user_profile_enabled false
 ```
 
 Then repeat the controlled retain and recall test. This removes one of the messiest sources of false positives.
 
-If you later decide you want the built-in tool back for a specific workflow, you can re-enable it:
-
-```bash
-hermes tools enable memory
-```
+If you later decide you want the built-in store back for a specific workflow, set the same flags back to `true`.
 
 ### 6. Inspect logs instead of guessing
 

--- a/hindsight-docs/guides/2026-04-14-guide-migrate-hindsight-hermes-to-native-hermes-memory.md
+++ b/hindsight-docs/guides/2026-04-14-guide-migrate-hindsight-hermes-to-native-hermes-memory.md
@@ -179,23 +179,20 @@ A minimal native local config looks like this:
 
 If you want a deeper mental model of what the provider is doing during retention and recall, the [Recall API reference](https://hindsight.vectorize.io/docs/api/recall) and [Retain API reference](https://hindsight.vectorize.io/docs/api/retain) are worth reading.
 
-### 4. Decide whether to disable Hermes's built-in memory tool
+### 4. Decide whether to disable Hermes's built-in memory store
 
-The native Hindsight provider gives you automatic recall through lifecycle hooks and can also expose explicit Hindsight tools. Hermes still has its built-in `memory` tool, which writes local markdown notes. If both are active, the model may keep choosing the built-in tool out of habit.
+The native Hindsight provider gives you automatic recall through lifecycle hooks and can also expose explicit Hindsight tools. Hermes still has its built-in memory store, which writes local markdown notes (`MEMORY.md`, plus a slimmer `USER.md` profile). If both are active, the model may keep choosing the built-in path out of habit.
 
-If you want Hindsight to be the only memory path, disable the built-in tool:
-
-```bash
-hermes tools disable memory
-```
-
-This is especially helpful after migration because it removes ambiguity. When you test storage and recall, you know the result came from Hindsight, not from the old markdown path.
-
-You can always turn it back on later:
+If you want Hindsight to be the only memory path, turn the flat-file stores off:
 
 ```bash
-hermes tools enable memory
+hermes config set memory.memory_enabled false
+hermes config set memory.user_profile_enabled false
 ```
+
+Setting both to `false` removes the built-in `memory` tool from the agent entirely. This is especially helpful after migration because it removes ambiguity. When you test storage and recall, you know the result came from Hindsight, not from the old markdown path.
+
+You can always turn them back on later by setting the same flags to `true`.
 
 ### 5. Set the integration mode you actually want
 

--- a/scripts/test-hermes-compat.sh
+++ b/scripts/test-hermes-compat.sh
@@ -230,11 +230,19 @@ echo ""
 # config.yaml and the Hindsight provider config under $HERMES_HOME. Keep this in
 # sync with plugins/memory/hindsight/__init__.py::post_setup if Hermes changes
 # the shape.
+#
+# memory_enabled/user_profile_enabled are the flags our docs tell users to set
+# so Hindsight is the only memory path (they silence the built-in MEMORY.md and
+# USER.md stores). They are set here so the status assertion below covers the
+# configuration we actually document: turning the flat-file stores off must not
+# take the Hindsight provider down with it.
 echo "--- [3/5] Configuring Hermes for local_embedded Hindsight ---"
 mkdir -p "$HERMES_HOME/hindsight"
 cat > "$HERMES_HOME/config.yaml" <<EOF
 memory:
   provider: hindsight
+  memory_enabled: false
+  user_profile_enabled: false
 EOF
 cat > "$HERMES_HOME/hindsight/config.json" <<EOF
 {

--- a/skills/hindsight-docs/references/sdks/integrations/hermes.md
+++ b/skills/hindsight-docs/references/sdks/integrations/hermes.md
@@ -176,13 +176,17 @@ When using Hermes in gateway mode (multi-platform messaging), the provider works
 
 ## Disabling Hermes's Built-in Memory
 
-Hermes has a built-in `memory` tool that saves to local markdown files. If both are active, the LLM may prefer the built-in one. Disable it:
+Hermes has a built-in memory store that saves to local markdown files (`MEMORY.md`, plus a slimmer `USER.md` profile). If both are active, the LLM may prefer the built-in one. Turn the flat-file stores off:
 
 ```bash
-hermes tools disable memory
+# Turn off the built-in MEMORY.md store
+hermes config set memory.memory_enabled false
+
+# Optional — also turn off the slimmer USER.md profile store
+hermes config set memory.user_profile_enabled false
 ```
 
-Re-enable later with `hermes tools enable memory`.
+Setting both to `false` removes the built-in `memory` tool from the agent entirely. Re-enable later by setting the same flags back to `true`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fixes #3849

`hermes tools disable memory` shuts down the entire memory toolset on current Hermes builds, so the native provider's `hindsight_retain`, `hindsight_recall` and `hindsight_reflect` tools stop loading too. Hermes treats memory as pluggable now, so the flat-file stores are turned off with config flags:

```bash
hermes config set memory.memory_enabled false        # MEMORY.md
hermes config set memory.user_profile_enabled false  # USER.md (optional)
```

Setting both to `false` removes the built-in `memory` tool from the agent entirely. Verified against the [upstream Hermes memory docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory).

**Docs** — the command appeared in five places, all updated: the Hermes integration page, both Hermes guides, and the two blog posts, plus the regenerated `skills/hindsight-docs` reference. `npm run build` in `hindsight-docs` passes.

**CI** — `scripts/test-hermes-compat.sh` wrote only `memory.provider: hindsight`, so the configuration we document was never exercised. It now writes both flags as well, which puts the existing `hermes memory status` assertion behind them: silencing the built-in stores must leave Hindsight the active, available provider. `scripts/**` is in the `core` path filter, so `test-hermes-compat` runs on this PR.

https://claude.ai/code/session_012gXUp1i7YrWmLJVUYki53g
