### PR TITLE
fix(search): align native knowledge BM25 semantics to disjunctive OR

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -16224,6 +16224,10 @@ class MemoryEngine(MemoryEngineInterface):
         mm = fq_table("mental_models")
         join = self._kp_join()
 
+        from .search.retrieval import tokenize_query
+
+        tokens = tokenize_query(query)
+
         # BM25 clauses for the configured text-search backend (same per-backend
         # dispatch the memory-recall BM25 arm uses — see knowledge_bm25_arm).
         cfg = get_config()
@@ -16236,12 +16240,18 @@ class MemoryEngine(MemoryEngineInterface):
         # so the search has no answer to give rather than a degraded one.
         bank_config = await self._config_resolver.get_bank_config(bank_id, request_context)
         enable_text_search = bool(bank_config.get("enable_text_search", True))
-        if not enable_text_search and emb_str is None:
+
+        # Native tsvector requires non-empty tokens to construct a valid to_tsquery expression.
+        include_bm25 = enable_text_search and (bool(tokens) or text_search_extension != "native")
+        if not include_bm25 and emb_str is None:
             return []
+
+        dialect = self._dialect if self._dialect is not None else create_sql_dialect(self._database_backend_type)
+        max_query_terms = cfg.bm25_max_query_terms
 
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
-            if emb_str is not None and not enable_text_search:
+            if emb_str is not None and not include_bm25:
                 # Vector-only: no BM25 arm to fuse with, so rank straight off the ANN scan.
                 sql = f"""
                     SELECT kp.id, kp.name, kp.mental_model_id,
@@ -16253,66 +16263,96 @@ class MemoryEngine(MemoryEngineInterface):
                     LIMIT {limit}
                 """
                 rows = await conn.fetch(sql, emb_str, bank_id)
-            elif emb_str is not None:
-                bm25 = knowledge_bm25_arm(
-                    text_search_extension,
-                    table_alias="mm",
-                    text_param="$3",
-                    pg_search_function_schema=pg_search_function_schema,
+            else:
+                bm25_tokens = tokens
+                if (
+                    text_search_extension == "native"
+                    and max_query_terms > 0
+                    and len(tokens) > max_query_terms
+                    and cfg.bm25_selective_terms
+                    and getattr(conn, "backend_type", "postgresql") == "postgresql"
+                ):
+                    from .search.bm25_term_selection import select_selective_bm25_tokens
+
+                    bm25_tokens = await select_selective_bm25_tokens(
+                        conn,
+                        tokens,
+                        schema=get_current_schema(),
+                        table="mental_models",
+                        language="english",
+                        max_terms=max_query_terms,
+                    )
+                bm25_text = (
+                    dialect.prepare_bm25_text(
+                        bm25_tokens,
+                        query,
+                        text_search_extension=text_search_extension,
+                        max_query_terms=max_query_terms,
+                    )
+                    if tokens
+                    else query
                 )
-                # Vector arm (ANN over mm.embedding) + BM25 arm, each ranked
-                # independently, then RRF-fused (k=60) in SQL.
-                sql = f"""
-                    WITH vec AS (
-                        SELECT kp.id AS page_id,
-                               ROW_NUMBER() OVER (ORDER BY mm.embedding <=> $1::vector) AS rnk
+
+                if emb_str is not None:
+                    bm25 = knowledge_bm25_arm(
+                        text_search_extension,
+                        table_alias="mm",
+                        text_param="$3",
+                        pg_search_function_schema=pg_search_function_schema,
+                    )
+                    # Vector arm (ANN over mm.embedding) + BM25 arm, each ranked
+                    # independently, then RRF-fused (k=60) in SQL.
+                    sql = f"""
+                        WITH vec AS (
+                            SELECT kp.id AS page_id,
+                                   ROW_NUMBER() OVER (ORDER BY mm.embedding <=> $1::vector) AS rnk
+                            FROM {join}
+                            WHERE kp.bank_id = $2 AND kp.kind = 'page' AND mm.embedding IS NOT NULL
+                            ORDER BY mm.embedding <=> $1::vector
+                            LIMIT {fetch}
+                        ),
+                        bm AS (
+                            SELECT kp.id AS page_id,
+                                   ROW_NUMBER() OVER (ORDER BY {bm25.order_by}) AS rnk
+                            FROM {join}
+                            WHERE kp.bank_id = $2 AND kp.kind = 'page'
+                                  {bm25.match_filter}
+                            ORDER BY {bm25.order_by}
+                            LIMIT {fetch}
+                        ),
+                        fused AS (
+                            SELECT COALESCE(vec.page_id, bm.page_id) AS page_id,
+                                   COALESCE(1.0 / (60 + vec.rnk), 0) + COALESCE(1.0 / (60 + bm.rnk), 0) AS score
+                            FROM vec FULL OUTER JOIN bm ON vec.page_id = bm.page_id
+                        )
+                        SELECT kp.id, kp.name, kp.mental_model_id,
+                               LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at, f.score
+                        FROM fused f
+                        JOIN {kp} kp ON kp.id = f.page_id AND kp.bank_id = $2
+                        LEFT JOIN {mm} mm ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id
+                        ORDER BY f.score DESC
+                        LIMIT {limit}
+                    """
+                    rows = await conn.fetch(sql, emb_str, bank_id, bm25_text)
+                else:
+                    # Embedding unavailable → BM25-only fallback (still useful).
+                    bm25 = knowledge_bm25_arm(
+                        text_search_extension,
+                        table_alias="mm",
+                        text_param="$2",
+                        pg_search_function_schema=pg_search_function_schema,
+                    )
+                    sql = f"""
+                        SELECT kp.id, kp.name, kp.mental_model_id,
+                               LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at,
+                               {bm25.score_expr} AS score
                         FROM {join}
-                        WHERE kp.bank_id = $2 AND kp.kind = 'page' AND mm.embedding IS NOT NULL
-                        ORDER BY mm.embedding <=> $1::vector
-                        LIMIT {fetch}
-                    ),
-                    bm AS (
-                        SELECT kp.id AS page_id,
-                               ROW_NUMBER() OVER (ORDER BY {bm25.order_by}) AS rnk
-                        FROM {join}
-                        WHERE kp.bank_id = $2 AND kp.kind = 'page'
+                        WHERE kp.bank_id = $1 AND kp.kind = 'page'
                               {bm25.match_filter}
                         ORDER BY {bm25.order_by}
-                        LIMIT {fetch}
-                    ),
-                    fused AS (
-                        SELECT COALESCE(vec.page_id, bm.page_id) AS page_id,
-                               COALESCE(1.0 / (60 + vec.rnk), 0) + COALESCE(1.0 / (60 + bm.rnk), 0) AS score
-                        FROM vec FULL OUTER JOIN bm ON vec.page_id = bm.page_id
-                    )
-                    SELECT kp.id, kp.name, kp.mental_model_id,
-                           LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at, f.score
-                    FROM fused f
-                    JOIN {kp} kp ON kp.id = f.page_id AND kp.bank_id = $2
-                    LEFT JOIN {mm} mm ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id
-                    ORDER BY f.score DESC
-                    LIMIT {limit}
-                """
-                rows = await conn.fetch(sql, emb_str, bank_id, query)
-            else:
-                # Embedding unavailable → BM25-only fallback (still useful).
-                bm25 = knowledge_bm25_arm(
-                    text_search_extension,
-                    table_alias="mm",
-                    text_param="$2",
-                    pg_search_function_schema=pg_search_function_schema,
-                )
-                sql = f"""
-                    SELECT kp.id, kp.name, kp.mental_model_id,
-                           LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at,
-                           {bm25.score_expr} AS score
-                    FROM {join}
-                    WHERE kp.bank_id = $1 AND kp.kind = 'page'
-                          {bm25.match_filter}
-                    ORDER BY {bm25.order_by}
-                    LIMIT {limit}
-                """
-                rows = await conn.fetch(sql, bank_id, query)
+                        LIMIT {limit}
+                    """
+                    rows = await conn.fetch(sql, bank_id, bm25_text)
 
         return [
             {

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -47,6 +47,12 @@ def knowledge_bm25_arm(
     ``table_alias`` is the alias the ``mental_models`` row carries in the query
     (``mm``); ``text_param`` is the bind placeholder holding the query text.
 
+    For the ``native`` backend, ``text_param`` must be bound to the output of
+    :meth:`prepare_bm25_text` (disjunctive ``" | "`` tokens). ``websearch_to_tsquery``
+    was originally used here as an error-free parser for raw strings (#2455), but
+    its default conjunctive AND (``&``) across space-separated words caused
+    multi-word natural-language queries to return 0 BM25 candidates.
+
     ``pgroonga`` queries the multilingual expression index over ``name +
     content``; ``ensure_text_search_extension`` reconciles ``mental_models`` to
     that shape (dummy TEXT ``search_vector``) like every other pgroonga table.
@@ -121,11 +127,18 @@ def knowledge_bm25_arm(
     # The generating expression hard-codes the 'english' config (see the
     # learnings/pinned_reflections migration), so query with 'english' regardless
     # of the configured native language.
-    score = f"ts_rank_cd({a}.search_vector, websearch_to_tsquery('english', {p}))"
+    #
+    # to_tsquery over disjunctive OR tokens prepared via prepare_bm25_text.
+    # websearch_to_tsquery was originally used here as an error-free parser for
+    # raw strings (#2455), but its default conjunctive AND (&) across words caused
+    # multi-word queries to return 0 hits. Joining tokens with OR aligns candidate
+    # recall with memory recall (build_bm25_arm); precision is restored downstream
+    # via ts_rank_cd ranking and RRF fusion.
+    score = f"ts_rank_cd({a}.search_vector, to_tsquery('english', {p}))"
     return KnowledgeBm25Arm(
         score_expr=score,
         order_by=f"{score} DESC",
-        match_filter=f"AND {a}.search_vector @@ websearch_to_tsquery('english', {p})",
+        match_filter=f"AND {a}.search_vector @@ to_tsquery('english', {p})",
     )
 
 

--- a/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
+++ b/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
@@ -29,8 +29,10 @@ def test_native_uses_tsvector_operators():
     arm = _arm("native")
     # The mental_models tsvector is generated with the 'english' config, so the
     # query must use 'english' regardless of the configured native language.
-    assert "ts_rank_cd(mm.search_vector, websearch_to_tsquery('english', $3))" in arm.score_expr
-    assert arm.match_filter == "AND mm.search_vector @@ websearch_to_tsquery('english', $3)"
+    # Joining tokens with OR aligns candidate recall with memory-recall BM25;
+    # precision is restored downstream via ts_rank_cd ranking and RRF fusion.
+    assert "ts_rank_cd(mm.search_vector, to_tsquery('english', $3))" in arm.score_expr
+    assert arm.match_filter == "AND mm.search_vector @@ to_tsquery('english', $3)"
 
 
 def test_pgroonga_uses_multilingual_expression_index():

--- a/hindsight-api-slim/tests/test_knowledge_search_text_search_disabled.py
+++ b/hindsight-api-slim/tests/test_knowledge_search_text_search_disabled.py
@@ -41,6 +41,8 @@ def search(monkeypatch):
     engine = MemoryEngine.__new__(MemoryEngine)
     engine._operation_validator = None
     engine.embeddings = object()
+    engine._dialect = None
+    engine._database_backend_type = "postgresql"
     resolved: dict[str, object] = {}
 
     async def fake_authenticate(request_context):
@@ -63,7 +65,14 @@ def search(monkeypatch):
     monkeypatch.setattr(engine_mod, "acquire_with_retry", fake_acquire)
     monkeypatch.setattr(engine_mod, "fq_table", lambda name: name)
 
-    async def run(*, enable_text_search: bool, embedding: list[float] | None):
+    async def run(
+        *,
+        enable_text_search: bool,
+        embedding: list[float] | None,
+        query: str = "some query",
+        ext: str = "native",
+        bm25_selective_terms: bool = False,
+    ):
         async def fake_embed(embeddings, texts, *, input_type=None):
             return [embedding]
 
@@ -72,15 +81,18 @@ def search(monkeypatch):
             engine_mod,
             "get_config",
             lambda: SimpleNamespace(
-                text_search_extension="native",
+                database_schema="public",
+                text_search_extension=ext,
                 text_search_extension_pg_search_function_schema="paradedb",
+                bm25_max_query_terms=20,
+                bm25_selective_terms=bm25_selective_terms,
             ),
         )
         resolved.clear()
         resolved["enable_text_search"] = enable_text_search
-        return await engine.search_knowledge_pages("bank-1", "some query", request_context=object())
+        return await engine.search_knowledge_pages("bank-1", query, request_context=object())
 
-    return SimpleNamespace(run=run, conn=conn)
+    return SimpleNamespace(run=run, conn=conn, engine=engine)
 
 
 @pytest.mark.asyncio
@@ -90,8 +102,9 @@ async def test_enabled_fuses_both_arms(search):
 
     sql = search.conn.queries[0]
     assert "ts_rank_cd" in sql  # the native BM25 arm
+    assert "to_tsquery('english', $3)" in sql
     assert "FULL OUTER JOIN" in sql  # fused with the vector arm
-    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1", "some query")
+    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1", "some | query")
 
 
 @pytest.mark.asyncio
@@ -127,4 +140,51 @@ async def test_enabled_without_embedding_still_falls_back_to_bm25(search):
     await search.run(enable_text_search=True, embedding=None)
 
     assert "ts_rank_cd" in search.conn.queries[0]
-    assert search.conn.params[0] == ("bank-1", "some query")
+    assert "to_tsquery('english', $2)" in search.conn.queries[0]
+    assert search.conn.params[0] == ("bank-1", "some | query")
+
+
+@pytest.mark.asyncio
+async def test_non_native_extension_passes_raw_query(search):
+    await search.run(enable_text_search=True, embedding=[0.1, 0.2], ext="pgroonga")
+    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1", "some query")
+
+
+@pytest.mark.asyncio
+async def test_native_empty_tokens_falls_back_to_vector_only(search):
+    await search.run(enable_text_search=True, embedding=[0.1, 0.2], query="???")
+    sql = search.conn.queries[0]
+    assert "mm.embedding <=> $1::vector" in sql
+    assert "ts_rank_cd" not in sql
+    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1")
+
+
+@pytest.mark.asyncio
+async def test_native_empty_tokens_without_embedding_returns_empty(search):
+    result = await search.run(enable_text_search=True, embedding=None, query="???")
+    assert result == []
+    assert search.conn.queries == []
+
+
+@pytest.mark.asyncio
+async def test_native_selective_terms_pruning(search, monkeypatch):
+    from hindsight_api.engine.search import bm25_term_selection
+
+    received_args = {}
+
+    async def fake_select(conn, tokens, *, schema, table, language, max_terms):
+        received_args.update(
+            {"tokens": tokens, "schema": schema, "table": table, "language": language, "max_terms": max_terms}
+        )
+        return ["selected", "tokens"]
+
+    monkeypatch.setattr(bm25_term_selection, "select_selective_bm25_tokens", fake_select)
+
+    long_query = " ".join([f"term{i}" for i in range(25)])
+    await search.run(enable_text_search=True, embedding=[0.1, 0.2], query=long_query, bm25_selective_terms=True)
+
+    assert received_args["table"] == "mental_models"
+    assert received_args["language"] == "english"
+    assert received_args["max_terms"] == 20
+    assert len(received_args["tokens"]) == 25
+    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1", "selected | tokens")


### PR DESCRIPTION
## Summary

When `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=native`, the BM25 retrieval arm in `search_knowledge_pages` used `websearch_to_tsquery('english', $text)`, which evaluates space-separated words with conjunctive `AND` (`&`). This diverged from memory recall (`build_bm25_arm`), which tokenizes and joins terms with disjunctive `OR` (`|`).

`websearch_to_tsquery` was originally chosen in #2455 because it safely parses arbitrary user text without throwing tsquery syntax errors, not as an intentional feature contract for websearch operators. However, its default conjunctive `AND` semantics caused multi-word natural-language queries to return 0 BM25 hits, degrading hybrid search to vector-only and causing BM25-only search to return 0 results.

This PR aligns the `native` knowledge BM25 path with the rest of the retrieval engine to use disjunctive `OR` candidate generation via `to_tsquery` and `prepare_bm25_text`.

---

## Retrieval Architecture & Data Flow

```mermaid
flowchart TB
    subgraph BEFORE["❌ BEFORE (Semantics Inconsistency)"]
        direction TB
        Q1["User Query: 'what are the gateway scheduled tasks'"]
        
        Q1 --> R_MEM1["Memory Recall Arm (recall)"]
        R_MEM1 -->|"tokenize + prepare_bm25_text (' | ')"| T1["to_tsquery('english', 'what | gateway | schedul | task')"]
        T1 -->|"OR Semantics"| M_OK1["✅ Broad Candidate Recall (High Hit Rate)"]
        
        Q1 --> R_KB1["Knowledge Search Arm (search_knowledge_pages)"]
        R_KB1 -->|"Raw Query Passthrough"| W1["websearch_to_tsquery('english', 'what are the gateway scheduled tasks')"]
        W1 -->|"Parsed as: 'what' & 'gateway' & 'schedul' & 'task' (AND Semantics)"| M_FAIL1["❌ 0 BM25 Hits<br/>(Lost arm in RRF; 0 results in BM25-only)"]
    end

    subgraph AFTER["✅ AFTER (Unified Disjunctive Candidate Generation)"]
        direction TB
        Q2["User Query: 'what are the gateway scheduled tasks'"]
        
        Q2 --> R_MEM2["Memory Recall Arm (recall)"]
        R_MEM2 -->|"tokenize + prepare_bm25_text (' | ')"| T2["to_tsquery('english', 'what | gateway | schedul | task')"]
        T2 -->|"OR Semantics"| M_OK2["✅ Broad Candidate Recall (High Hit Rate)"]
        
        Q2 --> R_KB2["Knowledge Search Arm (search_knowledge_pages)"]
        R_KB2 -->|"tokenize + prepare_bm25_text (' | ') + term cap"| T3["to_tsquery('english', 'what | gateway | schedul | task')"]
        T3 -->|"OR Semantics"| M_OK3["✅ Broad Candidate Recall<br/>(Properly ranks & fuses via RRF)"]
    end
```

---

## Backend Comparison Across Retrieval Arms

In Hindsight's multi-strategy retrieval architecture, BM25 arms are designed for **broad candidate generation**, while precision is restored downstream through BM25 scoring, multi-arm RRF fusion, and Cross-Encoder reranking.

| Text Search Backend | Memory Recall Arm (`recall`) | Knowledge Search Arm (`search_knowledge_pages`) | Status |
|---|---|---|---|
| `vchord` | `-(search_vector <&> ...) > score_min` | `-(mm.search_vector <&> ...) > 0` | ✅ Aligned (OR / score > 0) |
| `pg_search` | `paradedb.boolean(should => ARRAY[...])` | `paradedb.boolean(should => ARRAY[...])` | ✅ Aligned (OR / Lucene `should`) |
| `pg_textsearch` | `-(text <@> to_bm25query(...))` (No match gate) | `-(mm.content <@> to_bm25query(...))` (No match gate) | ✅ Aligned (OR / Distance ranking) |
| `pgroonga` | `pgroonga_tokenize` + `string_agg(..., ' OR ')` | `pgroonga_tokenize` + `string_agg(..., ' OR ')` | ✅ Aligned (OR / TokenBigram) |
| `native` (Before) | `prepare_bm25_text` (`" \| "`) + `to_tsquery` **(OR)** | `websearch_to_tsquery` **(AND)** | ❌ **Inconsistent (Sole AND Outlier)** |
| `native` (After) | `prepare_bm25_text` (`" \| "`) + `to_tsquery` **(OR)** | `prepare_bm25_text` (`" \| "`) + `to_tsquery` **(OR)** | ✅ **Aligned (OR)** |

---

## Key Technical Decisions & Edge Case Handling

1. **Reusing `self._dialect.prepare_bm25_text`**:
   - `search_knowledge_pages` now extracts tokens via `tokenize_query(query)` and passes them through `self._dialect.prepare_bm25_text()`.
   - For `native`, tokens are joined with `" | "`, and queries exceeding `bm25_max_query_terms` are capped to avoid stack depth limits (SQLSTATE 54001).
   - For all other backends (`vchord`, `pg_search`, `pg_textsearch`, `pgroonga`), `prepare_bm25_text` returns the raw query string unchanged, preserving verbatim SQL dispatch.

2. **Selective Term Pruning on `mental_models`**:
   - When query terms exceed `bm25_max_query_terms` and `bm25_selective_terms` is enabled on PostgreSQL, `search_knowledge_pages` uses `select_selective_bm25_tokens` on `mental_models` document frequency statistics from `pg_stats` to retain the highest-signal discriminative terms.

3. **Index Configuration Parity**:
   - `mental_models.search_vector` is defined as `GENERATED ALWAYS AS (to_tsvector('english', ...)) STORED` in migrations. The query side continues using the `'english'` tsquery config to ensure GIN index utilization.

4. **Empty-Token Query Resilience**:
   - For queries containing only punctuation or whitespace (where `tokenize_query()` yields an empty list):
     - If vector embeddings are present, the search smoothly executes a vector-only ANN scan without failing on `to_tsquery('')`.
     - If vector embeddings are absent, it returns `[]` cleanly.

---

## Changes by Component

- `hindsight_api/engine/sql/postgresql.py`:
  - `knowledge_bm25_arm`: Update `native` branch to generate `to_tsquery('english', $p)` clauses for `score_expr` and `match_filter`. Document previous vs current behavior in docstrings.
- `hindsight_api/engine/memory_engine.py`:
  - `search_knowledge_pages`: Tokenize query, reuse `self._dialect.prepare_bm25_text`, apply selective terms pruning on `mental_models`, handle empty-token fallback, and bind prepared text parameter to BM25 query.
- `tests/test_knowledge_bm25_dispatch.py`:
  - Update `test_native_uses_tsvector_operators` to assert `to_tsquery('english', $3)`.
- `tests/test_knowledge_search_text_search_disabled.py`:
  - Update expected parameter bindings to reflect `prepare_bm25_text` output (`"some | query"`).
  - Add tests verifying raw query passthrough for extension backends (`pgroonga`).
  - Add tests for selective terms pruning on `mental_models`.
  - Add tests for empty-token queries falling back to vector-only or returning empty results.

---

## Verification

Targeted pytest test suite passed:
```bash
uv run pytest tests/test_knowledge_bm25_dispatch.py \
              tests/test_knowledge_search_text_search_disabled.py \
              tests/test_db_abstraction.py \
              tests/test_multilingual_bm25.py \
              tests/test_recall_query_token_cap.py -v
```
Output: `186 passed, 18 warnings in 9.39s`
