### PR TITLE
fix(retain): force re-extraction on document reprocess bypassing crash-recovery and delta deduplication

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11421,6 +11421,7 @@ class MemoryEngine(MemoryEngineInterface):
             "content": original_text,
             "document_id": document_id,
             "update_mode": "replace",
+            "force_reextract": True,
         }
         # Replay everything the original retain supplied. Enumerating fields here
         # is what let `strategy`, `entities` and `resolve_entities` go missing one
@@ -11434,10 +11435,11 @@ class MemoryEngine(MemoryEngineInterface):
         # on the item, so retain_params came back without it and the NEXT reprocess
         # fell back to the bank default again.
         content_dict.update(retain_params)
-        # These three are the reprocess's own and must win over anything stored.
+        # These four are the reprocess's own and must win over anything stored.
         content_dict["content"] = original_text
         content_dict["document_id"] = document_id
         content_dict["update_mode"] = "replace"
+        content_dict["force_reextract"] = True
 
         tags = doc.get("tags") or []
         if tags:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -383,7 +383,7 @@ def _resolve_narrator(profile_name: str, bank_id: str) -> str | None:
 # and only the resulting facts are wrong. Inverting it makes the safe case the
 # default — a new retain field round-trips unless someone deliberately excludes it,
 # and the single source of truth becomes what api_retain puts on the content dict.
-_RETAIN_PARAMS_NOT_REPLAYED = frozenset({"content", "document_id", "update_mode", "tags"})
+_RETAIN_PARAMS_NOT_REPLAYED = frozenset({"content", "document_id", "update_mode", "tags", "force_reextract"})
 
 
 def _build_retain_params(contents_dicts, document_tags=None, doc_contents=None):
@@ -1708,10 +1708,16 @@ async def retain_batch(
     # entities against Postgres and takes its document lock on a `documents` row that store-owned
     # banks no longer have: `current_hash` comes back None, the stale-chunk guard never fires, and
     # delta ran with no concurrency control at all.
+    #
+    # Deduplication and crash recovery are document-scoped (delta diffing and recovery checks gate
+    # on `effective_doc_id` and the document's `content_hash`). Aggregating `force_reextract` across
+    # the batch is intentional: if any item requests full extraction, the entire document bypasses
+    # delta/recovery shortcuts and re-extracts every chunk wholesale.
+    force_reextract = any(bool(item.get("force_reextract")) for item in contents_dicts)
     from ..memories import get_memories as _get_memories_delta
 
     _delta_provider = _get_memories_delta()
-    if attempts_delta_retain(_delta_provider, bank_id, is_first_batch):
+    if not force_reextract and attempts_delta_retain(_delta_provider, bank_id, is_first_batch):
         delta_result = await _try_delta_retain(
             pool,
             embeddings_model,
@@ -1736,6 +1742,7 @@ async def retain_batch(
             document_body_override=document_body_override,
             delta_full_body=_delta_full_body,
             append_base_hash=append_base_hash,
+            force_reextract=force_reextract,
         )
         if delta_result is not None:
             return delta_result
@@ -1815,6 +1822,7 @@ async def retain_batch(
         progress_callback=progress_callback,
         append_base_hash=append_base_hash,
         append_base_watermark=append_base_watermark,
+        force_reextract=force_reextract,
     )
 
 
@@ -2233,6 +2241,7 @@ async def _streaming_retain_batch(
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
     append_base_hash: str | None = None,
     append_base_watermark: int | None = None,
+    force_reextract: bool = False,
 ) -> tuple[list[list[str]], TokenUsage]:
     """
     Process a large document in streaming mini-batches to bound memory usage.
@@ -2299,31 +2308,32 @@ async def _streaming_retain_batch(
         sanitized_content = ""
     is_recovery = False
 
-    # Same reason as the stale-request check above: the recovery probe reads the SQL `documents`
-    # row and the SQL chunk rows, and a store that owns its documents has neither -- so this found
-    # nothing, `is_recovery` stayed False, and it cost a pool acquire and a query per document.
-    from ..memories import get_memories as _get_memories_recov
+    if not force_reextract:
+        # Same reason as the stale-request check above: the recovery probe reads the SQL `documents`
+        # row and the SQL chunk rows, and a store that owns its documents has neither -- so this found
+        # nothing, `is_recovery` stayed False, and it cost a pool acquire and a query per document.
+        from ..memories import get_memories as _get_memories_recov
 
-    _sql_recovery_possible = not _get_memories_recov().store_owned_for(bank_id)
-    try:
-        if _sql_recovery_possible:
-            async with acquire_with_retry(pool) as conn:
-                doc_row = await conn.fetchrow(
-                    f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
-                    effective_doc_id,
-                    bank_id,
-                )
-                if doc_row and doc_row["content_hash"] == new_content_hash:
-                    existing_rows = await chunk_storage.load_existing_chunks(conn, bank_id, effective_doc_id)
-                    existing_chunk_hashes = {c.content_hash for c in existing_rows if c.content_hash}
-                    if existing_chunk_hashes:
-                        is_recovery = True
-                        log_buffer.append(
-                            f"[streaming] RECOVERY: found {len(existing_chunk_hashes)} already-committed chunks — "
-                            f"will skip matching and preserve existing data"
-                        )
-    except Exception:
-        pass  # If we can't load, just process all chunks
+        _sql_recovery_possible = not _get_memories_recov().store_owned_for(bank_id)
+        try:
+            if _sql_recovery_possible:
+                async with acquire_with_retry(pool) as conn:
+                    doc_row = await conn.fetchrow(
+                        f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2",
+                        effective_doc_id,
+                        bank_id,
+                    )
+                    if doc_row and doc_row["content_hash"] == new_content_hash:
+                        existing_rows = await chunk_storage.load_existing_chunks(conn, bank_id, effective_doc_id)
+                        existing_chunk_hashes = {c.content_hash for c in existing_rows if c.content_hash}
+                        if existing_chunk_hashes:
+                            is_recovery = True
+                            log_buffer.append(
+                                f"[streaming] RECOVERY: found {len(existing_chunk_hashes)} already-committed chunks — "
+                                f"will skip matching and preserve existing data"
+                            )
+        except Exception:
+            pass  # If we can't load, just process all chunks
 
     # ---------------------------------------------------------------------------
     # Document tracking is DEFERRED to the first consumer batch TXN.
@@ -2553,7 +2563,7 @@ async def _streaming_retain_batch(
         try:
             for i, chunk_text in enumerate(all_pre_chunks):
                 chunk_hash = chunk_storage.compute_chunk_hash(chunk_text)
-                if chunk_hash in existing_chunk_hashes:
+                if not force_reextract and chunk_hash in existing_chunk_hashes:
                     # Memory: skipped chunks aren't needed either.
                     all_pre_chunks[i] = ""
                     skipped_total += 1
@@ -3451,6 +3461,7 @@ async def _try_delta_retain(
     # `document_body_override`, which an append fills with only the new tail.
     delta_full_body: str | None = None,
     append_base_hash: str | None = None,
+    force_reextract: bool = False,
 ) -> tuple[list[list[str]], TokenUsage, int | None] | None:
     """
     Attempt delta retain for a document upsert. Returns result tuple if delta
@@ -3461,6 +3472,8 @@ async def _try_delta_retain(
     (``0`` if the submission matched prior content exactly and nothing was
     re-extracted).
     """
+    if force_reextract:
+        return None
     # Delta RUNS for a store-owned (PG-free) bank. It did not always: the two things this path
     # relies on are absent for such a bank, and each had to be replaced rather than assumed.
     #

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -117,6 +117,7 @@ class RetainContentDict(TypedDict, total=False):
         Literal["per_tag", "combined", "all_combinations", "shared"] | list[list[str]]
     )  # Observation scopes for consolidation
     update_mode: Literal["replace", "append"]
+    force_reextract: bool  # Force full re-extraction bypassing delta and crash-recovery deduplication
 
 
 @dataclass

--- a/hindsight-api-slim/tests/test_reprocess_force_reextract.py
+++ b/hindsight-api-slim/tests/test_reprocess_force_reextract.py
@@ -1,0 +1,115 @@
+"""Tests for document reprocess: forces LLM re-extraction and replaces memory units."""
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from hindsight_api.api import create_app
+
+
+@pytest_asyncio.fixture
+async def api_client(memory):
+    """Create an async test client for the FastAPI app."""
+    app = create_app(memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.fixture
+def bank_id():
+    return f"test_reprocess_reextract_{datetime.now(timezone.utc).timestamp()}"
+
+
+@pytest.mark.asyncio
+async def test_reprocess_document_forces_reextraction_and_replaces_units(memory, request_context):
+    """Calling reprocess_document on an existing document with unchanged content must
+    force re-extraction, deleting old units and creating new units rather than
+    silently classifying as crash recovery."""
+    bank_id = f"test_reprocess_force_{datetime.now(timezone.utc).timestamp()}"
+    document_id = "doc-force-reextract"
+    content = "Alice works at Google on Android. Bob works at Apple on iOS."
+
+    try:
+        # Initial retain
+        v1_units = await memory.retain_async(
+            bank_id=bank_id,
+            content=content,
+            document_id=document_id,
+            request_context=request_context,
+        )
+        assert len(v1_units) > 0, "Initial retain should extract facts"
+
+        # List units before reprocess using engine API
+        v1_listing = await memory.list_memory_units(
+            bank_id=bank_id,
+            document_id=document_id,
+            request_context=request_context,
+        )
+        v1_unit_ids = {item["id"] for item in v1_listing["items"]}
+        assert len(v1_unit_ids) > 0
+
+        # Reprocess the document with identical content
+        reprocess_result = await memory.reprocess_document(
+            bank_id=bank_id,
+            document_id=document_id,
+            request_context=request_context,
+        )
+        assert reprocess_result is not None
+        assert "operation_id" in reprocess_result
+
+        # Check document state after reprocess
+        doc_v2 = await memory.get_document(document_id, bank_id, request_context=request_context)
+        assert doc_v2 is not None
+        assert doc_v2["memory_unit_count"] > 0, "Reprocessed document must have memory units"
+
+        # List units after reprocess using engine API
+        v2_listing = await memory.list_memory_units(
+            bank_id=bank_id,
+            document_id=document_id,
+            request_context=request_context,
+        )
+        v2_unit_ids = {item["id"] for item in v2_listing["items"]}
+
+        assert len(v2_unit_ids) > 0, "Should have memory units after reprocess"
+        assert v2_unit_ids != v1_unit_ids, "Reprocess must replace old unit IDs with newly extracted unit IDs"
+        assert not (v1_unit_ids & v2_unit_ids), "Old unit IDs should have been cascade-deleted on replace"
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_http_reprocess_document_endpoint_replaces_facts(api_client, bank_id):
+    """HTTP POST /v1/default/banks/{bank_id}/documents/{document_id}/reprocess replaces existing facts."""
+    item = {"content": "Dave is a lead developer working on database engines.", "document_id": "doc-http-reprocess"}
+    response = await api_client.post(f"/v1/default/banks/{bank_id}/memories", json={"items": [item]})
+    assert response.status_code == 200
+
+    # Get initial graph memories
+    graph_res1 = await api_client.get(
+        f"/v1/default/banks/{bank_id}/graph", params={"document_id": "doc-http-reprocess"}
+    )
+    assert graph_res1.status_code == 200
+    rows_v1 = graph_res1.json()["table_rows"]
+    assert len(rows_v1) > 0
+    v1_ids = {r["id"] for r in rows_v1}
+
+    # Call reprocess HTTP endpoint
+    reprocess_res = await api_client.post(f"/v1/default/banks/{bank_id}/documents/doc-http-reprocess/reprocess")
+    assert reprocess_res.status_code == 200
+    assert reprocess_res.json()["success"] is True
+
+    # Get new graph memories
+    graph_res2 = await api_client.get(
+        f"/v1/default/banks/{bank_id}/graph", params={"document_id": "doc-http-reprocess"}
+    )
+    assert graph_res2.status_code == 200
+    rows_v2 = graph_res2.json()["table_rows"]
+    assert len(rows_v2) > 0
+    v2_ids = {r["id"] for r in rows_v2}
+
+    assert v1_ids != v2_ids, "HTTP reprocess must replace old facts with newly extracted facts"
+    assert not (v1_ids & v2_ids), "Old unit IDs must no longer exist"

--- a/hindsight-api-slim/tests/test_retain_params_roundtrip.py
+++ b/hindsight-api-slim/tests/test_retain_params_roundtrip.py
@@ -45,8 +45,8 @@ def test_captures_the_fields_that_used_to_go_missing():
 
 def test_excludes_what_a_reprocess_supplies_itself():
     """Replaying these would fight the reprocess: content is the stored
-    original_text, and document_id/update_mode/tags are set by the reprocess."""
-    p = _params(content="x", document_id="d1", update_mode="append", tags=["a"], context="ctx")
+    original_text, and document_id/update_mode/tags/force_reextract are set by the reprocess."""
+    p = _params(content="x", document_id="d1", update_mode="append", tags=["a"], force_reextract=True, context="ctx")
     assert set(p) == {"context"}
 
 


### PR DESCRIPTION
## Summary

Fixes #3899

When calling `POST /v1/default/banks/{bank_id}/documents/{document_id}/reprocess`, `reprocess_document` fetches the stored `original_text` and `retain_params` and resubmits them as a retain operation under the same `document_id` with `update_mode="replace"`.

Because the submitted text is identical to the currently stored document, the retain processing pipeline treated reprocessing as a **silent no-op** through two separate deduplication / recovery mechanisms:

1. **Delta Retain Early Exit (`_try_delta_retain`)**:
   Delta retain hashes incoming chunks and compares them against existing chunk hashes in Postgres. Because the text is identical, every chunk was categorized as unchanged, causing `_try_delta_retain` to take the `_delta_metadata_only` shortcut and return early without executing any LLM extraction calls.
2. **Crash-Recovery Chunk Skipping (`_streaming_retain_batch`)**:
   Even if delta retain was bypassed, `_streaming_retain_batch` checked whether `doc_row["content_hash"] == new_content_hash`. Because the hash matched and existing chunk rows were found, it flagged `is_recovery = True`. In `_llm_producer`, all chunks matching `existing_chunk_hashes` were skipped (0 LLM extractions). In the database consumer, `is_recovery = True` routed to `upsert_document_metadata` instead of `handle_document_tracking`, preserving the existing memory units without deletion or renewal.

This PR introduces an internal `force_reextract` control flag on `RetainContentDict` and throughout the retain orchestrator pipeline to ensure document reprocessing always bypasses delta optimization and crash-recovery deduplication, forcing full LLM re-extraction and clean replacement of existing memory units.

---

## Retain Pipeline & Control Flow

```mermaid
flowchart TD
    subgraph BEFORE["❌ BEFORE: Reprocess Silent No-Op Traps"]
        direction TB
        R1["POST /documents/{id}/reprocess<br/>(replays original_text, update_mode='replace')"]
        R1 --> D1{"_try_delta_retain<br/>Compare chunk hashes"}
        D1 -->|"All chunks match (unchanged)"| S1["_delta_metadata_only<br/>• 0 LLM extraction calls<br/>• Preserves old facts<br/>• Early return"]
        
        D1 -.->|"If Delta bypassed"| STR1{"_streaming_retain_batch<br/>Check content_hash match"}
        STR1 -->|"content_hash matches & chunks exist"| REC1["is_recovery = True"]
        REC1 --> PROD1["_llm_producer: Skips all chunks<br/>(0 LLM extractions)"]
        REC1 --> DB1["DB Consumer: upsert_document_metadata<br/>• No memory units deleted<br/>• No new memory units created"]
    end

    subgraph AFTER["✅ AFTER: Dedicated force_reextract Bypass Path"]
        direction TB
        R2["POST /documents/{id}/reprocess<br/>(sets internal force_reextract=True)"]
        R2 --> D2{"_try_delta_retain<br/>force_reextract is True"}
        D2 -->|"Bypass Delta Retain"| STR2["_streaming_retain_batch<br/>(force_reextract=True)"]
        STR2 --> REC2["is_recovery = False<br/>(Crash recovery disabled)"]
        REC2 --> PROD2["_llm_producer:<br/>Extracts all chunks via LLM"]
        REC2 --> DB2["DB Consumer: handle_document_tracking<br/>• Cascade-deletes old memory units<br/>• Inserts newly extracted facts"]
    end
```

---

## Execution Matrix Across Retain Scenarios

| Scenario | Trigger / Endpoint | Content Hash vs Stored | Delta Retain Action | LLM Producer Action | Database Consumer Action |
|---|---|---|---|---|---|
| **Standard Retain (New Doc)** | `POST /memories` | Distinct / New | Bypassed (new doc) | Extracts all chunks | `handle_document_tracking` inserts new doc & units |
| **Incremental Upsert** | `POST /memories` | Modified | Diff applied (only changed/new chunks extracted) | Extracts diff chunks | Replaces changed chunk facts, preserves unchanged units |
| **Identical Resubmit (No Change)** | `POST /memories` | Identical | `_delta_metadata_only` shortcut (0 LLM calls) | Skipped | `upsert_document_metadata` updates metadata only |
| **Worker Crash Recovery** | Async Operation Retry | Identical | Bypassed (first batch / retry) | Skips committed chunks; extracts uncommitted chunks | Re-anchors doc & commits uncommitted facts |
| **Explicit Document Reprocess** | `POST /documents/{id}/reprocess` | Identical | **Bypassed (`force_reextract=True`)** | **Extracts all chunks via LLM (`force_reextract=True`)** | **`handle_document_tracking` cascade-deletes old units and inserts fresh facts** |

---

## Key Technical Decisions

1. **Internal Engine-Level Scope for `force_reextract`**:
   - `force_reextract` is kept strictly internal on `RetainContentDict` rather than exposing it on the public HTTP `MemoryItem` schema. External callers already have the dedicated `POST /documents/{id}/reprocess` endpoint, avoiding schema pollution and preventing coupling external APIs to internal deduplication flags.
   - `reprocess_document` explicitly sets `content_dict["force_reextract"] = True`.

2. **Exclusion from Document `retain_params` Serialization**:
   - Added `"force_reextract"` to `_RETAIN_PARAMS_NOT_REPLAYED` in `orchestrator.py`.
   - Ensures `force_reextract` is treated as a transient operation flag and is not written to the JSON `retain_params` column in Postgres, avoiding accidental persistence to subsequent operations.

3. **Multi-layer Pipeline Bypass**:
   - **`retain_batch` / `_try_delta_retain`**: When `force_reextract` is True, `_try_delta_retain` immediately returns `None`, allowing execution to proceed directly to the full streaming extraction pipeline.
   - **`_streaming_retain_batch`**: Guards crash recovery detection with `if not force_reextract:`, keeping `is_recovery = False`.
   - **`_llm_producer`**: Guards chunk deduplication with `if not force_reextract and chunk_hash in existing_chunk_hashes:`, ensuring every chunk is queued for LLM extraction.
   - **DB Consumer**: Because `is_recovery` is `False`, the first batch transaction invokes `handle_document_tracking`, which cascade-deletes prior memory units and writes the freshly extracted units.

---

## Changes by Component

- **`hindsight_api/engine/retain/types.py`**:
  - Add `force_reextract: bool` to `RetainContentDict`.
- **`hindsight_api/engine/memory_engine.py`**:
  - In `reprocess_document`, set `content_dict["force_reextract"] = True`.
- **`hindsight_api/engine/retain/orchestrator.py`**:
  - Add `"force_reextract"` to `_RETAIN_PARAMS_NOT_REPLAYED`.
  - Pass and evaluate `force_reextract` in `retain_batch`, `_try_delta_retain`, and `_streaming_retain_batch`.
  - Disable crash recovery and chunk skipping when `force_reextract` is True.
- **`tests/test_retain_params_roundtrip.py`**:
  - Verify `force_reextract` is properly excluded from stored `retain_params` and handled on replay.
- **`tests/test_reprocess_force_reextract.py`**:
  - Add integration tests verifying reprocess deletes and replaces memory units on identical content using the `list_memory_units` engine API.
  - Verify HTTP `POST /documents/{id}/reprocess` endpoint replaces facts end-to-end.

---

## Verification

Full suite of retain, delta retain, roundtrip, and reprocess tests passed:
```bash
uv run pytest tests/test_delta_retain.py \
              tests/test_retain_params_roundtrip.py \
              tests/test_document_chunks_and_reprocess.py \
              tests/test_reprocess_force_reextract.py
============================== 55 passed in 17.58s =============================
```

Linters and type checks:
- `ruff check .` -> Passed
- `ty check hindsight_api/` -> Passed
- `./scripts/hooks/lint.sh` -> All linters passed
