### PR TITLE
fix(mental-models): skip the reflect loop when the scope holds nothing to read

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1437,6 +1437,28 @@ class _MentalModelScopeFilter:
     params: list[Any]
 
 
+@dataclass(frozen=True)
+class _MentalModelScopeWatermark:
+    """What one ``MAX(updated_at)`` over a mental model's scope tells a refresh.
+
+    Both answers come off the same aggregate, so they are returned together rather
+    than queried twice: whether there is anything in scope to read at all, and the
+    watermark to persist afterwards. They are not the same number — the watermark is
+    clamped so it can never regress — which is exactly why the raw reading has to
+    travel alongside it.
+    """
+
+    newest_in_scope: datetime | None
+    """Newest in-scope memory visible at the refresh snapshot; None when the scope
+    holds nothing at all. Unclamped, so it answers "is there anything here?" —
+    and, compared against the delta window's lower bound, "anything *new*?"."""
+
+    watermark: datetime | None
+    """The ``last_memory_seen_at`` a successful refresh persists: ``newest_in_scope``
+    raised to the model's current watermark so it never moves backwards. None leaves
+    the column untouched."""
+
+
 def _resolve_refresh_tag_filtering(
     model_tags: list[str] | None,
     trigger_data: dict[str, Any],
@@ -14632,24 +14654,31 @@ class MemoryEngine(MemoryEngineInterface):
                 mental_model_id,
             )
 
-    async def _mental_model_processed_watermark(
+    async def _mental_model_scope_watermark(
         self,
         bank_id: str,
         mental_model_id: str,
         scope_filter: "_MentalModelScopeFilter",
         refresh_cutoff: datetime,
-    ) -> datetime | None:
-        """Watermark to persist after a refresh: the newest in-scope memory visible at
-        the snapshot, clamped so it never regresses below the model's current
-        ``last_memory_seen_at`` (falling back to ``last_refreshed_at`` for a row no
-        refresh has stamped since the migration backfill).
+    ) -> _MentalModelScopeWatermark:
+        """One ``MAX(updated_at)`` over the model's scope, read for both its answers.
 
-        A still-uncommitted straddling row is excluded from this max, so when it commits
-        it stays newer than the watermark and is caught next time. Returns ``None`` when
-        no in-scope memory is visible (leave ``last_memory_seen_at`` untouched, so an
-        in-flight first row is not skipped). Kept as its own method — like
-        ``_mental_model_refresh_cutoff`` — so mock unit tests of the refresh wiring can
-        stub it instead of reaching a real pool.
+        ``watermark`` is what a successful refresh persists: the newest in-scope memory
+        visible at the snapshot, clamped so it never regresses below the model's current
+        ``last_memory_seen_at`` (falling back to ``last_refreshed_at`` for a row no
+        refresh has stamped since the migration backfill). A still-uncommitted straddling
+        row is excluded from the max, so when it commits it stays newer than the watermark
+        and is caught next time; ``None`` leaves the column untouched, so an in-flight
+        first row is not skipped.
+
+        ``newest_in_scope`` is the same reading *unclamped*, and is what
+        ``_mental_model_refresh_has_sources`` decides on — it has to be carried out of
+        here rather than re-queried, because the clamp destroys exactly the information
+        the emptiness check needs: a model whose watermark is already set reports that
+        watermark whether its scope holds a thousand memories or none.
+
+        Kept as its own method — like ``_mental_model_refresh_cutoff`` — so mock unit
+        tests of the refresh wiring can stub it instead of reaching a real pool.
         """
         backend = await self._get_backend()
         assert self._dialect is not None
@@ -14667,68 +14696,60 @@ class MemoryEngine(MemoryEngineInterface):
                 *watermark_params,
             )
         if newest_in_scope is None:
-            return None
+            return _MentalModelScopeWatermark(newest_in_scope=None, watermark=None)
         if current_memory_seen_at is not None:
-            return max(newest_in_scope, current_memory_seen_at)
-        return newest_in_scope
+            return _MentalModelScopeWatermark(
+                newest_in_scope=newest_in_scope, watermark=max(newest_in_scope, current_memory_seen_at)
+            )
+        return _MentalModelScopeWatermark(newest_in_scope=newest_in_scope, watermark=newest_in_scope)
 
     async def _mental_model_refresh_has_sources(
         self,
         bank_id: str,
         mental_model_id: str,
-        scope_filter: "_MentalModelScopeFilter",
         *,
+        newest_in_scope: datetime | None,
         created_after: datetime | None,
-        created_before: datetime,
         exclude_mental_models: bool,
     ) -> bool:
         """Is there anything for this refresh's reflect to read?
 
-        Answers the question under the model's OWN flags, because they are what
-        decides it: ``tags``/``tag_groups``/``fact_types`` (carried in
-        ``scope_filter``) bound which memory units the agent's tools can return,
-        ``exclude_mental_models`` decides whether sibling documents are readable at
-        all, and the window — open-ended in full mode, the watermark window in delta
-        mode — bounds both retrieval tools. Same predicates as the recall arms:
-        ``updated_at`` strictly after the delta watermark, at or before the snapshot.
+        Answers the question under the model's OWN flags, because they are what decides
+        it. ``newest_in_scope`` already carries most of the answer: it is the newest
+        memory visible at the snapshot *within this model's scope*, so
+        ``tags``/``tag_groups``/``fact_types`` are applied to it, and it costs nothing
+        here — the refresh reads it for the watermark either way. A ``None`` means the
+        scope is empty; otherwise the delta window's lower bound settles it, since a max
+        newer than the bound is exactly "at least one row is in the window" (recall
+        filters ``updated_at > created_after``, so the comparison is the same one). Full
+        mode has no lower bound, so any memory at all counts.
 
-        Deliberately over-inclusive: it counts memory units of any fact type the
-        scope admits, and any sibling document with real content, whether or not the
-        agent's query would have matched them. A false "yes" costs one ordinary
-        refresh; a false "no" would silently stop a document from ever updating.
+        Only a scope with no readable memory pays a query, and only when
+        ``exclude_mental_models`` leaves the sibling documents in reach.
+
+        Deliberately over-inclusive: any fact type the scope admits counts, as does any
+        sibling document with real content, whether or not the agent's query would have
+        matched it. A false "yes" costs one ordinary refresh; a false "no" would silently
+        stop a document from ever updating.
 
         A sibling still holding the ``Generating content...`` placeholder is not a
         source — that is exactly the state a bank's default pages are all in while
         they wait on each other, and treating it as content would defeat the check
         for the case it was written for (#3875).
 
-        Kept as its own method — like ``_mental_model_refresh_cutoff`` — so mock unit
-        tests of the refresh wiring can stub it instead of reaching a real pool.
+        Kept as its own method so mock unit tests of the refresh wiring can stub it
+        instead of reaching a real pool.
         """
-        params: list[Any] = [*scope_filter.params]
-        where: list[str] = [*scope_filter.where]
-        if created_after is not None:
-            params.append(created_after)
-            where.append(f"updated_at > ${len(params)}")
-        params.append(created_before)
-        where.append(f"updated_at <= ${len(params)}")
-
+        if newest_in_scope is not None and (created_after is None or newest_in_scope > created_after):
+            return True
+        if exclude_mental_models:
+            return False
+        # ``search_mental_models`` applies no time bound, so a sibling document is a
+        # source in delta mode too — an empty window does not put it out of reach. Only
+        # self is excluded here, not the model's full ``exclude_mental_model_ids`` list:
+        # over-counting keeps the refresh running, which is the safe direction.
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
-            # MAX() rather than a LIMIT/EXISTS so this is the same shape as the
-            # watermark query above, which is already known to run on both dialects.
-            newest_in_scope = await conn.fetchval(
-                f"SELECT MAX(updated_at) FROM {fq_table('memory_units')} WHERE {' AND '.join(where)}",
-                *params,
-            )
-            if newest_in_scope is not None:
-                return True
-            if exclude_mental_models:
-                return False
-            # ``search_mental_models`` applies no time bound, so a sibling document is
-            # a source in delta mode too. Only self is excluded here, not the model's
-            # full ``exclude_mental_model_ids`` list: over-counting keeps the refresh
-            # running, which is the safe direction.
             other_documents = await conn.fetchval(
                 f"SELECT COUNT(*) FROM {fq_table('mental_models')} "
                 f"WHERE bank_id = $1 AND id <> $2 AND LENGTH(TRIM(content)) > 0 AND content NOT LIKE $3",
@@ -14848,9 +14869,10 @@ class MemoryEngine(MemoryEngineInterface):
         # such a straddling commit stays newer than the watermark and is caught next
         # time, instead of being stamped "already processed" and dropped forever.
         scope_filter = self._build_mm_scope_filter(bank_id, tag_filtering, fact_types)
-        processed_watermark = await self._mental_model_processed_watermark(
+        scope_watermark = await self._mental_model_scope_watermark(
             bank_id, mental_model_id, scope_filter, refresh_cutoff
         )
+        processed_watermark = scope_watermark.watermark
 
         # Run reflect with the source query, excluding the mental model being refreshed
         # Skip creating a nested "hindsight.reflect" span since we already have "hindsight.mental_model_refresh"
@@ -14931,15 +14953,15 @@ class MemoryEngine(MemoryEngineInterface):
         # its whole LLM budget on five worst-case reflects over an empty graph — the
         # budget it needed to ingest the content those pages were waiting for.
         #
-        # So ask first, in one query, whether this model's flags leave the agent
-        # anything to retrieve. This covers both modes: a full refresh short-circuits
-        # on an empty (or entirely out-of-scope) bank, a delta refresh on a quiet one.
+        # So ask first whether this model's flags leave the agent anything to retrieve.
+        # This covers both modes: a full refresh short-circuits on an empty (or entirely
+        # out-of-scope) bank, a delta refresh on a quiet one. Normally it costs nothing —
+        # the reading it decides on is the watermark query the refresh already ran.
         has_sources = await self._mental_model_refresh_has_sources(
             bank_id,
             mental_model_id,
-            scope_filter,
+            newest_in_scope=scope_watermark.newest_in_scope,
             created_after=created_after,
-            created_before=refresh_cutoff,
             exclude_mental_models=exclude_mental_models,
         )
         if has_sources:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14671,11 +14671,11 @@ class MemoryEngine(MemoryEngineInterface):
         and is caught next time; ``None`` leaves the column untouched, so an in-flight
         first row is not skipped.
 
-        ``newest_in_scope`` is the same reading *unclamped*, and is what
-        ``_mental_model_refresh_has_sources`` decides on — it has to be carried out of
-        here rather than re-queried, because the clamp destroys exactly the information
-        the emptiness check needs: a model whose watermark is already set reports that
-        watermark whether its scope holds a thousand memories or none.
+        ``newest_in_scope`` is the same reading *unclamped*, and is what the refresh's
+        emptiness check (#3875) decides on — it has to be carried out of here rather
+        than re-queried, because the clamp destroys exactly the information that check
+        needs: a model whose watermark is already set reports that watermark whether its
+        scope holds a thousand memories or none.
 
         Kept as its own method — like ``_mental_model_refresh_cutoff`` — so mock unit
         tests of the refresh wiring can stub it instead of reaching a real pool.
@@ -14703,58 +14703,27 @@ class MemoryEngine(MemoryEngineInterface):
             )
         return _MentalModelScopeWatermark(newest_in_scope=newest_in_scope, watermark=newest_in_scope)
 
-    async def _mental_model_refresh_has_sources(
-        self,
-        bank_id: str,
-        mental_model_id: str,
-        *,
-        newest_in_scope: datetime | None,
-        created_after: datetime | None,
-        exclude_mental_models: bool,
-    ) -> bool:
-        """Is there anything for this refresh's reflect to read?
+    async def _bank_has_readable_document(self, bank_id: str, *, excluding_id: str) -> bool:
+        """Does this bank hold another mental model the reflect agent could read?
 
-        Answers the question under the model's OWN flags, because they are what decides
-        it. ``newest_in_scope`` already carries most of the answer: it is the newest
-        memory visible at the snapshot *within this model's scope*, so
-        ``tags``/``tag_groups``/``fact_types`` are applied to it, and it costs nothing
-        here — the refresh reads it for the watermark either way. A ``None`` means the
-        scope is empty; otherwise the delta window's lower bound settles it, since a max
-        newer than the bound is exactly "at least one row is in the window" (recall
-        filters ``updated_at > created_after``, so the comparison is the same one). Full
-        mode has no lower bound, so any memory at all counts.
+        ``search_mental_models`` returns sibling documents, so one with real content is
+        something to reflect over even when no memory is — and it applies no time bound,
+        so that holds inside a delta window too. Only the model being refreshed is
+        excluded, not its full ``exclude_mental_model_ids`` list: over-counting keeps a
+        refresh running, which is the safe direction to be wrong in.
 
-        Only a scope with no readable memory pays a query, and only when
-        ``exclude_mental_models`` leaves the sibling documents in reach.
-
-        Deliberately over-inclusive: any fact type the scope admits counts, as does any
-        sibling document with real content, whether or not the agent's query would have
-        matched it. A false "yes" costs one ordinary refresh; a false "no" would silently
-        stop a document from ever updating.
-
-        A sibling still holding the ``Generating content...`` placeholder is not a
-        source — that is exactly the state a bank's default pages are all in while
-        they wait on each other, and treating it as content would defeat the check
+        A sibling still holding the ``Generating content...`` placeholder does not
+        count. That is exactly the state a bank's default pages are all in while they
+        wait on each other, and treating it as content would defeat the emptiness check
         for the case it was written for (#3875).
-
-        Kept as its own method so mock unit tests of the refresh wiring can stub it
-        instead of reaching a real pool.
         """
-        if newest_in_scope is not None and (created_after is None or newest_in_scope > created_after):
-            return True
-        if exclude_mental_models:
-            return False
-        # ``search_mental_models`` applies no time bound, so a sibling document is a
-        # source in delta mode too — an empty window does not put it out of reach. Only
-        # self is excluded here, not the model's full ``exclude_mental_model_ids`` list:
-        # over-counting keeps the refresh running, which is the safe direction.
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             other_documents = await conn.fetchval(
                 f"SELECT COUNT(*) FROM {fq_table('mental_models')} "
                 f"WHERE bank_id = $1 AND id <> $2 AND LENGTH(TRIM(content)) > 0 AND content NOT LIKE $3",
                 bank_id,
-                mental_model_id,
+                excluding_id,
                 # Prefix match, not equality: the placeholder is stored as written but read
                 # back through the structured render, which ends it with a newline. It
                 # carries no LIKE wildcard of its own, so the pattern needs no escaping.
@@ -14954,16 +14923,19 @@ class MemoryEngine(MemoryEngineInterface):
         # budget it needed to ingest the content those pages were waiting for.
         #
         # So ask first whether this model's flags leave the agent anything to retrieve.
-        # This covers both modes: a full refresh short-circuits on an empty (or entirely
-        # out-of-scope) bank, a delta refresh on a quiet one. Normally it costs nothing —
-        # the reading it decides on is the watermark query the refresh already ran.
-        has_sources = await self._mental_model_refresh_has_sources(
-            bank_id,
-            mental_model_id,
-            newest_in_scope=scope_watermark.newest_in_scope,
-            created_after=created_after,
-            exclude_mental_models=exclude_mental_models,
+        # The watermark reading already answers it for memories, at no cost: it is the
+        # newest memory visible at the snapshot *within this model's scope*, so
+        # tags/tag_groups/fact_types are already applied to it. ``None`` means the scope
+        # is empty; otherwise the delta window's lower bound settles it, because a max
+        # newer than the bound is exactly "at least one row is in the window" — the same
+        # comparison recall makes with ``updated_at > created_after``. Full mode has no
+        # lower bound, so any memory at all counts. Only when that comes back empty is
+        # there a query to pay, and only while sibling documents are still in reach.
+        has_sources = scope_watermark.newest_in_scope is not None and (
+            created_after is None or scope_watermark.newest_in_scope > created_after
         )
+        if not has_sources and not exclude_mental_models:
+            has_sources = await self._bank_has_readable_document(bank_id, excluding_id=mental_model_id)
         if has_sources:
             reflect_result = await self.reflect_async(**reflect_kwargs)
         else:

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14672,6 +14672,75 @@ class MemoryEngine(MemoryEngineInterface):
             return max(newest_in_scope, current_memory_seen_at)
         return newest_in_scope
 
+    async def _mental_model_refresh_has_sources(
+        self,
+        bank_id: str,
+        mental_model_id: str,
+        scope_filter: "_MentalModelScopeFilter",
+        *,
+        created_after: datetime | None,
+        created_before: datetime,
+        exclude_mental_models: bool,
+    ) -> bool:
+        """Is there anything for this refresh's reflect to read?
+
+        Answers the question under the model's OWN flags, because they are what
+        decides it: ``tags``/``tag_groups``/``fact_types`` (carried in
+        ``scope_filter``) bound which memory units the agent's tools can return,
+        ``exclude_mental_models`` decides whether sibling documents are readable at
+        all, and the window — open-ended in full mode, the watermark window in delta
+        mode — bounds both retrieval tools. Same predicates as the recall arms:
+        ``updated_at`` strictly after the delta watermark, at or before the snapshot.
+
+        Deliberately over-inclusive: it counts memory units of any fact type the
+        scope admits, and any sibling document with real content, whether or not the
+        agent's query would have matched them. A false "yes" costs one ordinary
+        refresh; a false "no" would silently stop a document from ever updating.
+
+        A sibling still holding the ``Generating content...`` placeholder is not a
+        source — that is exactly the state a bank's default pages are all in while
+        they wait on each other, and treating it as content would defeat the check
+        for the case it was written for (#3875).
+
+        Kept as its own method — like ``_mental_model_refresh_cutoff`` — so mock unit
+        tests of the refresh wiring can stub it instead of reaching a real pool.
+        """
+        params: list[Any] = [*scope_filter.params]
+        where: list[str] = [*scope_filter.where]
+        if created_after is not None:
+            params.append(created_after)
+            where.append(f"updated_at > ${len(params)}")
+        params.append(created_before)
+        where.append(f"updated_at <= ${len(params)}")
+
+        backend = await self._get_backend()
+        async with acquire_with_retry(backend) as conn:
+            # MAX() rather than a LIMIT/EXISTS so this is the same shape as the
+            # watermark query above, which is already known to run on both dialects.
+            newest_in_scope = await conn.fetchval(
+                f"SELECT MAX(updated_at) FROM {fq_table('memory_units')} WHERE {' AND '.join(where)}",
+                *params,
+            )
+            if newest_in_scope is not None:
+                return True
+            if exclude_mental_models:
+                return False
+            # ``search_mental_models`` applies no time bound, so a sibling document is
+            # a source in delta mode too. Only self is excluded here, not the model's
+            # full ``exclude_mental_model_ids`` list: over-counting keeps the refresh
+            # running, which is the safe direction.
+            other_documents = await conn.fetchval(
+                f"SELECT COUNT(*) FROM {fq_table('mental_models')} "
+                f"WHERE bank_id = $1 AND id <> $2 AND LENGTH(TRIM(content)) > 0 AND content NOT LIKE $3",
+                bank_id,
+                mental_model_id,
+                # Prefix match, not equality: the placeholder is stored as written but read
+                # back through the structured render, which ends it with a newline. It
+                # carries no LIKE wildcard of its own, so the pattern needs no escaping.
+                f"{MENTAL_MODEL_PENDING_CONTENT}%",
+            )
+        return bool(other_documents)
+
     async def _execute_mental_model_refresh(
         self,
         bank_id: str,
@@ -14853,7 +14922,41 @@ class MemoryEngine(MemoryEngineInterface):
             watermark=processed_watermark,
         )
 
-        reflect_result = await self.reflect_async(**reflect_kwargs)
+        # Having nothing to read is not a cheap reflect — it is the most expensive
+        # one there is (#3875). The forced retrieval turns all come back empty, and
+        # the agent's evidence guardrail then refuses every ``done`` call, because
+        # evidence is exactly what it cannot gather; the loop runs to its iteration
+        # limit and pays a forced synthesis on top. A bank's default knowledge pages
+        # each enqueue a refresh the moment they are created, so a fresh bank spent
+        # its whole LLM budget on five worst-case reflects over an empty graph — the
+        # budget it needed to ingest the content those pages were waiting for.
+        #
+        # So ask first, in one query, whether this model's flags leave the agent
+        # anything to retrieve. This covers both modes: a full refresh short-circuits
+        # on an empty (or entirely out-of-scope) bank, a delta refresh on a quiet one.
+        has_sources = await self._mental_model_refresh_has_sources(
+            bank_id,
+            mental_model_id,
+            scope_filter,
+            created_after=created_after,
+            created_before=refresh_cutoff,
+            exclude_mental_models=exclude_mental_models,
+        )
+        if has_sources:
+            reflect_result = await self.reflect_async(**reflect_kwargs)
+        else:
+            # An empty result, not a shortcut around the rest of the pipeline: the
+            # delta legs below still run. A retraction is a reason to edit the
+            # document all by itself, and gating it on new facts arriving is the
+            # coupling that lets a retired claim survive forever on a quiet bank —
+            # the same reason the unsay pass runs before the no-new-facts return.
+            logger.info(
+                f"[MENTAL_MODELS] Refresh for {mental_model_id}: nothing in scope to reflect over "
+                f"(mode={'delta' if use_delta else 'full'}"
+                f"{f', window opens {created_after.isoformat()}' if created_after else ''}); "
+                f"skipping the reflect loop"
+            )
+            reflect_result = ReflectResult(text="", based_on={})
 
         # Build reflect_response payload to store
         # based_on contains MemoryFact objects for most types, but plain dicts for directives
@@ -14967,10 +15070,22 @@ class MemoryEngine(MemoryEngineInterface):
             "mental_models": [],  # Mental models are included in based_on["mental-models"]
         }
 
+        if not has_sources:
+            # Recorded on the model so a refresh that did nothing says why it did
+            # nothing — distinct from a reflect that ran and came back empty-handed.
+            reflect_response_payload["reflect_skipped"] = "no_sources_in_scope"
+
         warnings: list[str] = []
         retrieved_total = sum(facts.retrieved.values())
         used_total = sum(facts.used.values())
-        if retrieved_total == 0:
+        if not has_sources:
+            warnings.append(
+                "Nothing in this document's scope was readable, so the reflect loop was skipped and the "
+                "document left as it is. Check the resolved scope — tags, tag_groups and fact_types all "
+                "narrow it — and, in delta mode, the time window: only memories changed after the last "
+                "refresh are in range."
+            )
+        elif retrieved_total == 0:
             warnings.append(
                 "Retrieval returned no facts at all. Check the resolved scope and the time window — "
                 "in delta mode nothing created after the last refresh is in range."
@@ -15353,6 +15468,25 @@ class MemoryEngine(MemoryEngineInterface):
 
         effective_mode: RefreshMode = "delta" if delta_applied else "full"
 
+        # Nothing was read, and no delta edit was made from what was not read. The
+        # candidate is empty by construction rather than by failure, so this must not
+        # fall into the empty-candidate guard below: that raises, and the worker would
+        # retry a refresh whose inputs are guaranteed identical next time. Preserve the
+        # document and report the same outcome the delta leg reports for an empty
+        # window — which is what this is, in full mode with the window wide open.
+        #
+        # Reached by a full refresh, and by a delta refresh whose baseline could not be
+        # read (a delta with a baseline has already returned via the no-new-facts leg).
+        if not has_sources and not delta_applied:
+            return _finish(
+                effective_mode=effective_mode,
+                mode_fallback_reason=mode_fallback_reason,
+                final_content=current_content,
+                final_structured=None,
+                delta_operations=delta_operations,
+                outcome="content_preserved_no_new_facts",
+            )
+
         # Refuse to overwrite existing content with an empty render.
         # The reflect agent can return an empty answer (small models, all
         # tool-call retries failing, transient provider errors, the cleaner
@@ -15432,8 +15566,9 @@ class MemoryEngine(MemoryEngineInterface):
         # report ``content_written`` even though nothing about the document
         # changed. So does a full regeneration that reproduces the stored text.
         # ``content_preserved_no_new_facts`` does not cover either: it fires only
-        # when the delta window was empty, whereas these runs read facts and
-        # concluded there was nothing to change.
+        # when there was nothing to read — an empty delta window, or a scope with no
+        # readable memory at all — whereas these runs read facts and concluded there
+        # was nothing to change.
         return _finish(
             effective_mode=effective_mode,
             mode_fallback_reason=mode_fallback_reason,
@@ -15525,7 +15660,8 @@ class MemoryEngine(MemoryEngineInterface):
 
             if run.outcome == "content_preserved_no_new_facts":
                 logger.info(
-                    f"[MENTAL_MODELS] Delta refresh for {mental_model_id}: no new facts found, preserving content"
+                    f"[MENTAL_MODELS] Refresh for {mental_model_id} ({run.effective_mode}): "
+                    f"no new facts found, preserving content"
                 )
                 # Content is preserved unchanged, so the structured view must be too.
                 if prev_structured_output is not None:

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -671,7 +671,7 @@ async def api_client(memory):
 
 
 def stub_refresh_has_sources(monkeypatch, memory) -> None:
-    """Tell a mental-model refresh that its scope holds something to read.
+    """Tell a mental-model refresh that its bank holds something to read.
 
     A refresh whose scope is empty skips the reflect loop outright (#3875): running
     the agent over nothing is its worst case, not a cheap one. Tests that stub
@@ -679,12 +679,16 @@ def stub_refresh_has_sources(monkeypatch, memory) -> None:
     short-circuit would pre-empt the stub instead of the test exercising it — so any
     test that fakes retrieval has to say the bank is not empty. Tests that are about
     the short-circuit itself let the real check run (``TestRefreshSkipsEmptyScope``).
+
+    Answered on the sibling-documents leg, which is the one that runs when no memory
+    is in scope: that is the state these tests are in, and it needs no fake timestamps
+    to line up against a delta window.
     """
 
-    async def _has_sources(*args, **kwargs) -> bool:
+    async def _has_document(*args, **kwargs) -> bool:
         return True
 
-    monkeypatch.setattr(memory, "_mental_model_refresh_has_sources", _has_sources)
+    monkeypatch.setattr(memory, "_bank_has_readable_document", _has_document)
 
 
 def enable_audit_default(memory, enabled: bool) -> None:

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -670,6 +670,23 @@ async def api_client(memory):
         yield client
 
 
+def stub_refresh_has_sources(monkeypatch, memory) -> None:
+    """Tell a mental-model refresh that its scope holds something to read.
+
+    A refresh whose scope is empty skips the reflect loop outright (#3875): running
+    the agent over nothing is its worst case, not a cheap one. Tests that stub
+    ``reflect_async`` almost always do so on a bank with no memories, where that
+    short-circuit would pre-empt the stub instead of the test exercising it — so any
+    test that fakes retrieval has to say the bank is not empty. Tests that are about
+    the short-circuit itself let the real check run (``TestRefreshSkipsEmptyScope``).
+    """
+
+    async def _has_sources(*args, **kwargs) -> bool:
+        return True
+
+    monkeypatch.setattr(memory, "_mental_model_refresh_has_sources", _has_sources)
+
+
 def enable_audit_default(memory, enabled: bool) -> None:
     """Set the deployment-wide default for the hierarchical ``audit_log_enabled``.
 

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -32,6 +32,7 @@ from hindsight_api.engine.llm_wrapper import LLMConfig
 from hindsight_api.engine.maintenance import MaintenanceLoop
 from hindsight_api.engine.response_models import ReflectResult
 from hindsight_api.engine.retain import embedding_utils
+from tests.conftest import stub_refresh_has_sources
 
 
 def _canned_reflect_result(text: str, facts: list[dict] | None = None) -> ReflectResult:
@@ -71,6 +72,7 @@ def patch_reflect(monkeypatch):
             return result
 
         monkeypatch.setattr(memory, "reflect_async", fake_reflect_async)
+        stub_refresh_has_sources(monkeypatch, memory)
         return calls
 
     return _install

--- a/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
+++ b/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
@@ -24,6 +24,7 @@ import pytest_asyncio
 
 from hindsight_api import MemoryEngine, RequestContext
 from hindsight_api.engine.response_models import ReflectResult
+from tests.conftest import stub_refresh_has_sources
 
 
 def _reflect_result(
@@ -80,6 +81,7 @@ def patch_reflect(monkeypatch):
             return _reflect_result(text, facts=facts, retrieved=retrieved)
 
         monkeypatch.setattr(memory, "reflect_async", fake_reflect_async)
+        stub_refresh_has_sources(monkeypatch, memory)
         return calls
 
     return _install

--- a/hindsight-api-slim/tests/test_mental_model_no_answer_preserved.py
+++ b/hindsight-api-slim/tests/test_mental_model_no_answer_preserved.py
@@ -19,6 +19,7 @@ import pytest
 
 from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.engine.reflect import ReflectNoAnswerError
+from tests.conftest import stub_refresh_has_sources
 
 EXISTING = "# Team\n\nAlice leads platform. Bob owns ingest.\n"
 
@@ -46,6 +47,7 @@ async def test_refresh_preserves_content_when_reflect_has_no_answer(memory, requ
             raise ReflectNoAnswerError("Reflect's done tool returned no answer (iteration 3, 5 tool call(s) made).")
 
         monkeypatch.setattr(memory, "reflect_async", no_answer)
+        stub_refresh_has_sources(monkeypatch, memory)
 
         with pytest.raises(ReflectNoAnswerError):
             await memory.refresh_mental_model(
@@ -80,6 +82,7 @@ async def test_refresh_does_not_advance_the_watermark_on_no_answer(memory, reque
             raise ReflectNoAnswerError("Reflect's final synthesis returned no text after 4 iteration(s).")
 
         monkeypatch.setattr(memory, "reflect_async", no_answer)
+        stub_refresh_has_sources(monkeypatch, memory)
 
         with pytest.raises(ReflectNoAnswerError):
             await memory.refresh_mental_model(

--- a/hindsight-api-slim/tests/test_mental_model_structured_output.py
+++ b/hindsight-api-slim/tests/test_mental_model_structured_output.py
@@ -19,6 +19,7 @@ from hindsight_api.engine.memory_engine import MentalModelRefreshError
 from hindsight_api.engine.reflect import agent as reflect_agent
 from hindsight_api.engine.reflect.delta_ops import DeltaOperationList
 from hindsight_api.engine.response_models import ReflectResult
+from tests.conftest import stub_refresh_has_sources
 
 _SCHEMA = {
     "type": "object",
@@ -84,6 +85,7 @@ class TestMentalModelStructuredOutput:
             return _canned_reflect_result("# Team\n\nRegenerated answer.")
 
         monkeypatch.setattr(memory, "reflect_async", fake_reflect_async)
+        stub_refresh_has_sources(monkeypatch, memory)
         so_calls = _patch_structured_output(monkeypatch, {"summary": "A team."})
 
         refreshed = await memory.refresh_mental_model(
@@ -115,6 +117,7 @@ class TestMentalModelStructuredOutput:
             return _canned_reflect_result("# Team\n\nRegenerated.")
 
         monkeypatch.setattr(memory, "reflect_async", fake_reflect_async)
+        stub_refresh_has_sources(monkeypatch, memory)
         so_calls = _patch_structured_output(monkeypatch, {"summary": "x"})
 
         refreshed = await memory.refresh_mental_model(
@@ -149,6 +152,7 @@ class TestMentalModelStructuredOutput:
             )
 
         monkeypatch.setattr(memory, "reflect_async", fake_reflect_async)
+        stub_refresh_has_sources(monkeypatch, memory)
 
         # Delta-ops call returns no operations → the document is preserved and
         # re-rendered, so final_content is the merged doc (here: the original).
@@ -190,6 +194,7 @@ class TestMentalModelStructuredOutput:
             return _canned_reflect_result("# Doc\n\nBrand new content.")
 
         monkeypatch.setattr(memory, "reflect_async", fake_reflect_async)
+        stub_refresh_has_sources(monkeypatch, memory)
         # Extraction "fails": returns no structured output.
         _patch_structured_output(monkeypatch, None)
 

--- a/hindsight-api-slim/tests/test_mental_model_trigger_flags.py
+++ b/hindsight-api-slim/tests/test_mental_model_trigger_flags.py
@@ -50,6 +50,17 @@ async def _refresh_with_trigger(
         trigger={"mode": "delta", **trigger},
         request_context=request_context,
     )
+    # A real memory in the model's scope, retained after it: a refresh with nothing to
+    # read skips the reflect loop entirely (#3875), and every assertion here is about
+    # what reaches that call. Tagged to match, and written after the model's creation
+    # timestamp, so it falls inside the delta window these tests run in.
+    await memory.retain_batch_async(
+        bank_id=bank_id,
+        contents=[{"content": "The recall endpoint accepts a tags_match parameter."}],
+        document_tags=["team:core"],
+        request_context=request_context,
+    )
+    await memory.wait_for_background_tasks()
     reflect_calls = patch_reflect(memory, text="## Ops\n\nCandidate.\n", facts=_FACTS)
     llm_calls = patch_llm_call(memory, returns=_APPEND_OP)
 

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -10,6 +10,7 @@ import uuid
 import pytest
 
 from hindsight_api.engine.memory_engine import (
+    MENTAL_MODEL_PENDING_CONTENT,
     MemoryEngine,
     _mental_model_stale_scope_from_row,
     fq_table,
@@ -2415,6 +2416,9 @@ class TestMentalModelRefreshMaxTokens:
             return_value=datetime(2026, 1, 1, tzinfo=timezone.utc)
         )
         engine._mental_model_processed_watermark = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        # This bank has memories to reflect over; the empty-scope short-circuit
+        # (#3875) is exercised by TestRefreshSkipsEmptyScope below.
+        engine._mental_model_refresh_has_sources = AsyncMock(return_value=True)  # type: ignore[method-assign]
 
         await engine.refresh_mental_model(
             bank_id="bank-1",
@@ -2951,3 +2955,309 @@ class TestMentalModelRefreshFactTypeFilter:
             "use a tool that has been disabled, then either hallucinates the call "
             "(rejected by the agent) or gives up with 'I cannot find any information…'."
         )
+
+
+class TestRefreshSkipsEmptyScope:
+    """A refresh with nothing to read must not run the reflect loop (#3875).
+
+    An empty scope is the *worst* case for the agent, not a cheap one: every forced
+    retrieval turn comes back empty, and the evidence guardrail then refuses each
+    ``done`` call — evidence is precisely what cannot be gathered — so the loop runs to
+    its iteration limit and pays a forced synthesis on top. Five default knowledge
+    pages, each enqueuing a refresh the moment the bank is created, spent the whole LLM
+    budget on that before a single document had been ingested.
+
+    Reflect is stubbed rather than mocked out at the LLM: what these tests are about is
+    whether it is *called*, and a stub makes both the skip and the non-skip assertions
+    exact instead of inferred from content.
+    """
+
+    @staticmethod
+    def _stub_reflect(memory: MemoryEngine) -> list[dict]:
+        """Replace reflect_async with a stub, returning the list its calls land in."""
+        from hindsight_api.engine.response_models import ReflectResult
+
+        calls: list[dict] = []
+
+        async def fake_reflect_async(**kwargs):
+            calls.append(kwargs)
+            return ReflectResult(text="synthesised from real memories", based_on={})
+
+        memory.reflect_async = fake_reflect_async  # type: ignore[method-assign]
+        return calls
+
+    @staticmethod
+    async def _newest_memory_updated_at(memory: MemoryEngine, bank_id, request_context):
+        """The bank's write watermark — the ``last_memory_seen_at`` a refresh that had
+        already read everything would have persisted."""
+        from datetime import datetime
+
+        # force_refresh: the stats are TTL-cached, and this is read moments after a
+        # retain that must be reflected in the watermark.
+        stats = await memory.get_bank_stats(bank_id, request_context=request_context, force_refresh=True)
+        written_at = stats["last_memory_write_at"]
+        return datetime.fromisoformat(written_at) if written_at else None
+
+    async def test_full_refresh_over_empty_bank_skips_the_reflect_loop(self, memory: MemoryEngine, request_context):
+        """The reported shape: a page created with its bank, before anything is retained."""
+        bank_id = f"test-mm-empty-full-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Coding Style",
+            source_query="How does this project write code?",
+            content=MENTAL_MODEL_PENDING_CONTENT,
+            request_context=request_context,
+        )
+        calls = self._stub_reflect(memory)
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        assert calls == [], (
+            "refresh over a bank with no memories called reflect anyway — that is the "
+            "worst-case agentic loop (iteration limit + forced synthesis) for a "
+            "guaranteed-empty answer, and it is what starves a fresh bank of the LLM "
+            "slots it needs to ingest anything (#3875)"
+        )
+        assert refreshed is not None
+        assert refreshed["content"].strip() == MENTAL_MODEL_PENDING_CONTENT, (
+            "the document must be preserved, not overwritten from an empty synthesis"
+        )
+        reflect_response = refreshed["reflect_response"]
+        assert reflect_response["reflect_skipped"] == "no_sources_in_scope"
+        assert reflect_response["outcome"] == "content_preserved_no_new_facts", (
+            "a skipped refresh is a completed no-op, not a failure — failing it would "
+            "make the worker retry inputs that are guaranteed identical"
+        )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_full_refresh_runs_once_the_bank_has_memories(self, memory: MemoryEngine, request_context):
+        """The other half: the short-circuit must not outlive the emptiness."""
+        bank_id = f"test-mm-empty-seeded-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Coding Style",
+            source_query="How does this project write code?",
+            content=MENTAL_MODEL_PENDING_CONTENT,
+            request_context=request_context,
+        )
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "The team formats every Python file with ruff before committing."}],
+            request_context=request_context,
+        )
+        await memory.wait_for_background_tasks()
+        calls = self._stub_reflect(memory)
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        assert len(calls) == 1, "a bank with memories in scope must still be reflected over"
+        assert refreshed is not None
+        assert "synthesised from real memories" in refreshed["content"]
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_delta_refresh_skips_when_nothing_changed_since_the_watermark(
+        self, memory: MemoryEngine, request_context
+    ):
+        """Delta mode: the window, not the bank, is what has to be empty. A quiet bank
+        full of already-read memories is as unreadable to this refresh as an empty one."""
+        bank_id = f"test-mm-empty-delta-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "The team formats every Python file with ruff before committing."}],
+            request_context=request_context,
+        )
+        await memory.wait_for_background_tasks()
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Coding Style",
+            source_query="How does this project write code?",
+            content="# Coding Style\n\nRuff formats every file.",
+            trigger={"mode": "delta", "exclude_mental_models": True},
+            request_context=request_context,
+        )
+        # Pretend the previous refresh read everything currently in the bank.
+        watermark = await self._newest_memory_updated_at(memory, bank_id, request_context)
+        assert watermark is not None, "test premise broken — the retain produced no memory units"
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            refresh_watermark=watermark,
+            last_refreshed_source_query="How does this project write code?",
+            refresh_completed=True,
+            request_context=request_context,
+        )
+        calls = self._stub_reflect(memory)
+
+        refreshed = await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        assert calls == [], "a delta refresh whose window holds nothing must not reflect"
+        assert refreshed is not None
+        assert refreshed["content"].strip() == "# Coding Style\n\nRuff formats every file."
+        assert refreshed["reflect_response"]["reflect_skipped"] == "no_sources_in_scope"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_delta_refresh_runs_when_a_memory_landed_after_the_watermark(
+        self, memory: MemoryEngine, request_context
+    ):
+        bank_id = f"test-mm-delta-newer-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "The team formats every Python file with ruff before committing."}],
+            request_context=request_context,
+        )
+        await memory.wait_for_background_tasks()
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Coding Style",
+            source_query="How does this project write code?",
+            content="# Coding Style\n\nRuff formats every file.",
+            trigger={"mode": "delta", "exclude_mental_models": True},
+            request_context=request_context,
+        )
+        watermark = await self._newest_memory_updated_at(memory, bank_id, request_context)
+        await memory.update_mental_model(
+            bank_id=bank_id,
+            mental_model_id=mm["id"],
+            refresh_watermark=watermark,
+            last_refreshed_source_query="How does this project write code?",
+            refresh_completed=True,
+            request_context=request_context,
+        )
+        # New content lands after that watermark: this is what a delta refresh exists for.
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "Type checking runs with ty on every pull request."}],
+            request_context=request_context,
+        )
+        await memory.wait_for_background_tasks()
+        calls = self._stub_reflect(memory)
+
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+
+        assert len(calls) == 1, "a memory newer than the watermark is exactly what delta must read"
+        assert calls[0]["created_after"] == watermark
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_memories_outside_the_models_tag_scope_are_not_sources(self, memory: MemoryEngine, request_context):
+        """The bank is not empty — the model's *scope* is. Tags, tag_groups and
+        fact_types all narrow what the agent's tools can return, so the check has to be
+        made under the model's own flags rather than against a bank-wide count."""
+        bank_id = f"test-mm-scope-tags-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "The team formats every Python file with ruff before committing."}],
+            document_tags=["backend"],
+            request_context=request_context,
+        )
+        await memory.wait_for_background_tasks()
+        mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Design System",
+            source_query="How is the design system organised?",
+            content="# Design System\n\nnothing yet",
+            tags=["design-system"],
+            trigger={"tags_match": "all_strict", "exclude_mental_models": True},
+            request_context=request_context,
+        )
+        calls = self._stub_reflect(memory)
+
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+
+        assert calls == [], (
+            "every memory in the bank is out of this model's tag scope, so its reflect would have retrieved nothing"
+        )
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_sibling_document_counts_as_a_source_unless_excluded(self, memory: MemoryEngine, request_context):
+        """``search_mental_models`` reads sibling documents, and applies no time bound —
+        so with the door open, one of them is a source even on a bank with no memories.
+        The check must respect ``exclude_mental_models`` in both directions."""
+        bank_id = f"test-mm-sibling-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Architecture",
+            source_query="How is the system built?",
+            content="# Architecture\n\nA monorepo with an API and a control plane.",
+            request_context=request_context,
+        )
+        open_mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Onboarding",
+            source_query="What should a new engineer read first?",
+            content=MENTAL_MODEL_PENDING_CONTENT,
+            trigger={"exclude_mental_models": False},
+            request_context=request_context,
+        )
+        closed_mm = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="Onboarding (isolated)",
+            source_query="What should a new engineer read first?",
+            content=MENTAL_MODEL_PENDING_CONTENT,
+            trigger={"exclude_mental_models": True},
+            request_context=request_context,
+        )
+        calls = self._stub_reflect(memory)
+
+        await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=open_mm["id"], request_context=request_context
+        )
+        assert len(calls) == 1, (
+            "a sibling document with real content is readable, so this refresh had "
+            "something to reflect over even with no memories in the bank"
+        )
+
+        calls.clear()
+        await memory.refresh_mental_model(
+            bank_id=bank_id, mental_model_id=closed_mm["id"], request_context=request_context
+        )
+        assert calls == [], "exclude_mental_models closes the only door left — nothing to read"
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    async def test_siblings_still_generating_are_not_sources(self, memory: MemoryEngine, request_context):
+        """The bank-init shape exactly: several pages created together, each holding the
+        placeholder and each waiting on content none of them has. Counting a placeholder
+        as a source would defeat the check for the case it was written for."""
+        bank_id = f"test-mm-siblings-pending-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        pages = [
+            await memory.create_mental_model(
+                bank_id=bank_id,
+                name=f"Page {i}",
+                source_query=f"topic {i}",
+                content=MENTAL_MODEL_PENDING_CONTENT,
+                trigger={"exclude_mental_models": False},
+                request_context=request_context,
+            )
+            for i in range(5)
+        ]
+        calls = self._stub_reflect(memory)
+
+        for page in pages:
+            await memory.refresh_mental_model(
+                bank_id=bank_id, mental_model_id=page["id"], request_context=request_context
+            )
+
+        assert calls == [], (
+            "five pages created with the bank each ran a full reflect over an empty "
+            "graph, holding the LLM slots the bank needed to seed itself (#3875)"
+        )
+
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -12,6 +12,7 @@ import pytest
 from hindsight_api.engine.memory_engine import (
     MENTAL_MODEL_PENDING_CONTENT,
     MemoryEngine,
+    _MentalModelScopeWatermark,
     _mental_model_stale_scope_from_row,
     fq_table,
 )
@@ -2415,10 +2416,15 @@ class TestMentalModelRefreshMaxTokens:
         engine._mental_model_refresh_cutoff = AsyncMock(  # type: ignore[method-assign]
             return_value=datetime(2026, 1, 1, tzinfo=timezone.utc)
         )
-        engine._mental_model_processed_watermark = AsyncMock(return_value=None)  # type: ignore[method-assign]
-        # This bank has memories to reflect over; the empty-scope short-circuit
-        # (#3875) is exercised by TestRefreshSkipsEmptyScope below.
-        engine._mental_model_refresh_has_sources = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        # A scope with a memory in it: the reading this returns is also what decides
+        # whether the refresh has anything to reflect over (#3875), so a stub saying
+        # "empty" would skip the reflect call this test asserts on. The short-circuit
+        # itself is covered by TestRefreshSkipsEmptyScope below.
+        engine._mental_model_scope_watermark = AsyncMock(  # type: ignore[method-assign]
+            return_value=_MentalModelScopeWatermark(
+                newest_in_scope=datetime(2025, 12, 1, tzinfo=timezone.utc), watermark=None
+            )
+        )
 
         await engine.refresh_mental_model(
             bank_id="bank-1",

--- a/hindsight-api-slim/tests/test_recall_config.py
+++ b/hindsight-api-slim/tests/test_recall_config.py
@@ -165,7 +165,7 @@ class TestRefreshTriggerWiring:
     async def test_trigger_overrides_passed_to_reflect_async(self, mock_request_context):
         from datetime import datetime, timezone
 
-        from hindsight_api.engine.memory_engine import MemoryEngine
+        from hindsight_api.engine.memory_engine import MemoryEngine, _MentalModelScopeWatermark
         from hindsight_api.engine.response_models import ReflectResult
 
         engine = MemoryEngine.__new__(MemoryEngine)
@@ -200,10 +200,14 @@ class TestRefreshTriggerWiring:
         # DB-time refresh watermark — stub so this mock test doesn't reach a real
         # pool (matches the other collaborator stubs above).
         engine._mental_model_refresh_cutoff = AsyncMock(return_value=datetime(2026, 1, 1, tzinfo=timezone.utc))
-        engine._mental_model_processed_watermark = AsyncMock(return_value=None)
-        # This bank has memories to reflect over; the empty-scope short-circuit
-        # (#3875) is exercised in test_mental_models.py.
-        engine._mental_model_refresh_has_sources = AsyncMock(return_value=True)
+        # A scope with a memory in it: the reading this returns is also what decides
+        # whether the refresh has anything to reflect over (#3875), so a stub saying
+        # "empty" would skip the reflect call these tests assert on.
+        engine._mental_model_scope_watermark = AsyncMock(
+            return_value=_MentalModelScopeWatermark(
+                newest_in_scope=datetime(2025, 12, 1, tzinfo=timezone.utc), watermark=None
+            )
+        )
 
         await engine.refresh_mental_model(
             bank_id="bank-1",
@@ -220,7 +224,7 @@ class TestRefreshTriggerWiring:
     async def test_missing_trigger_fields_pass_none(self, mock_request_context):
         from datetime import datetime, timezone
 
-        from hindsight_api.engine.memory_engine import MemoryEngine
+        from hindsight_api.engine.memory_engine import MemoryEngine, _MentalModelScopeWatermark
         from hindsight_api.engine.response_models import ReflectResult
 
         engine = MemoryEngine.__new__(MemoryEngine)
@@ -245,10 +249,14 @@ class TestRefreshTriggerWiring:
         # DB-time refresh watermark — stub so this mock test doesn't reach a real
         # pool (matches the other collaborator stubs above).
         engine._mental_model_refresh_cutoff = AsyncMock(return_value=datetime(2026, 1, 1, tzinfo=timezone.utc))
-        engine._mental_model_processed_watermark = AsyncMock(return_value=None)
-        # This bank has memories to reflect over; the empty-scope short-circuit
-        # (#3875) is exercised in test_mental_models.py.
-        engine._mental_model_refresh_has_sources = AsyncMock(return_value=True)
+        # A scope with a memory in it: the reading this returns is also what decides
+        # whether the refresh has anything to reflect over (#3875), so a stub saying
+        # "empty" would skip the reflect call these tests assert on.
+        engine._mental_model_scope_watermark = AsyncMock(
+            return_value=_MentalModelScopeWatermark(
+                newest_in_scope=datetime(2025, 12, 1, tzinfo=timezone.utc), watermark=None
+            )
+        )
 
         await engine.refresh_mental_model(
             bank_id="bank-1",

--- a/hindsight-api-slim/tests/test_recall_config.py
+++ b/hindsight-api-slim/tests/test_recall_config.py
@@ -201,6 +201,9 @@ class TestRefreshTriggerWiring:
         # pool (matches the other collaborator stubs above).
         engine._mental_model_refresh_cutoff = AsyncMock(return_value=datetime(2026, 1, 1, tzinfo=timezone.utc))
         engine._mental_model_processed_watermark = AsyncMock(return_value=None)
+        # This bank has memories to reflect over; the empty-scope short-circuit
+        # (#3875) is exercised in test_mental_models.py.
+        engine._mental_model_refresh_has_sources = AsyncMock(return_value=True)
 
         await engine.refresh_mental_model(
             bank_id="bank-1",
@@ -243,6 +246,9 @@ class TestRefreshTriggerWiring:
         # pool (matches the other collaborator stubs above).
         engine._mental_model_refresh_cutoff = AsyncMock(return_value=datetime(2026, 1, 1, tzinfo=timezone.utc))
         engine._mental_model_processed_watermark = AsyncMock(return_value=None)
+        # This bank has memories to reflect over; the empty-scope short-circuit
+        # (#3875) is exercised in test_mental_models.py.
+        engine._mental_model_refresh_has_sources = AsyncMock(return_value=True)
 
         await engine.refresh_mental_model(
             bank_id="bank-1",

--- a/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
+++ b/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
@@ -17,6 +17,7 @@ import pytest
 from hindsight_api.api.http import OperationResponse, OperationStatusResponse
 from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.worker.exceptions import RetryTaskAt
+from tests.conftest import stub_refresh_has_sources
 
 
 @pytest.fixture
@@ -131,6 +132,7 @@ def _patch_reflect(monkeypatch, memory: MemoryEngine, *, text: str, facts: list[
         )
 
     monkeypatch.setattr(memory, "reflect_async", fake_reflect_async)
+    stub_refresh_has_sources(monkeypatch, memory)
 
 
 def _patch_delta_llm(monkeypatch, memory: MemoryEngine, *, returns) -> None:

--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -219,6 +219,7 @@ Listing does not cost one query per model — the whole page is answered togethe
 - **Only what's new, in `delta` mode.** A delta refresh scopes its retrieval to memories created since the last refresh, so the LLM reads genuinely new information rather than re-reading the whole bank.
 - **Cumulative grounding.** Even in delta mode, `reflect_response.based_on` accumulates: the facts from this refresh are merged with everything previous refreshes relied on, deduplicated by id. The document rests on all of them, not just the latest slice.
 - **Nothing, if nothing is relevant.** A refresh that finds no topic-relevant memories leaves the content alone and only advances the watermark, so the same empty window stops re-triggering.
+- **No LLM call at all, if there is nothing to read.** Before the agentic loop starts, a refresh checks whether anything is in reach under this model's own settings: an in-scope memory (`tags`/`tags_match`, `tag_groups` and `fact_types` all narrow it) inside the window it would read — the whole bank in `full` mode, everything since `last_memory_seen_at` in `delta` mode — or a sibling mental model, unless `exclude_mental_models` closed that door. When there is nothing, the refresh completes immediately, leaves the document untouched, and spends nothing. This is the common case on a bank that was just created: its pages are refreshed the moment they exist, before anything has been retained.
 
 ### Refresh Mode
 

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -266,6 +266,7 @@ Listing does not cost one query per model — the whole page is answered togethe
 - **Only what's new, in `delta` mode.** A delta refresh scopes its retrieval to memories created since the last refresh, so the LLM reads genuinely new information rather than re-reading the whole bank.
 - **Cumulative grounding.** Even in delta mode, `reflect_response.based_on` accumulates: the facts from this refresh are merged with everything previous refreshes relied on, deduplicated by id. The document rests on all of them, not just the latest slice.
 - **Nothing, if nothing is relevant.** A refresh that finds no topic-relevant memories leaves the content alone and only advances the watermark, so the same empty window stops re-triggering.
+- **No LLM call at all, if there is nothing to read.** Before the agentic loop starts, a refresh checks whether anything is in reach under this model's own settings: an in-scope memory (`tags`/`tags_match`, `tag_groups` and `fact_types` all narrow it) inside the window it would read — the whole bank in `full` mode, everything since `last_memory_seen_at` in `delta` mode — or a sibling mental model, unless `exclude_mental_models` closed that door. When there is nothing, the refresh completes immediately, leaves the document untouched, and spends nothing. This is the common case on a bank that was just created: its pages are refreshed the moment they exist, before anything has been retained.
 
 ### Refresh Mode
 


### PR DESCRIPTION
Fixes #3875.

## The problem

The issue reads like it should be cheap — a reflect over an empty bank finds nothing and returns. It is the opposite: an empty scope is the agent's **worst** case.

- `_execute_mental_model_refresh` had no emptiness check anywhere before `reflect_async`. Its only early return is "the mental-model row disappeared".
- Iterations 0-2 are *forced* tool calls (`search_mental_models`, `search_observations`, `recall`), so three LLM round trips happen before the model gets a say.
- Then the evidence guardrail: on `done` it checks `has_gathered_evidence = bool(available_memory_ids) or bool(available_mental_model_ids) or bool(available_observation_ids)`. On an empty bank that is permanently `False`, so `done` is rejected, a synthetic *"You must search for information first…"* tool error is appended, and the loop `continue`s — every time, until the last iteration, which then pays a forced synthesis.

So the empty-bank refresh can never take the 1-2-turn path a bank with content can; it always burns the full `DEFAULT_MAX_ITERATIONS = 10` plus synthesis. Creating a knowledge page enqueues its refresh immediately, so a bank created with its default pages puts five of these into the queue before a single document has been retained — each holding an LLM slot for the full reflect wall clock, timing out, and retrying.

## The fix

Ask, before the loop, whether **this model's own flags** leave the agent anything to retrieve:

- **Scope, not bank.** `tags` / `tags_match` / `tag_groups` / `fact_types` are applied, so a page scoped to `["observation"]` + tags asks about *its* memories.
- **Window.** Open-ended in **full** mode, the watermark window in **delta** mode, compared the way recall's `updated_at > created_after` compares — so full short-circuits on an empty or entirely out-of-scope bank, and delta on a quiet one.
- **`exclude_mental_models`.** With it off, a sibling document with real content is a source — `search_mental_models` applies no time bound, so that holds in delta mode too — and the refresh runs. A sibling still holding the `Generating content...` placeholder is not, which is exactly the state a bank's default pages are all in while waiting on each other.

It is over-inclusive everywhere else (any fact type the scope admits, any sibling with content, whether or not the query would have matched): a false "yes" costs one ordinary refresh, a false "no" would stop a document updating forever.

**It costs nothing on a refresh that goes on to reflect** (second commit). The check decides on the `MAX(updated_at)` the refresh already runs to compute its watermark — same scope, same cutoff. That reading now travels out of the watermark query *unclamped* (`_MentalModelScopeWatermark`), because the clamp that keeps a watermark from regressing destroys precisely what the check needs: a model with a watermark already set reports it whether its scope holds a thousand memories or none. Only a scope with no readable memory pays a query, and only when `exclude_mental_models` leaves siblings in reach — the case where a whole agentic loop is about to be skipped.

Two design points worth review:

- **The reflect call is gated, not the function.** With no sources the pipeline continues with an empty `ReflectResult` so the delta legs still run. A retraction is a reason to edit the document all by itself, and gating the unsay pass on new facts arriving is the coupling that lets a retired claim survive on a quiet bank.
- **No new outcome literal.** Full mode returns `content_preserved_no_new_facts` *before* the empty-candidate guard — that guard raises, and the worker would retry a refresh whose inputs are guaranteed identical. Reusing the outcome the delta leg already reports for an empty window keeps this off the API surface (no OpenAPI/client/control-plane ripple); `reflect_response.reflect_skipped = "no_sources_in_scope"` plus a warning record *why*.

## Tests

`TestRefreshSkipsEmptyScope` — 7 DB tests, no LLM, reflect stubbed so "was it called" is exact: empty bank skips; a seeded bank still reflects; delta skips inside a watermark-closed window and runs when a memory lands after it (asserting the `created_after` it was given); a tag-scoped model over out-of-scope memories skips; a sibling with content is a source **unless** `exclude_mental_models`; five pending pages skip all five.

Every existing test that stubs `reflect_async` does so on an empty bank, where the short-circuit would pre-empt the stub instead of the test exercising it. Those now declare the bank non-empty through a shared `stub_refresh_has_sources` helper in `conftest.py`; the mock-only wiring tests say it through the watermark stub they already had.

## Not in scope

The evidence guardrail in `reflect/agent.py` is the amplifier: *any* reflect over an empty result set runs to the iteration limit, not just a refresh. Changing it affects every reflect, so it is left for a separate call.

https://claude.ai/code/session_01UBcDzagMhuXsYZDp63i7aB