### PR TITLE
fix(structured-output): strip $ref sibling keywords from strict schemas

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/structured_output.py
+++ b/hindsight-api-slim/hindsight_api/engine/structured_output.py
@@ -25,9 +25,42 @@ class OpenAIStrictSchemaGenerator(GenerateJsonSchema):
         return json_schema
 
 
+# Keywords whose value is a map of *names* to subschemas, not a subschema itself.
+# Their keys are user-controlled, so a key literally called "$ref" must not be
+# mistaken for a reference node while walking the tree.
+_SUBSCHEMA_NAME_MAPS = frozenset({"$defs", "definitions", "properties", "patternProperties"})
+
+
+def _strip_ref_siblings(node: Any) -> Any:
+    """Drop every sibling keyword of a ``$ref``.
+
+    Pydantic emits ``{"$ref": ..., "description": ...}`` for a field that both
+    references a nested model and carries its own ``Field(description=...)``
+    (JSON Schema 2020-12 allows that; the dynamic ``labels`` field built for
+    entity-label banks hits it). OpenAI-compatible strict mode rejects it with
+    ``$ref cannot have keywords {'description'}``, so a reference node keeps
+    nothing but the reference.
+    """
+    if isinstance(node, dict):
+        if "$ref" in node:
+            return {"$ref": node["$ref"]}
+        return {
+            key: (
+                {name: _strip_ref_siblings(sub) for name, sub in value.items()}
+                if key in _SUBSCHEMA_NAME_MAPS and isinstance(value, dict)
+                else _strip_ref_siblings(value)
+            )
+            for key, value in node.items()
+        }
+    if isinstance(node, list):
+        return [_strip_ref_siblings(item) for item in node]
+    return node
+
+
 def strict_json_schema(response_format: type[BaseModel]) -> dict[str, Any]:
     """Serialize a typed response model directly into OpenAI's strict subset."""
-    return response_format.model_json_schema(schema_generator=OpenAIStrictSchemaGenerator)
+    schema = response_format.model_json_schema(schema_generator=OpenAIStrictSchemaGenerator)
+    return _strip_ref_siblings(schema)
 
 
 # Types the structured-output extractor knows how to build a Pydantic field for

--- a/hindsight-api-slim/tests/test_strict_json_schema.py
+++ b/hindsight-api-slim/tests/test_strict_json_schema.py
@@ -1,6 +1,11 @@
+from unittest.mock import MagicMock
+
 from pydantic import BaseModel, Field
 
-from hindsight_api.engine.retain.fact_extraction import FactExtractionResponse
+from hindsight_api.engine.retain.fact_extraction import (
+    FactExtractionResponse,
+    _build_extraction_prompt_and_schema,
+)
 from hindsight_api.engine.structured_output import strict_json_schema
 
 
@@ -32,3 +37,52 @@ def test_fact_extraction_schema_is_accepted_by_openai_strict_output_contract() -
     assert schema["required"] == ["facts"]
     assert extracted_fact["additionalProperties"] is False
     assert extracted_fact["required"] == list(extracted_fact["properties"])
+
+
+class StrictSchemaDescribedRef(BaseModel):
+    child: StrictSchemaChild = Field(description="A described nested model.")
+
+
+def _iter_ref_nodes(node: object):
+    """Yield every dict in ``node`` that carries a ``$ref``."""
+    if isinstance(node, dict):
+        if "$ref" in node:
+            yield node
+        for value in node.values():
+            yield from _iter_ref_nodes(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_ref_nodes(item)
+
+
+def test_strict_json_schema_leaves_no_sibling_keywords_next_to_a_ref() -> None:
+    # Pydantic emits {"$ref": ..., "description": ...} for a described field that
+    # points at a nested model; OpenAI strict mode rejects it with
+    # "$ref cannot have keywords {'description'}".
+    schema = strict_json_schema(StrictSchemaDescribedRef)
+
+    assert schema["properties"]["child"] == {"$ref": "#/$defs/StrictSchemaChild"}
+    assert [set(ref) for ref in _iter_ref_nodes(schema)] == [{"$ref"}]
+
+
+def test_entity_labels_extraction_schema_has_no_ref_siblings() -> None:
+    config = MagicMock()
+    config.entity_labels = [
+        {"key": "knowledge", "type": "multi-values", "values": [{"value": "python"}, {"value": "rust"}]}
+    ]
+    config.entities_allow_free_form = True
+    config.retain_extraction_mode = "concise"
+    config.retain_extract_causal_links = False
+    config.retain_mission = None
+    config.retain_custom_instructions = None
+    config.llm_output_language = None
+    config.llm_supports_string_pattern = False
+
+    _, response_schema = _build_extraction_prompt_and_schema(config)
+    schema = strict_json_schema(response_schema)
+
+    labels_property = schema["$defs"]["LabelsFact"]["properties"]["labels"]
+    assert labels_property == {"$ref": "#/$defs/Labels"}
+    refs = list(_iter_ref_nodes(schema))
+    assert refs, "expected the labels schema to use $ref"
+    assert all(set(ref) == {"$ref"} for ref in refs)

--- a/hindsight-api-slim/tests/test_strict_schema_entity_labels.py
+++ b/hindsight-api-slim/tests/test_strict_schema_entity_labels.py
@@ -1,0 +1,91 @@
+"""Retain with entity labels under HINDSIGHT_API_LLM_STRICT_SCHEMA (#3904).
+
+The dynamic ``LabelsFact`` model gives its ``labels`` field both a nested model
+and a ``Field(description=...)``, which pydantic serializes as
+``{"$ref": ..., "description": ...}``. That is legal JSON Schema 2020-12 but
+illegal in OpenAI's strict subset, which rejects the request outright with
+``$ref cannot have keywords {'description'}`` — so retain failed before
+inference for every labelled bank running with strict schema on.
+
+Marked ``hs_llm_mat``, not ``hs_llm_core``: the core job runs
+vertexai/gemini-2.5-flash-lite, and the Gemini provider grammar-enforces its own
+native ``response_schema`` without ever calling ``strict_json_schema()``. A core
+run would pass no matter what the serializer emits — which is precisely why the
+existing entity-label LLM tests never caught this. The matrix job includes
+openai/gpt-4.1-nano and litellmrouter, whose validators are the ones that reject
+the sibling keyword.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api.config import ENV_LLM_STRICT_SCHEMA_RETAIN, clear_config_cache
+
+pytestmark = pytest.mark.hs_llm_mat
+
+
+@pytest.fixture
+def strict_retain_schema(monkeypatch):
+    """Force retain onto the strict-schema path (static config, so env + cache reset)."""
+    monkeypatch.setenv(ENV_LLM_STRICT_SCHEMA_RETAIN, "true")
+    clear_config_cache()
+    yield
+    monkeypatch.undo()
+    clear_config_cache()
+
+
+async def test_retain_with_entity_labels_under_strict_schema(
+    # strict_retain_schema comes FIRST on purpose: ConfigResolver snapshots
+    # _get_raw_config() in its constructor, so the env has to be set before
+    # memory_real_llm builds the engine, or retain silently runs non-strict.
+    strict_retain_schema,
+    memory_real_llm,
+    request_context,
+):
+    """A labelled bank retains successfully when the provider enforces the schema.
+
+    The assertion is that the call completes and extracts facts: an invalid
+    strict schema is rejected by the provider before inference, so the failure
+    mode this covers is an HTTP 400 (surfaced as "Fact extraction failed"), not
+    a wrong label. Label assignment quality is covered by the hs_llm_core tests
+    in test_entity_labels.py.
+    """
+    memory = memory_real_llm
+    # Guard against the test going vacuous: without this, a fixture-ordering or
+    # config-caching regression would leave retain on the non-strict path, where
+    # the schema is never serialized into the strict subset and nothing is checked.
+    assert memory._config_resolver._global_config.llm_strict_schema_retain is True
+
+    bank_id = f"test-labels-strict-{uuid.uuid4().hex[:8]}"
+    try:
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+        await memory._config_resolver.update_bank_config(
+            bank_id=bank_id,
+            updates={
+                "entity_labels": [
+                    {
+                        "key": "engagement",
+                        "description": "Student engagement level during the session",
+                        "values": [
+                            {"value": "active", "description": "Student is actively participating"},
+                            {"value": "passive", "description": "Student is listening but not participating"},
+                        ],
+                    }
+                ]
+            },
+            context=request_context,
+        )
+
+        unit_ids = await memory.retain_async(
+            bank_id=bank_id,
+            content=(
+                "During today's tutoring session, Maria asked many questions, "
+                "participated in every exercise, and solved the problems independently."
+            ),
+            request_context=request_context,
+        )
+
+        assert len(unit_ids) > 0, "Retain under a strict schema should still extract facts"
+    finally:
+        await memory.delete_bank(bank_id=bank_id, request_context=request_context)


### PR DESCRIPTION
Fixes #3904.

## The bug

With entity labels configured on a bank and `HINDSIGHT_API_LLM_STRICT_SCHEMA=true`, every retain failed before inference:

```
Invalid schema for response_format 'response': context=('properties', 'labels'), $ref cannot have keywords {'description'}
```

`_build_extraction_prompt_and_schema` builds a dynamic `LabelsFact` whose `labels` field both points at the nested `Labels` model and carries `Field(description=...)`. Pydantic serializes that as `{"$ref": "#/$defs/Labels", "description": "..."}`. JSON Schema 2020-12 permits sibling keywords beside a `$ref`; OpenAI's strict subset does not — the provider 400s and the API surfaces HTTP 500 `Fact extraction failed`. Recall is unaffected because it never emits this schema.

Reproduced on `main` with no provider needed, by putting the labels model through `strict_json_schema()`.

## The fix

Normalize in `strict_json_schema()` rather than at the call site: a node carrying a `$ref` now keeps only `$ref`.

Fixing it at that chokepoint covers all five providers that serialize through it (`openai_compatible`, `openai_responses`, `litellm`, `codex`, `xai_oauth`) and any future nested model with a described field — dropping the single `labels` description would fix this field and leave the next one to hit the same 400. The traversal special-cases `$defs` / `properties` / `patternProperties`, whose keys are names rather than keywords, so a property literally called `$ref` is not mistaken for a reference node.

Dropping the description costs nothing at inference time: `_build_labels_prompt_section` already describes the labels object in the prompt, and the non-strict path still sends the full unmodified schema. Nullable nested models are unaffected — their description sits on the `anyOf` wrapper, not on the `$ref`.

## Tests

`tests/test_strict_json_schema.py` gains two regressions, both failing on the current `main`:

- a described `$ref` field serializes to `{"$ref": ...}` alone;
- a real entity-label config run through `_build_extraction_prompt_and_schema` → `strict_json_schema()` has no `$ref` node with siblings — the check the issue asks for.

`./scripts/hooks/lint.sh` is clean.

https://claude.ai/code/session_01J52s5Lbg5Lp7KwRyhqg8f3