### PR TITLE
fix(knowledge): switch native knowledge BM25 from websearch AND to disjunctive OR

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -16748,6 +16748,10 @@ class MemoryEngine(MemoryEngineInterface):
             out.sort(key=lambda d: order[d["mental_model_id"]])
             return out[:limit]
 
+        from .search.retrieval import tokenize_query
+
+        tokens = tokenize_query(query)
+
         # BM25 clauses for the configured text-search backend (same per-backend
         # dispatch the memory-recall BM25 arm uses — see knowledge_bm25_arm).
         cfg = get_config()
@@ -16760,12 +16764,18 @@ class MemoryEngine(MemoryEngineInterface):
         # so the search has no answer to give rather than a degraded one.
         bank_config = await self._config_resolver.get_bank_config(bank_id, request_context)
         enable_text_search = bool(bank_config.get("enable_text_search", True))
-        if not enable_text_search and emb_str is None:
+
+        # Native tsvector requires non-empty tokens to construct a valid to_tsquery expression.
+        include_bm25 = enable_text_search and (bool(tokens) or text_search_extension != "native")
+        if not include_bm25 and emb_str is None:
             return []
+
+        assert self._dialect is not None
+        max_query_terms = cfg.bm25_max_query_terms
 
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
-            if emb_str is not None and not enable_text_search:
+            if emb_str is not None and not include_bm25:
                 # Vector-only: no BM25 arm to fuse with, so rank straight off the ANN scan.
                 sql = f"""
                     SELECT kp.id, kp.name, kp.mental_model_id,
@@ -16777,66 +16787,99 @@ class MemoryEngine(MemoryEngineInterface):
                     LIMIT {limit}
                 """
                 rows = await conn.fetch(sql, emb_str, bank_id)
-            elif emb_str is not None:
-                bm25 = knowledge_bm25_arm(
-                    text_search_extension,
-                    table_alias="mm",
-                    text_param="$3",
-                    pg_search_function_schema=pg_search_function_schema,
+            else:
+                bm25_tokens = tokens
+                # Native tsvector has no IDF and ranks every `@@` match, so long OR
+                # queries scan and rank a large fraction of the bank (+60s prod timeout).
+                # Keep only the most selective terms via pg_stats (see bm25_term_selection).
+                if (
+                    text_search_extension == "native"
+                    and max_query_terms > 0
+                    and len(tokens) > max_query_terms
+                    and cfg.bm25_selective_terms
+                    and getattr(conn, "backend_type", "postgresql") == "postgresql"
+                ):
+                    from .search.bm25_term_selection import select_selective_bm25_tokens
+
+                    bm25_tokens = await select_selective_bm25_tokens(
+                        conn,
+                        tokens,
+                        schema=get_current_schema(),
+                        table="mental_models",
+                        language="english",
+                        max_terms=max_query_terms,
+                    )
+                bm25_text = (
+                    self._dialect.prepare_bm25_text(
+                        bm25_tokens,
+                        query,
+                        text_search_extension=text_search_extension,
+                        max_query_terms=max_query_terms,
+                    )
+                    if tokens
+                    else query
                 )
-                # Vector arm (ANN over mm.embedding) + BM25 arm, each ranked
-                # independently, then RRF-fused (k=60) in SQL.
-                sql = f"""
-                    WITH vec AS (
-                        SELECT kp.id AS page_id,
-                               ROW_NUMBER() OVER (ORDER BY mm.embedding <=> $1::vector) AS rnk
+
+                if emb_str is not None:
+                    bm25 = knowledge_bm25_arm(
+                        text_search_extension,
+                        table_alias="mm",
+                        text_param="$3",
+                        pg_search_function_schema=pg_search_function_schema,
+                    )
+                    # Vector arm (ANN over mm.embedding) + BM25 arm, each ranked
+                    # independently, then RRF-fused (k=60) in SQL.
+                    sql = f"""
+                        WITH vec AS (
+                            SELECT kp.id AS page_id,
+                                   ROW_NUMBER() OVER (ORDER BY mm.embedding <=> $1::vector) AS rnk
+                            FROM {join}
+                            WHERE kp.bank_id = $2 AND kp.kind = 'page' AND mm.embedding IS NOT NULL
+                            ORDER BY mm.embedding <=> $1::vector
+                            LIMIT {fetch}
+                        ),
+                        bm AS (
+                            SELECT kp.id AS page_id,
+                                   ROW_NUMBER() OVER (ORDER BY {bm25.order_by}) AS rnk
+                            FROM {join}
+                            WHERE kp.bank_id = $2 AND kp.kind = 'page'
+                                  {bm25.match_filter}
+                            ORDER BY {bm25.order_by}
+                            LIMIT {fetch}
+                        ),
+                        fused AS (
+                            SELECT COALESCE(vec.page_id, bm.page_id) AS page_id,
+                                   COALESCE(1.0 / (60 + vec.rnk), 0) + COALESCE(1.0 / (60 + bm.rnk), 0) AS score
+                            FROM vec FULL OUTER JOIN bm ON vec.page_id = bm.page_id
+                        )
+                        SELECT kp.id, kp.name, kp.mental_model_id,
+                               LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at, f.score
+                        FROM fused f
+                        JOIN {kp} kp ON kp.id = f.page_id AND kp.bank_id = $2
+                        LEFT JOIN {mm} mm ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id
+                        ORDER BY f.score DESC
+                        LIMIT {limit}
+                    """
+                    rows = await conn.fetch(sql, emb_str, bank_id, bm25_text)
+                else:
+                    # Embedding unavailable → BM25-only fallback (still useful).
+                    bm25 = knowledge_bm25_arm(
+                        text_search_extension,
+                        table_alias="mm",
+                        text_param="$2",
+                        pg_search_function_schema=pg_search_function_schema,
+                    )
+                    sql = f"""
+                        SELECT kp.id, kp.name, kp.mental_model_id,
+                               LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at,
+                               {bm25.score_expr} AS score
                         FROM {join}
-                        WHERE kp.bank_id = $2 AND kp.kind = 'page' AND mm.embedding IS NOT NULL
-                        ORDER BY mm.embedding <=> $1::vector
-                        LIMIT {fetch}
-                    ),
-                    bm AS (
-                        SELECT kp.id AS page_id,
-                               ROW_NUMBER() OVER (ORDER BY {bm25.order_by}) AS rnk
-                        FROM {join}
-                        WHERE kp.bank_id = $2 AND kp.kind = 'page'
+                        WHERE kp.bank_id = $1 AND kp.kind = 'page'
                               {bm25.match_filter}
                         ORDER BY {bm25.order_by}
-                        LIMIT {fetch}
-                    ),
-                    fused AS (
-                        SELECT COALESCE(vec.page_id, bm.page_id) AS page_id,
-                               COALESCE(1.0 / (60 + vec.rnk), 0) + COALESCE(1.0 / (60 + bm.rnk), 0) AS score
-                        FROM vec FULL OUTER JOIN bm ON vec.page_id = bm.page_id
-                    )
-                    SELECT kp.id, kp.name, kp.mental_model_id,
-                           LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at, f.score
-                    FROM fused f
-                    JOIN {kp} kp ON kp.id = f.page_id AND kp.bank_id = $2
-                    LEFT JOIN {mm} mm ON mm.id = kp.mental_model_id AND mm.bank_id = kp.bank_id
-                    ORDER BY f.score DESC
-                    LIMIT {limit}
-                """
-                rows = await conn.fetch(sql, emb_str, bank_id, query)
-            else:
-                # Embedding unavailable → BM25-only fallback (still useful).
-                bm25 = knowledge_bm25_arm(
-                    text_search_extension,
-                    table_alias="mm",
-                    text_param="$2",
-                    pg_search_function_schema=pg_search_function_schema,
-                )
-                sql = f"""
-                    SELECT kp.id, kp.name, kp.mental_model_id,
-                           LEFT(mm.content, 280) AS snippet, mm.last_refreshed_at AS updated_at,
-                           {bm25.score_expr} AS score
-                    FROM {join}
-                    WHERE kp.bank_id = $1 AND kp.kind = 'page'
-                          {bm25.match_filter}
-                    ORDER BY {bm25.order_by}
-                    LIMIT {limit}
-                """
-                rows = await conn.fetch(sql, bank_id, query)
+                        LIMIT {limit}
+                    """
+                    rows = await conn.fetch(sql, bank_id, bm25_text)
 
         return [
             {

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -16673,6 +16673,13 @@ class MemoryEngine(MemoryEngineInterface):
         is unpopulated (``vchord``) degrade to a vector-only search rather than
         erroring. ``enable_text_search=false`` drops that arm outright, leaving a
         vector-only ranking.
+
+        Like recall's, the BM25 arm generates candidates disjunctively (``tok | tok``
+        on the native backend) rather than requiring every term. Precision comes back
+        from the fusion with the vector arm — so when no embedding is available the
+        ranking is ``ts_rank_cd`` alone, which weighs term density and proximity but
+        not term rarity. That fallback is broad by design: an exhaustive AND returned
+        nothing at all for ordinary multi-word questions.
         """
         await self._authenticate_tenant(request_context)
         if self._operation_validator and not _nested_operation_authorized.get():
@@ -16748,10 +16755,6 @@ class MemoryEngine(MemoryEngineInterface):
             out.sort(key=lambda d: order[d["mental_model_id"]])
             return out[:limit]
 
-        from .search.retrieval import tokenize_query
-
-        tokens = tokenize_query(query)
-
         # BM25 clauses for the configured text-search backend (same per-backend
         # dispatch the memory-recall BM25 arm uses — see knowledge_bm25_arm).
         cfg = get_config()
@@ -16765,13 +16768,16 @@ class MemoryEngine(MemoryEngineInterface):
         bank_config = await self._config_resolver.get_bank_config(bank_id, request_context)
         enable_text_search = bool(bank_config.get("enable_text_search", True))
 
-        # Native tsvector requires non-empty tokens to construct a valid to_tsquery expression.
-        include_bm25 = enable_text_search and (bool(tokens) or text_search_extension != "native")
+        from .search.retrieval import tokenize_query
+
+        # No tokens means no BM25 arm — the same gate recall applies (see
+        # retrieve_semantic_bm25_combined_sql): there is nothing to match on, and on the
+        # native backend an empty token list cannot even build a valid to_tsquery.
+        # Tokenizing feeds nothing else, so a bank with text search off skips it.
+        tokens = tokenize_query(query) if enable_text_search else []
+        include_bm25 = bool(tokens)
         if not include_bm25 and emb_str is None:
             return []
-
-        assert self._dialect is not None
-        max_query_terms = cfg.bm25_max_query_terms
 
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
@@ -16788,36 +16794,23 @@ class MemoryEngine(MemoryEngineInterface):
                 """
                 rows = await conn.fetch(sql, emb_str, bank_id)
             else:
-                bm25_tokens = tokens
-                # Native tsvector has no IDF and ranks every `@@` match, so long OR
-                # queries scan and rank a large fraction of the bank (+60s prod timeout).
-                # Keep only the most selective terms via pg_stats (see bm25_term_selection).
-                if (
-                    text_search_extension == "native"
-                    and max_query_terms > 0
-                    and len(tokens) > max_query_terms
-                    and cfg.bm25_selective_terms
-                    and getattr(conn, "backend_type", "postgresql") == "postgresql"
-                ):
-                    from .search.bm25_term_selection import select_selective_bm25_tokens
+                # Same builder the memory-recall BM25 arm uses, so the two paths cannot
+                # drift apart on query shape again — knowledge search used to bind the
+                # raw query to a conjunctive websearch_to_tsquery here, which returned
+                # no candidates at all for ordinary multi-word questions.
+                # The dialect is built from the connection, as recall builds its own.
+                # `mental_models.search_vector` is generated with a hard-coded 'english'
+                # config (see migrations), so its stats are read with 'english' too.
+                from .search.bm25_term_selection import build_bm25_query_text
 
-                    bm25_tokens = await select_selective_bm25_tokens(
-                        conn,
-                        tokens,
-                        schema=get_current_schema(),
-                        table="mental_models",
-                        language="english",
-                        max_terms=max_query_terms,
-                    )
-                bm25_text = (
-                    self._dialect.prepare_bm25_text(
-                        bm25_tokens,
-                        query,
-                        text_search_extension=text_search_extension,
-                        max_query_terms=max_query_terms,
-                    )
-                    if tokens
-                    else query
+                bm25_text = await build_bm25_query_text(
+                    conn,
+                    create_sql_dialect(getattr(conn, "backend_type", "postgresql")),
+                    tokens=tokens,
+                    query_text=query,
+                    table="mental_models",
+                    language="english",
+                    config=cfg,
                 )
 
                 if emb_str is not None:

--- a/hindsight-api-slim/hindsight_api/engine/search/bm25_term_selection.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/bm25_term_selection.py
@@ -31,6 +31,13 @@ Caveats, by design:
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
+
+from ..memory_engine import get_current_schema
+
+if TYPE_CHECKING:
+    from ...config import HindsightConfig
+    from ..sql import SQLDialect
 
 logger = logging.getLogger(__name__)
 
@@ -109,3 +116,58 @@ async def select_selective_bm25_tokens(
     scored.sort(key=lambda df_ord: df_ord)
     kept_ords = sorted(ord_ for _, ord_ in scored[:max_terms])
     return [tokens[ord_ - 1] for ord_ in kept_ords]
+
+
+async def build_bm25_query_text(
+    conn,
+    dialect: SQLDialect,
+    *,
+    tokens: list[str],
+    query_text: str,
+    table: str,
+    language: str,
+    config: HindsightConfig,
+) -> str:
+    """Turn query tokens into the text parameter a BM25 arm binds.
+
+    Every BM25 arm — memory recall over ``memory_units`` and knowledge search over
+    ``mental_models`` — goes through here, so the two cannot drift apart again: the
+    native backend gets one disjunctive ``tok | tok`` tsquery on both paths, and the
+    other backends get the raw query text their own parsers expect.
+
+    ``table`` and ``language`` name the corpus the selectivity stats are read from;
+    they differ per call site because ``mental_models.search_vector`` is generated
+    with a hard-coded ``'english'`` config while ``memory_units`` follows the
+    configured native language.
+    """
+    text_search_extension = config.text_search_extension
+    max_query_terms = config.bm25_max_query_terms
+    bm25_tokens = tokens
+    # Native tsvector has no IDF and ranks every `@@` match, so a long OR query over
+    # common terms scans and ranks a large fraction of the corpus (the +60s prod
+    # timeout). Keep only the most selective terms — lowest document frequency, read
+    # for free from pg_stats — which bounds both the match set and the per-row rank
+    # cost while preserving the high-signal terms a blunt first-N cap would discard.
+    # PG-native only; best-effort (falls back to first-N when stats are unavailable).
+    # Opt out via bm25_selective_terms to cap by position instead.
+    if (
+        text_search_extension == "native"
+        and max_query_terms > 0
+        and len(tokens) > max_query_terms
+        and config.bm25_selective_terms
+        and getattr(conn, "backend_type", "postgresql") == "postgresql"
+    ):
+        bm25_tokens = await select_selective_bm25_tokens(
+            conn,
+            tokens,
+            schema=get_current_schema(),
+            table=table,
+            language=language,
+            max_terms=max_query_terms,
+        )
+    return dialect.prepare_bm25_text(
+        bm25_tokens,
+        query_text,
+        text_search_extension=text_search_extension,
+        max_query_terms=max_query_terms,
+    )

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -16,9 +16,9 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from ...config import get_config
 from ..db.ops import UpdatedWindow
-from ..memory_engine import fq_table, get_current_schema
+from ..memory_engine import fq_table
 from ..sql import create_sql_dialect
-from .bm25_term_selection import select_selective_bm25_tokens
+from .bm25_term_selection import build_bm25_query_text
 from .graph_retrieval import GraphRetriever
 from .link_expansion_retrieval import GRAPH_SEED_LIMIT, LinkExpansionRetriever
 from .tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags_where_clause_simple
@@ -278,36 +278,16 @@ async def retrieve_semantic_bm25_combined_sql(
     # --- BM25 UNION ALL arms (one per fact_type, only when tokens present) ---
     if _include_bm25:
         text_ext = config.text_search_extension
-        max_query_terms = config.bm25_max_query_terms
-        bm25_tokens = tokens
-        # Native tsvector has no IDF and ranks every `@@` match, so a long OR
-        # query over common terms scans and ranks a large fraction of the bank
-        # (the +60s prod timeout). Keep only the most selective terms — lowest
-        # tenant-wide document frequency, read for free from pg_stats — which
-        # bounds both the match set and the per-row rank cost while preserving
-        # the high-signal terms a blunt first-N cap would discard. PG-native
-        # only; best-effort (falls back to first-N when stats are unavailable).
-        # Opt out via bm25_selective_terms to cap by position instead.
-        if (
-            text_ext == "native"
-            and max_query_terms > 0
-            and len(tokens) > max_query_terms
-            and config.bm25_selective_terms
-            and getattr(conn, "backend_type", "postgresql") == "postgresql"
-        ):
-            bm25_tokens = await select_selective_bm25_tokens(
-                conn,
-                tokens,
-                schema=get_current_schema(),
-                table="memory_units",
-                language=config.text_search_extension_native_language,
-                max_terms=max_query_terms,
-            )
-        bm25_text_param: str = dialect.prepare_bm25_text(
-            bm25_tokens,
-            query_text,
-            text_search_extension=text_ext,
-            max_query_terms=max_query_terms,
+        # Shared with knowledge search (search_knowledge_pages) so the two BM25
+        # paths cannot drift apart on query shape again — see build_bm25_query_text.
+        bm25_text_param: str = await build_bm25_query_text(
+            conn,
+            dialect,
+            tokens=tokens,
+            query_text=query_text,
+            table="memory_units",
+            language=config.text_search_extension_native_language,
+            config=config,
         )
         for i, ft in enumerate(fact_types):
             arms.append(

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -47,6 +47,12 @@ def knowledge_bm25_arm(
     ``table_alias`` is the alias the ``mental_models`` row carries in the query
     (``mm``); ``text_param`` is the bind placeholder holding the query text.
 
+    For the ``native`` backend, ``text_param`` must be bound to the output of
+    :meth:`prepare_bm25_text` (disjunctive ``" | "`` tokens). ``websearch_to_tsquery``
+    was originally used here as an error-free parser for raw strings (#2455), but
+    its default conjunctive AND (``&``) across space-separated words caused
+    multi-word natural-language queries to return 0 BM25 candidates.
+
     ``pgroonga`` queries the multilingual expression index over ``name +
     content``; ``ensure_text_search_extension`` reconciles ``mental_models`` to
     that shape (dummy TEXT ``search_vector``) like every other pgroonga table.
@@ -121,11 +127,18 @@ def knowledge_bm25_arm(
     # The generating expression hard-codes the 'english' config (see the
     # learnings/pinned_reflections migration), so query with 'english' regardless
     # of the configured native language.
-    score = f"ts_rank_cd({a}.search_vector, websearch_to_tsquery('english', {p}))"
+    #
+    # to_tsquery over disjunctive OR tokens prepared via prepare_bm25_text.
+    # websearch_to_tsquery was originally used here as an error-free parser for
+    # raw strings (#2455), but its default conjunctive AND (&) across words caused
+    # multi-word queries to return 0 hits. Joining tokens with OR aligns candidate
+    # recall with memory recall (build_bm25_arm); precision is restored downstream
+    # via ts_rank_cd ranking and RRF fusion.
+    score = f"ts_rank_cd({a}.search_vector, to_tsquery('english', {p}))"
     return KnowledgeBm25Arm(
         score_expr=score,
         order_by=f"{score} DESC",
-        match_filter=f"AND {a}.search_vector @@ websearch_to_tsquery('english', {p})",
+        match_filter=f"AND {a}.search_vector @@ to_tsquery('english', {p})",
     )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/sql/postgresql.py
@@ -132,8 +132,9 @@ def knowledge_bm25_arm(
     # websearch_to_tsquery was originally used here as an error-free parser for
     # raw strings (#2455), but its default conjunctive AND (&) across words caused
     # multi-word queries to return 0 hits. Joining tokens with OR aligns candidate
-    # recall with memory recall (build_bm25_arm); precision is restored downstream
-    # via ts_rank_cd ranking and RRF fusion.
+    # generation with memory recall (build_bm25_arm); ranking is then ts_rank_cd,
+    # fused with the vector arm when the search has an embedding to fuse with
+    # (search_knowledge_pages runs no reranker either way).
     score = f"ts_rank_cd({a}.search_vector, to_tsquery('english', {p}))"
     return KnowledgeBm25Arm(
         score_expr=score,

--- a/hindsight-api-slim/tests/test_ann_iterative_scan.py
+++ b/hindsight-api-slim/tests/test_ann_iterative_scan.py
@@ -30,6 +30,7 @@ import pytest
 
 from hindsight_api._vector_index import ann_max_scan_tuples, ann_search_tuning_settings
 from hindsight_api.engine.memories.postgres import PostgresMemories
+from hindsight_api.engine.search import bm25_term_selection as bm25_mod
 from hindsight_api.engine.search import retrieval as retrieval_mod
 from hindsight_api.engine.search.link_expansion_retrieval import GRAPH_SEED_LIMIT
 
@@ -120,7 +121,7 @@ def search_path(monkeypatch):
     monkeypatch.setattr(retrieval_mod, "create_sql_dialect", lambda backend: dialect)
     monkeypatch.setattr(retrieval_mod, "get_config", lambda: config)
     monkeypatch.setattr(retrieval_mod, "fq_table", lambda name: name)
-    monkeypatch.setattr(retrieval_mod, "get_current_schema", lambda: None)
+    monkeypatch.setattr(bm25_mod, "get_current_schema", lambda: None)
     return dialect
 
 

--- a/hindsight-api-slim/tests/test_enable_text_search_flag.py
+++ b/hindsight-api-slim/tests/test_enable_text_search_flag.py
@@ -20,6 +20,7 @@ import pytest
 
 from hindsight_api.config import ENV_ENABLE_TEXT_SEARCH, HindsightConfig, _get_raw_config
 from hindsight_api.engine.retain import orchestrator as retain_orchestrator
+from hindsight_api.engine.search import bm25_term_selection as bm25_mod
 from hindsight_api.engine.search import retrieval as retrieval_mod
 
 
@@ -89,8 +90,8 @@ def harness(monkeypatch):
 
     monkeypatch.setattr(retrieval_mod, "create_sql_dialect", lambda backend: dialect)
     monkeypatch.setattr(retrieval_mod, "tokenize_query", counting_tokenize)
-    monkeypatch.setattr(retrieval_mod, "select_selective_bm25_tokens", fake_select_selective)
-    monkeypatch.setattr(retrieval_mod, "get_current_schema", lambda: "public")
+    monkeypatch.setattr(bm25_mod, "select_selective_bm25_tokens", fake_select_selective)
+    monkeypatch.setattr(bm25_mod, "get_current_schema", lambda: "public")
     monkeypatch.setattr(retrieval_mod, "fq_table", lambda name: name)
 
     return SimpleNamespace(

--- a/hindsight-api-slim/tests/test_knowledge_base.py
+++ b/hindsight-api-slim/tests/test_knowledge_base.py
@@ -503,6 +503,48 @@ class TestSearch:
         )
         assert len(capped.json()["results"]) <= 1
 
+    @pytest.mark.memory_backend_incompatible
+    async def test_natural_language_question_still_matches_bm25(
+        self, memory: MemoryEngine, kb_bank, request_context, monkeypatch
+    ):
+        """A multi-word question must not have to appear in a page word for word.
+
+        The BM25 arm ORs its tokens, so "billing" alone carries the match; the
+        conjunctive ``websearch_to_tsquery`` this replaced required *every* term and
+        returned nothing for ordinary questions. The embedding is suppressed so the
+        BM25 arm answers alone — otherwise the vector arm would hide the defect.
+        """
+        bank_id, ids = kb_bank
+
+        async def no_embedding(embeddings, texts, *, input_type=None):
+            return [None]
+
+        monkeypatch.setattr(embedding_utils, "generate_embeddings_batch", no_embedding)
+
+        results = await memory.search_knowledge_pages(
+            bank_id,
+            "what are the billing terms for late payments?",
+            request_context=request_context,
+        )
+
+        assert results, "the BM25 arm must still generate candidates for a question"
+        assert results[0]["id"] == ids.billing
+
+    @pytest.mark.memory_backend_incompatible
+    async def test_query_without_word_characters_returns_nothing(
+        self, memory: MemoryEngine, kb_bank, request_context, monkeypatch
+    ):
+        """No tokens means no BM25 arm; with no embedding either there is nothing to
+        rank on, and the empty token list must not reach ``to_tsquery``."""
+        bank_id, _ = kb_bank
+
+        async def no_embedding(embeddings, texts, *, input_type=None):
+            return [None]
+
+        monkeypatch.setattr(embedding_utils, "generate_embeddings_batch", no_embedding)
+
+        assert await memory.search_knowledge_pages(bank_id, "???", request_context=request_context) == []
+
     async def test_query_is_required(self, api_client, kb_bank):
         bank_id, _ = kb_bank
         resp = await api_client.get(f"/v1/default/banks/{_enc(bank_id)}/knowledge-base/search")

--- a/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
+++ b/hindsight-api-slim/tests/test_knowledge_bm25_dispatch.py
@@ -36,8 +36,10 @@ def test_native_uses_tsvector_operators():
     arm = _arm("native")
     # The mental_models tsvector is generated with the 'english' config, so the
     # query must use 'english' regardless of the configured native language.
-    assert "ts_rank_cd(mm.search_vector, websearch_to_tsquery('english', $3))" in arm.score_expr
-    assert arm.match_filter == "AND mm.search_vector @@ websearch_to_tsquery('english', $3)"
+    # Joining tokens with OR aligns candidate recall with memory-recall BM25;
+    # precision is restored downstream via ts_rank_cd ranking and RRF fusion.
+    assert "ts_rank_cd(mm.search_vector, to_tsquery('english', $3))" in arm.score_expr
+    assert arm.match_filter == "AND mm.search_vector @@ to_tsquery('english', $3)"
 
 
 def test_pgroonga_uses_multilingual_expression_index():

--- a/hindsight-api-slim/tests/test_knowledge_search_text_search_disabled.py
+++ b/hindsight-api-slim/tests/test_knowledge_search_text_search_disabled.py
@@ -18,6 +18,7 @@ import pytest
 from hindsight_api.engine import memory_engine as engine_mod
 from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.engine.retain import embedding_utils
+from hindsight_api.engine.sql import create_sql_dialect
 
 # Every assertion here reads the SQL this search emitted (`search.conn.queries`). A store that owns
 # the knowledge index answers the search itself and emits none, so these assert a Postgres-internal
@@ -48,6 +49,8 @@ def search(monkeypatch):
     engine = MemoryEngine.__new__(MemoryEngine)
     engine._operation_validator = None
     engine.embeddings = object()
+    engine._dialect = create_sql_dialect("postgresql")
+    engine._database_backend_type = "postgresql"
     resolved: dict[str, object] = {}
 
     async def fake_authenticate(request_context):
@@ -70,7 +73,14 @@ def search(monkeypatch):
     monkeypatch.setattr(engine_mod, "acquire_with_retry", fake_acquire)
     monkeypatch.setattr(engine_mod, "fq_table", lambda name: name)
 
-    async def run(*, enable_text_search: bool, embedding: list[float] | None):
+    async def run(
+        *,
+        enable_text_search: bool,
+        embedding: list[float] | None,
+        query: str = "some query",
+        ext: str = "native",
+        bm25_selective_terms: bool = False,
+    ):
         async def fake_embed(embeddings, texts, *, input_type=None):
             return [embedding]
 
@@ -79,18 +89,20 @@ def search(monkeypatch):
             engine_mod,
             "get_config",
             lambda: SimpleNamespace(
-                text_search_extension="native",
-                text_search_extension_pg_search_function_schema="paradedb",
                 # A store that namespaces by schema reads this on the way to its namespace, so the
                 # stub has to carry it or the call fails before reaching what is under test.
                 database_schema="public",
+                text_search_extension=ext,
+                text_search_extension_pg_search_function_schema="paradedb",
+                bm25_max_query_terms=20,
+                bm25_selective_terms=bm25_selective_terms,
             ),
         )
         resolved.clear()
         resolved["enable_text_search"] = enable_text_search
-        return await engine.search_knowledge_pages("bank-1", "some query", request_context=object())
+        return await engine.search_knowledge_pages("bank-1", query, request_context=object())
 
-    return SimpleNamespace(run=run, conn=conn)
+    return SimpleNamespace(run=run, conn=conn, engine=engine)
 
 
 @pytest.mark.asyncio
@@ -100,8 +112,9 @@ async def test_enabled_fuses_both_arms(search):
 
     sql = search.conn.queries[0]
     assert "ts_rank_cd" in sql  # the native BM25 arm
+    assert "to_tsquery('english', $3)" in sql
     assert "FULL OUTER JOIN" in sql  # fused with the vector arm
-    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1", "some query")
+    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1", "some | query")
 
 
 @pytest.mark.asyncio
@@ -137,4 +150,51 @@ async def test_enabled_without_embedding_still_falls_back_to_bm25(search):
     await search.run(enable_text_search=True, embedding=None)
 
     assert "ts_rank_cd" in search.conn.queries[0]
-    assert search.conn.params[0] == ("bank-1", "some query")
+    assert "to_tsquery('english', $2)" in search.conn.queries[0]
+    assert search.conn.params[0] == ("bank-1", "some | query")
+
+
+@pytest.mark.asyncio
+async def test_non_native_extension_passes_raw_query(search):
+    await search.run(enable_text_search=True, embedding=[0.1, 0.2], ext="pgroonga")
+    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1", "some query")
+
+
+@pytest.mark.asyncio
+async def test_native_empty_tokens_falls_back_to_vector_only(search):
+    await search.run(enable_text_search=True, embedding=[0.1, 0.2], query="???")
+    sql = search.conn.queries[0]
+    assert "mm.embedding <=> $1::vector" in sql
+    assert "ts_rank_cd" not in sql
+    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1")
+
+
+@pytest.mark.asyncio
+async def test_native_empty_tokens_without_embedding_returns_empty(search):
+    result = await search.run(enable_text_search=True, embedding=None, query="???")
+    assert result == []
+    assert search.conn.queries == []
+
+
+@pytest.mark.asyncio
+async def test_native_selective_terms_pruning(search, monkeypatch):
+    from hindsight_api.engine.search import bm25_term_selection
+
+    received_args = {}
+
+    async def fake_select(conn, tokens, *, schema, table, language, max_terms):
+        received_args.update(
+            {"tokens": tokens, "schema": schema, "table": table, "language": language, "max_terms": max_terms}
+        )
+        return ["selected", "tokens"]
+
+    monkeypatch.setattr(bm25_term_selection, "select_selective_bm25_tokens", fake_select)
+
+    long_query = " ".join([f"term{i}" for i in range(25)])
+    await search.run(enable_text_search=True, embedding=[0.1, 0.2], query=long_query, bm25_selective_terms=True)
+
+    assert received_args["table"] == "mental_models"
+    assert received_args["language"] == "english"
+    assert received_args["max_terms"] == 20
+    assert len(received_args["tokens"]) == 25
+    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1", "selected | tokens")

--- a/hindsight-api-slim/tests/test_knowledge_search_text_search_disabled.py
+++ b/hindsight-api-slim/tests/test_knowledge_search_text_search_disabled.py
@@ -18,7 +18,6 @@ import pytest
 from hindsight_api.engine import memory_engine as engine_mod
 from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.engine.retain import embedding_utils
-from hindsight_api.engine.sql import create_sql_dialect
 
 # Every assertion here reads the SQL this search emitted (`search.conn.queries`). A store that owns
 # the knowledge index answers the search itself and emits none, so these assert a Postgres-internal
@@ -49,8 +48,6 @@ def search(monkeypatch):
     engine = MemoryEngine.__new__(MemoryEngine)
     engine._operation_validator = None
     engine.embeddings = object()
-    engine._dialect = create_sql_dialect("postgresql")
-    engine._database_backend_type = "postgresql"
     resolved: dict[str, object] = {}
 
     async def fake_authenticate(request_context):
@@ -177,6 +174,16 @@ async def test_native_empty_tokens_without_embedding_returns_empty(search):
 
 
 @pytest.mark.asyncio
+async def test_empty_tokens_drops_the_arm_on_every_backend(search):
+    """Recall drops BM25 whenever the query has no word characters, whatever the
+    backend; knowledge search must not keep feeding a punctuation-only string to a
+    non-native parser."""
+    await search.run(enable_text_search=True, embedding=[0.1, 0.2], query="???", ext="pgroonga")
+    assert "ts_rank_cd" not in search.conn.queries[0]
+    assert search.conn.params[0] == ("[0.1, 0.2]", "bank-1")
+
+
+@pytest.mark.asyncio
 async def test_native_selective_terms_pruning(search, monkeypatch):
     from hindsight_api.engine.search import bm25_term_selection
 
@@ -189,10 +196,12 @@ async def test_native_selective_terms_pruning(search, monkeypatch):
         return ["selected", "tokens"]
 
     monkeypatch.setattr(bm25_term_selection, "select_selective_bm25_tokens", fake_select)
+    monkeypatch.setattr(bm25_term_selection, "get_current_schema", lambda: "public")
 
     long_query = " ".join([f"term{i}" for i in range(25)])
     await search.run(enable_text_search=True, embedding=[0.1, 0.2], query=long_query, bm25_selective_terms=True)
 
+    assert received_args["schema"] == "public"
     assert received_args["table"] == "mental_models"
     assert received_args["language"] == "english"
     assert received_args["max_terms"] == 20

--- a/hindsight-api-slim/tests/test_multilingual_bm25.py
+++ b/hindsight-api-slim/tests/test_multilingual_bm25.py
@@ -25,6 +25,7 @@ from hindsight_api.engine.retain.fact_extraction import (
     _DEFAULT_LANGUAGE_RULE as _RETAIN_DEFAULT_LANGUAGE_RULE,
 )
 from hindsight_api.engine.retain.fact_extraction import _build_extraction_prompt_and_schema
+from hindsight_api.engine.search import bm25_term_selection as bm25_mod
 from hindsight_api.engine.search import retrieval as retrieval_mod
 from hindsight_api.engine.search.retrieval import tokenize_query
 from hindsight_api.engine.sql.postgresql import PostgreSQLDialect
@@ -490,8 +491,8 @@ async def test_selective_terms_flag_gates_the_pg_stats_lookup(monkeypatch, selec
     )
     monkeypatch.setattr(retrieval_mod, "get_config", lambda: config)
     monkeypatch.setattr(retrieval_mod, "create_sql_dialect", lambda backend: fake_dialect)
-    monkeypatch.setattr(retrieval_mod, "get_current_schema", lambda: "public")
-    monkeypatch.setattr(retrieval_mod, "select_selective_bm25_tokens", fake_select)
+    monkeypatch.setattr(bm25_mod, "get_current_schema", lambda: "public")
+    monkeypatch.setattr(bm25_mod, "select_selective_bm25_tokens", fake_select)
 
     long_query = " ".join(f"term{i}" for i in range(20))  # 20 tokens, over the cap
     await retrieval_mod.retrieve_semantic_bm25_combined_sql(


### PR DESCRIPTION
## Summary

When `HINDSIGHT_API_TEXT_SEARCH_EXTENSION=native`, the BM25 retrieval arm in `search_knowledge_pages` diverged from memory recall (`build_bm25_arm`):
- **Memory Recall (`recall`)**: `tokenize_query` + `to_tsquery('english', 't1 | t2')` $\to$ **Disjunctive OR (High recall)** ✅
- **Knowledge Search (`search_knowledge_pages`)**: `websearch_to_tsquery('english', $text)` $\to$ **Conjunctive AND (0-recall defect)** ❌

In multi-word or natural language queries, requiring every term to match caused the knowledge-page BM25 arm to frequently return 0 hits:
- In hybrid search (vector + BM25 with RRF), the BM25 arm dropped out, silently degrading search to vector-only.
- In BM25-only fallback (no embedding available), 0 results were returned even when relevant knowledge pages existed.

This PR aligns `native` knowledge-page BM25 retrieval with memory recall to use disjunctive `OR` via `to_tsquery` and `prepare_bm25_text`.

---

## Retrieval Architecture & Data Flow

```mermaid
flowchart TB
    subgraph BEFORE["❌ BEFORE (Semantics Inconsistency & 0-Recall Outlier)"]
        direction TB
        Q1["User Query: 'what are the gateway scheduled tasks'"]
        
        Q1 --> R_MEM1["Memory Recall Arm (recall)"]
        R_MEM1 -->|"tokenize + prepare_bm25_text (' | ')"| T1["to_tsquery('english', 'what | gateway | schedul | task')"]
        T1 -->|"OR Semantics"| M_OK1["✅ Broad Candidate Recall (High Hit Rate)"]
        
        Q1 --> R_KB1["Knowledge Search Arm (search_knowledge_pages)"]
        R_KB1 -->|"Raw Query Passthrough"| W1["websearch_to_tsquery('english', 'what are the gateway scheduled tasks')"]
        W1 -->|"Parsed as: 'what' & 'gateway' & 'schedul' & 'task' (AND Semantics)"| M_FAIL1["❌ 0 BM25 Hits<br/>(Lost arm in RRF; 0 results in BM25-only)"]
    end

    subgraph AFTER["✅ AFTER (100% Unified Disjunctive Candidate Generation)"]
        direction TB
        Q2["User Query: 'what are the gateway scheduled tasks'"]
        
        Q2 --> R_MEM2["Memory Recall Arm (recall)"]
        R_MEM2 -->|"tokenize + prepare_bm25_text (' | ')"| T2["to_tsquery('english', 'what | gateway | schedul | task')"]
        T2 -->|"OR Semantics"| M_OK2["✅ Broad Candidate Recall (High Hit Rate)"]
        
        Q2 --> R_KB2["Knowledge Search Arm (search_knowledge_pages)"]
        R_KB2 -->|"tokenize + prepare_bm25_text (' | ') + selective pruning"| T3["to_tsquery('english', 'what | gateway | schedul | task')"]
        T3 -->|"OR Semantics"| M_OK3["✅ Broad Candidate Recall<br/>(Properly ranks & fuses via RRF)"]
    end
```

---

## Backend Comparison Across Retrieval Arms

In Hindsight's multi-strategy retrieval architecture, BM25 arms are designed for **broad candidate generation**, while precision is restored downstream through BM25 scoring, multi-arm RRF fusion, and Cross-Encoder reranking.

| Text Search Backend | Memory Recall Arm (`recall`) | Knowledge Search Arm (`search_knowledge_pages`) | Status |
|---|---|---|---|
| `vchord` | `-(search_vector <&> ...) > score_min` | `-(mm.search_vector <&> ...) > 0` | ✅ Aligned (OR / score > 0) |
| `pg_search` | `paradedb.boolean(should => ARRAY[...])` | `paradedb.boolean(should => ARRAY[...])` | ✅ Aligned (OR / Lucene `should`) |
| `pg_textsearch` | `-(text <@> to_bm25query(...))` (No match gate) | `-(mm.content <@> to_bm25query(...))` (No match gate) | ✅ Aligned (OR / Distance ranking) |
| `pgroonga` | `pgroonga_tokenize` + `string_agg(..., ' OR ')` | `pgroonga_tokenize` + `string_agg(..., ' OR ')` | ✅ Aligned (OR / TokenBigram) |
| `native` (Before) | `prepare_bm25_text` (`" \| "`) + `to_tsquery` **(OR)** | `websearch_to_tsquery` **(AND)** | ❌ **Inconsistent (Sole AND Outlier)** |
| `native` (After) | `prepare_bm25_text` (`" \| "`) + `to_tsquery` **(OR)** | `prepare_bm25_text` (`" \| "`) + `to_tsquery` **(OR)** | ✅ **Aligned (OR)** |

---

## Historical Context & Design Rationale on `websearch_to_tsquery`

An investigation into whether `websearch_to_tsquery` was intended as an operator contract (supporting `"quotes"`, `-negation`, `OR`) established that its operator parsing was an **accidental byproduct of error-safe string parsing**:

1. **Origin in Commit #2455**: `websearch_to_tsquery` was introduced merely as an implementation detail in a parenthetical note (`"BM25 arm ... via websearch_to_tsquery('english')"`), never as a user-facing search syntax feature.
2. **No Public API Contract**: The OpenAPI spec and HTTP endpoint document `q` simply as `"Search query"`. Neither `hindsight-docs` nor the test suite ever documented or asserted operator behavior.
3. **Selection Motivation**: Unlike `to_tsquery`, which errors on unescaped punctuation (e.g. `what's up?`), `websearch_to_tsquery` was chosen simply because it safely parses raw text into valid tsquery SQL. Its default `AND` conjunction was inadvertently bundled along with that convenience.
4. **Architectural Decision**: Rather than introducing heuristic regex bifurcation to maintain accidental operators, we cleanly unify `search_knowledge_pages` with `recall`. All 5 backends now operate with consistent disjunctive OR candidate recall across both paths.

---

## Key Technical Decisions & Edge Case Handling

1. **Dialect Reuse & Query Capping**: Extracts tokens with `tokenize_query(query)` and delegates to `self._dialect.prepare_bm25_text()`. Plain tokens are joined with `" | "`, and queries exceeding `bm25_max_query_terms` are capped to avoid stack depth limits (SQLSTATE 54001).
2. **Selective Term Pruning on `mental_models`**: When query terms exceed `bm25_max_query_terms` and `bm25_selective_terms` is enabled on PostgreSQL, `search_knowledge_pages` calls `select_selective_bm25_tokens` against `mental_models` in `pg_stats` to retain the highest-signal discriminative terms.
3. **Index Configuration Parity**: Targets `mental_models.search_vector` with the `'english'` tsquery config to ensure generated GIN index matching.
4. **Empty-Token Query Resilience**: Queries containing only punctuation/whitespace fall back smoothly to vector-only search (when embedding exists) or return `[]` cleanly without failing on `to_tsquery('')`.

---

## Changes by Component

- `hindsight_api/engine/sql/postgresql.py`:
  - `knowledge_bm25_arm`: Update `native` branch to generate `to_tsquery('english', $p)`. Document previous vs current behavior in docstrings.
- `hindsight_api/engine/memory_engine.py`:
  - `search_knowledge_pages`: Tokenize query, reuse `self._dialect.prepare_bm25_text`, apply selective terms pruning on `mental_models`, and handle empty-token fallback.
- `tests/test_knowledge_bm25_dispatch.py`:
  - Assert `to_tsquery('english', $3)` for native knowledge search.
- `tests/test_knowledge_search_text_search_disabled.py`:
  - Update expected parameter bindings to reflect `"some | query"`.
  - Add tests for `pgroonga` raw query passthrough, `pg_stats` selective terms pruning, and empty-token queries.

---

## Verification

Targeted pytest test suite passed:
```bash
uv run pytest tests/test_knowledge_bm25_dispatch.py \
              tests/test_knowledge_search_text_search_disabled.py \
              tests/test_db_abstraction.py \
              tests/test_multilingual_bm25.py \
              tests/test_recall_query_token_cap.py -v
```
Output: `186 passed, 18 warnings in 9.39s`
