### PR TITLE
fix(search): drop search-trace fields that are structurally always empty

### DIFF
--- a/hindsight-api-slim/hindsight_api/__init__.py
+++ b/hindsight-api-slim/hindsight_api/__init__.py
@@ -50,9 +50,7 @@ _LAZY_EXPORTS: "dict[str, tuple[str, str]]" = {
     "LLMConfig": (".engine.llm_wrapper", "LLMConfig"),
     "MemoryEngine": (".engine.memory_engine", "MemoryEngine"),
     "EntryPoint": (".engine.search.trace", "EntryPoint"),
-    "LinkInfo": (".engine.search.trace", "LinkInfo"),
     "NodeVisit": (".engine.search.trace", "NodeVisit"),
-    "PruningDecision": (".engine.search.trace", "PruningDecision"),
     "QueryInfo": (".engine.search.trace", "QueryInfo"),
     "SearchPhaseMetrics": (".engine.search.trace", "SearchPhaseMetrics"),
     "SearchSummary": (".engine.search.trace", "SearchSummary"),
@@ -95,9 +93,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type checkers and IDEs, never at run
     from .engine.memory_engine import MemoryEngine  # noqa: F401
     from .engine.search.trace import (  # noqa: F401
         EntryPoint,
-        LinkInfo,
         NodeVisit,
-        PruningDecision,
         QueryInfo,
         SearchPhaseMetrics,
         SearchSummary,

--- a/hindsight-api-slim/hindsight_api/engine/__init__.py
+++ b/hindsight-api-slim/hindsight_api/engine/__init__.py
@@ -21,9 +21,7 @@ from .memory_engine import (
 from .response_models import MemoryFact, RecallResult, ReflectResult
 from .search.trace import (
     EntryPoint,
-    LinkInfo,
     NodeVisit,
-    PruningDecision,
     QueryInfo,
     SearchPhaseMetrics,
     SearchSummary,
@@ -47,8 +45,6 @@ __all__ = [
     "EntryPoint",
     "NodeVisit",
     "WeightComponents",
-    "LinkInfo",
-    "PruningDecision",
     "SearchSummary",
     "SearchPhaseMetrics",
     "LLMConfig",

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7719,9 +7719,6 @@ class MemoryEngine(MemoryEngineInterface):
                         context=sr.retrieval.context or "",
                         event_date=sr.retrieval.occurred_start,
                         is_entry_point=(sr.id in [ep.node_id for ep in tracer.entry_points]),
-                        parent_node_id=None,  # In parallel retrieval, there's no clear parent
-                        link_type=None,
-                        link_weight=None,
                         activation=sr.candidate.rrf_score,  # Use RRF score as activation
                         semantic_similarity=sr.retrieval.similarity or 0.0,
                         recency=sr.recency,

--- a/hindsight-api-slim/hindsight_api/engine/search/trace.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/trace.py
@@ -58,25 +58,6 @@ class WeightComponents(BaseModel):
     frequency_contribution: float = Field(description="0.15 * frequency")
 
 
-class LinkInfo(BaseModel):
-    """Information about a link to a neighbor."""
-
-    to_node_id: str = Field(description="Target node ID")
-    link_type: Literal["temporal", "semantic", "entity"] = Field(description="Type of link")
-    link_weight: float = Field(
-        description="Weight of the link (can exceed 1.0 when aggregating multiple connections)", ge=0.0
-    )
-    entity_id: str | None = Field(default=None, description="Entity ID if link_type is 'entity'")
-    new_activation: float | None = Field(
-        default=None, description="Activation that would be passed to neighbor (None for supplementary links)"
-    )
-    followed: bool = Field(description="Whether this link was followed (or pruned)")
-    prune_reason: str | None = Field(default=None, description="Why link was not followed (if not followed)")
-    is_supplementary: bool = Field(
-        default=False, description="Whether this is a supplementary link (multiple connections to same node)"
-    )
-
-
 class NodeVisit(BaseModel):
     """Information about visiting a node during search."""
 
@@ -88,31 +69,12 @@ class NodeVisit(BaseModel):
 
     # How this node was reached
     is_entry_point: bool = Field(description="Whether this is an entry point")
-    parent_node_id: str | None = Field(default=None, description="Node that led to this one")
-    link_type: Literal["temporal", "semantic", "entity"] | None = Field(
-        default=None, description="Type of link from parent"
-    )
-    link_weight: float | None = Field(default=None, description="Weight of link from parent")
 
     # Weights
     weights: WeightComponents = Field(description="Weight calculation breakdown")
 
-    # Neighbors discovered from this node
-    neighbors_explored: list[LinkInfo] = Field(default_factory=list, description="Links explored from this node")
-
     # Ranking
     final_rank: int | None = Field(default=None, description="Final rank in results (1-based, None if not in top-k)")
-
-
-class PruningDecision(BaseModel):
-    """Records when a node was considered but not visited."""
-
-    node_id: str = Field(description="Node that was pruned")
-    reason: Literal["already_visited", "activation_too_low", "budget_exhausted"] = Field(
-        description="Why it was pruned"
-    )
-    activation: float = Field(description="Activation value when pruned")
-    would_have_been_step: int = Field(description="What step it would have been if visited")
 
 
 class SearchPhaseMetrics(BaseModel):
@@ -172,17 +134,11 @@ class SearchSummary(BaseModel):
     """Summary statistics about the search."""
 
     total_nodes_visited: int = Field(description="Total nodes visited")
-    total_nodes_pruned: int = Field(description="Total nodes pruned")
     entry_points_found: int = Field(description="Number of entry points")
-    budget_used: int = Field(description="How much budget was used")
-    budget_remaining: int = Field(description="How much budget remained")
+    budget_used: int = Field(description="Nodes scored against the budget")
+    budget_remaining: int = Field(description="Budget left after scoring")
     total_duration_seconds: float = Field(description="Total search duration")
     results_returned: int = Field(description="Number of results returned")
-
-    # Link statistics
-    temporal_links_followed: int = Field(default=0, description="Temporal links followed")
-    semantic_links_followed: int = Field(default=0, description="Semantic links followed")
-    entity_links_followed: int = Field(default=0, description="Entity links followed")
 
     # Phase timings
     phase_metrics: list[SearchPhaseMetrics] = Field(default_factory=list, description="Metrics for each phase")
@@ -207,7 +163,6 @@ class SearchTrace(BaseModel):
     visits: list[NodeVisit] = Field(
         default_factory=list, description="All nodes visited during search (legacy, for graph viz)"
     )
-    pruned: list[PruningDecision] = Field(default_factory=list, description="Nodes that were pruned (legacy)")
 
     summary: SearchSummary = Field(description="Summary statistics")
 

--- a/hindsight-api-slim/hindsight_api/engine/search/tracer.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/tracer.py
@@ -12,7 +12,6 @@ from typing import Any, Literal
 from .trace import (
     EntryPoint,
     NodeVisit,
-    PruningDecision,
     QueryInfo,
     RerankedResult,
     RetrievalMethodResults,
@@ -38,7 +37,6 @@ class SearchTracer:
         tracer.record_query_embedding(embedding)
         tracer.add_entry_point(node_id, text, similarity, rank)
         tracer.visit_node(...)
-        tracer.prune_node(...)
 
         # After search...
         trace = tracer.finalize(final_results)
@@ -80,7 +78,6 @@ class SearchTracer:
         self.start_time: float | None = None
         self.entry_points: list[EntryPoint] = []
         self.visits: list[NodeVisit] = []
-        self.pruned: list[PruningDecision] = []
         self.phase_metrics: list[SearchPhaseMetrics] = []
 
         # Temporal constraint detected from query
@@ -94,11 +91,6 @@ class SearchTracer:
         # Tracking state
         self.current_step = 0
         self.nodes_visited_set = set()  # For quick lookups
-
-        # Link statistics
-        self.temporal_links_followed = 0
-        self.semantic_links_followed = 0
-        self.entity_links_followed = 0
 
     def start(self):
         """Start timing the search."""
@@ -146,9 +138,6 @@ class SearchTracer:
         context: str,
         event_date: datetime | None,
         is_entry_point: bool,
-        parent_node_id: str | None,
-        link_type: Literal["temporal", "semantic", "entity"] | None,
-        link_weight: float | None,
         activation: float,
         semantic_similarity: float,
         recency: float,
@@ -164,9 +153,6 @@ class SearchTracer:
             context: Memory unit context
             event_date: When the memory occurred
             is_entry_point: Whether this is an entry point
-            parent_node_id: Node that led here (None for entry points)
-            link_type: Type of link from parent
-            link_weight: Weight of link from parent
             activation: Activation score
             semantic_similarity: Semantic similarity to query
             recency: Recency weight
@@ -208,46 +194,11 @@ class SearchTracer:
             context=context,
             event_date=event_date,
             is_entry_point=is_entry_point,
-            parent_node_id=parent_node_id,
-            link_type=link_type,
-            link_weight=link_weight,
             weights=weights,
-            neighbors_explored=[],
             final_rank=None,  # Will be set later
         )
 
         self.visits.append(visit)
-
-        # Track link statistics
-        if link_type == "temporal":
-            self.temporal_links_followed += 1
-        elif link_type == "semantic":
-            self.semantic_links_followed += 1
-        elif link_type == "entity":
-            self.entity_links_followed += 1
-
-    def prune_node(
-        self,
-        node_id: str,
-        reason: Literal["already_visited", "activation_too_low", "budget_exhausted"],
-        activation: float,
-    ):
-        """
-        Record a node being pruned (not visited).
-
-        Args:
-            node_id: Node that was pruned
-            reason: Why it was pruned
-            activation: Activation value when pruned
-        """
-        self.pruned.append(
-            PruningDecision(
-                node_id=node_id,
-                reason=reason,
-                activation=activation,
-                would_have_been_step=self.current_step + 1,
-            )
-        )
 
     def add_phase_metric(self, phase_name: str, duration_seconds: float, details: dict[str, Any] | None = None):
         """
@@ -434,15 +385,11 @@ class SearchTracer:
         # Create summary
         summary = SearchSummary(
             total_nodes_visited=len(self.visits),
-            total_nodes_pruned=len(self.pruned),
             entry_points_found=len(self.entry_points),
             budget_used=len(self.visits),
             budget_remaining=self.budget - len(self.visits),
             total_duration_seconds=total_duration,
             results_returned=len(final_results),
-            temporal_links_followed=self.temporal_links_followed,
-            semantic_links_followed=self.semantic_links_followed,
-            entity_links_followed=self.entity_links_followed,
             phase_metrics=self.phase_metrics,
         )
 
@@ -454,7 +401,6 @@ class SearchTracer:
             reranked=self.reranked,
             entry_points=self.entry_points,
             visits=self.visits,
-            pruned=self.pruned,
             summary=summary,
             final_results=final_results,
         )

--- a/hindsight-api-slim/tests/test_search_trace.py
+++ b/hindsight-api-slim/tests/test_search_trace.py
@@ -99,14 +99,20 @@ async def test_search_with_trace(memory, request_context):
             assert visit["node_id"], "Visit should have node_id"
             assert visit["text"], "Visit should have text"
             assert visit["weights"]["final_weight"] >= 0, "Weight should be non-negative"
-            # Entry points should have no parent
-            if visit["is_entry_point"]:
-                assert visit["parent_node_id"] is None
-                assert visit["link_type"] is None
-            else:
-                # Non-entry points should have parent info (unless they're isolated)
-                # But we allow None parent if the node was reached differently
-                pass
+
+        # Retrieval is parallel and fused, so the trace carries no traversal
+        # vocabulary: link-follow counters and pruning decisions were removed
+        # rather than reported as a constant zero (issue #3817).
+        summary_keys = set(trace["summary"])
+        assert not summary_keys & {
+            "total_nodes_pruned",
+            "temporal_links_followed",
+            "semantic_links_followed",
+            "entity_links_followed",
+        }, "Structurally-zero counters should be gone from the summary"
+        assert "pruned" not in trace
+        for visit in trace["visits"]:
+            assert not set(visit) & {"parent_node_id", "link_type", "link_weight", "neighbors_explored"}
 
         # Verify summary
         assert trace["summary"]["total_nodes_visited"] == len(trace["visits"])
@@ -126,7 +132,6 @@ async def test_search_with_trace(memory, request_context):
         print(f"  - Query: {trace['query']['query_text']}")
         print(f"  - Entry points: {len(trace['entry_points'])}")
         print(f"  - Nodes visited: {trace['summary']['total_nodes_visited']}")
-        print(f"  - Nodes pruned: {trace['summary']['total_nodes_pruned']}")
         print(f"  - Results returned: {trace['summary']['results_returned']}")
         print(f"  - Duration: {trace['summary']['total_duration_seconds']:.3f}s")
 


### PR DESCRIPTION
Fixes #3817.

`SearchSummary` reported four counters that no code path can move off zero, and the trace carried two models nothing constructs. A reader of a recall trace saw *"semantic/entity/temporal links followed: 0, nodes pruned: 0"* and concluded the graph arm was broken — both numbers are artifacts of instrumentation written for a sequential spreading-activation walk that retrieval no longer performs.

## Removed (each verified to have no producer)

- **`SearchSummary.{total_nodes_pruned, temporal_links_followed, semantic_links_followed, entity_links_followed}`** — the link counters move only inside `visit_node()` for three literal `link_type` values, and the single call site in `memory_engine.py` passes `link_type=None`.
- **`SearchTrace.pruned` and the `PruningDecision` model** — `prune_node()` was the only thing appending to `self.pruned`, and it had zero callers.
- **`NodeVisit.{parent_node_id, link_type, link_weight}`** and the matching `visit_node()` parameters — all `None` at the one call site — plus **`NodeVisit.neighbors_explored`**, constructed as `[]` and never appended to, which left `LinkInfo` unreachable, so that model goes too.

## Kept

`budget_used` / `budget_remaining`. Unlike the above they *are* filled (with `len(self.visits)`), so only their descriptions change to say what they actually count rather than implying traversal spend. Option 2 in the issue — redefining them as per-arm candidate counts — is a separate call about what a reader should take them to mean, and isn't made here.

## No client-facing schema change

`RecallResponse.trace` is typed `dict[str, Any]`, so `SearchTrace` never enters the OpenAPI spec (`components.schemas` has no `SearchSummary`/`SearchTrace`) and no generated client references these names — `hindsight-clients/` and `hindsight-cli/` have zero hits. The control-plane debug view reads only `summary.total_duration_seconds`, `summary.total_nodes_visited`, and `visits[].weights.final_weight`, all of which survive, so it needs no change.

The one real compat surface is the Python package's public exports: `LinkInfo` and `PruningDecision` are dropped from `hindsight_api.__init__` / `hindsight_api.engine.__init__`. Nothing in-repo imports them.

## Testing

- `tests/test_search_trace.py` — 4 passed, run against an isolated pg0 instance. The stale asserts on `visit["parent_node_id"]` / `visit["link_type"]` are replaced by a regression assert that the removed keys stay gone, with a comment explaining why the traversal vocabulary doesn't apply to parallel fused retrieval.
- `./scripts/hooks/lint.sh` green; `ruff`, `ruff format --check`, `ty check` clean; `check-unused.sh` reports nothing new in the changed files.

https://claude.ai/code/session_01WbaYxouCERUv9djo3GnnA2