### PR TITLE
fix(embeddings): bound ONNX forward passes and import embed calls (#3891)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -304,6 +304,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_ONNX_NORMALIZE=true
 # HINDSIGHT_API_EMBEDDINGS_ONNX_QUERY_PREFIX="query: "
 # HINDSIGHT_API_EMBEDDINGS_ONNX_PASSAGE_PREFIX="passage: "
+# HINDSIGHT_API_EMBEDDINGS_ONNX_BATCH_SIZE=32              # Texts per forward pass; bounds peak memory
+# HINDSIGHT_API_EMBEDDINGS_ONNX_CPU_MEM_ARENA=false        # ONNX CPU memory arena; true lets RSS ratchet up
 # Optional for local model paths or pre-downloaded artifacts:
 # HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_PATH=/models/multilingual-e5-small/onnx/model.onnx
 # HINDSIGHT_API_EMBEDDINGS_ONNX_TOKENIZER_NAME_OR_PATH=/models/multilingual-e5-small

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -399,6 +399,8 @@ ENV_EMBEDDINGS_ONNX_NORMALIZE = "HINDSIGHT_API_EMBEDDINGS_ONNX_NORMALIZE"
 ENV_EMBEDDINGS_ONNX_QUERY_PREFIX = "HINDSIGHT_API_EMBEDDINGS_ONNX_QUERY_PREFIX"
 ENV_EMBEDDINGS_ONNX_PASSAGE_PREFIX = "HINDSIGHT_API_EMBEDDINGS_ONNX_PASSAGE_PREFIX"
 ENV_EMBEDDINGS_ONNX_OUTPUT_NAME = "HINDSIGHT_API_EMBEDDINGS_ONNX_OUTPUT_NAME"
+ENV_EMBEDDINGS_ONNX_BATCH_SIZE = "HINDSIGHT_API_EMBEDDINGS_ONNX_BATCH_SIZE"
+ENV_EMBEDDINGS_ONNX_CPU_MEM_ARENA = "HINDSIGHT_API_EMBEDDINGS_ONNX_CPU_MEM_ARENA"
 ENV_EMBEDDINGS_TEI_URL = "HINDSIGHT_API_EMBEDDINGS_TEI_URL"
 ENV_EMBEDDINGS_TEI_BATCH_SIZE = "HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE"
 ENV_EMBEDDINGS_OPENAI_API_KEY = "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"
@@ -1019,6 +1021,10 @@ DEFAULT_EMBEDDINGS_QUERY_PREFIX = ""
 DEFAULT_EMBEDDINGS_PASSAGE_PREFIX = ""
 DEFAULT_EMBEDDINGS_ONNX_QUERY_PREFIX = "query: "
 DEFAULT_EMBEDDINGS_ONNX_PASSAGE_PREFIX = "passage: "
+# Texts per ONNX forward pass. The provider runs in-process, so this is the only thing
+# bounding the activation tensor a caller can trigger; 32 matches TEI and the reranker.
+DEFAULT_EMBEDDINGS_ONNX_BATCH_SIZE = 32
+DEFAULT_EMBEDDINGS_ONNX_CPU_MEM_ARENA = False  # Disable ONNX CPU memory arena to bound RSS
 DEFAULT_EMBEDDINGS_OPENAI_MODEL = "text-embedding-3-small"
 DEFAULT_EMBEDDINGS_OPENAI_BATCH_SIZE = 100
 # Texts per TEI /embed request. Also the batch size the streaming retain producer
@@ -2542,6 +2548,8 @@ class HindsightConfig:
     embeddings_onnx_query_prefix: str
     embeddings_onnx_passage_prefix: str
     embeddings_onnx_output_name: str | None
+    embeddings_onnx_batch_size: int
+    embeddings_onnx_cpu_mem_arena: bool
     embeddings_tei_url: str | None
     embeddings_openai_base_url: str | None
     embeddings_cohere_api_key: str | None
@@ -3655,6 +3663,15 @@ class HindsightConfig:
                 ENV_EMBEDDINGS_ONNX_PASSAGE_PREFIX, DEFAULT_EMBEDDINGS_ONNX_PASSAGE_PREFIX
             ),
             embeddings_onnx_output_name=os.getenv(ENV_EMBEDDINGS_ONNX_OUTPUT_NAME) or None,
+            embeddings_onnx_batch_size=_parse_positive_int(
+                ENV_EMBEDDINGS_ONNX_BATCH_SIZE,
+                os.getenv(ENV_EMBEDDINGS_ONNX_BATCH_SIZE),
+                DEFAULT_EMBEDDINGS_ONNX_BATCH_SIZE,
+            ),
+            embeddings_onnx_cpu_mem_arena=os.getenv(
+                ENV_EMBEDDINGS_ONNX_CPU_MEM_ARENA, str(DEFAULT_EMBEDDINGS_ONNX_CPU_MEM_ARENA)
+            ).lower()
+            == "true",
             embeddings_tei_url=os.getenv(ENV_EMBEDDINGS_TEI_URL),
             embeddings_openai_base_url=os.getenv(ENV_EMBEDDINGS_OPENAI_BASE_URL) or None,
             embeddings_openai_batch_size=_parse_positive_int(

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -34,6 +34,8 @@ from ..config import (
     DEFAULT_EMBEDDINGS_LOCAL_MODEL,
     DEFAULT_EMBEDDINGS_MAX_BACKOFF,
     DEFAULT_EMBEDDINGS_MAX_RETRIES,
+    DEFAULT_EMBEDDINGS_ONNX_BATCH_SIZE,
+    DEFAULT_EMBEDDINGS_ONNX_CPU_MEM_ARENA,
     DEFAULT_EMBEDDINGS_OPENAI_MODEL,
     DEFAULT_EMBEDDINGS_RETRY_BUDGET,
     DEFAULT_EMBEDDINGS_ZEROENTROPY_BATCH_SIZE,
@@ -538,6 +540,8 @@ class OnnxEmbeddings(Embeddings):
         query_prefix: str = "query: ",
         passage_prefix: str = "passage: ",
         output_name: str | None = None,
+        batch_size: int = DEFAULT_EMBEDDINGS_ONNX_BATCH_SIZE,
+        cpu_mem_arena: bool = DEFAULT_EMBEDDINGS_ONNX_CPU_MEM_ARENA,
     ):
         self.model_id = model_id
         self.model_path = model_path
@@ -559,6 +563,10 @@ class OnnxEmbeddings(Embeddings):
         self.query_prefix = query_prefix
         self.passage_prefix = passage_prefix
         self.output_name = output_name
+        if batch_size < 1:
+            raise ValueError("ONNX embeddings batch_size must be >= 1")
+        self.batch_size = batch_size
+        self.cpu_mem_arena = cpu_mem_arena
         self._session = None
         self._tokenizer = None
         self._dimension: int | None = dimensions
@@ -610,14 +618,26 @@ class OnnxEmbeddings(Embeddings):
             model_path,
         )
         logger.info(
-            "Embeddings: ONNX query_prefix=%r passage_prefix=%r pooling=%s normalize=%s",
+            "Embeddings: ONNX query_prefix=%r passage_prefix=%r pooling=%s normalize=%s batch_size=%s cpu_mem_arena=%s",
             self.query_prefix,
             self.passage_prefix,
             self.pooling,
             self.normalize,
+            self.batch_size,
+            self.cpu_mem_arena,
         )
         self._tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name_or_path)
-        self._session = ort.InferenceSession(model_path, providers=["CPUExecutionProvider"])
+        # With the arena enabled (ORT's default) freed activation blocks are cached and
+        # never returned to the OS, so RSS ratchets up to the largest batch ever run and
+        # holds that plateau for the life of the process. The reranker disables it for
+        # the same reason (see FlashRankCrossEncoder).
+        session_options = None
+        if not self.cpu_mem_arena:
+            session_options = ort.SessionOptions()
+            session_options.enable_cpu_mem_arena = False
+        self._session = ort.InferenceSession(
+            model_path, sess_options=session_options, providers=["CPUExecutionProvider"]
+        )
 
         detected = len(self.encode(["test"])[0])
         if self.configured_dimensions is not None and detected != self.configured_dimensions:
@@ -628,10 +648,37 @@ class OnnxEmbeddings(Embeddings):
         logger.info("Embeddings: ONNX provider initialized (dim: %s)", self._dimension)
 
     def encode(self, texts: list[str]) -> list[list[float]]:
+        """Embed ``texts`` in bounded forward passes.
+
+        Every remote provider slices its input before calling out; this one runs the
+        model in-process, so nothing downstream bounds it and a caller that hands over
+        a whole bank's worth of text gets a single ``[n_texts x max_seq_len x hidden]``
+        float32 activation tensor (issue #3891).
+        """
         if self._session is None or self._tokenizer is None:
             raise RuntimeError("Embeddings not initialized. Call initialize() first.")
         if not texts:
             return []
+        if len(texts) <= self.batch_size:
+            return self._encode_batch(texts)
+
+        # Pack similar-length texts together: tokenization pads every text in a call up
+        # to the longest one in that same call, so one long text otherwise inflates the
+        # tensor for every short text batched with it. Character length is a cheap
+        # stand-in for token count — it only decides grouping, never the output, since
+        # both pooling modes mask padding and so cannot see batch composition.
+        order = sorted(range(len(texts)), key=lambda index: len(texts[index]), reverse=True)
+        embeddings: list[list[float]] = [[] for _ in texts]
+        for start in range(0, len(order), self.batch_size):
+            window = order[start : start + self.batch_size]
+            batch = self._encode_batch([texts[index] for index in window])
+            for index, embedding in zip(window, batch, strict=True):
+                embeddings[index] = embedding
+        return embeddings
+
+    def _encode_batch(self, texts: list[str]) -> list[list[float]]:
+        """Run one forward pass over at most ``batch_size`` texts."""
+        assert self._session is not None and self._tokenizer is not None
 
         import numpy as np
 
@@ -2074,6 +2121,8 @@ def create_embeddings_from_env() -> Embeddings:
             query_prefix=config.embeddings_onnx_query_prefix,
             passage_prefix=config.embeddings_onnx_passage_prefix,
             output_name=config.embeddings_onnx_output_name,
+            batch_size=config.embeddings_onnx_batch_size,
+            cpu_mem_arena=config.embeddings_onnx_cpu_mem_arena,
         )
     elif provider == "openai":
         # Use dedicated embeddings API key, or fall back to LLM API key

--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -49,6 +49,13 @@ logger = logging.getLogger(__name__)
 OnConflict = Literal["skip", "replace", "new-id"]
 _VALID_CONFLICT_MODES: tuple[OnConflict, ...] = ("skip", "replace", "new-id")
 
+#: Texts per embedding call for the import phases that are sized by the *bank* rather
+#: than by a document: observations and mental models arrive as one list covering the
+#: whole archive. Slicing here, above the provider, bounds peak memory for every
+#: provider — including in-process ones with nothing downstream to slice for them
+#: (issue #3891). Retain bounds itself the same way (#3763).
+_EMBED_BATCH_SIZE = 128
+
 
 @dataclass
 class ImportedDocument:
@@ -457,6 +464,18 @@ async def _restore_rows(
     return inserted
 
 
+async def _embed_in_batches(embeddings_model: Any, texts: list[str]) -> list[list[float]]:
+    """Embed ``texts`` in ``_EMBED_BATCH_SIZE`` slices, preserving input order."""
+    vectors: list[list[float]] = []
+    for start in range(0, len(texts), _EMBED_BATCH_SIZE):
+        vectors.extend(
+            await embedding_processing.generate_embeddings_batch(
+                embeddings_model, texts[start : start + _EMBED_BATCH_SIZE]
+            )
+        )
+    return vectors
+
+
 async def _regenerate_mental_model_embeddings(embeddings_model: Any, mm_rows: list[dict]) -> dict[str, list[float]]:
     """Re-embed each restored mental model with the *target* model.
 
@@ -469,7 +488,7 @@ async def _regenerate_mental_model_embeddings(embeddings_model: Any, mm_rows: li
     if not mm_rows:
         return {}
     texts = [f"{(r.get('name') or '')} {(r.get('content') or '')}" for r in mm_rows]
-    vectors = await embedding_processing.generate_embeddings_batch(embeddings_model, texts)
+    vectors = await _embed_in_batches(embeddings_model, texts)
     # The vectors themselves, not the ``str(...)`` Postgres wants: a store-owned bank indexes the
     # same vector, and re-parsing a repr to recover it would be lossy for nothing. The one caller
     # that needs the literal stringifies at its own INSERT.
@@ -1127,9 +1146,7 @@ async def _import_observations(
 
     # Observations embed the raw text (matching consolidation), not the
     # date-augmented text used for facts.
-    embeddings = await embedding_processing.generate_embeddings_batch(
-        embeddings_model, [obs.text for obs, _ in resolved]
-    )
+    embeddings = await _embed_in_batches(embeddings_model, [obs.text for obs, _ in resolved])
     processed = [
         ProcessedFact(
             fact_text=obs.text,

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -23,7 +23,7 @@ from hindsight_api.engine.consolidation.consolidator import (
 from hindsight_api.engine.db_utils import acquire_with_retry
 from hindsight_api.engine.schema import fq_table
 from hindsight_api.engine.transfer import import_documents
-from hindsight_api.engine.transfer.importer import parse_archive
+from hindsight_api.engine.transfer.importer import _EMBED_BATCH_SIZE, _embed_in_batches, parse_archive
 from hindsight_api.engine.transfer.schema import (
     SCHEMA_VERSION,
     TransferCausalRelation,
@@ -2279,3 +2279,40 @@ async def test_a_sql_backed_bank_is_not_read_through_the_store():
     with pytest.raises(Exception) as ei:  # noqa: PT011 - backend=None fails once SQL is reached
         await export_documents(None, "bank-x", None, memories=_SqlMemories())
     assert "list_documents" not in str(ei.value), "a SQL bank must not be read through the store"
+
+
+class _RecordingEmbedder:
+    """Minimal embeddings backend that records the size of every encode call."""
+
+    dimension = 2
+
+    def __init__(self):
+        self.batch_sizes: list[int] = []
+
+    def encode_documents(self, texts):
+        self.batch_sizes.append(len(texts))
+        return [[float(len(text)), 0.0] for text in texts]
+
+
+@pytest.mark.asyncio
+async def test_embed_in_batches_bounds_call_size_and_keeps_order():
+    """Import embeds bank-sized lists; nothing below it bounds an in-process provider.
+
+    Without this slice, ``_import_observations`` hands the embedder every observation in
+    the bank in a single call and peak memory scales with the bank (issue #3891).
+    """
+    embedder = _RecordingEmbedder()
+    texts = [f"observation {index}" for index in range(_EMBED_BATCH_SIZE * 2 + 5)]
+
+    vectors = await _embed_in_batches(embedder, texts)
+
+    assert embedder.batch_sizes == [_EMBED_BATCH_SIZE, _EMBED_BATCH_SIZE, 5]
+    assert vectors == [[float(len(text)), 0.0] for text in texts]
+
+
+@pytest.mark.asyncio
+async def test_embed_in_batches_handles_empty_input():
+    embedder = _RecordingEmbedder()
+
+    assert await _embed_in_batches(embedder, []) == []
+    assert embedder.batch_sizes == []

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -2289,7 +2289,7 @@ class _RecordingEmbedder:
     def __init__(self):
         self.batch_sizes: list[int] = []
 
-    def encode_documents(self, texts):
+    def encode_documents(self, texts: list[str]) -> list[list[float]]:
         self.batch_sizes.append(len(texts))
         return [[float(len(text)), 0.0] for text in texts]
 

--- a/hindsight-api-slim/tests/test_onnx_embeddings.py
+++ b/hindsight-api-slim/tests/test_onnx_embeddings.py
@@ -62,6 +62,59 @@ class FakeOnnxSession:
         return [token_embeddings]
 
 
+class FakeLengthTokenizer:
+    """Encodes each text's length into its ids, padding to the longest text *in this call*."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, texts, padding, truncation, max_length, return_tensors):
+        self.calls.append({"texts": list(texts)})
+        lengths = [len(text) for text in texts]
+        width = max(lengths)
+        input_ids = np.zeros((len(texts), width), dtype=np.int64)
+        attention_mask = np.zeros((len(texts), width), dtype=np.int64)
+        for row, length in enumerate(lengths):
+            input_ids[row, :length] = length
+            attention_mask[row, :length] = 1
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "token_type_ids": np.zeros_like(input_ids),
+        }
+
+
+class FakeLengthOnnxSession:
+    """Token embeddings read off the ids, so every text gets its own vector."""
+
+    def __init__(self):
+        self.batch_sizes = []
+
+    def get_inputs(self):
+        return [SimpleNamespace(name="input_ids"), SimpleNamespace(name="attention_mask")]
+
+    def run(self, output_names, inputs):
+        ids = inputs["input_ids"].astype(np.float32)
+        self.batch_sizes.append(ids.shape[0])
+        # [batch, seq, 2]: mean pooling over the unmasked tokens yields [length, 1.0].
+        # Padded positions carry 0 and are masked out, which is what makes the result
+        # independent of who else is in the batch.
+        return [np.stack([ids, np.ones_like(ids)], axis=-1)]
+
+
+def _length_embedder(batch_size: int) -> OnnxEmbeddings:
+    emb = OnnxEmbeddings(
+        model_id="intfloat/multilingual-e5-small",
+        dimensions=2,
+        normalize=False,
+        batch_size=batch_size,
+    )
+    emb._tokenizer = FakeLengthTokenizer()
+    emb._session = FakeLengthOnnxSession()
+    emb._dimension = 2
+    return emb
+
+
 class FakePooledOnnxSession:
     def get_inputs(self):
         return [SimpleNamespace(name="input_ids"), SimpleNamespace(name="attention_mask")]
@@ -235,49 +288,40 @@ def test_create_embeddings_from_env_supports_onnx_provider():
 
 def test_onnx_embeddings_chunks_into_batches_and_preserves_order():
     """One forward pass per batch, with the caller's ordering restored (issue #3891)."""
-    emb = OnnxEmbeddings(model_id="intfloat/multilingual-e5-small", dimensions=2, batch_size=2)
-    emb._tokenizer = FakeTokenizer()
-    emb._session = FakeOnnxSession()
-    emb._dimension = 2
-
+    emb = _length_embedder(batch_size=2)
     texts = ["a", "bbbb", "cc", "ddddddd", "e"]
+
     result = emb.encode(texts)
 
     assert emb._session.batch_sizes == [2, 2, 1]
-    assert result == [pytest.approx([0.6, 0.8])] * len(texts)
+    # Each vector carries its own text's length, so a misplaced scatter-back shows up here.
+    assert result == [pytest.approx([float(len(text)), 1.0]) for text in texts]
     # Longest first, so a single long text cannot pad an entire batch of short ones.
-    batched = [call["texts"] for call in emb._tokenizer.calls]
-    assert batched == [["ddddddd", "bbbb"], ["cc", "a"], ["e"]]
+    assert [call["texts"] for call in emb._tokenizer.calls] == [["ddddddd", "bbbb"], ["cc", "a"], ["e"]]
 
 
 def test_onnx_embeddings_single_batch_when_input_fits():
-    emb = OnnxEmbeddings(model_id="intfloat/multilingual-e5-small", dimensions=2, batch_size=8)
-    emb._tokenizer = FakeTokenizer()
-    emb._session = FakeOnnxSession()
-    emb._dimension = 2
+    emb = _length_embedder(batch_size=8)
 
-    emb.encode(["a", "bbb", "cc"])
+    result = emb.encode(["a", "bbb", "cc"])
 
     assert emb._session.batch_sizes == [3]
     # Input order is untouched when nothing needs splitting.
     assert emb._tokenizer.calls[0]["texts"] == ["a", "bbb", "cc"]
+    assert result == [pytest.approx([1.0, 1.0]), pytest.approx([3.0, 1.0]), pytest.approx([2.0, 1.0])]
 
 
 def test_onnx_embeddings_batching_does_not_change_vectors():
     """Batch composition cannot move a vector: pooling masks padding."""
-    texts = [f"text {'x' * i}" for i in range(10)]
+    texts = [f"text {'x' * index}" for index in range(10)]
 
-    unbatched = OnnxEmbeddings(model_id="intfloat/multilingual-e5-small", dimensions=2, batch_size=len(texts))
-    unbatched._tokenizer = FakeTokenizer()
-    unbatched._session = FakeOnnxSession()
-    unbatched._dimension = 2
-
-    batched = OnnxEmbeddings(model_id="intfloat/multilingual-e5-small", dimensions=2, batch_size=3)
-    batched._tokenizer = FakeTokenizer()
-    batched._session = FakeOnnxSession()
-    batched._dimension = 2
+    unbatched = _length_embedder(batch_size=len(texts))
+    batched = _length_embedder(batch_size=3)
 
     assert batched.encode(texts) == unbatched.encode(texts)
+    # The two runs really did pad to different widths — otherwise this proves nothing.
+    assert unbatched._session.batch_sizes == [10]
+    assert batched._session.batch_sizes == [3, 3, 3, 1]
 
 
 def test_onnx_embeddings_rejects_non_positive_batch_size():

--- a/hindsight-api-slim/tests/test_onnx_embeddings.py
+++ b/hindsight-api-slim/tests/test_onnx_embeddings.py
@@ -7,7 +7,16 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+from hindsight_api.config import DEFAULT_EMBEDDINGS_ONNX_BATCH_SIZE, clear_config_cache
 from hindsight_api.engine.embeddings import OnnxEmbeddings, create_embeddings_from_env
+
+
+@pytest.fixture
+def _fresh_config():
+    """``create_embeddings_from_env`` reads the cached config; keep env-driven tests isolated."""
+    clear_config_cache()
+    yield
+    clear_config_cache()
 
 
 class FakeTokenizer:
@@ -32,12 +41,21 @@ class FakeTokenizer:
         }
 
 
+class FakeSessionOptions:
+    def __init__(self):
+        self.enable_cpu_mem_arena = True
+
+
 class FakeOnnxSession:
+    def __init__(self):
+        self.batch_sizes = []
+
     def get_inputs(self):
         return [SimpleNamespace(name="input_ids"), SimpleNamespace(name="attention_mask")]
 
     def run(self, output_names, inputs):
         batch = inputs["input_ids"].shape[0]
+        self.batch_sizes.append(batch)
         # Last token is masked out. Mean pooling should average first two tokens:
         # ([3, 4] + [0, 0]) / 2 = [1.5, 2.0], then normalize to [0.6, 0.8].
         token_embeddings = np.array([[[3.0, 4.0], [0.0, 0.0], [100.0, 100.0]]] * batch, dtype=np.float32)
@@ -142,7 +160,10 @@ async def test_onnx_embeddings_dimension_mismatch_raises_value_error():
     fake_transformers = SimpleNamespace(
         AutoTokenizer=SimpleNamespace(from_pretrained=MagicMock(return_value=FakeTokenizer()))
     )
-    fake_onnxruntime = SimpleNamespace(InferenceSession=MagicMock(return_value=FakeOnnxSession()))
+    fake_onnxruntime = SimpleNamespace(
+        InferenceSession=MagicMock(return_value=FakeOnnxSession()),
+        SessionOptions=FakeSessionOptions,
+    )
 
     with patch.dict(sys.modules, {"transformers": fake_transformers, "onnxruntime": fake_onnxruntime}):
         with pytest.raises(ValueError, match="does not match model output"):
@@ -158,7 +179,7 @@ async def test_onnx_embeddings_downloads_external_data_sidecar_when_needed():
     fake_transformers = SimpleNamespace(
         AutoTokenizer=SimpleNamespace(from_pretrained=MagicMock(return_value=FakeTokenizer()))
     )
-    fake_onnxruntime = SimpleNamespace(InferenceSession=session)
+    fake_onnxruntime = SimpleNamespace(InferenceSession=session, SessionOptions=FakeSessionOptions)
 
     with patch.dict(
         sys.modules,
@@ -174,7 +195,12 @@ async def test_onnx_embeddings_downloads_external_data_sidecar_when_needed():
         repo_id="BAAI/bge-m3",
         allow_patterns=["onnx/model.onnx", "onnx/model.onnx_data"],
     )
-    session.assert_called_once_with("/hf/bge-m3/onnx/model.onnx", providers=["CPUExecutionProvider"])
+    assert session.call_count == 1
+    assert session.call_args.args == ("/hf/bge-m3/onnx/model.onnx",)
+    assert session.call_args.kwargs["providers"] == ["CPUExecutionProvider"]
+    # The CPU memory arena caches freed activation blocks and never returns them, so
+    # RSS would hold the high-water plateau for the life of the process (issue #3891).
+    assert session.call_args.kwargs["sess_options"].enable_cpu_mem_arena is False
 
 
 def test_create_embeddings_from_env_supports_onnx_provider():
@@ -191,6 +217,8 @@ def test_create_embeddings_from_env_supports_onnx_provider():
     mock_config.embeddings_onnx_query_prefix = "query: "
     mock_config.embeddings_onnx_passage_prefix = "passage: "
     mock_config.embeddings_onnx_output_name = None
+    mock_config.embeddings_onnx_batch_size = 16
+    mock_config.embeddings_onnx_cpu_mem_arena = False
 
     with patch("hindsight_api.config.get_config", return_value=mock_config):
         emb = create_embeddings_from_env()
@@ -201,3 +229,82 @@ def test_create_embeddings_from_env_supports_onnx_provider():
     assert emb.model_path == "/models/e5/onnx/model.onnx"
     assert emb.tokenizer_name_or_path == "/models/e5"
     assert emb.dimension == 384
+    assert emb.batch_size == 16
+    assert emb.cpu_mem_arena is False
+
+
+def test_onnx_embeddings_chunks_into_batches_and_preserves_order():
+    """One forward pass per batch, with the caller's ordering restored (issue #3891)."""
+    emb = OnnxEmbeddings(model_id="intfloat/multilingual-e5-small", dimensions=2, batch_size=2)
+    emb._tokenizer = FakeTokenizer()
+    emb._session = FakeOnnxSession()
+    emb._dimension = 2
+
+    texts = ["a", "bbbb", "cc", "ddddddd", "e"]
+    result = emb.encode(texts)
+
+    assert emb._session.batch_sizes == [2, 2, 1]
+    assert result == [pytest.approx([0.6, 0.8])] * len(texts)
+    # Longest first, so a single long text cannot pad an entire batch of short ones.
+    batched = [call["texts"] for call in emb._tokenizer.calls]
+    assert batched == [["ddddddd", "bbbb"], ["cc", "a"], ["e"]]
+
+
+def test_onnx_embeddings_single_batch_when_input_fits():
+    emb = OnnxEmbeddings(model_id="intfloat/multilingual-e5-small", dimensions=2, batch_size=8)
+    emb._tokenizer = FakeTokenizer()
+    emb._session = FakeOnnxSession()
+    emb._dimension = 2
+
+    emb.encode(["a", "bbb", "cc"])
+
+    assert emb._session.batch_sizes == [3]
+    # Input order is untouched when nothing needs splitting.
+    assert emb._tokenizer.calls[0]["texts"] == ["a", "bbb", "cc"]
+
+
+def test_onnx_embeddings_batching_does_not_change_vectors():
+    """Batch composition cannot move a vector: pooling masks padding."""
+    texts = [f"text {'x' * i}" for i in range(10)]
+
+    unbatched = OnnxEmbeddings(model_id="intfloat/multilingual-e5-small", dimensions=2, batch_size=len(texts))
+    unbatched._tokenizer = FakeTokenizer()
+    unbatched._session = FakeOnnxSession()
+    unbatched._dimension = 2
+
+    batched = OnnxEmbeddings(model_id="intfloat/multilingual-e5-small", dimensions=2, batch_size=3)
+    batched._tokenizer = FakeTokenizer()
+    batched._session = FakeOnnxSession()
+    batched._dimension = 2
+
+    assert batched.encode(texts) == unbatched.encode(texts)
+
+
+def test_onnx_embeddings_rejects_non_positive_batch_size():
+    with pytest.raises(ValueError, match="batch_size"):
+        OnnxEmbeddings(model_id="intfloat/multilingual-e5-small", batch_size=0)
+
+
+def test_onnx_batch_size_and_arena_come_from_env(monkeypatch, _fresh_config):
+    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_PROVIDER", "onnx")
+    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_ONNX_BATCH_SIZE", "8")
+    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_ONNX_CPU_MEM_ARENA", "true")
+
+    embeddings = create_embeddings_from_env()
+
+    assert isinstance(embeddings, OnnxEmbeddings)
+    assert embeddings.batch_size == 8
+    assert embeddings.cpu_mem_arena is True
+
+
+def test_onnx_batch_size_and_arena_defaults(monkeypatch, _fresh_config):
+    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_PROVIDER", "onnx")
+    monkeypatch.delenv("HINDSIGHT_API_EMBEDDINGS_ONNX_BATCH_SIZE", raising=False)
+    monkeypatch.delenv("HINDSIGHT_API_EMBEDDINGS_ONNX_CPU_MEM_ARENA", raising=False)
+
+    embeddings = create_embeddings_from_env()
+
+    assert isinstance(embeddings, OnnxEmbeddings)
+    assert embeddings.batch_size == DEFAULT_EMBEDDINGS_ONNX_BATCH_SIZE
+    # Off by default: an enabled arena never returns freed blocks to the OS.
+    assert embeddings.cpu_mem_arena is False

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -723,6 +723,8 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_ONNX_QUERY_PREFIX` | Prefix applied to query/search text before ONNX embedding. Keep `query: ` for E5 models; set to empty for non-E5 models such as MiniLM or BGE. | `query: ` |
 | `HINDSIGHT_API_EMBEDDINGS_ONNX_PASSAGE_PREFIX` | Prefix applied to stored memory/document text before ONNX embedding. Keep `passage: ` for E5 models; set to empty for non-E5 models such as MiniLM or BGE. | `passage: ` |
 | `HINDSIGHT_API_EMBEDDINGS_ONNX_OUTPUT_NAME` | Optional ONNX output name to request when an exported graph exposes a pooled embedding output. | - |
+| `HINDSIGHT_API_EMBEDDINGS_ONNX_BATCH_SIZE` | Texts per ONNX forward pass. The provider runs in-process, so this is what bounds the activation tensor (and therefore peak memory) when a caller embeds a large list — an import, for example. | `32` |
+| `HINDSIGHT_API_EMBEDDINGS_ONNX_CPU_MEM_ARENA` | Enable ONNX Runtime's CPU memory arena. The arena caches freed blocks and never returns them, so RSS holds its high-water mark for the life of the process. | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_TEI_URL` | TEI server URL | - |
 | `HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE` | Max texts per TEI `/embed` request. Also the batch size retain coalesces a document's per-chunk embeddings up to, so raise it when the TEI deployment has headroom for larger requests | `32` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY` | OpenAI API key (falls back to `HINDSIGHT_API_LLM_API_KEY`) | - |

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -304,6 +304,8 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_ONNX_NORMALIZE=true
 # HINDSIGHT_API_EMBEDDINGS_ONNX_QUERY_PREFIX="query: "
 # HINDSIGHT_API_EMBEDDINGS_ONNX_PASSAGE_PREFIX="passage: "
+# HINDSIGHT_API_EMBEDDINGS_ONNX_BATCH_SIZE=32              # Texts per forward pass; bounds peak memory
+# HINDSIGHT_API_EMBEDDINGS_ONNX_CPU_MEM_ARENA=false        # ONNX CPU memory arena; true lets RSS ratchet up
 # Optional for local model paths or pre-downloaded artifacts:
 # HINDSIGHT_API_EMBEDDINGS_ONNX_MODEL_PATH=/models/multilingual-e5-small/onnx/model.onnx
 # HINDSIGHT_API_EMBEDDINGS_ONNX_TOKENIZER_NAME_OR_PATH=/models/multilingual-e5-small

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -723,6 +723,8 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | `HINDSIGHT_API_EMBEDDINGS_ONNX_QUERY_PREFIX` | Prefix applied to query/search text before ONNX embedding. Keep `query: ` for E5 models; set to empty for non-E5 models such as MiniLM or BGE. | `query: ` |
 | `HINDSIGHT_API_EMBEDDINGS_ONNX_PASSAGE_PREFIX` | Prefix applied to stored memory/document text before ONNX embedding. Keep `passage: ` for E5 models; set to empty for non-E5 models such as MiniLM or BGE. | `passage: ` |
 | `HINDSIGHT_API_EMBEDDINGS_ONNX_OUTPUT_NAME` | Optional ONNX output name to request when an exported graph exposes a pooled embedding output. | - |
+| `HINDSIGHT_API_EMBEDDINGS_ONNX_BATCH_SIZE` | Texts per ONNX forward pass. The provider runs in-process, so this is what bounds the activation tensor (and therefore peak memory) when a caller embeds a large list — an import, for example. | `32` |
+| `HINDSIGHT_API_EMBEDDINGS_ONNX_CPU_MEM_ARENA` | Enable ONNX Runtime's CPU memory arena. The arena caches freed blocks and never returns them, so RSS holds its high-water mark for the life of the process. | `false` |
 | `HINDSIGHT_API_EMBEDDINGS_TEI_URL` | TEI server URL | - |
 | `HINDSIGHT_API_EMBEDDINGS_TEI_BATCH_SIZE` | Max texts per TEI `/embed` request. Also the batch size retain coalesces a document's per-chunk embeddings up to, so raise it when the TEI deployment has headroom for larger requests | `32` |
 | `HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY` | OpenAI API key (falls back to `HINDSIGHT_API_LLM_API_KEY`) | - |


### PR DESCRIPTION
Fixes #3891.

## The problem

`OnnxEmbeddings.encode()` tokenized and ran `session.run()` over its entire input in one pass. It was the only provider that did — TEI (32), Cohere (96), OpenAI (100) and ZeroEntropy (100) all slice their input, and there was no `..._ONNX_BATCH_SIZE` to set. Tokenization pads every text in a call up to the longest one *in that same call*, so peak memory was `n_texts × max_seq_len × hidden` float32.

Nothing above it bounded the input either. `_import_observations` embeds every observation in the bank in one call, so a whole-bank import OOM-killed the process (43.3 GB RSS on a 4,138-observation bank) — and because observations are imported last, the kill landed after the document and fact phases had committed, leaving a bank with the right document count, the right fact count, and zero observations.

Same class as #3756/#3763 (retain) and #3848 (delta), with the difference that here no lower layer can save it: with the ONNX provider nothing between the caller and `session.run()` bounds anything.

## The fix

- **`encode()` runs `batch_size` texts per forward pass** — `HINDSIGHT_API_EMBEDDINGS_ONNX_BATCH_SIZE`, default 32, matching TEI and the reranker. Batches are packed longest-first so a single long text can't pad a whole batch of short ones. Vectors are unchanged by construction: both pooling modes mask padding, so batch composition cannot move an output.
- **The CPU memory arena is off** — `HINDSIGHT_API_EMBEDDINGS_ONNX_CPU_MEM_ARENA`, default `false`. The arena caches freed activation blocks and never returns them, so RSS held its high-water plateau for the life of the process. The reranker has disabled it for exactly this reason since #1717; the embedder never got the same treatment.
- **The import phases sized by the bank, not by a document** — observations and mental models — embed in slices, so the bound holds for every provider, not just ONNX.

## Verification

Reported end to end in #3891 with measurements: peak RSS ~44,300 MiB (OOM) → 3,483 MiB, ~12.7× lower, and slightly *faster* (~31 min vs ~37 min to the kill), with `max elementwise |single-batch − chunked| = 0.000e+00`.

New tests: batching splits into the expected passes and restores caller order; batched and unbatched encodes agree; a non-positive batch size is rejected; `initialize()` disables the arena; both env vars reach the provider; and `_embed_in_batches` bounds call size while preserving order.