### PR TITLE
fix(retain): make reprocess re-extract instead of silently no-opping (#3899)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -11434,10 +11434,19 @@ class MemoryEngine(MemoryEngineInterface):
         # on the item, so retain_params came back without it and the NEXT reprocess
         # fell back to the bank default again.
         content_dict.update(retain_params)
-        # These three are the reprocess's own and must win over anything stored.
+        # These are the reprocess's own and must win over anything stored.
         content_dict["content"] = original_text
         content_dict["document_id"] = document_id
         content_dict["update_mode"] = "replace"
+        # A reprocess replays the SAME content by construction, and the retain pipeline has two
+        # skips for exactly that: the delta path sees no changed chunk and updates metadata only,
+        # and the crash-recovery gate sees the matching content_hash plus surviving chunk hashes
+        # and preserves every existing unit. Either one makes the reprocess a silent no-op — zero
+        # LLM calls, `unit_ids_count: 0`, operation `completed` — which is the opposite of what
+        # this endpoint is for ("re-extract using the current engine configuration"). Whether it
+        # no-opped or re-extracted depended on how faithfully retain_params happened to replay
+        # (#3873), so the outcome was not even stable. Force it (#3899).
+        content_dict["force_reextract"] = True
 
         tags = doc.get("tags") or []
         if tags:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -383,7 +383,7 @@ def _resolve_narrator(profile_name: str, bank_id: str) -> str | None:
 # and only the resulting facts are wrong. Inverting it makes the safe case the
 # default — a new retain field round-trips unless someone deliberately excludes it,
 # and the single source of truth becomes what api_retain puts on the content dict.
-_RETAIN_PARAMS_NOT_REPLAYED = frozenset({"content", "document_id", "update_mode", "tags"})
+_RETAIN_PARAMS_NOT_REPLAYED = frozenset({"content", "document_id", "update_mode", "tags", "force_reextract"})
 
 
 def _build_retain_params(contents_dicts, document_tags=None, doc_contents=None):
@@ -1526,6 +1526,18 @@ async def retain_batch(
             update_mode = item_mode
             break
 
+    # --- Forced re-extraction ---
+    # Two independent skips make a re-retain of byte-identical content a no-op: the delta
+    # path finds no changed chunk and updates document metadata only, and the recovery gate
+    # in `_streaming_retain_batch` treats a matching content_hash plus surviving chunk hashes
+    # as a crashed retain being resumed and preserves every existing unit. Both are right for
+    # a re-push of unchanged content; both are wrong for `reprocess_document`, whose whole
+    # purpose is "extract this again under the CURRENT config", where the content is unchanged
+    # by definition (#3899). The flag rides on the content item, so it survives the async
+    # operation payload and the oversized-item splitter (which copies every field onto each
+    # slice) without a parameter on every frame in between.
+    force_reextract = any(bool(item.get("force_reextract")) for item in contents_dicts)
+
     # The document version this append was built on. Captured with the text it
     # reads so the write path can prove nothing else appended in between — see
     # ``ConcurrentAppendConflict`` and the gate in ``_streaming_retain_batch``.
@@ -1711,7 +1723,7 @@ async def retain_batch(
     from ..memories import get_memories as _get_memories_delta
 
     _delta_provider = _get_memories_delta()
-    if attempts_delta_retain(_delta_provider, bank_id, is_first_batch):
+    if not force_reextract and attempts_delta_retain(_delta_provider, bank_id, is_first_batch):
         delta_result = await _try_delta_retain(
             pool,
             embeddings_model,
@@ -1815,6 +1827,7 @@ async def retain_batch(
         progress_callback=progress_callback,
         append_base_hash=append_base_hash,
         append_base_watermark=append_base_watermark,
+        force_reextract=force_reextract,
     )
 
 
@@ -2233,6 +2246,7 @@ async def _streaming_retain_batch(
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
     append_base_hash: str | None = None,
     append_base_watermark: int | None = None,
+    force_reextract: bool = False,
 ) -> tuple[list[list[str]], TokenUsage]:
     """
     Process a large document in streaming mini-batches to bound memory usage.
@@ -2304,7 +2318,11 @@ async def _streaming_retain_batch(
     # nothing, `is_recovery` stayed False, and it cost a pool acquire and a query per document.
     from ..memories import get_memories as _get_memories_recov
 
-    _sql_recovery_possible = not _get_memories_recov().store_owned_for(bank_id)
+    # A forced re-extraction is an operator saying "extract this again under the current
+    # config", so it must never be classified as a crashed retain being resumed: recovery
+    # preserves every existing unit and skips every matching chunk, which is exactly the
+    # silent no-op #3899 reports. Skipping the probe also skips its two queries.
+    _sql_recovery_possible = not force_reextract and not _get_memories_recov().store_owned_for(bank_id)
     try:
         if _sql_recovery_possible:
             async with acquire_with_retry(pool) as conn:

--- a/hindsight-api-slim/hindsight_api/engine/retain/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/types.py
@@ -103,6 +103,10 @@ class RetainContentDict(TypedDict, total=False):
         update_mode: How to handle existing documents with the same document_id (optional).
             "replace" (default) deletes old data and reprocesses. "append" concatenates
             new content to the existing document and reprocesses.
+        force_reextract: Re-run extraction even when the content is byte-identical to what
+            is already stored (optional, default False). Internal — set by
+            ``reprocess_document``, not accepted on the public retain API. See
+            ``retain_batch`` for the two skips it suppresses.
     """
 
     content: str  # Required
@@ -117,6 +121,7 @@ class RetainContentDict(TypedDict, total=False):
         Literal["per_tag", "combined", "all_combinations", "shared"] | list[list[str]]
     )  # Observation scopes for consolidation
     update_mode: Literal["replace", "append"]
+    force_reextract: bool
 
 
 @dataclass

--- a/hindsight-api-slim/tests/test_reprocess_force_reextract.py
+++ b/hindsight-api-slim/tests/test_reprocess_force_reextract.py
@@ -1,0 +1,146 @@
+"""#3899: an explicit reprocess must re-extract, never be classified as a no-op.
+
+A reprocess replays the document's own stored text, so the content is byte-identical
+by construction — and the retain pipeline has two skips for exactly that shape: the
+delta path finds no changed chunk and updates document metadata only, and the
+crash-recovery gate sees the matching ``content_hash`` plus surviving chunk hashes,
+preserves every existing unit and makes zero LLM calls. Either one settles the
+operation ``completed`` with ``unit_ids_count: 0``, indistinguishable from a real
+re-extraction unless you read the facts.
+
+Both skips stay in place for an ordinary re-push of unchanged content, which is what
+they are for; only ``force_reextract`` suppresses them.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from hindsight_api.api import create_app
+
+_CONTENT = "Alice works at Google. Bob works at Meta."
+
+
+@pytest.fixture(scope="session")
+def db_url():
+    """Isolated pg0 instance so this module never touches the dev database."""
+    return "pg0://hs3899:55499"
+
+
+@pytest_asyncio.fixture
+async def api_client(memory):
+    app = create_app(memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+async def _child_metadata(memory, bank_id, parent_id, request_context):
+    """The child operation's result_metadata — where ``unit_ids_count`` lives."""
+    status = await memory.get_operation_status(bank_id=bank_id, operation_id=parent_id, request_context=request_context)
+    assert status["status"] == "completed", status
+    children = status.get("child_operations") or []
+    assert len(children) == 1, children
+    child = await memory.get_operation_status(
+        bank_id=bank_id, operation_id=children[0]["operation_id"], request_context=request_context
+    )
+    return child["result_metadata"]
+
+
+async def _unit_ids(memory, bank_id, document_id, request_context):
+    result = await memory.list_memory_units(
+        bank_id, document_id=document_id, limit=100, request_context=request_context
+    )
+    return {u["id"] for u in result["items"]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_reprocess_reextracts_unchanged_content(memory, request_context):
+    """The reported symptom: reprocess settled ``completed`` with nothing extracted."""
+    bank_id = f"test_reprocess_force_{datetime.now(timezone.utc).timestamp()}"
+    try:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": _CONTENT, "document_id": "doc-force"}],
+            request_context=request_context,
+        )
+        before = await _unit_ids(memory, bank_id, "doc-force", request_context)
+        assert before
+
+        result = await memory.reprocess_document(
+            bank_id=bank_id, document_id="doc-force", request_context=request_context
+        )
+        assert result is not None
+        await asyncio.sleep(0.5)
+
+        meta = await _child_metadata(memory, bank_id, result["operation_id"], request_context)
+        assert meta["unit_ids_count"] > 0, f"reprocess was a silent no-op: {meta}"
+
+        # A replace, not an append: the old units are gone and the new ones are new rows.
+        after = await _unit_ids(memory, bank_id, "doc-force", request_context)
+        assert after
+        assert not (after & before), "reprocess preserved the existing units instead of re-extracting"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_http_reprocess_reextracts(api_client, memory, request_context):
+    """Same through the endpoint the issue reports, which is how operators reach it."""
+    bank_id = f"test_reprocess_http_{datetime.now(timezone.utc).timestamp()}"
+    try:
+        response = await api_client.post(
+            f"/v1/default/banks/{bank_id}/memories",
+            json={"items": [{"content": _CONTENT, "document_id": "doc-http"}]},
+        )
+        assert response.status_code == 200
+        before = await _unit_ids(memory, bank_id, "doc-http", request_context)
+        assert before
+
+        response = await api_client.post(f"/v1/default/banks/{bank_id}/documents/doc-http/reprocess")
+        assert response.status_code == 200, response.text
+        await asyncio.sleep(0.5)
+
+        meta = await _child_metadata(memory, bank_id, response.json()["operation_id"], request_context)
+        assert meta["unit_ids_count"] > 0, f"reprocess was a silent no-op: {meta}"
+        after = await _unit_ids(memory, bank_id, "doc-http", request_context)
+        assert not (after & before)
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_plain_re_retain_of_unchanged_content_still_skips(memory, request_context):
+    """The other half of the fix: forcing must not leak into ordinary retains.
+
+    A sync layer that re-pushes unchanged content relies on this skip — re-extracting
+    every unchanged push is the cost the delta/recovery paths exist to avoid.
+    """
+    bank_id = f"test_reprocess_noforce_{datetime.now(timezone.utc).timestamp()}"
+    try:
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": _CONTENT, "document_id": "doc-nochange"}],
+            request_context=request_context,
+        )
+        before = await _unit_ids(memory, bank_id, "doc-nochange", request_context)
+        assert before
+
+        result = await memory.submit_async_retain(
+            bank_id,
+            [{"content": _CONTENT, "document_id": "doc-nochange"}],
+            request_context=request_context,
+        )
+        await asyncio.sleep(0.5)
+
+        meta = await _child_metadata(memory, bank_id, result["operation_id"], request_context)
+        assert meta["unit_ids_count"] == 0, f"unchanged re-push re-extracted: {meta}"
+        assert await _unit_ids(memory, bank_id, "doc-nochange", request_context) == before
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_retain_params_roundtrip.py
+++ b/hindsight-api-slim/tests/test_retain_params_roundtrip.py
@@ -178,3 +178,20 @@ async def test_strategy_survives_more_than_one_reprocess():
         stored = _params(**item)
 
     assert stored["strategy"] == "survey"
+
+
+@pytest.mark.asyncio
+async def test_reprocess_forces_reextraction():
+    """A reprocess replays identical content, which the delta and crash-recovery
+    paths both read as "nothing to do" — so it has to say it means it (#3899)."""
+    item, _strategy = await _reprocess(_params(content="STATUS: survey started"))
+    assert item["force_reextract"] is True
+
+
+@pytest.mark.asyncio
+async def test_force_reextract_is_not_stored_in_retain_params():
+    """It is the reprocess's own instruction, not something the document carries:
+    storing it would put an internal flag on every reprocessed document's
+    retain_params (and back onto the next replay) for no added effect."""
+    item, _strategy = await _reprocess(_params(content="STATUS: survey started"))
+    assert "force_reextract" not in _params(**item)


### PR DESCRIPTION
Fixes #3899.

## The bug, and the gate the issue does not name

Reproduced on current main: retain a document, then reprocess it — the operation settles
`completed` with `unit_ids_count: 0` and the existing units untouched. Exactly as reported.

But the log shows the default path never reaches the crash-recovery gate the issue points at:

```
[delta] No chunk changes detected — updating document metadata only
```

**Delta retain short-circuits first.** A reprocess replays the document's own stored text, so
`_try_delta_retain` diffs it against the stored chunks, gets `0 changed / 0 new / 0 removed`, and
takes `_delta_metadata_only`. The recovery classification in `_streaming_retain_batch` is the
*second* skip with the same effect — it fires where delta is not attempted (a non-first sub-batch,
or a bank whose store owns retain). A fix that suppressed only `is_recovery` would look correct on
inspection and still no-op on the common path, so both had to go.

The issue's reading of #3874 holds: making the replay faithful makes the hash match more often,
which turns #3873's wrong-strategy re-extractions into this silent no-op. The two compose only
with an explicit force.

## Fix

`force_reextract`, the flag shape the issue offered. Clearing the document's `content_hash` — the
alternative it raises — defeats recovery but **not** delta, which diffs the chunk rows, so it would
not have fixed the path actually taken.

- `reprocess_document` sets `force_reextract` on the replayed content item.
- `retain_batch` reads it, skips the delta attempt, and passes it to `_streaming_retain_batch`,
  which then never classifies the retain as a crashed one being resumed.

It rides on the **content item** rather than as a parameter: that way it survives the async
operation payload and the oversized-item splitter (`{**item, "content": slice}` copies every field
onto each slice) without threading a kwarg through every frame in between. It is added to
`_RETAIN_PARAMS_NOT_REPLAYED` so it is not stored back onto the document, and `api_retain` assigns
its content dict field by field, so a client cannot set it.

Sub-batches 2..N are unaffected by losing recovery: `is_first_batch` is `idx == 1`, and
`handle_document_tracking` cascade-deletes only on the first batch — so for the later slices this
is upsert-versus-upsert.

## Tests

`tests/test_reprocess_force_reextract.py` (isolated pg0 via a shadowed `db_url` fixture):

- reprocess re-extracts and *replaces* the units (new ids), through the engine and through
  `POST /v1/default/banks/{bank_id}/documents/{document_id}/reprocess`;
- a plain re-push of unchanged content **still** no-ops — that skip is what content-hash-gated
  sync layers rely on, and forcing must not leak into ordinary retains.

The pure-function half (flag set on the replayed item; not persisted into `retain_params`) sits in
`test_retain_params_roundtrip.py` next to the #3874 round-trip tests.

`./scripts/hooks/lint.sh` passes; the delta / append / same-document-concurrency suites (60 tests)
pass alongside the new ones.

## Not included

The `reextracted: true/false` response field the issue suggests: it changes the response model
(OpenAPI + client regeneration), and with forcing in place the child operation's `unit_ids_count`
already distinguishes the outcomes. Happy to add it if you'd rather have it explicit.

https://claude.ai/code/session_0134gt96Tyi2Yi55yDH5s4Rb