### PR TITLE
config: read a bank's own config fresh, not through the per-process cache

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -7314,7 +7314,9 @@ def _register_routes(app: FastAPI):
             # Get bank-specific config overrides (not the fully resolved config,
             # so the template only contains what was explicitly set on this bank)
             await app.state.memory._authenticate_tenant(request_context)
-            bank_overrides = await app.state.memory._config_resolver._load_bank_config(bank_id)
+            # Fresh, not cached: this exports what is stored ON the bank, and a template taken
+            # right after a config edit must not carry the values that edit replaced.
+            bank_overrides = await app.state.memory._config_resolver._load_bank_config(bank_id, cached=False)
 
             # Filter to only BankTemplateConfig fields (exclude credentials, static fields)
             template_config_fields = set(BankTemplateConfig.model_fields.keys())

--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -176,7 +176,9 @@ class ConfigResolver:
 
         return config_dict
 
-    async def resolve_full_config(self, bank_id: str, context: RequestContext | None = None) -> HindsightConfig:
+    async def resolve_full_config(
+        self, bank_id: str, context: RequestContext | None = None, *, cached: bool = True
+    ) -> HindsightConfig:
         """
         Resolve full HindsightConfig for a bank with hierarchical overrides applied.
 
@@ -198,7 +200,7 @@ class ConfigResolver:
         config_dict = await self._resolve_parent_config_dict(bank_id, context)
 
         # Load bank config overrides
-        bank_overrides = await self._load_bank_config(bank_id)
+        bank_overrides = await self._load_bank_config(bank_id, cached=cached)
         if bank_overrides:
             config_dict.update(bank_overrides)
             logger.debug(f"Applied bank config overrides for bank {bank_id}: {list(bank_overrides.keys())}")
@@ -237,8 +239,11 @@ class ConfigResolver:
         2. Tenant config overrides (from TenantExtension.get_tenant_config())
         3. Bank config overrides (from banks.config JSONB)
 
-        Note: Config is resolved on every call (not cached) to ensure consistency
-        across multiple API servers.
+        Note: the bank's stored overrides are read fresh on every call (``cached=False`` below),
+        not through the per-process cache, to ensure consistency across multiple API servers.
+        This is the endpoint a caller reads back after editing a bank's config, and the cache is
+        per process — so a cached read here answers a successful write with the values it just
+        replaced, on whichever pod did not serve the write.
 
         SECURITY:
         - Only returns configurable fields (excludes static/infrastructure fields)
@@ -253,7 +258,7 @@ class ConfigResolver:
             Dict of allowed configurable fields only (never includes credentials or static fields)
         """
         # Resolve full config with all hierarchical overrides
-        resolved_config = await self.resolve_full_config(bank_id, context)
+        resolved_config = await self.resolve_full_config(bank_id, context, cached=False)
         config_dict = asdict(resolved_config)
 
         # SECURITY: drop static/infrastructure + credential fields, then permission-filter.
@@ -334,12 +339,18 @@ class ConfigResolver:
         )
         return dict(zip(bank_ids, permission_filtered, strict=True))
 
-    async def _load_bank_config(self, bank_id: str) -> dict[str, Any]:
+    async def _load_bank_config(self, bank_id: str, *, cached: bool = True) -> dict[str, Any]:
         """
         Load bank config overrides from banks.config JSONB column.
 
         Args:
             bank_id: Bank identifier
+            cached: read through the per-process cache. True on the RETAIN path, where this runs
+                once per sub-batch and a bank config that lags by one TTL changes nothing a caller
+                can see. False for anything that answers a reader about the bank's own config: the
+                cache is per PROCESS, so a write served by one pod is invisible to the others until
+                their entry expires, and a deployment runs several. Read-your-writes on a config
+                edit is not a race a user should have to lose.
 
         Returns:
             Dict of config overrides (only configurable fields, normalized keys)
@@ -373,9 +384,13 @@ class ConfigResolver:
                 # answer -- bank_info_cache drops empty values for exactly this reason.
                 return {}
 
-        cached = await bank_info_cache.get_or_load(bank_id, "config", _read_config_row)
-        if cached.get("config"):
-            return self._active_bank_overrides(bank_id, cached["config"])
+        row = (
+            await bank_info_cache.get_or_load(bank_id, "config", _read_config_row)
+            if cached
+            else await _read_config_row()
+        )
+        if row.get("config"):
+            return self._active_bank_overrides(bank_id, row["config"])
 
         return {}
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12173,7 +12173,10 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> BankConfigState:
         """Load config after the caller has established tenant and operation access."""
         config = await self._config_resolver.get_bank_config(bank_id, request_context)
-        overrides = await self._config_resolver._load_bank_config(bank_id)
+        # Fresh, like the resolved config above: `overrides` is what the UI renders as "Bank
+        # override", so a cached read here answers a successful config edit with the values it
+        # replaced on any pod that did not serve the write.
+        overrides = await self._config_resolver._load_bank_config(bank_id, cached=False)
         return BankConfigState(config=config, overrides=overrides)
 
     @asynccontextmanager

--- a/hindsight-api-slim/tests/test_bank_info_cache_invalidation.py
+++ b/hindsight-api-slim/tests/test_bank_info_cache_invalidation.py
@@ -71,3 +71,34 @@ async def test_a_config_override_is_visible_to_the_next_resolve(memory: MemoryEn
 
     after = await resolver._load_bank_config(bank_id)
     assert after.get("retain_chunk_size") == 1234, "the cached config row survived a config write"
+
+
+@pytest.mark.asyncio
+async def test_a_config_read_back_does_not_go_through_the_cache(memory: MemoryEngine, request_context, monkeypatch):
+    """The cache is per PROCESS and a deployment runs several API pods, so invalidating on write
+    only ever fixes the pod that served the write. The endpoint a caller reads back through must
+    therefore not consult the cache at all.
+
+    The other pods are modelled by disabling invalidation entirely: that leaves this process in
+    exactly their state -- an entry cached before the write, and no notification that it moved.
+    A read that still sees the new value is one that did not come from the cache.
+    """
+    from hindsight_api.engine import bank_info_cache
+
+    bank_id = _bank("cache_bypass")
+    await memory.get_bank_profile(bank_id, request_context=request_context, create_if_missing=True)
+    # Warm the config entry, then take invalidation away before the write.
+    await memory.get_bank_config(bank_id, request_context=request_context)
+
+    async def _no_invalidation(*_a, **_kw):
+        return None
+
+    monkeypatch.setattr(bank_info_cache, "invalidate", _no_invalidation)
+    await memory.update_bank_config(bank_id, {"retain_chunk_size": 4321}, request_context=request_context)
+
+    state = await memory.get_bank_config(bank_id, request_context=request_context)
+    assert state.overrides.get("retain_chunk_size") == 4321, (
+        "get_bank_config served a cached config row; a caller reading back its own edit sees the "
+        "value it replaced on any pod that did not serve the write"
+    )
+    assert state.config.get("retain_chunk_size") == 4321, "the resolved config came from the cache too"


### PR DESCRIPTION
`ConfigResolver.get_bank_config` documents the property it needs:

> Config is resolved on every call (not cached) to ensure consistency across multiple API servers.

The bank-info cache took that away. The control-plane E2E caught it: setting a bank-level config override left the **"Bank override" badge absent**, so a saved edit looked like it had not saved.

## Why

The cache is per **process**. Invalidating on write only fixes the pod that served the write — dev runs four API replicas, so a read-back has a 3-in-4 chance of landing on a pod whose entry is up to a TTL (30s) old.

That cross-process trade is fine for what the cache exists for: the retain path reads this once per sub-batch, and a bank config lagging by one TTL changes nothing a caller can observe. It is not fine for the endpoint a user reads back immediately after editing.

## What

`_load_bank_config` takes the choice explicitly and still defaults to cached, so the retain path is untouched. Three reader-facing paths pass `cached=False`:

- the resolved config
- the `overrides` beside it — what the UI renders as the badge, and a **separate** call that is easy to miss
- the bank-template export, so a template taken right after an edit does not carry the replaced values

## Test

`test_a_config_read_back_does_not_go_through_the_cache` models the other pods the only way a single process can: it warms the entry, then removes invalidation before the write, which leaves this process in exactly their state.

Verified by mutation — restore either cached read and it fails.

https://claude.ai/code/session_01V3ViCQDM6pPSCfntZam3Kg