### PR TITLE
fix(consolidation): resolve observation_scopes before tag-set batching

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -654,6 +654,28 @@ def _resolve_write_scopes(memory: dict[str, Any]) -> list[frozenset[str]]:
     return [frozenset(s) for s in parsed]  # explicit list[list[str]]
 
 
+def _consolidation_batch_key(memory: dict[str, Any]) -> tuple[str, ...]:
+    """Return the key that decides which memories may share an LLM batch.
+
+    The real security requirement is "memories targeting different observation
+    scopes must never share an LLM call" — tags are only a proxy for that in
+    the default ``combined`` mode, where a memory's target scope *is* its own
+    tag set. A memory that names a single alternate scope (``shared``, an
+    explicit one-scope list, or ``per_tag`` with exactly one tag) targets that
+    scope instead, so it batches with any other memory naming the identical
+    scope regardless of native tags — that is the whole point of requesting
+    it. A memory that fans out to *multiple* scopes (``per_tag`` with more
+    than one tag, ``all_combinations``, or a multi-scope explicit list) writes
+    several observations from one LLM call; there is no single target scope
+    to key on, so it keeps grouping by native tags like the default case
+    (unchanged from before this function existed).
+    """
+    resolved = _resolve_obs_tags_list(memory)
+    if resolved is not None and len(resolved) == 1:
+        return tuple(sorted(resolved[0]))
+    return tuple(sorted(memory.get("tags") or []))
+
+
 def _scope_sort_key(scope: frozenset[str]) -> tuple[str, ...]:
     """Total ordering on scope frozensets for deadlock-free lock acquisition.
 
@@ -1433,11 +1455,15 @@ async def _run_consolidation_job(
         if not memories:
             break  # No more unconsolidated memories
 
-        # Group memories by exact tag set before batching — security requirement:
-        # memories with different tags must never share an LLM call.
+        # Group memories by target observation scope before batching — security
+        # requirement: memories targeting different scopes must never share an
+        # LLM call. See _consolidation_batch_key for why that's scope, not raw
+        # tags: a memory requesting observation_scopes="shared" (or another
+        # single-scope override) targets a scope that can differ from its own
+        # tags, and must only batch with peers naming that same scope (#3924).
         tag_groups: dict[tuple[str, ...], list[dict[str, Any]]] = {}
         for m in memories:
-            tag_key = tuple(sorted(m.get("tags") or []))
+            tag_key = _consolidation_batch_key(m)
             tag_groups.setdefault(tag_key, []).append(dict(m))
 
         # Split each tag group into LLM batches respecting llm_batch_size, keeping

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -658,22 +658,32 @@ def _consolidation_batch_key(memory: dict[str, Any]) -> tuple[str, ...]:
     """Return the key that decides which memories may share an LLM batch.
 
     The real security requirement is "memories targeting different observation
-    scopes must never share an LLM call" — tags are only a proxy for that in
-    the default ``combined`` mode, where a memory's target scope *is* its own
-    tag set. A memory that names a single alternate scope (``shared``, an
-    explicit one-scope list, or ``per_tag`` with exactly one tag) targets that
-    scope instead, so it batches with any other memory naming the identical
-    scope regardless of native tags — that is the whole point of requesting
-    it. A memory that fans out to *multiple* scopes (``per_tag`` with more
-    than one tag, ``all_combinations``, or a multi-scope explicit list) writes
-    several observations from one LLM call; there is no single target scope
-    to key on, so it keeps grouping by native tags like the default case
-    (unchanged from before this function existed).
+    scopes must never share an LLM call" — every branch below keys on the
+    memory's *resolved* scope(s), never on raw tags, so two memories with the
+    same native tags but different ``observation_scopes`` modes can never
+    collide into the same group:
+
+    - default ``combined`` (``resolved is None``): the memory's target scope
+      *is* its own tag set, so it keys on those tags.
+    - a single alternate scope (``shared``, an explicit one-scope list, or
+      ``per_tag`` with exactly one tag): keys on that resolved scope instead,
+      so it batches with any other memory naming the identical scope
+      regardless of native tags — that is the whole point of requesting it.
+    - fan-out to *multiple* scopes (``per_tag`` with more than one tag,
+      ``all_combinations``, or a multi-scope explicit list): writes several
+      observations from one LLM call, so it keys on the full resolved
+      scope-list, not native tags — two fan-out memories only share a batch
+      when every one of their target scopes matches exactly. A distinct
+      leading marker per branch keeps e.g. a ``combined`` memory tagged
+      ``["a","b"]`` out of the same key as a ``per_tag`` memory tagged
+      ``["a","b"]``, even though both would otherwise sort to ``("a","b")``.
     """
     resolved = _resolve_obs_tags_list(memory)
-    if resolved is not None and len(resolved) == 1:
-        return tuple(sorted(resolved[0]))
-    return tuple(sorted(memory.get("tags") or []))
+    if resolved is None:
+        return ("combined", *sorted(memory.get("tags") or []))
+    if len(resolved) == 1:
+        return ("scope", *sorted(resolved[0]))
+    return ("fanout", *sorted("\x1f".join(sorted(scope)) for scope in resolved))
 
 
 def _scope_sort_key(scope: frozenset[str]) -> tuple[str, ...]:

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -651,7 +651,29 @@ def _resolve_write_scopes(memory: dict[str, Any]) -> list[frozenset[str]]:
         return [frozenset()]
     if parsed == "combined" or parsed is None:
         return [frozenset(tags)]
-    return [frozenset(s) for s in parsed]  # explicit list[list[str]]
+    # Explicit list[list[str]]. An *empty* list resolves to no passes at all, and
+    # the pass loop (``if obs_tags_list:``) then falls back to the combined
+    # single pass over the memory's own tags — so report that scope here too,
+    # or the group takes no lock for the scope it actually writes.
+    return [frozenset(s) for s in parsed] or [frozenset(tags)]
+
+
+def _batch_scope_signature(memory: dict[str, Any]) -> tuple[tuple[str, ...], ...]:
+    """The exact set of observation scopes consolidating this memory will write.
+
+    Derived from the pass loop rather than from the grouping key, so it can be
+    used to *check* the key: a truthy ``_resolve_obs_tags_list`` yields one pass
+    per resolved scope (each written with that ``obs_tags_override``), and a
+    falsy one — ``None`` from ``combined``, or a degenerate empty explicit list —
+    yields the single combined pass whose tags come from the memory's own tag set.
+
+    Two memories may share an LLM call only if their signatures are equal, because
+    the batch resolves its scope once from ``sub_batch[0]`` and applies it to all.
+    """
+    obs_tags_list = _resolve_obs_tags_list(memory)
+    if not obs_tags_list:
+        return (tuple(sorted(memory.get("tags") or [])),)
+    return tuple(sorted(tuple(sorted(scope)) for scope in obs_tags_list))
 
 
 def _consolidation_batch_key(memory: dict[str, Any]) -> tuple[str, ...]:
@@ -663,8 +685,10 @@ def _consolidation_batch_key(memory: dict[str, Any]) -> tuple[str, ...]:
     same native tags but different ``observation_scopes`` modes can never
     collide into the same group:
 
-    - default ``combined`` (``resolved is None``): the memory's target scope
-      *is* its own tag set, so it keys on those tags.
+    - default ``combined`` (``resolved is None``), and the degenerate empty
+      resolution (an explicit ``[]``, which the pass loop below treats as
+      combined because ``if obs_tags_list:`` is falsy): the memory's target
+      scope *is* its own tag set, so it keys on those tags.
     - a single alternate scope (``shared``, an explicit one-scope list, or
       ``per_tag`` with exactly one tag): keys on that resolved scope instead,
       so it batches with any other memory naming the identical scope
@@ -679,7 +703,14 @@ def _consolidation_batch_key(memory: dict[str, Any]) -> tuple[str, ...]:
       ``["a","b"]``, even though both would otherwise sort to ``("a","b")``.
     """
     resolved = _resolve_obs_tags_list(memory)
-    if resolved is None:
+    if not resolved:
+        # ``None`` (combined) and ``[]`` (an explicit empty scope list) both fall
+        # through to the combined pass downstream — ``if obs_tags_list:`` is
+        # falsy for each — so they must key the same way. Testing ``is None``
+        # alone sent ``[]`` down the fan-out branch, where every such memory
+        # keyed to the tag-free ``("fanout",)`` and pooled with memories of
+        # unrelated tags; ``obs_tags_override`` then being ``None``, the whole
+        # group took ``memories[0]``'s tags and leaked across scopes.
         return ("combined", *sorted(memory.get("tags") or []))
     if len(resolved) == 1:
         return ("scope", *sorted(resolved[0]))
@@ -1526,6 +1557,30 @@ async def _run_consolidation_job(
             pending: list[list[dict[str, Any]]] = [llm_batch_local]
             while pending:
                 sub_batch = pending.pop(0)
+
+                # Defence in depth. Everything below writes the sub-batch at ONE
+                # resolved scope, read off ``sub_batch[0]``. If a memory with a
+                # different scope ever reaches this batch — a regression in
+                # ``_consolidation_batch_key``, or in how groups are split into
+                # batches — that single read stamps one memory's scope onto
+                # another's observation: an untagged, globally recallable
+                # observation built from a tagged fact, or a dropped override
+                # (#3953). So verify the invariant against the scopes the pass
+                # loop will actually write, independently of the grouping key,
+                # and split instead of trusting it. The cost in the case that
+                # must never happen is one extra LLM call.
+                if len(sub_batch) > 1:
+                    by_scope: dict[tuple[tuple[str, ...], ...], list[dict[str, Any]]] = {}
+                    for m in sub_batch:
+                        by_scope.setdefault(_batch_scope_signature(m), []).append(m)
+                    if len(by_scope) > 1:
+                        logger.error(
+                            f"[CONSOLIDATION] bank={bank_id} sub-batch of {len(sub_batch)} memories mixes"
+                            f" {len(by_scope)} observation scopes {sorted(by_scope)} — splitting it."
+                            " LLM batches must be scope-homogeneous; this is a grouping bug."
+                        )
+                        pending[0:0] = list(by_scope.values())
+                        continue
 
                 # No connection is held across the batch: recall, the main LLM call, the
                 # per-action embeds, and dedup adjudication all run connection-free. Only then

--- a/hindsight-api-slim/tests/test_consolidation_scope_parallelism.py
+++ b/hindsight-api-slim/tests/test_consolidation_scope_parallelism.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 import uuid
 from collections import defaultdict
@@ -452,6 +453,103 @@ async def test_explicit_scope_list_parallel_writes_declared_scopes(memory: Memor
         assert tag_sets == {frozenset({"scope_a"}), frozenset({"scope_b", "scope_c"})}
         # And NOT the memory's own tag.
         assert frozenset({"tag_ignored"}) not in tag_sets
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_empty_explicit_scope_list_does_not_pool_across_tags(memory: MemoryEngine, request_context):
+    """An explicit ``observation_scopes: []`` resolves to no passes, so the pass
+    loop falls back to the combined single pass over the memory's own tags. It
+    must therefore batch as ``combined`` — keying it as a multi-scope fan-out
+    gave every such memory the same tag-free key, pooling unrelated tag sets
+    into one call whose ``obs_tags_override`` was then ``None``: both
+    observations took ``memories[0]``'s tags and alice's observation carried
+    bob's fact (or vice versa)."""
+    bank_id = f"test-empty-scope-list-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice likes tea", ["user:alice"], [])
+            await _insert_memory(conn, bank_id, "Bob bikes daily", ["user:bob"], [])
+
+        wrapper, _ = _mock_llm_one_obs_per_fact()
+        original_llm = memory._consolidation_llm_config
+        memory._consolidation_llm_config = wrapper
+        try:
+            with (
+                _override_config(memory, consolidation_llm_parallelism=2, consolidation_llm_batch_size=2),
+                patch.object(memory, "submit_async_consolidation"),
+            ):
+                result = await run_consolidation_job(
+                    memory_engine=memory, bank_id=bank_id, request_context=request_context
+                )
+        finally:
+            memory._consolidation_llm_config = original_llm
+
+        assert result["status"] == "completed"
+        tag_sets = _ag_sorted(await _fetch_observation_tag_sets(memory, bank_id, request_context))
+        assert tag_sets == _ag_sorted([frozenset({"user:alice"}), frozenset({"user:bob"})])
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_heterogeneous_batch_is_split_not_leaked(memory: MemoryEngine, request_context, caplog):
+    """Defence in depth: even with the grouping key deliberately broken, a batch
+    is never written at another memory's scope.
+
+    ``_consolidation_batch_key`` is patched to a constant — the shape of every
+    bug in this class, including the original #3953 native-tag key — so all four
+    memories land in one group and one ``llm_batch_size=4`` batch. The sub-batch
+    loop must notice the mixed scopes, split on the scopes the pass loop will
+    actually write, and log the grouping bug, leaving every observation at its
+    own scope: no untagged observation built from a tagged fact, no dropped
+    ``shared`` override."""
+    bank_id = f"test-hetero-split-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "A session note", ["user:alice"], "shared")
+            await _insert_memory(conn, bank_id, "Alice's salary is private", ["user:alice"], None)
+            await _insert_memory(conn, bank_id, "Bob bikes daily", ["user:bob"], None)
+            await _insert_memory(conn, bank_id, "Carol reads books", ["user:carol", "team:x"], "per_tag")
+
+        wrapper, _ = _mock_llm_one_obs_per_fact()
+        original_llm = memory._consolidation_llm_config
+        memory._consolidation_llm_config = wrapper
+        try:
+            with (
+                _override_config(memory, consolidation_llm_parallelism=1, consolidation_llm_batch_size=4),
+                patch.object(memory, "submit_async_consolidation"),
+                patch(
+                    "hindsight_api.engine.consolidation.consolidator._consolidation_batch_key",
+                    lambda _memory: ("everything-collides",),
+                ),
+                caplog.at_level(logging.ERROR, logger="hindsight_api.engine.consolidation.consolidator"),
+            ):
+                result = await run_consolidation_job(
+                    memory_engine=memory, bank_id=bank_id, request_context=request_context
+                )
+        finally:
+            memory._consolidation_llm_config = original_llm
+
+        assert result["status"] == "completed"
+        assert any("scope-homogeneous" in r.message for r in caplog.records), (
+            "the broken grouping should have been reported"
+        )
+        tag_sets = _ag_sorted(await _fetch_observation_tag_sets(memory, bank_id, request_context))
+        assert tag_sets == _ag_sorted(
+            [
+                frozenset(),  # the shared memory, at the untagged scope
+                frozenset({"user:alice"}),
+                frozenset({"user:bob"}),
+                frozenset({"user:carol"}),  # per_tag fan-out, one per tag
+                frozenset({"team:x"}),
+            ]
+        )
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_consolidation_scope_parallelism.py
+++ b/hindsight-api-slim/tests/test_consolidation_scope_parallelism.py
@@ -282,6 +282,58 @@ async def test_shared_mode_pools_different_native_tags_into_one_llm_batch(memory
 
 @pytest.mark.asyncio
 @pytest.mark.memory_backend_incompatible
+async def test_combined_and_per_tag_same_tags_do_not_share_a_batch(memory: MemoryEngine, request_context):
+    """Regression test: a ``combined`` memory and a ``per_tag`` memory that
+    happen to share the same native tags must never land in the same
+    ``tag_groups`` bucket.
+
+    Before this fix, ``_consolidation_batch_key`` fell back to native tags
+    whenever a memory's resolved scope list had length != 1 (the per_tag/
+    all_combinations/multi-scope-explicit fan-out branch), so a combined
+    memory and a same-tagged per_tag memory both sorted to the same native
+    tag tuple and collided into one group. Whichever memory then happened to
+    land as ``sub_batch[0]`` after the ``llm_batch_size`` split decided the
+    scope for *both* — silently dropping the per_tag fan-out, or wrongly
+    fanning the combined memory out per tag.
+    """
+    bank_id = f"test-combined-per-tag-collision-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice likes tea and coffee", ["a", "b"], None)
+            await _insert_memory(conn, bank_id, "Bob likes tea and coffee too", ["a", "b"], "per_tag")
+
+        wrapper, _ = _mock_llm_one_obs_per_fact()
+        original_llm = memory._consolidation_llm_config
+        memory._consolidation_llm_config = wrapper
+        try:
+            with (
+                _override_config(memory, consolidation_llm_parallelism=2, consolidation_llm_batch_size=2),
+                patch.object(memory, "submit_async_consolidation"),
+            ):
+                result = await run_consolidation_job(
+                    memory_engine=memory, bank_id=bank_id, request_context=request_context
+                )
+        finally:
+            memory._consolidation_llm_config = original_llm
+
+        assert result["status"] == "completed"
+        tag_sets = _ag_sorted(await _fetch_observation_tag_sets(memory, bank_id, request_context))
+        # combined memory -> one observation over its full tag set; per_tag
+        # memory -> one observation per tag. Neither scope leaks into the other.
+        assert tag_sets == _ag_sorted(
+            [
+                frozenset({"a", "b"}),
+                frozenset({"a"}),
+                frozenset({"b"}),
+            ]
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
 async def test_per_tag_mode_parallel_writes_one_observation_per_tag(memory: MemoryEngine, request_context):
     """per_tag with tags [a, b] → two observations, tagged [a] and [b] respectively.
 

--- a/hindsight-api-slim/tests/test_consolidation_scope_parallelism.py
+++ b/hindsight-api-slim/tests/test_consolidation_scope_parallelism.py
@@ -216,6 +216,72 @@ async def test_shared_mode_parallel_writes_only_untagged_scope(memory: MemoryEng
 
 @pytest.mark.asyncio
 @pytest.mark.memory_backend_incompatible
+async def test_shared_mode_pools_different_native_tags_into_one_llm_batch(memory: MemoryEngine, request_context):
+    """Regression test for #3953: two memories with different native tags,
+    both requesting ``observation_scopes="shared"``, must be pooled into the
+    same LLM consolidation batch/call — not split into two calls before their
+    scope override is ever consulted.
+
+    Before the fix, ``tag_groups`` keyed on each memory's raw native tag set,
+    so these two memories (different tags) landed in two separate tag groups
+    and were never presented to the LLM together, even though both named the
+    identical target scope. ``consolidation_llm_batch_size=1`` (used by the
+    sibling ``shared`` test above) doesn't exercise this: with batch size 1,
+    every memory gets its own LLM call regardless of grouping. This test uses
+    batch_size=2 so a single shared batch is actually observable.
+    """
+    bank_id = f"test-shared-pool-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            mem_a = await _insert_memory(
+                conn, bank_id, "Terraform Cloud is our IaC tool", ["suggested_tool:terraform-cloud"], "shared"
+            )
+            mem_b = await _insert_memory(
+                conn, bank_id, "Gardea helps with garden planning", ["suggested_tool:gardea"], "shared"
+            )
+
+        calls: list[set[str]] = []
+
+        mock_llm = MockLLM(provider="mock", api_key="", base_url="", model="mock-model")
+
+        def callback(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = set(re.findall(r"\[([0-9a-f-]{36})\]", prompt))
+            calls.append(fact_ids)
+            creates = [
+                _CreateAction(text=f"Observation about fact {fid[:8]}", source_fact_ids=[fid]) for fid in fact_ids
+            ]
+            return _ConsolidationBatchResponse(creates=creates)
+
+        mock_llm.set_response_callback(callback)
+        wrapper = MagicMock()
+        wrapper.with_config.return_value = mock_llm
+
+        original_llm = memory._consolidation_llm_config
+        memory._consolidation_llm_config = wrapper
+        try:
+            with (
+                _override_config(memory, consolidation_llm_parallelism=2, consolidation_llm_batch_size=2),
+                patch.object(memory, "submit_async_consolidation"),
+            ):
+                result = await run_consolidation_job(
+                    memory_engine=memory, bank_id=bank_id, request_context=request_context
+                )
+        finally:
+            memory._consolidation_llm_config = original_llm
+
+        assert result["status"] == "completed"
+        assert len(calls) == 1, f"expected exactly one LLM consolidation call, got {len(calls)}: {calls}"
+        assert calls[0] == {str(mem_a), str(mem_b)}, calls[0]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
 async def test_per_tag_mode_parallel_writes_one_observation_per_tag(memory: MemoryEngine, request_context):
     """per_tag with tags [a, b] → two observations, tagged [a] and [b] respectively.
 

--- a/hindsight-api-slim/tests/test_consolidation_write_scopes.py
+++ b/hindsight-api-slim/tests/test_consolidation_write_scopes.py
@@ -13,6 +13,8 @@ import json
 import pytest
 
 from hindsight_api.engine.consolidation.consolidator import (
+    _batch_scope_signature,
+    _consolidation_batch_key,
     _resolve_obs_tags_list,
     _resolve_write_scopes,
     _scope_sort_key,
@@ -206,17 +208,25 @@ class TestDispatchLockAgreement:
             {"tags": ["a", "b"], "observation_scopes": json.dumps("shared")},
             {"tags": ["a", "b"], "observation_scopes": json.dumps([["a"], ["b"], ["a", "b"]])},
             {"tags": ["a"], "observation_scopes": json.dumps([["a"], ["x"]])},
+            {"tags": [], "observation_scopes": json.dumps("per_tag")},
+            # Degenerate explicit list: resolves to no passes, so the pass loop
+            # falls back to the combined single pass over the memory's own tags.
+            {"tags": ["a", "b"], "observation_scopes": json.dumps([])},
+            {"tags": [], "observation_scopes": json.dumps([])},
             # Pre-parsed Python shape (defensive — covers callers that hand the
             # helper a memory dict with a non-string value).
             {"tags": ["a", "b"], "observation_scopes": [["a"], ["b"], ["a", "b"]]},
+            {"tags": ["a", "b"], "observation_scopes": []},
         ],
     )
     def test_every_dispatched_scope_has_a_lock(self, memory):
         dispatched = _resolve_obs_tags_list(memory)
         write_scopes = set(_resolve_write_scopes(memory))
 
-        if dispatched is None:
-            # Combined-mode single pass: memory's own tags are the write scope.
+        if not dispatched:
+            # Combined-mode single pass — either the explicit ``combined``/None
+            # resolution or a falsy one the pass loop treats identically: the
+            # memory's own tags are the write scope.
             expected = {frozenset(memory.get("tags") or [])}
         else:
             expected = {frozenset(s) for s in dispatched}
@@ -254,3 +264,183 @@ class TestScopeSortKey:
         scope_a = frozenset(["x", "y", "z"])
         scope_b = frozenset({"z", "y", "x"})  # built differently, same set
         assert _scope_sort_key(scope_a) == _scope_sort_key(scope_b)
+
+
+# ---------------------------------------------------------------------------
+# _consolidation_batch_key — the grouping key that decides who shares an LLM call
+# ---------------------------------------------------------------------------
+
+
+def _effective_pass_scopes(memory) -> set[frozenset[str]]:
+    """The scopes ``run_consolidation_job`` will actually write for this memory.
+
+    Reads the production signature so the invariants below are pinned to the same
+    derivation the runtime split uses; ``TestBatchScopeSignature`` is what pins
+    that derivation to the pass loop.
+    """
+    return {frozenset(scope) for scope in _batch_scope_signature(memory)}
+
+
+#: Every (tags, observation_scopes) shape the write path can produce, crossed
+#: below into pairs. Kept exhaustive on purpose: the batch key is the only thing
+#: standing between two memories and a shared LLM call, and the loop reads the
+#: scope off ``sub_batch[0]`` for the whole batch.
+_SCOPE_SPECS = [
+    None,
+    "combined",
+    "per_tag",
+    "all_combinations",
+    "shared",
+    [],
+    [[]],
+    [["a"]],
+    [["b"]],
+    [["a"], ["b"]],
+    [["a", "b"]],
+    [["x"]],
+]
+
+_TAG_SETS = [[], ["a"], ["b"], ["a", "b"], ["b", "a"], ["a", "c"]]
+
+_ALL_MEMORIES = [
+    {"tags": list(tags), "observation_scopes": json.dumps(spec) if spec is not None else None}
+    for tags in _TAG_SETS
+    for spec in _SCOPE_SPECS
+]
+
+
+class TestConsolidationBatchKey:
+    """A batch's observation scope is resolved once, from ``sub_batch[0]``, and
+    applied to every memory in it. So the grouping key has exactly one job: two
+    memories may share a key **only if** they write the identical set of scopes.
+
+    Break that and the failure is silent and severe — a memory tagged
+    ``user:alice`` batched behind a ``shared`` memory has its observation written
+    untagged (globally recallable: a cross-tag leak), and a ``shared`` memory
+    batched behind a ``combined`` one has its override dropped. That is #3953,
+    and it is why the invariant below is exhaustive over the spec matrix rather
+    than a handful of examples.
+    """
+
+    def test_same_key_implies_same_written_scopes(self):
+        """The load-bearing invariant: key collision ⇒ identical write scopes."""
+        by_key: dict[tuple[str, ...], list[dict]] = {}
+        for memory in _ALL_MEMORIES:
+            by_key.setdefault(_consolidation_batch_key(memory), []).append(memory)
+
+        for key, members in by_key.items():
+            scope_sets = {frozenset(_effective_pass_scopes(m)) for m in members}
+            assert len(scope_sets) == 1, f"batch key {key!r} pools memories that write different scopes: " + ", ".join(
+                f"{m!r} -> {sorted(map(sorted, _effective_pass_scopes(m)))}" for m in members
+            )
+
+    def test_same_key_implies_same_lock_scopes(self):
+        """Groups take locks per member, but a shared key must not smuggle a
+        memory into a group whose lock set doesn't cover it."""
+        by_key: dict[tuple[str, ...], list[dict]] = {}
+        for memory in _ALL_MEMORIES:
+            by_key.setdefault(_consolidation_batch_key(memory), []).append(memory)
+
+        for key, members in by_key.items():
+            lock_sets = {frozenset(_resolve_write_scopes(m)) for m in members}
+            assert len(lock_sets) == 1, f"batch key {key!r} pools memories with different lock scopes: {members!r}"
+
+    def test_key_is_stable_across_tag_order_and_encoding(self):
+        """Tag order and the JSONB string/parsed shapes are incidental; a key
+        that varied with them would split batches that belong together."""
+        assert _consolidation_batch_key({"tags": ["a", "b"], "observation_scopes": None}) == _consolidation_batch_key(
+            {"tags": ["b", "a"], "observation_scopes": json.dumps("combined")}
+        )
+        assert _consolidation_batch_key(
+            {"tags": ["a"], "observation_scopes": json.dumps([["b"], ["a"]])}
+        ) == _consolidation_batch_key({"tags": ["z"], "observation_scopes": [["a"], ["b"]]})
+
+    def test_shared_pools_across_different_native_tags(self):
+        """#3953: the whole point of ``shared`` — same target scope, so the same
+        batch, whatever the source facts happen to be tagged with."""
+        a = {"tags": ["suggested_tool:terraform"], "observation_scopes": json.dumps("shared")}
+        b = {"tags": ["suggested_tool:gardea"], "observation_scopes": json.dumps("shared")}
+        assert _consolidation_batch_key(a) == _consolidation_batch_key(b)
+
+    @pytest.mark.parametrize(
+        ("spec_a", "spec_b"),
+        [
+            (None, "shared"),
+            (None, "per_tag"),
+            (None, "all_combinations"),
+            ("shared", "per_tag"),
+            ("per_tag", "all_combinations"),
+            (None, [["a"]]),
+            ("shared", [[]]),  # equivalent target scope, reached two ways
+        ],
+    )
+    def test_same_tags_different_modes(self, spec_a, spec_b):
+        """Two memories with identical tags but different modes may share a key
+        only when the scopes they write are genuinely identical."""
+        mem_a = {"tags": ["a", "b"], "observation_scopes": json.dumps(spec_a) if spec_a is not None else None}
+        mem_b = {"tags": ["a", "b"], "observation_scopes": json.dumps(spec_b) if spec_b is not None else None}
+
+        same_key = _consolidation_batch_key(mem_a) == _consolidation_batch_key(mem_b)
+        same_scopes = _effective_pass_scopes(mem_a) == _effective_pass_scopes(mem_b)
+        assert same_key == same_scopes, (
+            f"{spec_a!r} vs {spec_b!r}: keys {'match' if same_key else 'differ'} but written scopes "
+            f"{'match' if same_scopes else 'differ'}"
+        )
+
+    @pytest.mark.parametrize("spec", [None, "combined", []])
+    def test_falsy_resolution_keys_as_combined(self, spec):
+        """``[]`` resolves to no passes and the loop falls back to combined, so
+        it must key as combined — keying it as a fan-out gave every such memory
+        the tag-free ``("fanout",)`` key, pooling unrelated tag sets into one
+        call that then took ``memories[0]``'s tags."""
+        memory = {"tags": ["a", "b"], "observation_scopes": json.dumps(spec) if spec is not None else None}
+        assert _consolidation_batch_key(memory) == ("combined", "a", "b")
+
+    def test_empty_explicit_list_does_not_pool_across_tags(self):
+        """The regression the ``not resolved`` branch closes, stated directly."""
+        alice = {"tags": ["user:alice"], "observation_scopes": json.dumps([])}
+        bob = {"tags": ["user:bob"], "observation_scopes": json.dumps([])}
+        assert _consolidation_batch_key(alice) != _consolidation_batch_key(bob)
+
+
+class TestBatchScopeSignature:
+    """``_batch_scope_signature`` is the runtime's last line of defence: the
+    sub-batch loop splits on it, so a batch can only ever be written at one
+    scope. It has to mirror the pass loop for every mode — pinned literally
+    here rather than derived, so a change to either side shows up as a diff."""
+
+    @pytest.mark.parametrize(
+        ("tags", "spec", "expected"),
+        [
+            (["b", "a"], None, (("a", "b"),)),
+            (["b", "a"], "combined", (("a", "b"),)),
+            (["a", "b"], "per_tag", (("a",), ("b",))),
+            (["a"], "per_tag", (("a",),)),
+            ([], "per_tag", ((),)),
+            (["a", "b"], "all_combinations", (("a",), ("a", "b"), ("b",))),
+            (["a", "b"], "shared", ((),)),
+            ([], None, ((),)),
+            # Degenerate explicit list -> the combined fallback over own tags.
+            (["a", "b"], [], (("a", "b"),)),
+            (["x"], [["b"], ["a"]], (("a",), ("b",))),
+            (["x"], [[]], ((),)),
+        ],
+    )
+    def test_signature_per_mode(self, tags, spec, expected):
+        memory = {"tags": tags, "observation_scopes": json.dumps(spec) if spec is not None else None}
+        assert _batch_scope_signature(memory) == expected
+
+    def test_signature_matches_the_pass_loop_fallback(self):
+        """Cross-check: the signature and the dispatcher agree on every memory
+        in the matrix, so neither can drift into agreeing with itself only."""
+        for memory in _ALL_MEMORIES:
+            dispatched = _resolve_obs_tags_list(memory)
+            expected = {frozenset(s) for s in dispatched} if dispatched else {frozenset(memory.get("tags") or [])}
+            assert _effective_pass_scopes(memory) == expected, memory
+
+    def test_signature_is_order_insensitive(self):
+        """The runtime splits a heterogeneous batch by grouping on this value,
+        so equal scope sets must hash equal regardless of how they were written."""
+        a = {"tags": ["x"], "observation_scopes": json.dumps([["b", "a"], ["c"]])}
+        b = {"tags": ["y"], "observation_scopes": json.dumps([["c"], ["a", "b"]])}
+        assert _batch_scope_signature(a) == _batch_scope_signature(b)


### PR DESCRIPTION
Fixes #3953
Related: #3924

## Root cause

`observation_scopes="shared"` (or any other single-scope override) is documented to ignore a memory's own tags for observation scoping, so memories with *different* tags all consolidate into the *same* observation.

That's not what happened: `run_consolidation_job` grouped memories into LLM consolidation batches by their **raw native tag set** (`tag_groups`) *before* `observation_scopes` was resolved at all:

```python
tag_groups: dict[tuple[str, ...], list[dict[str, Any]]] = {}
for m in memories:
    tag_key = tuple(sorted(m.get("tags") or []))
    tag_groups.setdefault(tag_key, []).append(dict(m))
```

`_resolve_obs_tags_list` was only consulted afterward, per batch, via `sub_batch[0]`. So two facts carrying different native tags but both requesting the identical target scope (e.g. both `observation_scopes: "shared"`) were split into two separate tag groups and therefore two separate LLM calls, before either memory's scope override was ever looked at. Each batch resolved and pooled merge candidates independently, so the two *new* facts could never be presented to the LLM together and could never be merged into one new shared observation — contradicting the documented `shared` behavior.

Full repro/trace: https://github.com/vectorize-io/hindsight/issues/3953

## Fix

Added `_consolidation_batch_key(memory)` in `consolidator.py`, which resolves each memory's *target* observation scope before grouping:

- Default `combined` mode, or a multi-scope fan-out (`per_tag` with more than one tag, `all_combinations`, or an explicit multi-scope list) — falls back to the memory's own native tags, unchanged from before.
- A single-scope override (`shared`, `per_tag` with exactly one tag, or an explicit one-scope list) — returns that resolved scope instead, so memories naming the *same target scope* batch together regardless of differing native tags.

`tag_groups` construction in `run_consolidation_job` now keys on `_consolidation_batch_key(m)` instead of the raw tag tuple. This preserves the "different observation scopes must never share an LLM call" security invariant that the original native-tag grouping only approximated correctly in the default `combined` case.

## Test added

`test_shared_mode_pools_different_native_tags_into_one_llm_batch` in `hindsight-api-slim/tests/test_consolidation_scope_parallelism.py`:

- Two memories with **different native tags**, both `observation_scopes="shared"`.
- Uses `consolidation_llm_batch_size=2` — the existing sibling test (`test_shared_mode_parallel_writes_only_untagged_scope`) uses `batch_size=1`, which doesn't exercise batching at all since every memory always gets its own LLM call regardless of grouping.
- A callback-based mock LLM records the set of fact ids seen in the prompt for every consolidation-scope call.
- Asserts exactly one LLM call was made and it contained both memories' fact ids, plus `result["status"] == "completed"`.

## CI notes

This change only touches `hindsight_api/engine/consolidation/consolidator.py` and a test file — no generated files, schemas, or OpenAPI spec are affected, so `verify-generated-files` and similar generation-check jobs should be unaffected.
