### PR TITLE
fix(consolidation): reject incomplete destructive batches

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -34,7 +34,7 @@ from pydantic import BaseModel, ValidationError, field_validator
 
 from ...config import get_config
 from ...worker.stage import set_stage
-from ..db import DatabaseBackend
+from ..db import DatabaseBackend, DatabaseConnection
 from ..db_utils import acquire_with_retry
 from ..llm_interface import OutputTooLongError, ProviderRateLimitResetError
 from ..llm_trace import (
@@ -284,6 +284,7 @@ class _DedupOutcome:
     # The twin's text at probe time. Guards the fold against a concurrent survivor
     # rewrite during the connection-free LLM window (set on the two non-None returns).
     best_text: str = ""
+    best_updated_at: datetime | None = None
 
 
 async def _dedup_adjudicate(
@@ -336,6 +337,7 @@ async def _dedup_adjudicate(
     results = grouped["observation"].semantic
     best_id: str | None = None
     best_text = ""
+    best_updated_at: datetime | None = None
     best_sim = threshold  # only candidates at/above the threshold are considered
     for r in results:
         rid = str(r.id)
@@ -343,7 +345,7 @@ async def _dedup_adjudicate(
             continue  # never match the anchor observation against itself
         sim = r.similarity or 0.0
         if sim >= best_sim:
-            best_id, best_text, best_sim = rid, r.text, sim
+            best_id, best_text, best_updated_at, best_sim = rid, r.text, _as_dt(r.updated_at), sim
 
     if best_id is None:
         return _DedupOutcome(best_id=None, merged_text="", should_merge=False)
@@ -358,9 +360,21 @@ async def _dedup_adjudicate(
         )
     )
     if decision.action != "merge":
-        return _DedupOutcome(best_id=best_id, merged_text="", should_merge=False, best_text=best_text)
+        return _DedupOutcome(
+            best_id=best_id,
+            merged_text="",
+            should_merge=False,
+            best_text=best_text,
+            best_updated_at=best_updated_at,
+        )
     merged_text = (sanitize_llm_output(decision.text) or "").strip() or best_text
-    return _DedupOutcome(best_id=best_id, merged_text=merged_text, should_merge=True, best_text=best_text)
+    return _DedupOutcome(
+        best_id=best_id,
+        merged_text=merged_text,
+        should_merge=True,
+        best_text=best_text,
+        best_updated_at=best_updated_at,
+    )
 
 
 async def _apply_dedup_create_fold(
@@ -824,6 +838,10 @@ class _BatchLLMResult:
     obs_count: int = 0
     prompt_chars: int = 0
     failed: bool = False
+
+
+class _DestructiveBatchIncomplete(Exception):
+    """A replacement action vanished; requested deletes must not be applied."""
 
 
 @dataclass
@@ -2105,6 +2123,11 @@ async def _process_memory_batch(
         if recall_result.source_facts:
             union_source_facts.update(recall_result.source_facts)
 
+    # The retrieval row carries its own write watermark. Destructive SQL writes later
+    # lock and compare this exact version, so recall content and its CAS witness cannot
+    # be separated by a second-query TOCTOU window.
+    recalled_versions = {str(obs.id): _as_dt(obs.updated_at) for obs in union_observations}
+
     # Determine effective tag scope for observations.
     # When obs_tags_override is set, use it; otherwise use the memory's own tags.
     if obs_tags_override is not None:
@@ -2167,6 +2190,63 @@ async def _process_memory_batch(
 
     mem_by_id = {str(m["id"]): m for m in memories}
 
+    # A schema-valid response can still reference an observation/fact that was not in
+    # this prompt. Silently dropping that action is unsafe when the same response also
+    # deletes the observation it intended to replace: the delete and source stamps would
+    # commit with no durable replacement. Reject the whole decision set before any slow
+    # preparation or write; the caller's existing adaptive bisection handles failed=True.
+    destructive = bool(llm_result.deletes)
+    requires_atomic_completion = destructive
+    rejected_action: str | None = None
+    if destructive:
+        delete_ids = [delete.observation_id for delete in llm_result.deletes]
+        if len(delete_ids) != len(set(delete_ids)):
+            rejected_action = "response contained duplicate DELETE targets"
+        for delete in llm_result.deletes:
+            if rejected_action is not None:
+                break
+            if delete.observation_id not in seen_ids:
+                rejected_action = f"DELETE observation {delete.observation_id} was not recalled"
+                break
+            if recalled_versions.get(delete.observation_id) is None:
+                rejected_action = f"DELETE observation {delete.observation_id} had no recall watermark"
+                break
+    if destructive and rejected_action is None:
+        deleted_ids = {delete.observation_id for delete in llm_result.deletes}
+        for update in llm_result.updates:
+            if update.observation_id in deleted_ids:
+                rejected_action = f"observation {update.observation_id} was both UPDATEd and DELETEd"
+                break
+            if not update.source_fact_ids or any(fid not in mem_by_id for fid in update.source_fact_ids):
+                rejected_action = f"UPDATE observation {update.observation_id} cited an out-of-batch source"
+                break
+            if not any(
+                update.observation_id in per_fact_obs_ids.get(source_id, set()) for source_id in update.source_fact_ids
+            ):
+                rejected_action = f"UPDATE observation {update.observation_id} was not recalled for its sources"
+                break
+            if recalled_versions.get(update.observation_id) is None:
+                rejected_action = f"UPDATE observation {update.observation_id} had no recall watermark"
+                break
+    if destructive and rejected_action is None:
+        for create in llm_result.creates:
+            if not create.source_fact_ids or any(fid not in mem_by_id for fid in create.source_fact_ids):
+                rejected_action = "CREATE cited an out-of-batch source"
+                break
+    if rejected_action is not None:
+        logger.warning(
+            "[CONSOLIDATION] rejected inconsistent LLM action set; no actions or source stamps applied: %s",
+            rejected_action,
+        )
+        return [{"action": "failed"} for _ in memories], 0, True
+
+    # A store-owned delete cannot participate in the SQL transaction or expose a CAS
+    # primitive for the recall watermark. Fail closed for every such delete rather than
+    # let a stale decision remove a concurrently rewritten external observation.
+    if destructive and get_memories().store_owned_for(bank_id):
+        logger.warning("[CONSOLIDATION] rejected destructive batch for non-transactional memory store")
+        return [{"action": "failed"} for _ in memories], 0, True
+
     # Semantic dedup: when enabled, an observation that is >= the threshold cosine to a DIFFERENT
     # existing observation is reconciled by a focused 1-by-1 LLM merge (anchored on the observation
     # text, not the source fact). It runs on both CREATE (a near-dup emitted despite the twin being
@@ -2183,17 +2263,19 @@ async def _process_memory_batch(
 
     # --- Prepare: deletes -----------------------------------------------------
     # Deletes carry no slow work; validating them here keeps the whole decision set in
-    # one place. They are still applied first inside the transaction, so an observation
-    # slot freed by a delete is available to a create in the same response.
-    prepared_deletes: list[str] = []
+    # one place. They are applied only after their replacement writes succeed, which is
+    # and every target is revalidated under lock before deletion.
+    prepared_deletes: list[tuple[str, str, datetime | None]] = []
+    prepared_duplicate_noops: list[tuple[str, str, datetime | None]] = []
     for delete in llm_result.deletes:
         # Security: the observation must be present in the unioned recall
-        if not any(str(obs.id) == delete.observation_id for obs in union_observations):
+        recalled = next((obs for obs in union_observations if str(obs.id) == delete.observation_id), None)
+        if recalled is None:
             logger.debug(
                 f"Batch consolidation: rejected delete — observation {delete.observation_id} not in unioned recall"
             )
             continue
-        prepared_deletes.append(delete.observation_id)
+        prepared_deletes.append((delete.observation_id, recalled.text, recalled_versions.get(delete.observation_id)))
 
     # --- Prepare: updates -----------------------------------------------------
     prepared_updates: list[_PreparedUpdate] = []
@@ -2222,6 +2304,8 @@ async def _process_memory_batch(
                     f"Update skipped: all {len(source_memory_ids)} source memories for observation "
                     f"{update.observation_id} were deleted before embedding"
                 )
+                if requires_atomic_completion:
+                    return [{"action": "failed"} for _ in memories], 0, True
                 continue
         embedding_str = await _embed_observation_text(memory_engine, update.text, perf)
         prepared = _PreparedUpdate(
@@ -2277,6 +2361,23 @@ async def _process_memory_batch(
         # here: the LLM frequently UPDATEd it earlier in this same batch, and a second update
         # would run off the pre-LLM snapshot and clobber that change (see _dedupe_updates).
         duplicate_of = _duplicate_create_target(create.text, shown_obs_by_text, update_texts)
+        matched_observation = shown_obs_by_text.get(_norm_obs_text(create.text))
+        matched_observation_id = str(matched_observation.id) if matched_observation is not None else None
+        deleted_duplicate = next(
+            (item for item in prepared_deletes if item[0] == matched_observation_id),
+            None,
+        )
+        if duplicate_of is not None and deleted_duplicate is not None:
+            # DELETE + a verbatim CREATE of that same row is not a replacement at all.
+            # Keep the durable row (and its occupied slot), consume the valid new source
+            # with the established duplicate no-op semantics, and cancel its paired delete.
+            prepared_deletes.remove(deleted_duplicate)
+            prepared_duplicate_noops.append(deleted_duplicate)
+            logger.warning(
+                "[CONSOLIDATION] cancelled DELETE plus verbatim CREATE for observation %s",
+                duplicate_of,
+            )
+            continue
         if duplicate_of is not None:
             logger.warning(
                 "[CONSOLIDATION] dropped duplicate observation CREATE — verbatim match of %s; llm_reason=%r",
@@ -2290,6 +2391,8 @@ async def _process_memory_batch(
                 logger.debug(
                     f"Create skipped: all {len(create_source_ids)} source memories were deleted before embedding"
                 )
+                if requires_atomic_completion:
+                    return [{"action": "failed"} for _ in memories], 0, True
                 continue
         embedding_str = await _embed_observation_text(memory_engine, create.text, perf)
         prepared_create = _PreparedCreate(
@@ -2319,91 +2422,169 @@ async def _process_memory_batch(
             )
         prepared_creates.append(prepared_create)
 
+    # A semantic fold mutates an existing observation (and UPDATE-fold also removes
+    # the rewritten row), so it needs the same closed CAS/rollback contract even when
+    # the LLM emitted no explicit DELETE.
+    dedup_outcomes = [
+        *(prepared.dedup for prepared in prepared_updates),
+        *(prepared.dedup for prepared in prepared_creates),
+    ]
+    requires_atomic_completion = requires_atomic_completion or any(
+        outcome is not None and outcome.should_merge for outcome in dedup_outcomes
+    )
+    if requires_atomic_completion and get_memories().store_owned_for(bank_id):
+        logger.warning("[CONSOLIDATION] rejected mutating batch for non-transactional memory store")
+        return [{"action": "failed"} for _ in memories], 0, True
+
     # --- Apply: one transaction for everything this LLM response decided ------
     deleted_count = 0
     # A failed LLM call yields no actions, and its memories must NOT be stamped: the caller
     # bisects and retries them, and a stamp would exclude them from pending consolidation
     # for good. With neither writes nor stamps there is nothing to open a transaction for.
     stamp_ids = list(mark_consolidated_ids or []) if not llm_result.failed else []
-    if prepared_deletes or prepared_updates or prepared_creates or stamp_ids:
-        async with acquire_with_retry(pool) as conn:
-            async with conn.transaction():
-                for observation_id in prepared_deletes:
-                    await _execute_delete_action(conn=conn, bank_id=bank_id, observation_id=observation_id)
-                    deleted_count += 1
+    if prepared_deletes or prepared_duplicate_noops or prepared_updates or prepared_creates or stamp_ids:
+        try:
+            async with acquire_with_retry(pool) as conn:
+                async with conn.transaction():
+                    # Validate and lock every existing row the destructive response
+                    # depends on before the first mutation. UPDATE targets can differ
+                    # from DELETE targets, but a stale rewrite must abort them together.
+                    # Sort all target IDs so overlapping batches acquire locks in the same
+                    # order instead of deadlocking on reversed LLM action order.
+                    if requires_atomic_completion:
+                        witness_targets: dict[str, tuple[str, datetime | None]] = {}
 
-                for prepared in prepared_updates:
-                    updated_emb_str = await _apply_update_action(
-                        conn=conn,
-                        memory_engine=memory_engine,
-                        bank_id=bank_id,
-                        prepared=prepared,
-                        perf=perf,
-                    )
-                    if updated_emb_str is None:
-                        # Skipped inside the write (sources or the observation vanished).
-                        continue
-                    for m in prepared.source_mems:
-                        per_memory_updated.add(str(m["id"]))
-                    if prepared.dedup is not None:
-                        await _apply_dedup_update_fold(
-                            conn,
-                            memory_engine,
-                            bank_id,
-                            config,
-                            prepared.dedup,
-                            prepared.update.observation_id,
-                            prepared.update.text,
-                        )
+                        def add_witness(
+                            observation_id: str,
+                            expected_text: str,
+                            expected_updated_at: datetime | None,
+                        ) -> None:
+                            witness = (expected_text, expected_updated_at)
+                            previous = witness_targets.get(observation_id)
+                            if previous is not None and previous != witness:
+                                raise _DestructiveBatchIncomplete(
+                                    f"target {observation_id} had conflicting action snapshots"
+                                )
+                            witness_targets[observation_id] = witness
 
-                for prepared_create in prepared_creates:
-                    if prepared_create.dedup is not None:
-                        merged_into = await _apply_dedup_create_fold(
-                            conn,
-                            memory_engine,
-                            bank_id,
-                            config,
-                            prepared_create.dedup,
-                            prepared_create.source_memory_ids,
-                            _TemporalBounds.of(prepared_create.agg),
-                        )
-                        if merged_into is not None:
-                            logger.info(
-                                "[CONSOLIDATION] dedup-merged observation CREATE into %s (cosine>=%.2f)",
-                                merged_into[:8],
-                                config.consolidation_dedup_threshold,
+                        for prepared in prepared_updates:
+                            add_witness(
+                                prepared.update.observation_id,
+                                prepared.model.text,
+                                _as_dt(prepared.model.updated_at),
                             )
+                        for observation_id, recalled_text, recalled_updated_at in (
+                            prepared_deletes + prepared_duplicate_noops
+                        ):
+                            add_witness(observation_id, recalled_text, recalled_updated_at)
+                        for outcome in dedup_outcomes:
+                            if outcome is not None and outcome.should_merge and outcome.best_id is not None:
+                                add_witness(
+                                    outcome.best_id,
+                                    outcome.best_text,
+                                    outcome.best_updated_at,
+                                )
+                        for observation_id in sorted(witness_targets):
+                            recalled_text, recalled_updated_at = witness_targets[observation_id]
+                            if not await _observation_matches_witness(
+                                conn,
+                                bank_id,
+                                observation_id,
+                                recalled_text,
+                                recalled_updated_at,
+                            ):
+                                raise _DestructiveBatchIncomplete(
+                                    f"target {observation_id} changed since it was recalled"
+                                )
+
+                        # SQL deletes are transactional, so freeing slots first is safe:
+                        # a later skipped/failed replacement rolls these rows back.
+                        for observation_id, _, _ in prepared_deletes:
+                            if not await _execute_delete_action(conn, bank_id, observation_id):
+                                raise _DestructiveBatchIncomplete(
+                                    f"DELETE target {observation_id} vanished after witness lock"
+                                )
+                            deleted_count += 1
+
+                    for prepared in prepared_updates:
+                        updated_emb_str = await _apply_update_action(
+                            conn=conn,
+                            memory_engine=memory_engine,
+                            bank_id=bank_id,
+                            prepared=prepared,
+                            perf=perf,
+                        )
+                        if updated_emb_str is None:
+                            # Skipped inside the write (sources or the observation vanished).
+                            if requires_atomic_completion:
+                                raise _DestructiveBatchIncomplete("UPDATE became inapplicable during write")
+                            continue
+                        for m in prepared.source_mems:
+                            per_memory_updated.add(str(m["id"]))
+                        if prepared.dedup is not None:
+                            await _apply_dedup_update_fold(
+                                conn,
+                                memory_engine,
+                                bank_id,
+                                config,
+                                prepared.dedup,
+                                prepared.update.observation_id,
+                                prepared.update.text,
+                            )
+
+                    for prepared_create in prepared_creates:
+                        if prepared_create.dedup is not None:
+                            merged_into = await _apply_dedup_create_fold(
+                                conn,
+                                memory_engine,
+                                bank_id,
+                                config,
+                                prepared_create.dedup,
+                                prepared_create.source_memory_ids,
+                                _TemporalBounds.of(prepared_create.agg),
+                            )
+                            if merged_into is not None:
+                                logger.info(
+                                    "[CONSOLIDATION] dedup-merged observation CREATE into %s (cosine>=%.2f)",
+                                    merged_into[:8],
+                                    config.consolidation_dedup_threshold,
+                                )
+                                for m in prepared_create.source_mems:
+                                    per_memory_created.add(str(m["id"]))
+                                continue
+
+                        action = await _apply_create_action(
+                            conn=conn,
+                            memory_engine=memory_engine,
+                            bank_id=bank_id,
+                            prepared=prepared_create,
+                            perf=perf,
+                        )
+                        # Count a memory as created only when an observation was actually written (the
+                        # source-liveness recheck inside the write can skip it).
+                        if action == "created":
                             for m in prepared_create.source_mems:
                                 per_memory_created.add(str(m["id"]))
-                            continue
+                        elif requires_atomic_completion:
+                            raise _DestructiveBatchIncomplete("CREATE became inapplicable during write")
 
-                    action = await _apply_create_action(
-                        conn=conn,
-                        memory_engine=memory_engine,
-                        bank_id=bank_id,
-                        prepared=prepared_create,
-                        perf=perf,
-                    )
-                    # Count a memory as created only when an observation was actually written (the
-                    # source-liveness recheck inside the write can skip it).
-                    if action == "created":
-                        for m in prepared_create.source_mems:
-                            per_memory_created.add(str(m["id"]))
-
-                # The facts this response consumed are marked consolidated in the SAME transaction
-                # as the observations that now carry them. Stamping them separately is what let a
-                # half-applied batch orphan its sources forever: the pending-consolidation predicate
-                # excludes a stamped fact, so nothing would ever rebuild what the batch failed to
-                # write (#3876).
-                if stamp_ids:
-                    await get_memories().mark_consolidated(
-                        conn=conn,
-                        fq_table=fq_table,
-                        bank_id=bank_id,
-                        unit_ids=[str(mem_id) for mem_id in stamp_ids],
-                        when=datetime.now(timezone.utc),
-                        failed=False,
-                    )
+                    # The facts this response consumed are marked consolidated in the SAME transaction
+                    # as the observations that now carry them. Stamping them separately is what let a
+                    # half-applied batch orphan its sources forever: the pending-consolidation predicate
+                    # excludes a stamped fact, so nothing would ever rebuild what the batch failed to
+                    # write (#3876).
+                    if stamp_ids:
+                        await get_memories().mark_consolidated(
+                            conn=conn,
+                            fq_table=fq_table,
+                            bank_id=bank_id,
+                            unit_ids=[str(mem_id) for mem_id in stamp_ids],
+                            when=datetime.now(timezone.utc),
+                            failed=False,
+                        )
+        except _DestructiveBatchIncomplete as exc:
+            logger.warning("[CONSOLIDATION] rejected incomplete destructive batch: %s", exc)
+            return [{"action": "failed"} for _ in memories], 0, True
 
     # Build per-memory result dicts for the stats tracker in the outer loop
     results: list[dict[str, Any]] = []
@@ -2719,18 +2900,31 @@ async def _apply_create_action(
 
 
 async def _execute_delete_action(
-    conn: "Connection",
+    conn: DatabaseConnection,
     bank_id: str,
     observation_id: str,
-) -> None:
+    expected_text: str | None = None,
+    expected_updated_at: datetime | None = None,
+) -> bool:
     """Delete a superseded or contradicted observation."""
     store = get_memories()
     if not store.store_owned_for(bank_id):
-        await conn.execute(
+        if expected_text is not None:
+            if not await _observation_matches_witness(
+                conn,
+                bank_id,
+                observation_id,
+                expected_text,
+                expected_updated_at,
+            ):
+                return False
+        deleted_rows = await conn.execute_rows_affected(
             f"DELETE FROM {fq_table('memory_units')} WHERE id = $1 AND bank_id = $2 AND fact_type = 'observation'",
             uuid.UUID(observation_id),
             bank_id,
         )
+        if deleted_rows != 1:
+            return False
     else:
         await store.delete_facts(bank_id, [observation_id])
     # History lives in Postgres regardless of where the observation itself does, and no
@@ -2743,6 +2937,28 @@ async def _execute_delete_action(
         uuid.UUID(observation_id),
     )
     logger.debug(f"Deleted observation {observation_id}")
+    return True
+
+
+async def _observation_matches_witness(
+    conn: DatabaseConnection,
+    bank_id: str,
+    observation_id: str,
+    expected_text: str,
+    expected_updated_at: datetime | None,
+) -> bool:
+    """Lock an observation and compare the content/version returned by recall."""
+    current = await conn.fetchrow(
+        f"SELECT text, updated_at FROM {fq_table('memory_units')} "
+        "WHERE id = $1 AND bank_id = $2 AND fact_type = 'observation' FOR UPDATE",
+        uuid.UUID(observation_id),
+        bank_id,
+    )
+    return bool(
+        current is not None
+        and current["text"] == expected_text
+        and _as_dt(current["updated_at"]) == _as_dt(expected_updated_at)
+    )
 
 
 async def _embed_observation_text(
@@ -3015,8 +3231,8 @@ async def _consolidate_batch_with_llm(
         if remaining_observation_slots == 0:
             observation_capacity_note = (
                 f"OBSERVATION LIMIT REACHED ({max_observations_per_scope}/{max_observations_per_scope}). "
-                "Only UPDATE or DELETE existing observations. Do NOT create new ones — "
-                "merge new knowledge into existing observations via UPDATE."
+                "Prefer UPDATE. A CREATE is allowed only as a one-for-one replacement paired with a DELETE; "
+                "never increase the total observation count."
             )
         elif remaining_observation_slots <= len(memories):
             observation_capacity_note = (
@@ -3057,8 +3273,13 @@ async def _consolidate_batch_with_llm(
             cached_prefix_name = None
 
     # Use a constrained response model when observation limit is active
+    response_max_creates = remaining_observation_slots
+    if remaining_observation_slots is not None and remaining_observation_slots >= 0:
+        # The schema must leave room for delete+create replacements even at capacity.
+        # The response-dependent truncation below enforces the exact net slot budget.
+        response_max_creates = remaining_observation_slots + len(union_observations)
     response_model = _build_response_model(
-        max_creates=remaining_observation_slots,
+        max_creates=response_max_creates,
         supports_max_items=config.llm_supports_max_items,
     )
 
@@ -3107,12 +3328,25 @@ async def _consolidate_batch_with_llm(
             # Defensive truncation: some LLM providers may not enforce JSON schema max_length
             creates = response.creates
             if remaining_observation_slots is not None and remaining_observation_slots >= 0:
-                if len(creates) > remaining_observation_slots:
+                effective_create_slots = remaining_observation_slots + len(
+                    {delete.observation_id for delete in response.deletes}
+                )
+                if len(creates) > effective_create_slots:
+                    if response.deletes:
+                        logger.warning(
+                            f"[CONSOLIDATION] rejecting destructive response with {len(creates)} creates "
+                            f"for {effective_create_slots} net slot(s); no actions will be applied"
+                        )
+                        return _BatchLLMResult(
+                            obs_count=len(union_observations),
+                            prompt_chars=len(system_prompt) + len(user_content),
+                            failed=True,
+                        )
                     logger.info(
-                        f"[CONSOLIDATION] Truncating {len(creates)} creates to {remaining_observation_slots} "
+                        f"[CONSOLIDATION] Truncating {len(creates)} creates to {effective_create_slots} "
                         f"(max_observations_per_scope={max_observations_per_scope})"
                     )
-                    creates = creates[:remaining_observation_slots]
+                    creates = creates[:effective_create_slots]
             updates = _dedupe_updates(response.updates, batch_label=batch_label)
             return _BatchLLMResult(
                 creates=creates,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -7757,6 +7757,11 @@ class MemoryEngine(MemoryEngineInterface):
                     result_dict["mentioned_at"] = (
                         mentioned_at.isoformat() if hasattr(mentioned_at, "isoformat") else mentioned_at
                     )
+                if result_dict.get("updated_at"):
+                    updated_at = result_dict["updated_at"]
+                    result_dict["updated_at"] = (
+                        updated_at.isoformat() if hasattr(updated_at, "isoformat") else updated_at
+                    )
                 top_results_dicts.append(result_dict)
 
             if tracer:
@@ -8034,6 +8039,7 @@ class MemoryEngine(MemoryEngineInterface):
                         occurred_start=result_dict.get("occurred_start"),
                         occurred_end=result_dict.get("occurred_end"),
                         mentioned_at=result_dict.get("mentioned_at"),
+                        updated_at=result_dict.get("updated_at"),
                         document_id=result_dict.get("document_id"),
                         metadata=result_dict.get("metadata"),
                         chunk_id=result_dict.get("chunk_id"),

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -321,6 +321,7 @@ class MemoryFact(BaseModel):
     occurred_start: str | None = Field(None, description="ISO format date when the event started occurring")
     occurred_end: str | None = Field(None, description="ISO format date when the event ended occurring")
     mentioned_at: str | None = Field(None, description="ISO format date when the fact was mentioned/learned")
+    updated_at: str | None = Field(None, description="ISO format date when the memory was last written")
     document_id: str | None = Field(None, description="ID of the document this memory belongs to")
     metadata: dict[str, str] | None = Field(None, description="User-defined metadata")
 

--- a/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/link_expansion_retrieval.py
@@ -87,7 +87,7 @@ async def _find_semantic_seeds(
     rows = await conn.fetch(
         f"""
         SELECT id, text, context, event_date, occurred_start, occurred_end,
-               mentioned_at, fact_type, document_id, chunk_id, tags, proof_count,
+               mentioned_at, updated_at, fact_type, document_id, chunk_id, tags, proof_count,
                1 - (embedding <=> $1::vector) AS similarity
         FROM {fq_table("memory_units")}
         WHERE bank_id = $2

--- a/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/retrieval.py
@@ -208,7 +208,7 @@ async def retrieve_semantic_bm25_combined_sql(
     semantic_fetch = max(limit, GRAPH_SEED_LIMIT if graph_seed_threshold is not None else 0)
 
     cols = (
-        "id, text, context, event_date, occurred_start, occurred_end, mentioned_at, "
+        "id, text, context, event_date, occurred_start, occurred_end, mentioned_at, updated_at, "
         "fact_type, document_id, chunk_id, tags, metadata, proof_count"
     )
     table = fq_table("memory_units")
@@ -574,7 +574,7 @@ async def retrieve_temporal_combined_sql(
     # retrieve_semantic_bm25_combined_sql; this keeps the query free of `unnest`/LATERAL, which the
     # Oracle backend cannot translate.
     pool_cols = (
-        "id, text, context, event_date, occurred_start, occurred_end, mentioned_at, "
+        "id, text, context, event_date, occurred_start, occurred_end, mentioned_at, updated_at, "
         "fact_type, proof_count, document_id, chunk_id, tags, metadata"
     )
     table = fq_table("memory_units")
@@ -721,7 +721,7 @@ async def retrieve_temporal_combined_sql(
             # bank_id on memory_units lets the planner use idx_memory_units_bank_fact_type.
             neighbors = await conn.fetch(
                 f"""
-                SELECT src.from_unit_id, mu.id, mu.text, mu.context, mu.event_date, mu.occurred_start, mu.occurred_end, mu.mentioned_at, mu.fact_type, mu.document_id, mu.chunk_id, mu.tags, mu.metadata, mu.proof_count,
+                SELECT src.from_unit_id, mu.id, mu.text, mu.context, mu.event_date, mu.occurred_start, mu.occurred_end, mu.mentioned_at, mu.updated_at, mu.fact_type, mu.document_id, mu.chunk_id, mu.tags, mu.metadata, mu.proof_count,
                        l.weight, l.link_type,
                        1 - (mu.embedding <=> $1::vector) AS similarity
                 FROM unnest($2::uuid[]) AS src(from_unit_id)

--- a/hindsight-api-slim/hindsight_api/engine/search/types.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/types.py
@@ -44,6 +44,7 @@ class RetrievalResult:
     occurred_start: datetime | None = None
     occurred_end: datetime | None = None
     mentioned_at: datetime | None = None
+    updated_at: datetime | None = None
     document_id: str | None = None
     chunk_id: str | None = None
     tags: list[str] | None = None  # Visibility scope tags
@@ -96,6 +97,7 @@ class RetrievalResult:
             occurred_start=row.get("occurred_start"),
             occurred_end=row.get("occurred_end"),
             mentioned_at=row.get("mentioned_at"),
+            updated_at=row.get("updated_at"),
             document_id=row.get("document_id"),
             chunk_id=row.get("chunk_id"),
             tags=row.get("tags"),
@@ -197,6 +199,7 @@ class ScoredResult:
             "occurred_start": self.retrieval.occurred_start,
             "occurred_end": self.retrieval.occurred_end,
             "mentioned_at": self.retrieval.mentioned_at,
+            "updated_at": self.retrieval.updated_at,
             "document_id": self.retrieval.document_id,
             "chunk_id": self.retrieval.chunk_id,
             "tags": self.retrieval.tags,

--- a/hindsight-api-slim/tests/test_consolidation_batch_atomicity.py
+++ b/hindsight-api-slim/tests/test_consolidation_batch_atomicity.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import re
 import uuid
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -34,11 +35,29 @@ from hindsight_api.engine.consolidation import consolidator as consolidator_modu
 from hindsight_api.engine.consolidation.consolidator import (
     _ConsolidationBatchResponse,
     _CreateAction,
+    _DedupOutcome,
     _DeleteAction,
+    _UpdateAction,
     run_consolidation_job,
 )
 from hindsight_api.engine.memory_engine import MemoryEngine
 from hindsight_api.engine.providers.mock_llm import MockLLM
+from hindsight_api.engine.response_models import MemoryFact
+from hindsight_api.engine.search.types import MergedCandidate, RetrievalResult, ScoredResult
+
+
+def test_retrieval_watermark_round_trips_through_public_memory_fact():
+    """Every backend's shared retrieval model preserves the destructive CAS watermark."""
+    watermark = datetime(2026, 9, 1, tzinfo=timezone.utc)
+    retrieval = RetrievalResult.from_db_row(
+        {"id": str(uuid.uuid4()), "text": "Observation", "fact_type": "observation", "updated_at": watermark}
+    )
+    serialized = ScoredResult(candidate=MergedCandidate(retrieval=retrieval, rrf_score=1.0)).to_dict()
+    assert serialized["updated_at"] == watermark
+    serialized["updated_at"] = serialized["updated_at"].isoformat()
+    fact = MemoryFact(**serialized)
+
+    assert fact.updated_at == watermark.isoformat()
 
 
 @pytest.fixture(autouse=True)
@@ -117,12 +136,17 @@ async def _pending_facts(memory: MemoryEngine, bank_id: str) -> list[str]:
     return [r["text"] for r in rows]
 
 
-async def _run(memory: MemoryEngine, bank_id: str, request_context, callback):
+async def _run(memory: MemoryEngine, bank_id: str, request_context, callback, **config_overrides):
     original = memory._consolidation_llm_config
     memory._consolidation_llm_config = _llm(callback)
     try:
         with (
-            _override_config(memory, consolidation_llm_batch_size=4, consolidation_llm_parallelism=1),
+            _override_config(
+                memory,
+                consolidation_llm_batch_size=4,
+                consolidation_llm_parallelism=1,
+                **config_overrides,
+            ),
             patch.object(memory, "submit_async_consolidation"),
         ):
             return await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
@@ -224,5 +248,750 @@ async def test_successful_batch_commits_observations_and_stamps(memory: MemoryEn
         assert result["observations_created"] == 1
         assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
         assert await _pending_facts(memory, bank_id) == []
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_rejected_replacement_source_keeps_observation_and_marks_batch_failed(
+    memory: MemoryEngine, request_context
+):
+    """An out-of-batch replacement cannot accompany a destructive action."""
+    bank_id = f"atomic-ref-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            source_id = await _insert_memory(conn, bank_id, "Alice moved to Munich", ["user:alice"])
+
+        foreign_id = str(uuid.uuid4())
+
+        def invalid_replacement(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            return _ConsolidationBatchResponse(
+                creates=[_CreateAction(text="Alice lives in Munich", source_fact_ids=[foreign_id])],
+                deletes=[_DeleteAction(observation_id=str(obs_id))],
+            )
+
+        result = await _run(memory, bank_id, request_context, invalid_replacement)
+
+        assert result["memories_failed"] == 1
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+        async with memory._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT consolidated_at, consolidation_failed_at FROM memory_units WHERE id = $1", source_id
+            )
+        assert row["consolidated_at"] is None
+        assert row["consolidation_failed_at"] is not None
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_replacement_skipped_during_write_does_not_delete(memory: MemoryEngine, request_context):
+    """A replacement that becomes inapplicable aborts its destructive response."""
+    bank_id = f"atomic-skip-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice moved to Munich", ["user:alice"])
+
+        def delete_and_create(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[_CreateAction(text="Alice lives in Munich", source_fact_ids=fact_ids)],
+                deletes=[_DeleteAction(observation_id=str(obs_id))],
+            )
+
+        with patch.object(consolidator_module, "_apply_create_action", new=AsyncMock(return_value="skipped")):
+            result = await _run(memory, bank_id, request_context, delete_and_create)
+
+        assert result["memories_failed"] == 1
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_replacement_can_free_and_reuse_a_full_scope_slot(memory: MemoryEngine, request_context):
+    """At capacity, a one-for-one DELETE+CREATE replacement still makes progress."""
+    bank_id = f"atomic-cap-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        await _run(
+            memory,
+            bank_id,
+            request_context,
+            _create_one_per_fact("Alice lives in Berlin"),
+            max_observations_per_scope=1,
+        )
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice moved to Munich", ["user:alice"])
+
+        def replacement(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[_CreateAction(text="Alice lives in Munich", source_fact_ids=fact_ids)],
+                deletes=[_DeleteAction(observation_id=str(obs_id))],
+            )
+
+        result = await _run(
+            memory,
+            bank_id,
+            request_context,
+            replacement,
+            max_observations_per_scope=1,
+        )
+
+        assert result["memories_failed"] == 0
+        assert result["observations_created"] == 1
+        assert await _observations(memory, bank_id) == ["Alice lives in Munich"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_duplicate_delete_targets_cannot_mint_capacity(memory: MemoryEngine, request_context):
+    """One row can fund at most one replacement CREATE."""
+    bank_id = f"atomic-dupcap-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+        await _run(
+            memory,
+            bank_id,
+            request_context,
+            _create_one_per_fact("Alice lives in Berlin"),
+            max_observations_per_scope=1,
+        )
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice moved again", ["user:alice"])
+
+        def duplicate_deletes(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[
+                    _CreateAction(text="Replacement one", source_fact_ids=fact_ids),
+                ],
+                deletes=[
+                    _DeleteAction(observation_id=str(obs_id)),
+                    _DeleteAction(observation_id=str(obs_id)),
+                ],
+            )
+
+        result = await _run(
+            memory,
+            bank_id,
+            request_context,
+            duplicate_deletes,
+            max_observations_per_scope=1,
+        )
+
+        assert result["memories_failed"] == 1
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_destructive_capacity_overflow_rejects_whole_response(memory: MemoryEngine, request_context):
+    """A replacement CREATE cannot be silently truncated and its source stamped."""
+    bank_id = f"atomic-overcap-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+        await _run(
+            memory,
+            bank_id,
+            request_context,
+            _create_one_per_fact("Alice lives in Berlin"),
+            max_observations_per_scope=1,
+        )
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice moved again", ["user:alice"])
+
+        def overflowing_replacement(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[
+                    _CreateAction(text="Replacement one", source_fact_ids=fact_ids),
+                    _CreateAction(text="Replacement two", source_fact_ids=fact_ids),
+                ],
+                deletes=[_DeleteAction(observation_id=str(obs_id))],
+            )
+
+        result = await _run(
+            memory,
+            bank_id,
+            request_context,
+            overflowing_replacement,
+            max_observations_per_scope=1,
+        )
+
+        assert result["memories_failed"] == 1
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_destructive_batch_locks_dedup_target_in_global_order(memory: MemoryEngine, request_context):
+    """A semantic fold target joins the same deterministic witness lock set."""
+    bank_id = f"atomic-dedup-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice fact A", ["user:alice"])
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Observation A"))
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice fact B", ["user:alice"])
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Observation B"))
+        async with memory._pool.acquire() as conn:
+            delete_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND text = 'Observation A'", bank_id
+            )
+            target = await conn.fetchrow(
+                "SELECT id, updated_at FROM memory_units WHERE bank_id = $1 AND text = 'Observation B'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice moved to Munich", ["user:alice"])
+
+        def replacement(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[_CreateAction(text="Replacement observation", source_fact_ids=fact_ids)],
+                deletes=[_DeleteAction(observation_id=str(delete_id))],
+            )
+
+        outcome = _DedupOutcome(
+            best_id=str(target["id"]),
+            merged_text="Observation B enriched",
+            should_merge=True,
+            best_text="Observation B",
+            best_updated_at=target["updated_at"],
+        )
+        lock_order: list[str] = []
+        original_match = consolidator_module._observation_matches_witness
+
+        async def record_match(conn, bank_id, observation_id, expected_text, expected_updated_at):
+            lock_order.append(observation_id)
+            return await original_match(conn, bank_id, observation_id, expected_text, expected_updated_at)
+
+        with (
+            patch.object(consolidator_module, "_dedup_active", return_value=True),
+            patch.object(consolidator_module, "_dedup_adjudicate", new=AsyncMock(return_value=outcome)),
+            patch.object(consolidator_module, "_observation_matches_witness", new=record_match),
+        ):
+            result = await _run(memory, bank_id, request_context, replacement)
+
+        assert result["memories_failed"] == 0
+        assert lock_order == sorted(lock_order)
+        assert set(lock_order) == {str(delete_id), str(target["id"])}
+        assert await _observations(memory, bank_id) == ["Observation B enriched"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.parametrize("store_owned", [False, True])
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_dedup_fold_without_explicit_delete_uses_atomic_contract(
+    memory: MemoryEngine, request_context, store_owned: bool
+):
+    """A mutating semantic fold is CAS-locked, or fail-closed for an external store."""
+    bank_id = f"atomic-dedupcas-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    store_patch = None
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        async with memory._pool.acquire() as conn:
+            target = await conn.fetchrow(
+                "SELECT id, updated_at FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice confirmed the move", ["user:alice"])
+
+        if store_owned:
+            store_patch = patch.object(consolidator_module.get_memories(), "store_owned_for", return_value=True)
+
+        def create_only(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            if store_patch is not None:
+                store_patch.start()
+            return _ConsolidationBatchResponse(
+                creates=[_CreateAction(text="Alice remains in Berlin", source_fact_ids=fact_ids)]
+            )
+
+        outcome = _DedupOutcome(
+            best_id=str(target["id"]),
+            merged_text="Alice lives in Berlin",
+            should_merge=True,
+            best_text="Alice lives in Berlin",
+            best_updated_at=target["updated_at"],
+        )
+        lock_order: list[str] = []
+        original_match = consolidator_module._observation_matches_witness
+
+        async def record_match(conn, bank_id, observation_id, expected_text, expected_updated_at):
+            lock_order.append(observation_id)
+            return await original_match(conn, bank_id, observation_id, expected_text, expected_updated_at)
+
+        try:
+            with (
+                patch.object(consolidator_module, "_dedup_active", return_value=True),
+                patch.object(consolidator_module, "_dedup_adjudicate", new=AsyncMock(return_value=outcome)),
+                patch.object(consolidator_module, "_observation_matches_witness", new=record_match),
+            ):
+                result = await _run(memory, bank_id, request_context, create_only)
+        finally:
+            if store_patch is not None:
+                store_patch.stop()
+
+        if store_owned:
+            assert result["memories_failed"] == 1
+            assert lock_order == []
+        else:
+            assert result["memories_failed"] == 0
+            assert lock_order == [str(target["id"])]
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_exact_duplicate_create_remains_successful_noop(memory: MemoryEngine, request_context):
+    """The intentional exact-duplicate drop still consumes a valid source fact."""
+    bank_id = f"atomic-dup-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice confirmed the move", ["user:alice"])
+
+        result = await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+
+        assert result["memories_failed"] == 0
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+        assert await _pending_facts(memory, bank_id) == []
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_delete_plus_exact_duplicate_create_keeps_existing_observation(memory: MemoryEngine, request_context):
+    """A verbatim replacement cancels its paired delete instead of needing a free slot."""
+    bank_id = f"atomic-dupdel-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice confirmed the move", ["user:alice"])
+
+        def duplicate_replacement(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[_CreateAction(text="Alice lives in Berlin", source_fact_ids=fact_ids)],
+                deletes=[_DeleteAction(observation_id=str(obs_id))],
+            )
+
+        result = await _run(memory, bank_id, request_context, duplicate_replacement)
+
+        assert result["memories_failed"] == 0
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+        assert await _pending_facts(memory, bank_id) == []
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_duplicate_delete_cancellation_keeps_batch_atomic(memory: MemoryEngine, request_context):
+    """Folding one delete/create pair cannot weaken another replacement action."""
+    bank_id = f"atomic-dupatomic-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice confirmed the move", ["user:alice"])
+
+        def duplicate_and_novel(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[
+                    _CreateAction(text="Alice lives in Berlin", source_fact_ids=fact_ids),
+                    _CreateAction(text="Alice also works remotely", source_fact_ids=fact_ids),
+                ],
+                deletes=[_DeleteAction(observation_id=str(obs_id))],
+            )
+
+        with patch.object(consolidator_module, "_apply_create_action", new=AsyncMock(return_value="skipped")):
+            result = await _run(memory, bank_id, request_context, duplicate_and_novel)
+
+        assert result["memories_failed"] == 1
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.parametrize("mutation", ["rewrite", "delete"])
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_duplicate_noop_revalidates_target_before_stamping(memory: MemoryEngine, request_context, mutation: str):
+    """A stale duplicate target cannot turn the paired CREATE into a false success."""
+    bank_id = f"atomic-duprace-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            source_id = await _insert_memory(conn, bank_id, "Alice confirmed the move", ["user:alice"])
+
+        def duplicate_replacement(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[_CreateAction(text="Alice lives in Berlin", source_fact_ids=fact_ids)],
+                deletes=[_DeleteAction(observation_id=str(obs_id))],
+            )
+
+        original_match = consolidator_module._observation_matches_witness
+        mutated = False
+
+        async def mutate_then_match(conn, bank_id, observation_id, expected_text, expected_updated_at):
+            nonlocal mutated
+            if not mutated:
+                mutated = True
+                async with memory._pool.acquire() as other_conn:
+                    if mutation == "rewrite":
+                        await other_conn.execute(
+                            "UPDATE memory_units SET context = $1, updated_at = now() WHERE id = $2",
+                            "concurrently enriched",
+                            obs_id,
+                        )
+                    else:
+                        await other_conn.execute("DELETE FROM memory_units WHERE id = $1", obs_id)
+            return await original_match(conn, bank_id, observation_id, expected_text, expected_updated_at)
+
+        with patch.object(consolidator_module, "_observation_matches_witness", new=mutate_then_match):
+            result = await _run(memory, bank_id, request_context, duplicate_replacement)
+
+        assert result["memories_failed"] == 1
+        async with memory._pool.acquire() as conn:
+            source = await conn.fetchrow(
+                "SELECT consolidated_at, consolidation_failed_at FROM memory_units WHERE id = $1", source_id
+            )
+        assert source["consolidated_at"] is None
+        assert source["consolidation_failed_at"] is not None
+        if mutation == "rewrite":
+            assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+        else:
+            assert await _observations(memory, bank_id) == []
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_non_destructive_invalid_create_keeps_skip_semantics(memory: MemoryEngine, request_context):
+    """Hard rejection is limited to responses that can destroy observations."""
+    bank_id = f"atomic-nondel-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        def invalid_create(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            return _ConsolidationBatchResponse(
+                creates=[_CreateAction(text="Unusable", source_fact_ids=[str(uuid.uuid4())])]
+            )
+
+        result = await _run(memory, bank_id, request_context, invalid_create)
+
+        assert result["memories_failed"] == 0
+        assert await _observations(memory, bank_id) == []
+        assert await _pending_facts(memory, bank_id) == []
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_update_and_delete_same_observation_is_rejected(memory: MemoryEngine, request_context):
+    """A successful update must not be erased by a later delete in the same response."""
+    bank_id = f"atomic-overlap-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice moved to Munich", ["user:alice"])
+
+        def update_and_delete(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                updates=[
+                    _UpdateAction(text="Alice lives in Munich", observation_id=str(obs_id), source_fact_ids=fact_ids)
+                ],
+                deletes=[_DeleteAction(observation_id=str(obs_id))],
+            )
+
+        result = await _run(memory, bank_id, request_context, update_and_delete)
+
+        assert result["memories_failed"] == 1
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_changed_delete_target_is_not_removed(memory: MemoryEngine, request_context):
+    """A concurrent rewrite invalidates the recalled-state witness for DELETE."""
+    bank_id = f"atomic-race-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice moved to Munich", ["user:alice"])
+
+        def delete_and_create(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[_CreateAction(text="Alice lives in Munich", source_fact_ids=fact_ids)],
+                deletes=[_DeleteAction(observation_id=str(obs_id))],
+            )
+
+        original_match = consolidator_module._observation_matches_witness
+        mutated = False
+
+        async def concurrent_rewrite(conn, bank_id, observation_id, expected_text, expected_updated_at):
+            nonlocal mutated
+            if not mutated:
+                mutated = True
+                async with memory._pool.acquire() as other_conn:
+                    await other_conn.execute(
+                        "UPDATE memory_units SET context = $1, updated_at = now() WHERE id = $2",
+                        "concurrently enriched",
+                        obs_id,
+                    )
+            return await original_match(conn, bank_id, observation_id, expected_text, expected_updated_at)
+
+        with patch.object(consolidator_module, "_observation_matches_witness", new=concurrent_rewrite):
+            result = await _run(memory, bank_id, request_context, delete_and_create)
+
+        assert result["memories_failed"] == 1
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
+        async with memory._pool.acquire() as conn:
+            assert (
+                await conn.fetchval("SELECT context FROM memory_units WHERE id = $1", obs_id) == "concurrently enriched"
+            )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_changed_update_target_aborts_destructive_batch(memory: MemoryEngine, request_context):
+    """A stale UPDATE replacement cannot overwrite a concurrent rewrite before DELETE."""
+    bank_id = f"atomic-updrace-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice fact A", ["user:alice"])
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Observation A"))
+
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice fact B", ["user:alice"])
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Observation B"))
+
+        async with memory._pool.acquire() as conn:
+            update_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND text = 'Observation A'", bank_id
+            )
+            delete_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND text = 'Observation B'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice replacement fact", ["user:alice"])
+
+        def update_and_delete(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                updates=[
+                    _UpdateAction(
+                        text="Replacement observation",
+                        observation_id=str(update_id),
+                        source_fact_ids=fact_ids,
+                    )
+                ],
+                deletes=[_DeleteAction(observation_id=str(delete_id))],
+            )
+
+        original_match = consolidator_module._observation_matches_witness
+        mutated = False
+        lock_order: list[str] = []
+
+        async def mutate_update_target(conn, bank_id, observation_id, expected_text, expected_updated_at):
+            nonlocal mutated
+            lock_order.append(observation_id)
+            if observation_id == str(update_id) and not mutated:
+                mutated = True
+                async with memory._pool.acquire() as other_conn:
+                    await other_conn.execute(
+                        "UPDATE memory_units SET context = $1, updated_at = now() WHERE id = $2",
+                        "concurrently enriched",
+                        update_id,
+                    )
+            return await original_match(conn, bank_id, observation_id, expected_text, expected_updated_at)
+
+        with patch.object(consolidator_module, "_observation_matches_witness", new=mutate_update_target):
+            result = await _run(memory, bank_id, request_context, update_and_delete)
+
+        assert result["memories_failed"] == 1
+        assert lock_order == sorted(lock_order)
+        assert await _observations(memory, bank_id) == ["Observation A", "Observation B"]
+        async with memory._pool.acquire() as conn:
+            assert await conn.fetchval("SELECT context FROM memory_units WHERE id = $1", update_id) == (
+                "concurrently enriched"
+            )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_delete_only_batch_fails_closed_for_store_owned_bank(memory: MemoryEngine, request_context):
+    """External deletes are not attempted without a version-checked CAS primitive."""
+    bank_id = f"atomic-store-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Alice moved to Berlin", ["user:alice"])
+
+        await _run(memory, bank_id, request_context, _create_one_per_fact("Alice lives in Berlin"))
+        async with memory._pool.acquire() as conn:
+            obs_id = await conn.fetchval(
+                "SELECT id FROM memory_units WHERE bank_id = $1 AND fact_type = 'observation'", bank_id
+            )
+            await _insert_memory(conn, bank_id, "Alice moved to Munich", ["user:alice"])
+
+        store = consolidator_module.get_memories()
+        store_owned_patch = patch.object(store, "store_owned_for", return_value=True)
+
+        def delete_only(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            store_owned_patch.start()
+            return _ConsolidationBatchResponse(deletes=[_DeleteAction(observation_id=str(obs_id))])
+
+        try:
+            result = await _run(memory, bank_id, request_context, delete_only)
+        finally:
+            store_owned_patch.stop()
+
+        assert result["memories_failed"] == 1
+        assert await _observations(memory, bank_id) == ["Alice lives in Berlin"]
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Summary

- reject incomplete destructive LLM action sets before they can delete observations or stamp their source facts
- lock and compare recalled observation witnesses before destructive writes, then commit replacements, deletes, and source stamps together
- preserve exact-duplicate no-ops and fail closed when a store-owned backend cannot join the SQL transaction

## Why

#3923 made the writes from one LLM response transactional, but documented one remaining gap: a valid `DELETE` can still commit when its intended `CREATE` or `UPDATE` is silently discarded for an invalid reference. The source facts are then stamped as consolidated, the old observation is gone, and the operation can report success.

This follow-up treats a destructive response as one completion contract. Invalid references fail the response before preparation; a replacement that becomes inapplicable during the write rolls the transaction back; and a recalled observation must still match its text/version witness under a deterministic row-lock order before any mutation.

## Compatibility boundaries

- A create-only invalid reference keeps the existing skip behavior: its source fact remains durable and recallable but is considered processed, while no observation is created. Only an action set capable of deleting or folding an existing observation is promoted to failure and adaptive bisection.
- Update source validation keeps the existing "recalled for at least one source" relevance rule. A consolidation batch contains one exact tag set, so per-fact recall here is relevance ranking rather than an authorization boundary; requiring every source query to independently retrieve the same target would reject legitimate multi-fact aggregation.
- Store-owned observations have no SQL witness/CAS primitive. Destructive or semantic-fold batches therefore fail closed instead of issuing an external mutation that cannot share the transaction.

## Verification

- `uv run pytest tests/test_consolidation_batch_atomicity.py -q --disable-warnings` — 22 passed
- `uv run ruff check hindsight_api/ tests/test_consolidation_batch_atomicity.py`
- `uv run ruff format --check hindsight_api/ tests/test_consolidation_batch_atomicity.py`
- `uv run ty check hindsight_api/`
- repository `lint.sh` reached the unrelated control-plane ESLint step but that workspace lacks `@eslint/js`; the changed Python surface passed its lint and type gates

The regressions cover invalid replacement references, rollback after an in-transaction skip, capacity reuse and duplicate-delete accounting, exact-duplicate cancellation, stale delete/update witnesses, deterministic dedup-target locking, non-destructive compatibility, and store-owned fail-closed behavior.
