### PR TITLE
fix(docker): drop npm from the runtime stages and scan every runtime base

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,8 +8,9 @@ name: Security Scan
 # Two jobs, answering two different questions:
 #   scan-published  — do the images users are running right now have a fix
 #                     available? (seconds; no build)
-#   scan-next-build — would an image built from main today be clean? (one build;
-#                     catches a regression before it reaches a release tag)
+#   scan-next-build — would an image built from main today be clean? (one build
+#                     per runtime base; catches a regression before it reaches
+#                     a release tag)
 on:
   schedule:
     # 05:30 UTC daily, after Debian's usual security-update publication window.
@@ -49,9 +50,13 @@ jobs:
         TRIVY_PLATFORM: ${{ matrix.platform }}
 
   scan-next-build:
-    name: Scan a fresh build of main
+    name: Scan a fresh build of main (${{ matrix.target }})
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [api-only, cp-only, standalone]
 
     steps:
     - uses: actions/checkout@v6
@@ -70,28 +75,31 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    # The slim api image is the smallest one covering the Debian family: it
-    # shares its runtime base with the full and standalone images and its locked
-    # Python environment with all of them, so a finding in any of those shows up
-    # here for a fraction of the build time. The alpine control-plane image
-    # shares none of that and is covered by scan-published only.
-    - name: Build api-slim image
+    # One leg per runtime base, because they do not share a vulnerable surface:
+    # api-only is the Debian Python runtime, cp-only is the alpine Node runtime,
+    # and standalone carries both. api-only alone still covers the Debian family
+    # (it shares its runtime base with the full and standalone images and its
+    # locked Python environment with all of them), but it contains no Node at
+    # all, so on its own this job could not catch a Node-side regression before
+    # it reached a release tag. The local-models build args are unused by
+    # cp-only and keep the other two legs to the slim runtime surface.
+    - name: Build ${{ matrix.target }} image
       uses: docker/build-push-action@v7
       with:
         context: .
         file: docker/standalone/Dockerfile
-        target: api-only
+        target: ${{ matrix.target }}
         build-args: |
           INCLUDE_LOCAL_MODELS=false
           PRELOAD_ML_MODELS=false
         push: false
         load: true
-        tags: hindsight-api-slim:scan
+        tags: hindsight-${{ matrix.target }}:scan
 
     - name: Scan freshly built image
       uses: aquasecurity/trivy-action@v0.36.0
       with:
-        image-ref: hindsight-api-slim:scan
+        image-ref: hindsight-${{ matrix.target }}:scan
         scanners: vuln
         severity: HIGH,CRITICAL
         ignore-unfixed: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1622,28 +1622,39 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
+        # `smoke` decides which legs are loaded into the daemon and actually
+        # started. The full variants are skipped to save runner disk; cp-only
+        # is smoke tested despite being a full variant because the alpine
+        # image is small and it is the only leg that exercises the alpine Node
+        # runtime at all (it needs no LLM credentials - see NEEDS_LLM in
+        # docker/test-image.sh).
         include:
           - target: api-only
             name: api
             variant: full
+            smoke: false
             build_args: ""
           - target: api-only
             name: api-slim
             variant: slim
+            smoke: true
             build_args: |
               INCLUDE_LOCAL_MODELS=false
               PRELOAD_ML_MODELS=false
           - target: cp-only
             name: control-plane
             variant: full
+            smoke: true
             build_args: ""
           - target: standalone
             name: standalone
             variant: full
+            smoke: false
             build_args: ""
           - target: standalone
             name: standalone-slim
             variant: slim
+            smoke: true
             build_args: |
               INCLUDE_LOCAL_MODELS=false
               PRELOAD_ML_MODELS=false
@@ -1675,23 +1686,24 @@ jobs:
         target: ${{ matrix.target }}
         build-args: ${{ matrix.build_args }}
         push: false
-        load: ${{ matrix.variant == 'slim' }}
+        load: ${{ matrix.smoke }}
         tags: hindsight-${{ matrix.name }}:test
         # Removed GitHub Actions cache (type=gha) - it frequently returns 502 errors
         # causing buildx to fail with "failed to parse error response 502"
         # Build will be slower but more reliable
 
-    # Only test slim variants to save disk space (they're much smaller)
-    # Slim variants require external embedding providers
+    # Slim variants require external embedding providers; cp-only needs no
+    # credentials at all, so the credential step stays gated on the variant
+    # while the smoke test itself is gated on `smoke`.
     - name: Setup GCP credentials for smoke test
-      if: matrix.variant == 'slim'
+      if: matrix.variant == 'slim' && matrix.smoke
       run: |
         printf '%s' '${{ secrets.GCP_VERTEXAI_CREDENTIALS }}' > /tmp/gcp-credentials.json
         PROJECT_ID=$(jq -r '.project_id' /tmp/gcp-credentials.json)
         echo "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID=$PROJECT_ID" >> $GITHUB_ENV
 
     - name: Smoke test - verify container starts
-      if: matrix.variant == 'slim'
+      if: matrix.smoke
       env:
         HINDSIGHT_API_LLM_PROVIDER: vertexai
         HINDSIGHT_API_LLM_MODEL: google/gemini-2.5-flash-lite

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -284,8 +284,13 @@ RUN chmod +x /app/start-all.sh
 # kept: it has no node_modules tree and ships no tar package metadata, so a
 # scanner reports nothing for it. The node base image unpacks npm from its own
 # tarball rather than installing an apk package, so it has to go by path.
+# The `[ -e ]` guard is deliberate: a bare `rm -rf` on a path a future base
+# image no longer uses succeeds silently and npm quietly ships again. Fail the
+# build instead, so the path assumption has to be revisited on a base bump.
 RUN apk upgrade --no-cache && apk add --no-cache curl bash \
-    && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+    && [ -e /usr/local/lib/node_modules/npm ] \
+    && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
+    && ! command -v npm
 
 EXPOSE 9999
 
@@ -314,7 +319,8 @@ WORKDIR /app
 # metadata, so a scanner reports nothing for it. npm is not installed as a
 # separate apt package here - NodeSource's `nodejs` package ships it
 # (`dpkg -S /usr/bin/npm` resolves to `nodejs`), so `apt-get remove npm` is a
-# no-op and removal by path is the only option.
+# no-op and removal by path is the only option. The `[ -e ]` guard fails the
+# build if a base bump moves that path, rather than silently shipping npm.
 # `upgrade` before `install`: without it the image ships whatever package
 # snapshot the base image was cut with, so security updates published since
 # never reach the runtime layers - that is how 0.9.2 shipped openssl 3.5.6 with
@@ -331,7 +337,9 @@ RUN apt-get update && apt-get upgrade -y \
     && (apt-get install -y libicu72 2>/dev/null || apt-get install -y libicu74 2>/dev/null || apt-get install -y libicu76 2>/dev/null || true) \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
+    && [ -e /usr/lib/node_modules/npm ] \
     && rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx \
+    && ! command -v npm \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir uv \
     && pip uninstall --yes setuptools wheel

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -277,7 +277,15 @@ RUN chmod +x /app/start-all.sh
 
 # Install curl for health checks. `apk upgrade` first, for the same reason the
 # Debian stages run `apt-get upgrade` - see the comment on the api-only stage.
-RUN apk upgrade --no-cache && apk add --no-cache curl bash
+# npm is removed for the same reason the Debian stages remove pip's build
+# tooling: nothing invokes it at runtime - start-all.sh launches the pre-built
+# Next standalone bundle with `node server.js` - and dropping it leaves no
+# scannable vulnerable tar component in the stage. corepack is deliberately
+# kept: it has no node_modules tree and ships no tar package metadata, so a
+# scanner reports nothing for it. The node base image unpacks npm from its own
+# tarball rather than installing an apk package, so it has to go by path.
+RUN apk upgrade --no-cache && apk add --no-cache curl bash \
+    && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 EXPOSE 9999
 
@@ -299,6 +307,14 @@ WORKDIR /app
 # Note: libicu version varies by Debian version - try common versions in order
 # Runtime images use uv directly; remove pip build tooling after installation so
 # vulnerable setuptools-vendored packages and wheel are not shipped in production.
+# npm goes the same way: nothing invokes it at runtime - start-all.sh launches
+# the pre-built Next standalone bundle with `node server.js` - and dropping it
+# leaves no scannable vulnerable tar component in the stage. corepack is
+# deliberately kept: it has no node_modules tree and ships no tar package
+# metadata, so a scanner reports nothing for it. npm is not installed as a
+# separate apt package here - NodeSource's `nodejs` package ships it
+# (`dpkg -S /usr/bin/npm` resolves to `nodejs`), so `apt-get remove npm` is a
+# no-op and removal by path is the only option.
 # `upgrade` before `install`: without it the image ships whatever package
 # snapshot the base image was cut with, so security updates published since
 # never reach the runtime layers - that is how 0.9.2 shipped openssl 3.5.6 with
@@ -315,6 +331,7 @@ RUN apt-get update && apt-get upgrade -y \
     && (apt-get install -y libicu72 2>/dev/null || apt-get install -y libicu74 2>/dev/null || apt-get install -y libicu76 2>/dev/null || true) \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
+    && rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir uv \
     && pip uninstall --yes setuptools wheel

--- a/docker/test-image.sh
+++ b/docker/test-image.sh
@@ -80,6 +80,10 @@ if [ -z "$IMAGE" ]; then
 fi
 
 # Determine health endpoint based on target
+# CP_PORT is set only when the image also serves the control plane on its own
+# port: cp-only is checked through HEALTH_PORT already, standalone runs both
+# processes and would otherwise be declared healthy on the API alone.
+CP_PORT=""
 if [ "$TARGET" = "cp-only" ]; then
     HEALTH_PORT=9999
     HEALTH_PATH="/api/health"
@@ -88,6 +92,9 @@ else
     HEALTH_PORT=8888
     HEALTH_PATH="/health"
     NEEDS_LLM=true
+    if [ "$TARGET" = "standalone" ]; then
+        CP_PORT=9999
+    fi
 fi
 
 # Check for required environment variables
@@ -162,6 +169,9 @@ else
     fi
 
     DOCKER_CMD="$DOCKER_CMD -p ${HEALTH_PORT}:${HEALTH_PORT}"
+    if [ -n "$CP_PORT" ]; then
+        DOCKER_CMD="$DOCKER_CMD -p ${CP_PORT}:${CP_PORT}"
+    fi
     DOCKER_CMD="$DOCKER_CMD $IMAGE"
 
     eval $DOCKER_CMD
@@ -181,6 +191,32 @@ for i in $(seq 1 "$TIMEOUT"); do
         echo "=== Health Response ==="
         curl -s "http://localhost:${HEALTH_PORT}${HEALTH_PATH}" | python3 -m json.tool 2>/dev/null || curl -s "http://localhost:${HEALTH_PORT}${HEALTH_PATH}"
         echo ""
+
+        # Verify the control plane too when the image serves both. It is a
+        # separate process from the API, so an API-only probe would pass on an
+        # image whose control plane never came up.
+        if [ -n "$CP_PORT" ]; then
+            echo ""
+            echo "=== Control Plane Health (port ${CP_PORT}) ==="
+            cp_healthy=false
+            for j in $(seq 1 "$TIMEOUT"); do
+                if curl -sf "http://localhost:${CP_PORT}/api/health" > /dev/null 2>&1; then
+                    cp_healthy=true
+                    break
+                fi
+                sleep 1
+            done
+            if [ "$cp_healthy" != true ]; then
+                echo ""
+                echo "=== Container Logs (last 50 lines) ==="
+                docker logs "$CONTAINER_NAME" 2>&1 | tail -50
+                echo ""
+                echo -e "${RED}Control plane never became healthy on port ${CP_PORT}${NC}"
+                exit 1
+            fi
+            curl -s "http://localhost:${CP_PORT}/api/health"
+            echo ""
+        fi
 
         # Run retain/recall smoke test for API targets
         if [ "$TARGET" != "cp-only" ]; then


### PR DESCRIPTION
## What this fixes

Every published Hindsight image I scanned (the five digests listed below) ships npm's own bundled copy of `tar` 6.2.1, which carries one CRITICAL and eight HIGH advisories, all of them fixed upstream. Removing npm from the two runtime stages that contain Node removes the component all nine findings are reported against.

Reproduce against a published digest:

```
trivy image --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed \
  ghcr.io/vectorize-io/hindsight@sha256:3b46e26ec69355422c46ceb496cd758ae226d751be4a0799b4e844251d524d46
```

The finding reports as `tar` 6.2.1 at:

```
usr/lib/node_modules/npm/node_modules/tar/package.json          # standalone (Debian)
usr/local/lib/node_modules/npm/node_modules/tar/package.json    # cp-only (Alpine)
```

Same result on the control-plane image:

```
trivy image --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed \
  ghcr.io/vectorize-io/hindsight-control-plane@sha256:b1946e4f10a5e37ad8a5a8e673436d74b1b73692bb5c85bace50448d4b8b38a0
```

## Affected images

Scanned with Trivy 0.74.0 in registry mode, by digest. `linux/amd64` and `linux/arm64` were identical on every metric.

| Image | Digest |
| --- | --- |
| `hindsight:0.9.1-slim` | `sha256:c230756110b3965e89d485d130c40fb71a15dbcb7606366201b8e71a6ca1a082` |
| `hindsight:0.9.2-slim` (amd64) | `sha256:97ab9978ddf1394fc6a163f4c779fa9c7e5123770c881844bd2e0e9a60b0d18a` |
| `hindsight:0.9.2-slim` (arm64) | `sha256:1474fa28f7077241d82f9598613138dcefc094d7d86b1e360a4c5dea1a517e63` |
| `hindsight:0.9.2` | `sha256:3b46e26ec69355422c46ceb496cd758ae226d751be4a0799b4e844251d524d46` |
| `hindsight-control-plane:latest` | `sha256:b1946e4f10a5e37ad8a5a8e673436d74b1b73692bb5c85bace50448d4b8b38a0` |

Trivy reports exactly one `tar` component per image, and in each case it is npm's vendored copy. No application-level `node_modules/tar` appears at any depth in the scan output of any of them.

## This is npm's vendored tar, not a dependency you can pin

The vulnerable copy lives inside npm itself, at `node_modules/npm/node_modules/tar`, which npm ships as a bundled dependency. It is not reachable from any manifest in this repo:

- It is not in `hindsight-control-plane/package.json` or its transitive tree.
- It is not in `package-lock.json`.
- The root `package.json` `overrides` block does not apply to it, and could not: `overrides` rewrites resolution for the project's own dependency graph, and npm's bundled tree is not part of that graph.

So the obvious fix (add `"tar": "^7.5.21"` to `overrides`, or bump a lockfile entry) does nothing here. The only lever is what the image installs.

## CVEs

All nine are on `tar` 6.2.1, and all nine have a fixed version:

| CVE | Severity | Fixed in |
| --- | --- | --- |
| CVE-2026-59873 | CRITICAL | 7.5.19 |
| CVE-2026-23745 | HIGH | 7.5.3 |
| CVE-2026-23950 | HIGH | 7.5.4 |
| CVE-2026-24842 | HIGH | 7.5.7 |
| CVE-2026-26960 | HIGH | 7.5.8 |
| CVE-2026-29786 | HIGH | 7.5.10 |
| CVE-2026-31802 | HIGH | 7.5.11 |
| CVE-2026-59874 | HIGH | 7.5.18 |
| CVE-2026-73566 | HIGH | 7.5.21 |

Clearing the whole set requires `tar >= 7.5.21`, not 7.5.19. It is easy to stop at 7.5.19 because that is the CRITICAL's fix version, but CVE-2026-73566 sits above it.

## Why bumping Node does not fix this

Node pins an exact npm, and npm pins an exact bundled tar. I checked the bundled `node_modules/tar/package.json` inside each npm tarball from the registry, and the npm version for each Node line from `https://nodejs.org/dist/index.json`:

| Node line | Bundled npm | Bundled tar | Result |
| --- | --- | --- | --- |
| 20 (current v20.20.2, and every v20 back through v20.18.0) | 10.8.2 | 6.2.1 | all nine present |
| 22 (current v22.23.2) | 10.9.8 | 7.5.11 | CRITICAL plus two HIGH remain |
| 24 (current v24.20.0) | 11.19.0 | 7.5.19 | CRITICAL cleared, CVE-2026-73566 remains |
| n/a (latest npm) | 12.0.2 | 7.5.19 | CVE-2026-73566 remains |

None of the Node lines I checked, and not the latest npm release, bundles tar at 7.5.21 or newer. Bumping to Node 24 would be a larger change than this one and would still leave a HIGH finding. Removing npm is what clears the set.

## The change

`docker/standalone/Dockerfile`, runtime stages only:

- `cp-only` (`node:20-alpine`): `rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx`, folded into the existing `apk` layer.
- `standalone` (`python:3.11-slim` plus NodeSource `nodejs`): `rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx`, folded into the existing `apt-get` layer, immediately after the `nodejs` install.

Removal is by path in both cases, for a different reason in each.

- On `node:20-alpine`, the base image unpacks npm from the Node tarball rather than installing an apk package, so there is no apk package to remove. `/usr/local/bin/npm` and `/usr/local/bin/npx` are symlinks into `/usr/local/lib/node_modules/npm`.
- On the Debian stage, `npm` is not installed as a separate apt package either. NodeSource's `nodejs` package ships it: `dpkg -S /usr/bin/npm` resolves to `nodejs`, `dpkg -l` shows `nodejs 20.20.2-1nodesource1` installed and no `npm` package, and `apt-get -s remove npm` reports "Package 'npm' is not installed, so not removed" and exits 0. A separate `npm` package does exist in the Debian trixie archive (`apt-cache policy npm` shows `Installed: (none)`, `Candidate: 9.2.0~ds1-3`), but it is not what installed `/usr/bin/npm` here, so `apt-get remove npm` is a no-op and removal by path is the only option.

Both path sets were validated in live containers against the real base images (see "What was and was not tested" below).

This mirrors what the runtime stages already do with `pip uninstall --yes setuptools wheel`: install-time tooling that should not ship in a production layer.

The builder stages are untouched. `sdk-builder` and `cp-builder` both need npm (`Dockerfile:96`, `:97`, `:117`, `:134`) and both keep it. `api-only` installs no Node and is unchanged. `node` itself stays in both runtime stages, since the control plane is a Node process.

### What stays: corepack

`corepack` is deliberately left in place in both runtime stages. It ships no `node_modules` tree and no `tar` package metadata, so it contributes no scannable tar component of its own; Trivy and Grype report nothing for it. Combined with the published-image scans above, which show no application-level `node_modules/tar` at any depth, removing npm should leave no scannable vulnerable tar component in either stage. (The post-change image has not been built or scanned; see "What was and was not tested".)

For precision rather than as a finding: node-tar code is webpacked into corepack's `dist/lib/corepack.cjs` bundle (the strings `TAR_ENTRY_ERROR`, `TAR_BAD_ARCHIVE`, `minipass` and `ReadEntry` are all present in it) with no accompanying package metadata, so its version cannot be determined from the image. That is why the accurate way to state what this PR achieves is "no scannable vulnerable tar component remains", not "tar is gone from the image".

## Why npm is safe to remove at runtime

All three final stages run `CMD ["/app/start-all.sh"]` (`Dockerfile:254`, `:289`, `:407`). That script starts two things:

- the API, via the `hindsight-api` console script from the uv venv (`start-all.sh:271`)
- the control plane, via `PORT="${HINDSIGHT_CP_PORT:-9999}" node server.js` (`start-all.sh:305`)

The control plane is a pre-built Next standalone bundle. `hindsight-control-plane/next.config.ts:27` sets `output: 'standalone'`; `Dockerfile:134` runs `next build` in the builder; `Dockerfile:139-152` assembles the standalone tree; `Dockerfile:268-270` and `:332-334` copy that tree into the runtime stages. No `npm start`, `npm run start` or `next start` appears in the image's start path.

Beyond that:

- There is no `corepack enable` anywhere under `docker/`, and no global npm install in any image stage, so nothing re-adds `npm` or `npx` to PATH in the runtime layers. (The one `npm install -g` in the repo is a host-side instruction in `docker/docker-compose/claude-code/README.md:38` for an unrelated CLI.)
- No `HEALTHCHECK` instruction appears anywhere in `docker/standalone/Dockerfile`, and no compose healthcheck in `docker/docker-compose/**` calls npm. They use `curl` or `pg_isready`.
- No file under `hindsight-control-plane/src/` references `child_process`, `execa`, `spawn`, `exec` or `execSync`. I found no dynamic plugin install and no package-manager subprocess. `instrumentation.ts` and `middleware.ts` do no process work.
- Migrations are Alembic, on the Python side. There is no Prisma or Drizzle step.
- No source in this repo reads `npm_config_*` or `npm_lifecycle_event` at runtime.
- The two derived images in this repo that build `FROM` a published Hindsight image (`docker/docker-compose/cuda/Dockerfile:19` and `docker/docker-compose/custom-models/Dockerfile:10`) only use `uv pip install` and `python`. Neither uses npm.
- The image tests (`docker/test-image.sh`, `docker/test-slim-local.sh`, `docker/standalone/test-start-all.sh`) do not exec npm in the container.
- I found no docs instructing a user to run npm inside the container.

The npm invocations that do exist in the Dockerfile are all in `node:20-slim` builder stages, which are unaffected.

## The CI gap, and the second commit

`.github/workflows/security-scan.yml` has a `scan-next-build` job whose stated purpose is "would an image built from main today be clean?". It builds only `target: api-only` (`security-scan.yml:83`), which is `python:3.11-slim` with no Node in it. The comment above that step is explicit that the Alpine control-plane image is covered by `scan-published` only.

That means the fresh-build regression gate cannot catch a Node-side finding by construction. In this workflow such a finding can only surface in `scan-published`, which by definition runs after the image has shipped under a tag. That is the gap this one fell through.

The second commit turns `scan-next-build` into a matrix over `api-only`, `cp-only` and `standalone`, mirroring the matrix `scan-published` already uses. `api-only` keeps covering the Debian family for the reason already recorded in that comment; the two new legs add the Node surface. Build args are unchanged, and each leg runs on its own runner, so the legs do not contend for disk with each other and the existing disk-pressure workaround is unaffected. The job's wall time becomes that of its slowest leg rather than `api-only`'s, which is worth watching against the existing 45 minute timeout.

The two commits are independent on purpose. I have not run either job, so this is an expectation and not a report: taking only the CI commit should surface exactly this finding on the two new legs, which is the intended behavior for a regression gate. Taking only the Dockerfile commit changes the images without adding CI cost.

## Scope of the claim

This is a "vulnerable component is present in the shipped image" finding, not a runtime exploitability claim. I found no path in Hindsight that invokes npm's bundled tar, and I am not asserting a reachable code path or remote exploitability. The value of the fix is that it removes a component that has no reason to be in a production image and that will otherwise keep generating findings in downstream scanners, admission controllers and compliance gates that look at these images.

For completeness, dropping `--ignore-unfixed` surfaces four more CRITICAL findings in these images (`libxml2` CVE-2026-6653, and `perl-base` CVE-2026-13221, CVE-2026-42496, CVE-2026-8376). All four report `fixed=NONE`: no fixed Debian package was available at scan time, so there is nothing to do about them here. Noted only so the numbers reconcile.

## Context

This builds on the work in #3936 and #3906 rather than duplicating it. The 0.9.2 images are a real improvement over 0.9.1 on the same scan: HIGH went from 97 to 68 overall, and OS-package HIGH from 75 to 48. The `apt-get upgrade` / `apk upgrade` change in the runtime stages is doing its job. The CRITICAL set was the one thing that did not move between the two releases, and the tar finding is why.

## What was and was not tested

Verified:

- Both removal path sets were validated in live containers against the real base images. On `node:20-alpine` (Alpine 3.23.4, node v20.20.2, npm 10.8.2) and on `python:3.11-slim` plus NodeSource `setup_20.x` (Debian 13 trixie, python 3.11.16, node v20.20.2, npm 10.8.2), every target path existed before deletion, the vendored `tar` was confirmed at 6.2.1 in `node_modules/npm/node_modules/tar/package.json`, and after the `rm -rf` a filesystem-wide search for `*/node_modules/tar/package.json` returned no hits, `npm` and `npx` were gone from PATH (exit 127), and `node` still ran (plus `python3` on the Debian stage).
- The npm-to-tar version table was verified by downloading each npm tarball from the registry and reading the bundled `node_modules/tar/package.json`; the Node-to-npm pinning came from `https://nodejs.org/dist/index.json`.
- The Trivy findings above are from a registry-mode scan by digest.

Not tested:

- The full Hindsight image was **not built**. The modified Dockerfile has not been built end to end, and the post-change image was **not scanned**. CI will need to confirm both.
- The new `cp-only` and `standalone` legs of `scan-next-build` have **not been run**.
- `standalone` is the heaviest of the three targets. If its leg does not fit the existing 45 minute timeout on a GitHub runner, that leg may need a longer timeout.

## Related, not addressed here

`Dockerfile:114` copies only `hindsight-control-plane/package.json` into an isolated workdir, then runs `npm install` at `Dockerfile:117`. Because the root `package.json` is never copied into that stage, npm runs with no workspace root, so the 31 entries in the root `overrides` block (which exist specifically for CVE pinning, and which do cover `hindsight-control-plane` as a workspace member) do not apply to the control-plane image. That reading is from the Dockerfile; I have not diffed a built control-plane `node_modules` against a local workspace install to confirm it empirically.

That is a separate problem with a separate fix, and it would not have changed anything about the tar finding above, since `overrides` cannot reach npm's bundled tree either way. Happy to open it as its own issue or PR rather than widening this one.
