### PR TITLE
fix(memory-defense): warn when a policy names a detector this build cannot run

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -17,11 +17,14 @@ from datetime import UTC, datetime
 from typing import Any
 
 from ...extensions.memory_defense import (
+    REGEX_DETECTORS,
+    SENSITIVE_DATA_DETECTOR,
     DefenseAction,
     DefenseDecision,
     MemoryDefenseExtension,
     apply_redaction,
     parse_policy,
+    warn_unimplemented_detectors,
 )
 from ...metrics import get_metrics_collector
 from ...worker.stage import set_stage
@@ -81,9 +84,13 @@ def redact_document_body(body: str, config: Any) -> str:
     # path (the only caller) diverge from the small-batch path, which has always let
     # the same error propagate.
     policy = parse_policy(config.memory_defense)
+    # This scrubber runs the OSS regex detector directly rather than through a
+    # loaded extension, so its roster is REGEX_DETECTORS. Same warn-once state
+    # as the screen path: a name already reported there is not reported again.
+    warn_unimplemented_detectors(policy, REGEX_DETECTORS)
     if not policy.enabled:
         return body
-    if not any(r.on == "sensitive_data" for r in policy.rules):
+    if not any(r.on == SENSITIVE_DATA_DETECTOR for r in policy.rules):
         return body
     return apply_redaction(body).content
 

--- a/hindsight-api-slim/hindsight_api/extensions/builtin/memory_defense_regex.py
+++ b/hindsight-api-slim/hindsight_api/extensions/builtin/memory_defense_regex.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 import logging
 
 from hindsight_api.extensions.memory_defense import (
+    REGEX_DETECTORS,
+    SENSITIVE_DATA_DETECTOR,
     DefenseAction,
     DefenseDecision,
     DefensePolicy,
     MemoryDefenseExtension,
     apply_redaction,
+    warn_unimplemented_detectors,
 )
 
 logger = logging.getLogger(__name__)
@@ -23,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 class MemoryDefenseRegexExtension(MemoryDefenseExtension):
     """Default Memory Defense — regex-based secret/PII redaction."""
+
+    implemented_detectors = REGEX_DETECTORS
 
     async def screen(
         self,
@@ -33,12 +38,16 @@ class MemoryDefenseRegexExtension(MemoryDefenseExtension):
         content: str,
         tags: list[str],
     ) -> DefenseDecision:
+        # Say once, in the log, that a configured rule names a detector this
+        # build cannot run. No decision depends on this call.
+        warn_unimplemented_detectors(policy, self.implemented_detectors)
+
         if not policy.enabled:
             return DefenseDecision(action=DefenseAction.ALLOW)
 
         # The regex extension only runs the sensitive_data detector. If the
         # policy doesn't include a rule for it, there's nothing to do.
-        rule = next((r for r in policy.rules if r.on == "sensitive_data"), None)
+        rule = next((r for r in policy.rules if r.on == SENSITIVE_DATA_DETECTOR), None)
         if rule is None or rule.action is DefenseAction.ALLOW:
             return DefenseDecision(action=DefenseAction.ALLOW)
 
@@ -48,7 +57,7 @@ class MemoryDefenseRegexExtension(MemoryDefenseExtension):
 
         return DefenseDecision(
             action=rule.action,
-            detector="sensitive_data",
+            detector=SENSITIVE_DATA_DETECTOR,
             message=f"Sensitive data pattern matched: {', '.join(result.matched_types)}",
             redacted_content=result.content if rule.action is DefenseAction.REDACT else None,
             matched_types=result.matched_types,

--- a/hindsight-api-slim/hindsight_api/extensions/memory_defense.py
+++ b/hindsight-api-slim/hindsight_api/extensions/memory_defense.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
 from abc import ABC, abstractmethod
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -37,6 +39,20 @@ _VALID_ACTIONS = {a.value for a in DefenseAction}
 # new cloud detector just to avoid 422-ing a write it never interprets. We
 # only require ``on`` to be a non-empty string; entitlement and dispatch are
 # the loaded extension's ``screen()`` job.
+#
+# Dispatch being the extension's job does not make an undispatched rule
+# invisible: an extension declares the roster it implements (see
+# ``MemoryDefenseExtension.implemented_detectors``) and
+# ``warn_unimplemented_detectors`` logs, once per name, any rule outside it.
+# Parsing stays permissive; only the silence goes away.
+
+# The detector this module's ``apply_redaction`` implements. Named once so the
+# regex extension, the document-body scrubber and the roster below cannot
+# drift apart.
+SENSITIVE_DATA_DETECTOR = "sensitive_data"
+
+# The roster the OSS regex screening honours — the whole of it.
+REGEX_DETECTORS: frozenset[str] = frozenset({SENSITIVE_DATA_DETECTOR})
 
 
 @dataclass(frozen=True)
@@ -273,6 +289,49 @@ def apply_redaction(content: str) -> RedactionResult:
     return RedactionResult(content=content, matched_types=matched, hits=hits)
 
 
+# Detector names already warned about. The retain path screens every item
+# written, so warning per screened item would put the same line in the log
+# thousands of times for one misconfigured rule; warn once per name instead.
+# The set is bounded by the number of distinct detector names operators
+# actually configure, so it cannot grow with traffic. The lock is there
+# because screening runs on worker threads as well as the event loop and
+# check-then-add is not atomic: without it a concurrent pair of writes could
+# log the same name twice. Process-local, like any log-dedup state — a restart
+# warns again, which is what an operator reading a fresh log wants.
+_warned_detectors: set[str] = set()
+_warned_detectors_lock = threading.Lock()
+
+
+def warn_unimplemented_detectors(policy: DefensePolicy, implemented: Collection[str]) -> None:
+    """Log once per policy rule naming a detector this build does not implement.
+
+    The parser accepts any detector name on purpose (see the note above
+    :class:`PolicyRule`), so a well-formed policy can name a detector no loaded
+    extension dispatches. Such a rule is inert: the PATCH returns 200, the rule
+    is stored, and nothing ever screens for it. This makes that visible in the
+    log; it changes no decision and gates no write.
+
+    Only the detector name and the implemented roster are logged. Screened
+    content and every other field of the policy stay out of the line.
+    """
+    if not policy.enabled:
+        return
+    for rule in policy.rules:
+        if rule.on in implemented:
+            continue
+        with _warned_detectors_lock:
+            if rule.on in _warned_detectors:
+                continue
+            _warned_detectors.add(rule.on)
+        # Logged outside the lock: emitting to a handler under it would
+        # serialize screening on log I/O.
+        logger.warning(
+            f"Memory Defense policy names detector '{rule.on}', which this build does not implement. "
+            f"The rule is ignored and nothing is screened for it. "
+            f"Detectors implemented here: {sorted(implemented)}."
+        )
+
+
 class MemoryDefenseExtension(Extension, ABC):
     """Abstract base for Memory Defense extensions.
 
@@ -281,6 +340,14 @@ class MemoryDefenseExtension(Extension, ABC):
     applies the returned decision (redacts content / drops blocked items) and
     fires a webhook for non-allow decisions when one is configured.
     """
+
+    # Detector names this extension's ``screen()`` actually dispatches. A rule
+    # naming anything else is a no-op here, so ``screen()`` runs the policy
+    # through :func:`warn_unimplemented_detectors` against this roster to say
+    # so once. Downstream extensions declare their own roster; the default is
+    # empty so an implementation that forgets to declare one warns about every
+    # rule rather than silently swallowing them.
+    implemented_detectors: frozenset[str] = frozenset()
 
     @abstractmethod
     async def screen(

--- a/hindsight-api-slim/tests/test_memory_defense.py
+++ b/hindsight-api-slim/tests/test_memory_defense.py
@@ -21,6 +21,7 @@ from hindsight_api.extensions.loader import ExtensionLoadError, load_extension
 from hindsight_api.extensions.memory_defense import (
     _ASCII_TOKEN_START,
     _REDACTION_PATTERNS,
+    REGEX_DETECTORS,
     DefenseAction,
     MemoryDefenseExtension,
     _fingerprint_value,
@@ -393,6 +394,174 @@ async def test_screen_allows_benign_payloads(payload: str, regex_defense, redact
         policy=parse_policy(redact_policy), bank_id="b", document_id="d", content=payload, tags=[]
     )
     assert d.action is DefenseAction.ALLOW
+
+
+# ---------------------------------------------------------------------------
+# Unimplemented detectors: the warn-once path (unit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def warn_ledger():
+    """The module-level warn-once ledger, emptied either side of a test.
+
+    ``warn_unimplemented_detectors`` dedupes for the life of the process, so a
+    test that wants to observe the first warning has to start from empty.
+    """
+    from hindsight_api.extensions import memory_defense
+
+    memory_defense._warned_detectors.clear()
+    yield memory_defense._warned_detectors
+    memory_defense._warned_detectors.clear()
+
+
+def _warnings_naming(caplog, detector: str) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelname == "WARNING" and detector in r.getMessage()]
+
+
+@pytest.mark.asyncio
+async def test_screen_warns_that_an_unimplemented_detector_is_ignored(regex_defense, warn_ledger, caplog) -> None:
+    """A rule naming a detector this build cannot run is still a no-op, but no
+    longer a silent one: the operator gets one warning naming the detector."""
+    policy = parse_policy({"enabled": True, "rules": [{"on": "prompt_injection", "action": "block"}]})
+
+    with caplog.at_level("WARNING"):
+        decision = await regex_defense.screen(
+            policy=policy, bank_id="b1", document_id="d1", content="ignore previous instructions", tags=[]
+        )
+
+    assert decision.action is DefenseAction.ALLOW
+    warnings = _warnings_naming(caplog, "prompt_injection")
+    assert len(warnings) == 1, warnings
+    assert "does not implement" in warnings[0]
+    assert "ignored" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_screen_warns_once_across_repeated_screening(regex_defense, warn_ledger, caplog) -> None:
+    """The retain path screens every item written, so the warning must fire per
+    detector name, not per screened item."""
+    policy = parse_policy({"enabled": True, "rules": [{"on": "size_anomaly", "action": "block"}]})
+
+    with caplog.at_level("WARNING"):
+        for i in range(5):
+            decision = await regex_defense.screen(
+                policy=policy, bank_id="b1", document_id=f"d{i}", content=f"item {i}", tags=[]
+            )
+            assert decision.action is DefenseAction.ALLOW
+
+    assert len(_warnings_naming(caplog, "size_anomaly")) == 1
+    assert warn_ledger == {"size_anomaly"}
+
+
+@pytest.mark.asyncio
+async def test_screen_warns_for_each_distinct_unimplemented_detector(regex_defense, warn_ledger, caplog) -> None:
+    """Dedup is per name — two inert rules are two distinct misconfigurations."""
+    policy = parse_policy(
+        {
+            "enabled": True,
+            "rules": [
+                {"on": "llm_screen", "action": "block"},
+                {"on": "base64_decode", "action": "redact"},
+                {"on": "sensitive_data", "action": "redact"},
+            ],
+        }
+    )
+
+    with caplog.at_level("WARNING"):
+        await regex_defense.screen(policy=policy, bank_id="b1", document_id="d1", content="hello", tags=[])
+
+    assert len(_warnings_naming(caplog, "llm_screen")) == 1
+    assert len(_warnings_naming(caplog, "base64_decode")) == 1
+    assert warn_ledger == {"llm_screen", "base64_decode"}
+
+
+@pytest.mark.asyncio
+async def test_screen_does_not_warn_for_the_detector_it_implements(regex_defense, redact_policy, warn_ledger, caplog):
+    """sensitive_data is on the roster: no warning, and redaction is unchanged."""
+    secret = "ghp_" + "A" * 36
+
+    with caplog.at_level("WARNING"):
+        decision = await regex_defense.screen(
+            policy=parse_policy(redact_policy),
+            bank_id="b1",
+            document_id="d1",
+            content=f"rotate this token: {secret}",
+            tags=[],
+        )
+
+    assert decision.action is DefenseAction.REDACT
+    assert secret not in decision.redacted_content
+    assert "[REDACTED:github_token]" in decision.redacted_content
+    assert _warnings_naming(caplog, "sensitive_data") == []
+    assert warn_ledger == set()
+
+
+@pytest.mark.asyncio
+async def test_screen_does_not_warn_for_a_disabled_policy(regex_defense, warn_ledger, caplog) -> None:
+    """A disabled policy screens nothing at all; its rules are inert by request."""
+    policy = parse_policy({"enabled": False, "rules": [{"on": "protected_keys", "action": "block"}]})
+
+    with caplog.at_level("WARNING"):
+        await regex_defense.screen(policy=policy, bank_id="b1", document_id="d1", content="hello", tags=[])
+
+    assert _warnings_naming(caplog, "protected_keys") == []
+    assert warn_ledger == set()
+
+
+def test_regex_extension_declares_the_roster_it_implements() -> None:
+    """The roster is declared once, not hardcoded at each dispatch site, so a
+    downstream extension can declare its own."""
+    assert MemoryDefenseRegexExtension.implemented_detectors == REGEX_DETECTORS
+    assert REGEX_DETECTORS == frozenset({"sensitive_data"})
+    # An extension that declares nothing warns about every rule rather than
+    # swallowing them.
+    assert MemoryDefenseExtension.implemented_detectors == frozenset()
+
+
+def test_redact_document_body_warns_that_an_unimplemented_detector_is_ignored(warn_ledger, caplog) -> None:
+    """The oversized-body scrubber is the second place a rule can be silently
+    dropped; it warns on the same ledger and still passes the body through."""
+    from hindsight_api.engine.retain.orchestrator import redact_document_body
+
+    body = "deploy key: ghp_" + "Q" * 36
+    config = _defense_config({"enabled": True, "rules": [{"on": "detect_secrets", "action": "block"}]})
+
+    with caplog.at_level("WARNING"):
+        assert redact_document_body(body, config) == body
+        assert redact_document_body(body, config) == body
+
+    assert len(_warnings_naming(caplog, "detect_secrets")) == 1
+
+
+def test_redact_document_body_does_not_warn_for_the_detector_it_implements(warn_ledger, caplog) -> None:
+    from hindsight_api.engine.retain.orchestrator import redact_document_body
+
+    secret = "ghp_" + "Q" * 36
+    config = _defense_config({"enabled": True, "rules": [{"on": "sensitive_data", "action": "redact"}]})
+
+    with caplog.at_level("WARNING"):
+        out = redact_document_body(f"deploy key: {secret}", config)
+
+    assert secret not in out
+    assert warn_ledger == set()
+
+
+def test_warning_carries_only_the_detector_name(warn_ledger, caplog) -> None:
+    """The line is safe to ship to a log aggregator: no screened content, and no
+    policy field other than the detector name."""
+    from hindsight_api.engine.retain.orchestrator import redact_document_body
+
+    secret = "ghp_" + "R" * 36
+    config = _defense_config({"enabled": True, "rules": [{"on": "pii_ner", "action": "block"}]})
+
+    with caplog.at_level("WARNING"):
+        redact_document_body(f"deploy key: {secret}", config)
+
+    line = _warnings_naming(caplog, "pii_ner")[0]
+    assert secret not in line
+    assert "deploy key" not in line
+    assert "block" not in line
 
 
 # ---------------------------------------------------------------------------

--- a/hindsight-docs/docs/developer/memory-defense/index.md
+++ b/hindsight-docs/docs/developer/memory-defense/index.md
@@ -46,6 +46,19 @@ Enabling Memory Defense on a bank only affects future retain calls. Memories alr
 
 Memory Defense is off on every bank until you set a policy. A bank with no `memory_defense` field, with `enabled: false`, or with no `sensitive_data` rule is treated identically: the extension returns ALLOW and content passes through unchanged. To stop redacting on a bank that has it on, set `enabled: false` or remove the policy.
 
+### Detectors this build does not implement
+
+A policy may name any detector. The config API does not gate `on` against a fixed list, so a policy written for a build with more detectors than yours is accepted and stored as-is rather than rejected.
+
+A rule naming a detector the running build does not implement has no effect: nothing is screened for it. Because that is easy to mistake for a protection being active, the API logs a warning the first time it screens under such a policy, naming the detector and the roster it does implement:
+
+```
+Memory Defense policy names detector 'prompt_injection', which this build does not implement.
+The rule is ignored and nothing is screened for it. Detectors implemented here: ['sensitive_data'].
+```
+
+The line is emitted once per detector name per process, not once per retained item.
+
 ## Notifications
 
 When an item is redacted or blocked, Hindsight fires a [`memory_defense.triggered` webhook](../api/webhooks.mdx#memory_defensetriggered) if a webhook on the bank is subscribed to that event type. The payload reports the action taken, the document ID, and which redaction patterns matched — useful for routing security alerts to a SIEM or Slack. Clean items fire no event.


### PR DESCRIPTION
# Warn when a Memory Defense policy names a detector the running build cannot run

## The symptom

Set this on a bank running the OSS build:

```bash
curl -X PATCH "$HINDSIGHT/v1/default/banks/my-bank/config" \
  -H 'content-type: application/json' \
  -d '{
    "memory_defense": {
      "enabled": true,
      "rules": [
        { "on": "prompt_injection", "action": "block" }
      ]
    }
  }'
```

You get a `200`. `GET .../config` reads the rule back verbatim. Every retain to
the bank is then screened against nothing at all, because the loaded extension
implements only `sensitive_data`. No error, no warning, no log line, and no
`memory_defense.triggered` webhook to notice the absence of. The bank config is
the operator's only feedback surface, and it says the control is on.

The same holds for `size_anomaly`, `detect_secrets`, `llm_screen`, or any other
name. It is not limited to typos: a policy copied from a build with a larger
detector roster lands in exactly this state.

## What this does not change

This does not touch parsing. `parse_policy` still accepts any non-empty string
for `on`, and `test_parse_policy_accepts_any_detector_name` still passes
unmodified, `some_future_cloud_detector` included. The forward-compatibility
property described at
[`memory_defense.py:32-39`](hindsight-api-slim/hindsight_api/extensions/memory_defense.py#L32-L39)
is preserved intact:

> The parser therefore does NOT validate `on` against a fixed list — pinning
> the OSS roster to cloud's would force an OSS bump for every new cloud
> detector just to avoid 422-ing a write it never interprets.

That reasoning is right and this change depends on it. Rejecting unknown names
would break every deployment whose policy is authored against a build with more
detectors than the one running. Screening behavior is likewise unchanged: the
same decisions, the same redactions, the same blocks, the same webhooks. The
only thing added is a log line.

## Why the current behavior is worth changing

Thirteen lines above the site in question, in
[`orchestrator.py:70-73`](hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py#L70-L73):

```python
# No try/except around the parse. A malformed policy must fail the retain, not
# quietly skip screening: this is a security control, so fail-open is the wrong
# default even for an unreachable state (the HTTP layer 422s a bad policy on
# write, so one can only reach the store by a direct DB edit).
```

The principle stated there is the one this PR applies. That comment concerns a
state described as unreachable, and it still rejects failing open. At
[`orchestrator.py:86`](hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py#L86)
the code fails open silently for a state that is entirely reachable through the
public API: a well-formed policy, accepted with a 200, naming a detector this
build cannot honor.

```python
if not any(r.on == "sensitive_data" for r in policy.rules):
    return body
```

The other site is
[`memory_defense_regex.py:41-43`](hindsight-api-slim/hindsight_api/extensions/builtin/memory_defense_regex.py#L41-L43):

```python
rule = next((r for r in policy.rules if r.on == "sensitive_data"), None)
if rule is None or rule.action is DefenseAction.ALLOW:
    return DefenseDecision(action=DefenseAction.ALLOW)
```

Every rule that is not `sensitive_data` is discarded without being looked at.
The module declares a logger at line 21 and never uses it.

Failing open is arguably the right runtime behavior here, and this PR keeps it.
Doing it silently is the part that is not: an operator has no way to learn that
a configured control is inert. That is an observability gap, not an enforcement
one, so the fix is a log line rather than a behavior change.

## The change

`MemoryDefenseExtension` gains a class attribute naming the detectors its
`screen()` actually dispatches:

```python
implemented_detectors: frozenset[str] = frozenset()
```

`MemoryDefenseRegexExtension` declares `REGEX_DETECTORS`
(`frozenset({"sensitive_data"})`). A downstream extension declares its own
roster the same way and gets the same reporting for free, with no OSS release
needed when its roster grows. The default is empty rather than
`{"sensitive_data"}` so an extension that forgets to declare one is noisy
instead of silent.

Both paths call one shared helper, `warn_unimplemented_detectors(policy,
implemented)`, which logs any rule whose `on` is outside the roster and returns.
It reads the policy, makes no decision, and is a no-op for a disabled policy
(a disabled policy screens nothing by request, so there is nothing to report).
The literal `"sensitive_data"` moves to a `SENSITIVE_DATA_DETECTOR` constant
that the roster and both dispatch sites share, so a fourth copy of the string is
not introduced.

The line:

```
Memory Defense policy names detector 'prompt_injection', which this build does not implement.
The rule is ignored and nothing is screened for it. Detectors implemented here: ['sensitive_data'].
```

It carries the detector name and the implemented roster and nothing else. No
screened content, no other policy field, no bank id, nothing that could carry
user data. A test asserts that the secret and the surrounding body are absent
from the line.

## On log spam

A warning on the retain path that fires per screened item would be unacceptable:
one misconfigured rule would repeat the same line for every write to the bank
forever. The helper keeps a module-level set of names already warned about and
logs each one once per process. Notes on the mechanism:

- Deduplication is by detector name, so the two call sites share one ledger and
  a name reported by the screen path is not reported again by the document-body
  scrubber.
- Growth is bounded by the number of distinct detector names operators actually
  configure, not by traffic or by bank count. This is stated in a comment beside
  the set.
- The set is guarded by a `threading.Lock` because screening runs from worker
  threads as well as the event loop and check-then-add is not atomic. The log
  call itself happens outside the lock so screening never serializes on log I/O.
- The state is process-local. A restart warns again, which is what an operator
  reading a fresh log wants.
- A test screens five items under the same policy and asserts exactly one
  record.

## Tests

Nine tests added to `hindsight-api-slim/tests/test_memory_defense.py`, in the
`caplog` idiom already used elsewhere in the suite:

- an unimplemented detector produces exactly one warning and the decision is
  still ALLOW
- the warning fires once across repeated screening with the same policy
- two distinct unimplemented names produce one warning each
- a `sensitive_data` rule produces no warning and still redacts, hits and all
- a disabled policy produces no warning
- the extension declares its roster, and the base class default is empty
- `redact_document_body` warns once and still returns the body unchanged
- `redact_document_body` does not warn for `sensitive_data` and still scrubs
- the warning line contains neither the screened content nor the rule action

`test_parse_policy_accepts_any_detector_name` is untouched and passes.

Full file, including the DB-backed retain tests:

```
$ uv run pytest tests/test_memory_defense.py
270 passed   # before
279 passed   # after (+9 new, 0 changed, 0 removed)
```

`ruff check`, `ruff format --check`, and `ty check` are clean on the changed
modules.

## Files

- `hindsight-api-slim/hindsight_api/extensions/memory_defense.py`: the
  `implemented_detectors` roster attribute, the `SENSITIVE_DATA_DETECTOR` and
  `REGEX_DETECTORS` constants, and the `warn_unimplemented_detectors` helper
  with its warn-once ledger.
- `hindsight-api-slim/hindsight_api/extensions/builtin/memory_defense_regex.py`:
  declares its roster and calls the helper at the top of `screen()`.
- `hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py`: the same
  call in `redact_document_body`, against `REGEX_DETECTORS` since that path runs
  the regex detector directly rather than through a loaded extension.
- `hindsight-api-slim/tests/test_memory_defense.py`: the nine tests.
- `hindsight-docs/docs/developer/memory-defense/index.md`: a short subsection
  documenting that an unimplemented detector is accepted, ignored, and logged.

Happy to drop the docs hunk, move the warning to the extension's own logger, or
key deduplication on `(bank_id, detector)` instead of the name alone if you'd
rather have the bank in the line. The behavior change is confined to logging
either way.
