### PR TITLE
memories: an edit writes its own vector, in the same write as the fields

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -1737,14 +1737,29 @@ class MemoriesExtension(Extension, ABC):
         mentioned_at,
         entity_ids: list[str] | None,
         entity_names: list[str] | None = None,
+        embedding=None,
+        current_fact_type: str | None = None,
     ) -> None:
         """Apply a curation field edit to a live memory.
 
         Writes the new text / context / fact_type / occurred window, resets the
         consolidation markers (the memory re-consolidates) and stamps the edit
-        time, and drops the memory's derived links (they are recomputed). The
-        embedding is *not* written here — the caller re-embeds from the new fields
-        and calls :meth:`set_memory_embedding` after.
+        time, and drops the memory's derived links (they are recomputed).
+
+        ``embedding`` is the vector the caller re-embedded from the new fields, and
+        writing it is **part of applying the edit** — an implementation writes it
+        alongside the fields above rather than leaving it for a following
+        :meth:`set_memory_embedding`. Where a write is a durable append rather than
+        a row update, a separate call is a second write of the row this one just
+        wrote and doubles what an edit costs. ``None`` leaves the stored vector
+        alone. (:meth:`set_memory_embedding` remains for the paths that write a
+        vector without editing fields, such as restoring an invalidated memory.)
+
+        ``current_fact_type`` is the memory's fact_type BEFORE this edit, which the
+        caller has just read under this transaction. A fact-type change is the one
+        part of an edit that some stores cannot apply as a partial update, and
+        discovering it here would cost a read the caller has already paid for. It
+        may be ``None``, from a caller that does not have it.
 
         The new entity set for the memory is supplied one of two ways, and a store
         uses whichever fits how it keeps its registry:

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -1702,15 +1702,21 @@ class MemoriesExtension(Extension, ABC):
 
     @abstractmethod
     async def set_memory_embedding(self, *, conn, fq_table, bank_id: str, unit_id: str, embedding) -> None:
-        """Write a memory's embedding, recomputed by the caller.
+        """Write a memory's embedding, recomputed by the caller, leaving its fields as they are.
 
         Its own method because the general :meth:`update_memories` is a no-op for
-        the store whose write is the row itself — reverting or editing a memory has
-        to put a freshly computed vector back on it, so this is a real write for
-        both. ``embedding`` is a float list or the pgvector literal.
+        the store whose write is the row itself — restoring an invalidated memory has
+        to put a freshly computed vector back on it, so this is a real write.
+        ``embedding`` is a float list or the pgvector literal.
+
+        A curation edit no longer arrives here. It used to call this straight after
+        :meth:`apply_edit` — a second write of the row that call had just written, which
+        for a store whose write is a durable append is the whole cost of the edit again —
+        so the vector now rides the edit itself as ``apply_edit(embedding=...)``. What is
+        left for this method is writing a vector when no field is changing alongside it.
 
         The vector is part of the memory, so this stamps ``updated_at`` itself rather
-        than leaning on the edit statement its in-tree callers happen to pair it with
+        than leaning on a statement a caller happens to pair it with
         (see :data:`META_UPDATED_AT`).
         """
 

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/writes.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/writes.py
@@ -529,6 +529,7 @@ async def apply_edit(
     event_date,
     mentioned_at,
     entity_ids: list[str] | None,
+    embedding=None,
 ) -> None:
     # `entity_ids` and `mentioned_at` are unused here: the entity postings are
     # re-linked into `unit_entities` by the caller, and an edit does not move the
@@ -548,22 +549,23 @@ async def apply_edit(
     # would see the pre-edit values.
     sv_expr = pg_search_vector_expr(get_config(), text_col="$3", context_col="$4")
     sv_clause = f", search_vector = {sv_expr}" if sv_expr else ""
+    # The re-embedded vector rides the edit's own UPDATE. It describes the text being written by
+    # this statement, so writing it here is what keeps the two from ever disagreeing — and it
+    # spares a store whose write is not a row update a second write of this row.
+    params: list = [str(unit_id), bank_id, text, context, fact_type, occurred_start, occurred_end, event_date]
+    embedding_clause = ""
+    if embedding is not None:
+        params.append(embedding)
+        embedding_clause = f", embedding = ${len(params)}::vector"
     await conn.execute(
         f"""
         UPDATE {mu}
         SET text = $3, context = $4, fact_type = $5, occurred_start = $6, occurred_end = $7,
             event_date = $8, consolidated_at = NULL, consolidation_failed_at = NULL,
-            edited_at = now(), updated_at = now(){sv_clause}
+            edited_at = now(), updated_at = now(){sv_clause}{embedding_clause}
         WHERE id = $1 AND bank_id = $2
         """,
-        str(unit_id),
-        bank_id,
-        text,
-        context,
-        fact_type,
-        occurred_start,
-        occurred_end,
-        event_date,
+        *params,
     )
     # Drop only the DERIVED links — graph maintenance recomputes temporal/semantic. Causal edges
     # are retain-time extraction output that nothing recreates, so an edit preserves them (#2864).

--- a/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
@@ -555,6 +555,8 @@ class PostgresMemories(MemoriesExtension):
         mentioned_at,
         entity_ids: list[str] | None,
         entity_names: list[str] | None = None,  # noqa: ARG002 — this store's registry is SQL; the host already minted+linked, so entity_ids is authoritative.
+        embedding=None,
+        current_fact_type: str | None = None,  # noqa: ARG002 — one UPDATE writes every field, so a fact-type change needs no different path.
     ) -> None:
         await writes.apply_edit(
             conn=conn,
@@ -569,6 +571,7 @@ class PostgresMemories(MemoriesExtension):
             event_date=event_date,
             mentioned_at=mentioned_at,
             entity_ids=entity_ids,
+            embedding=embedding,
         )
 
     async def list_entities(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -10131,15 +10131,15 @@ class MemoryEngine(MemoryEngineInterface):
                             mentioned_at=edit_plan.mentioned_at,
                             entity_ids=edit_plan.edit_entity_ids,
                             entity_names=edit_plan.entity_names_for_store,
+                            # The vector describes the text being written by this same call, so
+                            # it goes with it: a following set_memory_embedding would be a second
+                            # write of the row apply_edit just wrote.
+                            embedding=edit_embedding,
+                            # The memory's type as it stands, so the store need not re-read the
+                            # memory to see whether this edit changes it. `live2` is the re-read
+                            # this transaction already did, so it is free here.
+                            current_fact_type=live2.fact_type,
                         )
-                        if edit_embedding is not None:
-                            await store.set_memory_embedding(
-                                conn=conn,
-                                fq_table=fq_table,
-                                bank_id=bank_id,
-                                unit_id=str(memory_uuid),
-                                embedding=edit_embedding,
-                            )
                         await self._delete_stale_observations_for_memories(conn, bank_id, [memory_id])
                         need_consolidation = True
                         need_graph = True

--- a/hindsight-api-slim/tests/test_memories_extension.py
+++ b/hindsight-api-slim/tests/test_memories_extension.py
@@ -75,6 +75,10 @@ class InMemoryMemories(MemoriesExtension):
         self.archive: dict[str, StoredMemory] = {}
         self.invalidation_reason: dict[str, str | None] = {}
         self.embeddings: dict[str, object] = {}
+        # What `apply_edit` was handed, so a test can tell which door the vector came through and
+        # whether the caller supplied the pre-edit fact type.
+        self.edit_embedding: object = None
+        self.edit_current_fact_type: str | None = None
         # The document store: one record per document, each carrying its extracted text and the
         # ordered chunk texts — the bodies a store that owns them keeps out of Postgres.
         self.documents: dict[str, dict] = {}
@@ -447,6 +451,7 @@ class InMemoryMemories(MemoriesExtension):
         return row
 
     async def set_memory_embedding(self, *, conn, fq_table, bank_id, unit_id, embedding):
+        self.calls.append("set_memory_embedding")
         self.embeddings[str(unit_id)] = embedding
 
     async def list_entities(self, *, conn, fq_table, bank_id, search=None, limit=100, offset=0):
@@ -529,11 +534,18 @@ class InMemoryMemories(MemoriesExtension):
         mentioned_at,
         entity_ids,
         entity_names=None,
+        embedding=None,
+        current_fact_type=None,
     ):
         self.calls.append("apply_edit")
+        self.edit_embedding = embedding
+        self.edit_current_fact_type = current_fact_type
         row = self.rows.get(str(unit_id))
         if row is None:
             return
+        if embedding is not None:
+            # Applying an edit includes writing its vector — the same call, not a following one.
+            self.embeddings[str(unit_id)] = embedding
         row.text = text
         row.context = context
         row.fact_type = fact_type
@@ -1083,6 +1095,39 @@ async def test_engine_list_memory_units_routes_through_store(memory, request_con
     res = await memory.list_memory_units("seam-bank", request_context=request_context)
     assert "list_memory_units" in store.calls
     assert res["total"] == 1  # the row exists only in the stub, so it can only have come from it
+
+
+async def test_an_edit_writes_its_vector_in_the_edit_itself(memory, request_context, restore_default_store):
+    """Applying an edit writes its re-embedded vector — with no second call to do it.
+
+    The property is not "the vector ends up stored": that passed while the edit was making two
+    writes to get it there, which is the whole cost of an edit again for a store whose write is a
+    durable append rather than a row update. It is that the vector arrives through `apply_edit`
+    and that nothing follows it to write the same row again.
+    """
+    store = InMemoryMemories({})
+    set_memories(store)
+    unit_ids = await _seed(store, "seam-bank", text="before the edit", fact_type="world")
+
+    await memory.update_memory_unit("seam-bank", unit_ids[0], text="after the edit", request_context=request_context)
+
+    assert "apply_edit" in store.calls
+    assert store.edit_embedding is not None, "the store is handed the re-embedded vector"
+    assert store.embeddings.get(unit_ids[0]) is not None, "…and applying the edit stored it"
+    assert "set_memory_embedding" not in store.calls, "a second write of the row just written"
+
+
+async def test_apply_edit_is_told_the_pre_edit_fact_type(memory, request_context, restore_default_store):
+    """A store that can apply a type-preserving edit more cheaply needs to know the type did not
+    change, and re-reading the memory to find that out costs the round trip the cheap path saves.
+    The caller has it from the re-read it already did, so it passes it."""
+    store = InMemoryMemories({})
+    set_memories(store)
+    unit_ids = await _seed(store, "seam-bank", text="before the edit", fact_type="world")
+
+    await memory.update_memory_unit("seam-bank", unit_ids[0], text="after the edit", request_context=request_context)
+
+    assert store.edit_current_fact_type == "world"
 
 
 async def test_engine_list_entities_routes_through_store(memory, request_context, restore_default_store):


### PR DESCRIPTION
A curation edit writes the memory twice. `apply_edit` writes the edited fields, and the caller then calls `set_memory_embedding` with the vector it re-embedded from those same fields — a second update of the row the first call just wrote.

## What changes

Writing that vector becomes part of applying the edit. `apply_edit` takes an `embedding`, and both stores write it alongside the fields it describes:

- **Postgres** — one more assignment in an `UPDATE` it was already issuing. It also makes the two impossible to disagree: the vector and the text it embeds are now written by a single statement.
- **A store whose write is a durable append** rather than a row update — the separate call was the entire cost of the edit a second time.

`set_memory_embedding` stays on the seam for the paths that write a vector *without* editing fields. Restoring an invalidated memory re-embeds and calls it, and that is still right.

`apply_edit` also receives `current_fact_type`, the memory's type before the edit. A fact-type change is the one part of an edit that a store may not be able to apply as a partial update, and discovering that inside the store costs a read the caller has already paid for — it has the value from the re-read it does under its write transaction. It may be `None` from a caller that does not have it.

## Tests

`test_an_edit_writes_its_vector_in_the_edit_itself` asserts the vector arrives through `apply_edit` and that nothing follows it to write the same row again. Asserting only that the vector ends up stored passes for any number of writes — which is how the second one went unnoticed. Verified it fails when the caller-side change is reverted.

243 passed across `test_memories_extension.py`, `test_memory_curation.py` and `test_memory_units_updated_at.py`; ruff clean on the changed files.

https://claude.ai/code/session_01B2EL3hsUaRgtDRQH879kDW
