### PR TITLE
fix(coding-agents): only ever ADD to a bank's config, never overwrite it

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -419,6 +419,7 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `resolveWorktrees`      | `true`                               | linked worktrees inherit the main checkout's bank identity, path approval, and mapping                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `manageBankConfig`      | `true`                               | let the plugin shape the bank's own configuration — the retain strategies it writes under, the `knowledge` entity-label group, and, on a bank that has none, the missions. Writing is strictly **additive**: it adds what the bank does not define and never overwrites what is there, so your control-plane edits survive. Set `false` to keep it out of the bank config entirely — see **A bank you shape yourself** below                                                                                                                                                                                                                                                                 |
 | `observationScopes`     | `"shared"`                           | how consolidation groups observations: `"shared"` (default) = ONE global scope per bank, so every agent on a repo builds one set of beliefs; also `"combined"` (the server default), `"per_tag"`, `"all_combinations"`, `[["t"]]`                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `reflectTimeoutMs`      | `120000`                             | **automatic** session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -452,6 +453,36 @@ repo already has: a page keeps the trigger it was created with, so a bank seeded
 `"manual"` keeps refreshing on every consolidation. To move an existing page, change its trigger
 through the API (`PATCH /knowledge-base/nodes/{id}`), an SDK, or the control plane — or delete it
 and let the next session seed it again.
+
+### A bank you shape yourself — `manageBankConfig`
+
+Pointed at a bank, this plugin gives it the shape its ingestion needs: retain strategies for the
+kinds of document it writes (`git`, `gitlog`, `conversation`, `document`, `survey`), a `knowledge`
+entity-label group that routes facts to the knowledge pages, and — on a bank that has no missions of
+its own — the coding missions.
+
+**It only ever adds what is missing.** A strategy you defined, an edit you made to one of the
+plugin's, a reworded label group, a mission you rewrote in the control plane: each is left exactly
+as it is, on every session, forever. What the bank already says wins. The cost of that promise is
+that a plugin release which _rewords_ an existing strategy or label does not reach a bank that
+already has it. To take the current default back, clear that override on the bank (delete the
+strategy, or the whole `retain_strategies` entry, in the control plane): the next session finds the
+bank silent there and seeds it again.
+
+Set `manageBankConfig: false` to keep the plugin out of the bank's configuration altogether — the
+right setting for a bank you share with non-coding work, or one you configure yourself. That bank
+must then define the five strategies above itself, because a retain naming a strategy the bank does
+not have is rejected. Knowledge pages are seeded either way; `pageTriggerType` governs what they
+cost.
+
+Like every field here it can be set per bank, which is usually where it belongs:
+
+```json
+{
+  "bankId": "my-global-bank",
+  "banks": { "my-global-bank": { "manageBankConfig": false } }
+}
+```
 
 ### Per-repo opt-in/out — `banks.<bankId>`
 

--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -471,9 +471,11 @@ bank silent there and seeds it again.
 
 Set `manageBankConfig: false` to keep the plugin out of the bank's configuration altogether — the
 right setting for a bank you share with non-coding work, or one you configure yourself. That bank
-must then define the five strategies above itself, because a retain naming a strategy the bank does
-not have is rejected. Knowledge pages are seeded either way; `pageTriggerType` governs what they
-cost.
+should then define the five strategies above itself. Note that the miss is **silent**: the server
+does not reject a retain naming a strategy the bank lacks, it logs a warning and extracts with the
+bank's own configuration — so a commit diff, a session transcript and a survey marker would all get
+the same generic treatment instead of the extraction each needs. Knowledge pages are seeded either
+way; `pageTriggerType` governs what they cost.
 
 Like every field here it can be set per bank, which is usually where it belongs:
 

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -474,9 +474,11 @@ bank silent there and seeds it again.
 
 Set `manageBankConfig: false` to keep the plugin out of the bank's configuration altogether — the
 right setting for a bank you share with non-coding work, or one you configure yourself. That bank
-must then define the five strategies above itself, because a retain naming a strategy the bank does
-not have is rejected. Knowledge pages are seeded either way; `pageTriggerType` governs what they
-cost.
+should then define the five strategies above itself. Note that the miss is **silent**: the server
+does not reject a retain naming a strategy the bank lacks, it logs a warning and extracts with the
+bank's own configuration — so a commit diff, a session transcript and a survey marker would all get
+the same generic treatment instead of the extraction each needs. Knowledge pages are seeded either
+way; `pageTriggerType` governs what they cost.
 
 Like every field here it can be set per bank, which is usually where it belongs:
 

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -422,6 +422,7 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `resolveWorktrees`      | `true`                               | linked worktrees inherit the main checkout's bank identity, path approval, and mapping                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `manageBankConfig`      | `true`                               | let the plugin shape the bank's own configuration — the retain strategies it writes under, the `knowledge` entity-label group, and, on a bank that has none, the missions. Writing is strictly **additive**: it adds what the bank does not define and never overwrites what is there, so your control-plane edits survive. Set `false` to keep it out of the bank config entirely — see **A bank you shape yourself** below                                                                                                                                                                                                                                                                 |
 | `observationScopes`     | `"shared"`                           | how consolidation groups observations: `"shared"` (default) = ONE global scope per bank, so every agent on a repo builds one set of beliefs; also `"combined"` (the server default), `"per_tag"`, `"all_combinations"`, `[["t"]]`                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `reflectTimeoutMs`      | `120000`                             | **automatic** session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -455,6 +456,36 @@ repo already has: a page keeps the trigger it was created with, so a bank seeded
 `"manual"` keeps refreshing on every consolidation. To move an existing page, change its trigger
 through the API (`PATCH /knowledge-base/nodes/{id}`), an SDK, or the control plane — or delete it
 and let the next session seed it again.
+
+### A bank you shape yourself — `manageBankConfig`
+
+Pointed at a bank, this plugin gives it the shape its ingestion needs: retain strategies for the
+kinds of document it writes (`git`, `gitlog`, `conversation`, `document`, `survey`), a `knowledge`
+entity-label group that routes facts to the knowledge pages, and — on a bank that has no missions of
+its own — the coding missions.
+
+**It only ever adds what is missing.** A strategy you defined, an edit you made to one of the
+plugin's, a reworded label group, a mission you rewrote in the control plane: each is left exactly
+as it is, on every session, forever. What the bank already says wins. The cost of that promise is
+that a plugin release which _rewords_ an existing strategy or label does not reach a bank that
+already has it. To take the current default back, clear that override on the bank (delete the
+strategy, or the whole `retain_strategies` entry, in the control plane): the next session finds the
+bank silent there and seeds it again.
+
+Set `manageBankConfig: false` to keep the plugin out of the bank's configuration altogether — the
+right setting for a bank you share with non-coding work, or one you configure yourself. That bank
+must then define the five strategies above itself, because a retain naming a strategy the bank does
+not have is rejected. Knowledge pages are seeded either way; `pageTriggerType` governs what they
+cost.
+
+Like every field here it can be set per bank, which is usually where it belongs:
+
+```json
+{
+  "bankId": "my-global-bank",
+  "banks": { "my-global-bank": { "manageBankConfig": false } }
+}
+```
 
 ### Per-repo opt-in/out — `banks.<bankId>`
 

--- a/hindsight-integrations/coding-agents/skill/SKILL.md
+++ b/hindsight-integrations/coding-agents/skill/SKILL.md
@@ -201,6 +201,7 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `resolveWorktrees`      | `true`                               | linked worktrees inherit the main checkout's bank identity, path approval, and mapping                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `manageBankConfig`      | `true`                               | let the plugin shape the bank's own configuration — the retain strategies it writes under, the `knowledge` entity-label group, and, on a bank that has none, the missions. Writing is strictly **additive**: it adds what the bank does not define and never overwrites what is there, so your control-plane edits survive. Set `false` to keep it out of the bank config entirely — see **A bank you shape yourself** below                                                                                                                                                                                                                                                                 |
 | `observationScopes`     | `"shared"`                           | how consolidation groups observations: `"shared"` (default) = ONE global scope per bank, so every agent on a repo builds one set of beliefs; also `"combined"` (the server default), `"per_tag"`, `"all_combinations"`, `[["t"]]`                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `reflectTimeoutMs`      | `120000`                             | **automatic** session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -234,6 +235,36 @@ repo already has: a page keeps the trigger it was created with, so a bank seeded
 `"manual"` keeps refreshing on every consolidation. To move an existing page, change its trigger
 through the API (`PATCH /knowledge-base/nodes/{id}`), an SDK, or the control plane — or delete it
 and let the next session seed it again.
+
+### A bank you shape yourself — `manageBankConfig`
+
+Pointed at a bank, this plugin gives it the shape its ingestion needs: retain strategies for the
+kinds of document it writes (`git`, `gitlog`, `conversation`, `document`, `survey`), a `knowledge`
+entity-label group that routes facts to the knowledge pages, and — on a bank that has no missions of
+its own — the coding missions.
+
+**It only ever adds what is missing.** A strategy you defined, an edit you made to one of the
+plugin's, a reworded label group, a mission you rewrote in the control plane: each is left exactly
+as it is, on every session, forever. What the bank already says wins. The cost of that promise is
+that a plugin release which _rewords_ an existing strategy or label does not reach a bank that
+already has it. To take the current default back, clear that override on the bank (delete the
+strategy, or the whole `retain_strategies` entry, in the control plane): the next session finds the
+bank silent there and seeds it again.
+
+Set `manageBankConfig: false` to keep the plugin out of the bank's configuration altogether — the
+right setting for a bank you share with non-coding work, or one you configure yourself. That bank
+must then define the five strategies above itself, because a retain naming a strategy the bank does
+not have is rejected. Knowledge pages are seeded either way; `pageTriggerType` governs what they
+cost.
+
+Like every field here it can be set per bank, which is usually where it belongs:
+
+```json
+{
+  "bankId": "my-global-bank",
+  "banks": { "my-global-bank": { "manageBankConfig": false } }
+}
+```
 
 ### Per-repo opt-in/out — `banks.<bankId>`
 

--- a/hindsight-integrations/coding-agents/skill/SKILL.md
+++ b/hindsight-integrations/coding-agents/skill/SKILL.md
@@ -253,9 +253,11 @@ bank silent there and seeds it again.
 
 Set `manageBankConfig: false` to keep the plugin out of the bank's configuration altogether — the
 right setting for a bank you share with non-coding work, or one you configure yourself. That bank
-must then define the five strategies above itself, because a retain naming a strategy the bank does
-not have is rejected. Knowledge pages are seeded either way; `pageTriggerType` governs what they
-cost.
+should then define the five strategies above itself. Note that the miss is **silent**: the server
+does not reject a retain naming a strategy the bank lacks, it logs a warning and extracts with the
+bank's own configuration — so a commit diff, a session transcript and a survey marker would all get
+the same generic treatment instead of the extraction each needs. Knowledge pages are seeded either
+way; `pageTriggerType` governs what they cost.
 
 Like every field here it can be set per bank, which is usually where it belongs:
 

--- a/hindsight-integrations/coding-agents/src/core/config.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.test.ts
@@ -170,6 +170,22 @@ describe("loadConfig — untrusted project-local layer is sanitized (security)",
   });
 });
 
+describe("manageBankConfig (#3927)", () => {
+  it("defaults to true — a bank the plugin creates still gets the shape its ingestion needs", () => {
+    expect(resolveConfig({}).manageBankConfig).toBe(true);
+  });
+
+  it("is settable per bank, which is where a shared global bank needs it", () => {
+    // The #3927 setup: ONE bank for coding and personal-assistant work alike. The plugin keeps
+    // managing every other bank; this one is the user's to shape.
+    const cfg = resolveConfig({
+      banks: { "my-global-bank": { manageBankConfig: false } },
+    });
+    expect(applyBankConfig(cfg, "my-global-bank").cfg.manageBankConfig).toBe(false);
+    expect(applyBankConfig(cfg, "coding-agent::repo").cfg.manageBankConfig).toBe(true);
+  });
+});
+
 describe("banks.<bankId> overrides (per-repo opt-in/out, applied AFTER bank resolution)", () => {
   it("overrides behavioral fields for the matching bank only; others untouched", () => {
     const cfg = resolveConfig({
@@ -265,10 +281,12 @@ describe("environment fallback", () => {
   it("parses booleans and numbers rather than passing strings through", () => {
     writeJson(globalCfg, {});
     process.env.HINDSIGHT_AUTO_REFLECT = "false";
+    process.env.HINDSIGHT_MANAGE_BANK_CONFIG = "false";
     process.env.HINDSIGHT_DISABLED = "1";
     process.env.HINDSIGHT_SEED_LIMIT = "5";
     const cfg = loadConfig({ path: globalCfg });
     expect(cfg.autoReflect).toBe(false);
+    expect(cfg.manageBankConfig).toBe(false);
     expect(cfg.disabled).toBe(true);
     expect(cfg.seedLimit).toBe(5);
   });

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -151,9 +151,11 @@ export interface RawConfig {
    *  Writing is strictly ADDITIVE: the plugin adds what the bank does not already define and never
    *  overwrites an existing value, so an edit made in the control plane survives (#3927). Set false
    *  to keep it out of the bank's configuration entirely — for a bank you shape yourself, or share
-   *  with non-coding work. That bank must then define the strategies this plugin retains under
-   *  (`git`, `gitlog`, `conversation`, `document`, `survey`), since a retain naming a strategy the
-   *  bank lacks is rejected. Knowledge pages are seeded either way (see `pageTriggerType`). */
+   *  with non-coding work. That bank should then define the strategies this plugin retains under
+   *  (`git`, `gitlog`, `conversation`, `document`, `survey`): the server does not reject a retain
+   *  naming a strategy the bank lacks, it logs a warning and extracts with the bank's own config
+   *  instead — so a diff, a transcript and a survey marker all get the same generic treatment.
+   *  Knowledge pages are seeded either way (see `pageTriggerType`). */
   manageBankConfig?: boolean;
   /** How consolidation groups the observations this plugin's memories feed (default "shared" — one
    *  global scope per bank, so every agent working a repo builds ONE set of beliefs; see

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -145,6 +145,16 @@ export interface RawConfig {
   /** Extra metadata stamped on every session write-back, e.g. {"repo": "{gitProject}"}. Same
    *  placeholders as retainTags; built-in metadata (harness attribution) wins on conflict. */
   retainMetadata?: Record<string, string>;
+  /** Let the plugin shape the bank's own configuration — the retain strategies it writes under,
+   *  the `knowledge` entity-label group, and (on a bank that has none) the missions (default true).
+   *
+   *  Writing is strictly ADDITIVE: the plugin adds what the bank does not already define and never
+   *  overwrites an existing value, so an edit made in the control plane survives (#3927). Set false
+   *  to keep it out of the bank's configuration entirely — for a bank you shape yourself, or share
+   *  with non-coding work. That bank must then define the strategies this plugin retains under
+   *  (`git`, `gitlog`, `conversation`, `document`, `survey`), since a retain naming a strategy the
+   *  bank lacks is rejected. Knowledge pages are seeded either way (see `pageTriggerType`). */
+  manageBankConfig?: boolean;
   /** How consolidation groups the observations this plugin's memories feed (default "shared" — one
    *  global scope per bank, so every agent working a repo builds ONE set of beliefs; see
    *  DEFAULT_OBSERVATION_SCOPES). "combined" restores the server default of one scope per distinct
@@ -205,6 +215,7 @@ export interface Config {
   gitIngest: "message" | "full" | "none";
   retainTags: string[];
   retainMetadata: Record<string, string>;
+  manageBankConfig: boolean;
   observationScopes: ObservationScopes;
   banks: Record<string, Omit<RawConfig, "banks" | "harnesses"> & { bank?: string }>;
   logLevel: "debug" | "info" | "warn" | "error";
@@ -314,6 +325,7 @@ export function resolveConfig(raw: RawConfig = {}): Config {
     harness: raw.harness ?? "opencode",
     disabled: raw.disabled ?? false,
     retainSessions: raw.retainSessions ?? true, // write sessions back by default, every harness
+    manageBankConfig: raw.manageBankConfig ?? true,
     maxParallelRetains: raw.maxParallelRetains || 10,
     reflectTimeoutMs: raw.reflectTimeoutMs || 120000,
     // Inherit an explicitly-raised reflectTimeoutMs (that is what users reaching for a longer
@@ -450,6 +462,7 @@ const ENV_KEYS = {
   // Comma-separated, e.g. HINDSIGHT_RETAIN_TAGS="project:{gitProject},env:work". A LIST rather than
   // a map, so it flattens cleanly; its sibling retainMetadata stays file-only for the reason above.
   retainTags: "HINDSIGHT_RETAIN_TAGS",
+  manageBankConfig: "HINDSIGHT_MANAGE_BANK_CONFIG",
 } as const satisfies Partial<Record<keyof RawConfig, string>>;
 
 /** Fields parsed as booleans/numbers/comma-separated lists; everything else is taken as a string. */
@@ -463,6 +476,7 @@ const ENV_BOOLEANS = new Set<keyof RawConfig>([
   "autoSeed",
   "codebaseSurvey",
   "autoUpdate",
+  "manageBankConfig",
 ]);
 const ENV_LISTS = new Set<keyof RawConfig>(["retainTags", "optInPaths"]);
 const ENV_NUMBERS = new Set<keyof RawConfig>([

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -730,8 +730,10 @@ describe("HindsightClient.configureBank — missions are seeded once (#2492)", (
     expect(body.bank.observations_mission).toBeUndefined();
   });
 
-  it("still re-applies the strategies and labels the plugin writes through", async () => {
-    // Not preferences: a bank missing `conversation` would reject the session write-back.
+  it("still adds the strategies and labels the plugin writes through", async () => {
+    // Not preferences: without `conversation` the session write-back silently extracts under the
+    // bank's own config (the server warns on an unknown strategy, it does not reject), so a
+    // transcript would get whatever a commit diff gets. A bank that has none must still get them.
     const body = await run([], routes({ retain_mission: "mine" }));
     expect(Object.keys(body.bank.retain_strategies)).toEqual(
       expect.arrayContaining(["git", "gitlog", "conversation", "document"])

--- a/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.pages.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HindsightClient } from "./hindsight";
-import { buildPageTrigger, PAGE_MAX_TOKENS, pagesFor } from "./missions";
+import {
+  buildPageTrigger,
+  KNOWLEDGE_LABELS,
+  PAGE_MAX_TOKENS,
+  pagesFor,
+  RETAIN_STRATEGIES,
+} from "./missions";
 import { resolveConfig } from "./config";
 
 /** What a client built with `bank: "repo-a"` and no `project` seeds — the bank id is the fallback. */
@@ -705,7 +711,8 @@ describe("HindsightClient.configureBank — missions are seeded once (#2492)", (
       })
     );
     await new HindsightClient({ apiUrl: "http://x", bank: "repo-a" }).configureBank();
-    return calls.find((k) => k.method === "POST" && k.url.endsWith("/import")).body;
+    // Optional: a bank that already carries the whole structure is not imported to at all (#3927).
+    return calls.find((k) => k.method === "POST" && k.url.endsWith("/import"))?.body;
   };
 
   it("seeds the full template — missions included — on a bank with no mission overrides", async () => {
@@ -743,6 +750,44 @@ describe("HindsightClient.configureBank — missions are seeded once (#2492)", (
     // With that API off a user cannot set per-bank missions at all, so there is no edit to protect.
     const body = await run([], routes(undefined, false));
     expect(typeof body.bank.reflect_mission).toBe("string");
+  });
+
+  it("makes no import call at all once the bank carries the whole structure (#3927)", async () => {
+    // The settled steady state: deepen runs on every session start, and on a bank that already has
+    // everything there is nothing left to write. Not a harmless no-op POST — an import of the
+    // strategies IS the overwrite, since the server replaces the whole map.
+    const calls: any[] = [];
+    await run(
+      calls,
+      routes({
+        reflect_mission: "mine",
+        retain_default_strategy: "git",
+        entities_allow_free_form: true,
+        retain_strategies: RETAIN_STRATEGIES,
+        entity_labels: [KNOWLEDGE_LABELS],
+      })
+    );
+    expect(calls.some((k) => k.method === "POST" && k.url.endsWith("/import"))).toBe(false);
+    // Pages are seeded either way — they are not bank configuration.
+    expect(calls.some((k) => k.url.includes("/knowledge-base/"))).toBe(true);
+  });
+
+  it("manageBankConfig: false keeps the plugin out of the bank's config entirely", async () => {
+    const calls: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: any) => {
+        calls.push({ url, method: init?.method });
+        return { ok: true, status: 200, json: async () => ({ roots: [] }) } as any;
+      })
+    );
+    await new HindsightClient({ apiUrl: "http://x", bank: "repo-a" }).configureBank({
+      manage: false,
+    });
+    expect(calls.some((k) => k.url.endsWith("/import"))).toBe(false);
+    // Not even the probe: the bank's configuration is none of this plugin's business.
+    expect(calls.some((k) => k.url.endsWith("/config"))).toBe(false);
+    expect(calls.some((k) => k.url.includes("/knowledge-base/"))).toBe(true);
   });
 
   it("re-seeds the missions after an explicit reset", async () => {

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -6,9 +6,9 @@
  * creates knowledge pages. Nothing here knows about opencode/claude-code/etc.
  */
 import {
+  type BankOverrides,
   buildPageTrigger,
-  CODING_BANK_STRUCTURE,
-  CODING_BANK_TEMPLATE,
+  codingBankManifest,
   PAGE_MAX_TOKENS,
   pagesFor,
   type PageTrigger,
@@ -142,9 +142,6 @@ const RETRY_AFTER_FLOOR_MS = 10 * 1000;
  * another 429 and backs off again.
  */
 const RETRY_AFTER_CEILING_MS = 60 * 1000;
-
-/** Bank-level missions the template seeds once and then leaves alone (#2492). */
-const MISSION_FIELDS = ["reflect_mission", "retain_mission", "observations_mission"] as const;
 
 export class HindsightClient {
   readonly apiUrl: string;
@@ -343,52 +340,55 @@ export class HindsightClient {
     return ids;
   }
 
-  /** Configure the bank: POST the coding bank template manifest to /import (missions, retain
-   *  strategies, entity labels), then seed knowledge pages when the server supports them. Both
-   *  halves are idempotent, so the deepen engine can re-run this every pass. Creates the bank if
-   *  missing; legacy servers continue with the template-only path. */
-  async configureBank(opts: { reset?: boolean; pageTrigger?: PageTrigger } = {}): Promise<void> {
+  /** Configure the bank: POST the coding bank manifest to /import (missions, retain strategies,
+   *  entity labels), then seed knowledge pages when the server supports them. Both halves are
+   *  idempotent and strictly ADDITIVE — nothing the bank already says is overwritten (#3927) — so
+   *  the deepen engine can re-run this every pass. Creates the bank if missing; legacy servers
+   *  continue with the template-only path.
+   *
+   *  `manage: false` skips the config half entirely, for a bank whose owner shapes it themselves.
+   *  That bank must then define the strategies this plugin writes under (`git`, `gitlog`,
+   *  `conversation`, `document`, `survey`) — a retain naming a strategy the bank lacks is rejected. */
+  async configureBank(
+    opts: { reset?: boolean; pageTrigger?: PageTrigger; manage?: boolean } = {}
+  ): Promise<void> {
     if (opts.reset) {
       await this.req("DELETE", this.bankUrl());
       this.log(`[bank] reset ${this.bank}`);
     }
-    // Seed the missions ONCE. After that they belong to whoever set them — see CODING_BANK_STRUCTURE.
-    const seeded = opts.reset ? false : await this.hasBankMissions();
-    await this.req(
-      "POST",
-      this.bankUrl("/import"),
-      seeded ? CODING_BANK_STRUCTURE : CODING_BANK_TEMPLATE
-    );
-    this.log(
-      seeded
-        ? `[bank] structure applied to ${this.bank}: entity_labels {knowledge}, ` +
-            `strategies {git, gitlog, conversation, document} — missions left as configured`
-        : `[bank] template applied to ${this.bank}: missions, entity_labels {knowledge}, ` +
-            `strategies {git, gitlog, conversation, document}`
-    );
+    if (opts.manage === false) {
+      this.log(`[bank] manageBankConfig: false — leaving ${this.bank}'s configuration alone`);
+    } else {
+      // What the bank ALREADY overrides decides what is left to write: the missions are seeded once
+      // and then belong to whoever set them (#2492), and every other field is added only where the
+      // bank is silent (#3927). A reset just deleted the bank, so there is nothing to read.
+      const manifest = codingBankManifest(opts.reset ? undefined : await this.readBankOverrides());
+      if (!manifest) {
+        this.log(`[bank] ${this.bank} already carries the coding structure — nothing to apply`);
+      } else {
+        await this.req("POST", this.bankUrl("/import"), manifest);
+        this.log(`[bank] applied to ${this.bank}: ${Object.keys(manifest.bank).sort().join(", ")}`);
+      }
+    }
     await this.seedPages(opts.pageTrigger);
   }
 
   /**
-   * Whether this bank already carries bank-level mission overrides — ours from an earlier seed, or
-   * the user's own edit. Either way they are not ours to overwrite.
+   * This bank's own config OVERRIDES, or undefined when there are none to read.
    *
-   * Reads the bank-scoped OVERRIDES, not the resolved config, so inherited global defaults don't
-   * read as "already set". A missing bank, or a deployment with the bank-config API switched off,
-   * answers false: there is nothing to preserve, and without that API a user cannot set per-bank
-   * missions in the first place.
+   * Deliberately the overrides and not the resolved config: an inherited global default is not
+   * something this bank's owner chose, so it must not read as "already set". `undefined` means the
+   * bank does not exist yet, or the deployment has the bank-config API switched off — in neither
+   * case can anything have been customised, so the caller seeds the full template.
    */
-  private async hasBankMissions(): Promise<boolean> {
+  private async readBankOverrides(): Promise<BankOverrides | undefined> {
     try {
       const r = await this.req("GET", this.bankUrl("/config"));
-      if (!r.ok) return false;
-      const j = (await r.json()) as { overrides?: Record<string, unknown> };
-      return MISSION_FIELDS.some((f) => {
-        const v = j.overrides?.[f];
-        return typeof v === "string" && v.trim() !== "";
-      });
+      if (!r.ok) return undefined;
+      const j = (await r.json()) as { overrides?: BankOverrides };
+      return j.overrides ?? {};
     } catch {
-      return false;
+      return undefined;
     }
   }
 

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -347,8 +347,9 @@ export class HindsightClient {
    *  continue with the template-only path.
    *
    *  `manage: false` skips the config half entirely, for a bank whose owner shapes it themselves.
-   *  That bank must then define the strategies this plugin writes under (`git`, `gitlog`,
-   *  `conversation`, `document`, `survey`) — a retain naming a strategy the bank lacks is rejected. */
+   *  That bank should then define the strategies this plugin writes under (`git`, `gitlog`,
+   *  `conversation`, `document`, `survey`): an unknown strategy name is not an error server-side,
+   *  it just falls back to the bank's own config, so the miss is silent. */
   async configureBank(
     opts: { reset?: boolean; pageTrigger?: PageTrigger; manage?: boolean } = {}
   ): Promise<void> {

--- a/hindsight-integrations/coding-agents/src/core/missions.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { resolveConfig } from "./config";
-import { buildPageTrigger, PAGE_FACT_TYPES } from "./missions";
+import {
+  type BankOverrides,
+  buildPageTrigger,
+  CODING_BANK_TEMPLATE,
+  codingBankManifest,
+  KNOWLEDGE_LABELS,
+  PAGE_FACT_TYPES,
+  REFLECT_MISSION,
+  RETAIN_STRATEGIES,
+} from "./missions";
 
 /**
  * The page trigger is what a project's knowledge pages COST to keep current: auto-refresh means one
@@ -85,5 +94,112 @@ describe("page trigger config resolution", () => {
     expect(resolveConfig({ pageTriggerType: "whenever" as never }).pageTriggerType).toBe(
       "auto-refresh"
     );
+  });
+});
+
+/**
+ * Applying the whole template on every pass is how a plugin takes a bank over. #1270 fixed it for
+ * OpenClaw's missions, #2492 for this plugin's; #3927 is the same bug on the half both fixes left
+ * un-guarded — the strategies and labels, re-sent wholesale on every session start. Because the
+ * server stores each of those as ONE config value, re-sending them deleted a user's own strategy,
+ * reverted their edits to the plugin's, and could leave `retain_default_strategy` pointing at a
+ * strategy that no longer existed.
+ */
+describe("codingBankManifest (#3927)", () => {
+  const bankOf = (overrides: BankOverrides | undefined) => codingBankManifest(overrides)?.bank;
+
+  it("seeds the full template on a bank with no overrides of its own", () => {
+    // Unreadable overrides (no bank yet, or the bank-config API switched off) seed the same lot:
+    // nothing can have been customised through an API that is not there.
+    for (const empty of [undefined, {}]) {
+      expect(codingBankManifest(empty)).toEqual(CODING_BANK_TEMPLATE);
+    }
+  });
+
+  it("adds a strategy a newer plugin release introduced, keeping the ones already there", () => {
+    // The reason the re-apply exists at all: a bank seeded before `survey` shipped must still get
+    // it, or the survey's documents retain under a strategy the bank does not have.
+    const { survey: _survey, ...seededByAnOlderRelease } = RETAIN_STRATEGIES;
+    const bank = bankOf({
+      reflect_mission: "seeded",
+      retain_strategies: { ...seededByAnOlderRelease, mycustom: { retain_chunk_size: 500 } },
+    });
+    expect(Object.keys(bank!.retain_strategies as object).sort()).toEqual([
+      "conversation",
+      "document",
+      "git",
+      "gitlog",
+      "mycustom",
+      "survey",
+    ]);
+    expect((bank!.retain_strategies as Record<string, unknown>).survey).toEqual(
+      RETAIN_STRATEGIES.survey
+    );
+  });
+
+  it("never deletes a strategy the user defined, nor reverts their edits to ours", () => {
+    const mine = {
+      ...RETAIN_STRATEGIES,
+      // The user made the conversation strategy concise and small; that is theirs to decide.
+      conversation: { retain_mission: "MINE", retain_extraction_mode: "concise" },
+      mycustom: { retain_chunk_size: 500 },
+    };
+    // Nothing missing => the field is not written at all, so no import can revert it.
+    expect(bankOf({ reflect_mission: "seeded", retain_strategies: mine })).not.toHaveProperty(
+      "retain_strategies"
+    );
+  });
+
+  it("leaves a bank that already carries the whole structure completely alone", () => {
+    // Every session start calls this. On a settled bank it must be a no-op — no manifest, no POST.
+    expect(
+      codingBankManifest({
+        reflect_mission: "seeded",
+        retain_default_strategy: "mycustom",
+        entities_allow_free_form: false,
+        retain_strategies: RETAIN_STRATEGIES,
+        entity_labels: [KNOWLEDGE_LABELS],
+      })
+    ).toBeUndefined();
+  });
+
+  it("keeps retain_default_strategy pointing where the user aimed it", () => {
+    // The dangling half of #3927: the map was replaced (deleting `mycustom`) while the pointer to
+    // it survived, leaving the bank naming a strategy that no longer existed.
+    const bank = bankOf({
+      retain_default_strategy: "mycustom",
+      retain_strategies: { mycustom: { retain_chunk_size: 500 } },
+    });
+    expect(bank).not.toHaveProperty("retain_default_strategy");
+    expect(bank!.retain_strategies).toHaveProperty("mycustom");
+  });
+
+  it("adds the knowledge label group alongside the user's own, and only once", () => {
+    const mine = { key: "audience", type: "multi-values", values: [] };
+    expect(bankOf({ reflect_mission: "seeded", entity_labels: [mine] })!.entity_labels).toEqual([
+      mine,
+      KNOWLEDGE_LABELS,
+    ]);
+    // Already present — including a version the user reworded — is left as it is.
+    expect(
+      bankOf({
+        reflect_mission: "seeded",
+        entity_labels: [{ ...KNOWLEDGE_LABELS, description: "my wording" }],
+      })
+    ).not.toHaveProperty("entity_labels");
+  });
+
+  it("still seeds the missions as a group, once (#2492)", () => {
+    // Spelled out rather than imported: the contract is these three fields, whatever the
+    // implementation happens to call its list of them.
+    const missions = ["reflect_mission", "retain_mission", "observations_mission"] as const;
+    expect(bankOf({})!.reflect_mission).toBe(REFLECT_MISSION);
+    for (const field of missions) {
+      // Any one mission present means the bank has been through here; none of the three is rewritten.
+      const bank = bankOf({ [field]: "MY OWN MISSION" })!;
+      for (const f of missions) expect(bank).not.toHaveProperty(f);
+    }
+    // A blank override is not a choice.
+    expect(bankOf({ reflect_mission: "   " })!.reflect_mission).toBe(REFLECT_MISSION);
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/missions.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.ts
@@ -209,7 +209,7 @@ export interface KnowledgePage {
  * Naming the repo and stating the exclusion is what lets the synthesizer make that call while it
  * still has the fact's text in front of it. It rides on `source_query` rather than the bank's
  * `reflect_mission` because the mission is seeded ONCE and then belongs to whoever set it
- * (CODING_BANK_STRUCTURE, #2492) — a mission-only fix would never reach an existing bank, while a
+ * (`codingBankManifest`, #2492) — a mission-only fix would never reach an existing bank, while a
  * reworded query re-syncs through `seedPages()`'s drift PATCH on the next run.
  */
 function pageScopeRule(project: string): string {
@@ -378,21 +378,86 @@ export const CODING_BANK_TEMPLATE = {
   },
 } as const;
 
+/** Bank-level missions the template seeds ONCE and then leaves alone (#2492). */
+const MISSION_FIELDS = ["reflect_mission", "retain_mission", "observations_mission"] as const;
+
+/** Bank-scoped config OVERRIDES exactly as `GET /banks/{id}/config` reports them. */
+export type BankOverrides = Record<string, unknown>;
+
+/** The manifest `configureBank` POSTs to `/banks/{id}/import`. */
+export interface BankManifest {
+  version: "1";
+  bank: Record<string, unknown>;
+}
+
+/** A bank-config override the bank's owner actually made. Blank is not a choice; `false` is. */
+function isSet(v: unknown): boolean {
+  if (v === null || v === undefined) return false;
+  if (typeof v === "string") return v.trim() !== "";
+  return true;
+}
+
 /**
- * The subset re-applied to a bank that is ALREADY configured — everything above minus the missions.
+ * The template fields still missing from a bank whose overrides are `overrides` — or `undefined`
+ * when it already carries them all and there is nothing to write.
  *
- * The full template seeds a bank once. After that the missions are the user's: someone who rewrites
- * `reflect_mission` in the control plane means it, and re-importing the manifest on every seed pass
- * silently stamped the defaults back over it (#2492 — the same regression #1270 fixed for OpenClaw).
+ * **This plugin only ever ADDS what is missing; it never overwrites what the bank already says.**
  *
- * The retain strategies and entity labels stay, because they are not preferences: this plugin writes
- * documents under `git` / `gitlog` / `conversation` / `document`, and a bank missing one of those
- * would reject the write. A newer plugin adding a strategy needs it to land on existing banks too.
+ * Re-applying the whole template on every pass is how a plugin takes a bank over, and it has now
+ * been fixed three times over the same shape: #1270 for OpenClaw's missions, #2492 for this
+ * plugin's, and #3927 for everything those two left un-guarded. Each earlier fix protected only the
+ * fields that had just been noticed, so the rest kept being stamped back on every session start.
+ * Reading the current overrides and writing only where the bank is silent covers the whole surface
+ * at once, including whatever gets added to the template next.
+ *
+ * The two container fields merge PER ENTRY, because the server stores each as ONE config value and
+ * an import replaces it outright: re-sending the five strategies wholesale deleted any strategy the
+ * user had defined, reverted their edits to the plugin's own (mission, extraction mode, chunk
+ * size), and could leave `retain_default_strategy` naming a strategy that no longer existed.
+ * Merging still lets a strategy ADDED by a newer plugin release reach an existing bank — the reason
+ * the re-apply exists — without touching the entries already there.
+ *
+ * The consequence is deliberate: a release that REWORDS an existing strategy or label does not
+ * reach a bank that already has it. Clearing that override on the bank takes the current default
+ * back, since the next pass then finds the bank silent there.
  */
-export const CODING_BANK_STRUCTURE = {
-  version: "1",
-  bank: {
-    retain_strategies: RETAIN_STRATEGIES,
-    entity_labels: [KNOWLEDGE_LABELS],
-  },
-} as const;
+export function codingBankManifest(overrides: BankOverrides | undefined): BankManifest | undefined {
+  // Unreadable overrides — the bank does not exist yet, or the deployment has the bank-config API
+  // switched off. Nothing can have been customised through an API that is not there, and this same
+  // POST is what CREATES the bank, so `{}` seeds the lot (every branch below fires, and the result
+  // is CODING_BANK_TEMPLATE — asserted in missions.test.ts).
+  const current = overrides ?? {};
+  const template = CODING_BANK_TEMPLATE.bank;
+  const bank: Record<string, unknown> = {};
+
+  // The missions are seeded as a GROUP: the plugin writes all three together, so any one of them
+  // being present means this bank has been seeded already, or its owner wrote their own (#2492).
+  if (!MISSION_FIELDS.some((f) => isSet(current[f]))) {
+    bank.reflect_mission = template.reflect_mission;
+    bank.enable_observations = template.enable_observations;
+    bank.observations_mission = template.observations_mission;
+    bank.retain_mission = template.retain_mission;
+    bank.retain_extraction_mode = template.retain_extraction_mode;
+  }
+
+  if (!isSet(current.retain_default_strategy))
+    bank.retain_default_strategy = template.retain_default_strategy;
+  if (!isSet(current.entities_allow_free_form))
+    bank.entities_allow_free_form = template.entities_allow_free_form;
+
+  const strategies =
+    current.retain_strategies && typeof current.retain_strategies === "object"
+      ? (current.retain_strategies as Record<string, unknown>)
+      : {};
+  const missing = Object.entries(template.retain_strategies).filter(([n]) => !(n in strategies));
+  // The whole map is one config value, so the UNION has to be sent — not just the additions.
+  if (missing.length > 0)
+    bank.retain_strategies = { ...strategies, ...Object.fromEntries(missing) };
+
+  const labels = Array.isArray(current.entity_labels) ? current.entity_labels : [];
+  const [knowledgeGroup] = template.entity_labels;
+  if (!labels.some((g) => (g as { key?: unknown } | null)?.key === knowledgeGroup.key))
+    bank.entity_labels = [...labels, knowledgeGroup];
+
+  return Object.keys(bank).length > 0 ? { version: "1", bank } : undefined;
+}

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -151,7 +151,10 @@ async function main() {
         sessionId,
       });
 
-    await client.configureBank({ pageTrigger: buildPageTrigger(cfg) });
+    await client.configureBank({
+      pageTrigger: buildPageTrigger(cfg),
+      manage: cfg.manageBankConfig,
+    });
     if (client.knowledgePagesSupported === false) {
       diag(harness.name, "knowledge_pages_unavailable", {
         bank: FINAL_BANK,

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -414,6 +414,7 @@ hook by Codex...), so one shared config serves several agents side by side:
 | `resolveWorktrees`      | `true`                               | linked worktrees inherit the main checkout's bank identity, path approval, and mapping                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `retainTags`            | —                                    | extra tags on every document written by the integration, e.g. `["project:{gitProject}"]` — see **Recording where a memory came from** below                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `retainMetadata`        | —                                    | extra metadata on every document written by the integration, e.g. `{"repo": "{gitProject}"}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `manageBankConfig`      | `true`                               | let the plugin shape the bank's own configuration — the retain strategies it writes under, the `knowledge` entity-label group, and, on a bank that has none, the missions. Writing is strictly **additive**: it adds what the bank does not define and never overwrites what is there, so your control-plane edits survive. Set `false` to keep it out of the bank config entirely — see **A bank you shape yourself** below                                                                                                                                                                                                                                                                 |
 | `observationScopes`     | `"shared"`                           | how consolidation groups observations: `"shared"` (default) = ONE global scope per bank, so every agent on a repo builds one set of beliefs; also `"combined"` (the server default), `"per_tag"`, `"all_combinations"`, `[["t"]]`                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `disabled`              | `false`                              | hard off-switch (inert plugin/hook — a no-memory baseline)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `reflectTimeoutMs`      | `120000`                             | **automatic** session-reflect timeout (hook harnesses additionally cap it at 25s to fit the host's hook window); on timeout the session runs without reflect (recorded)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -447,6 +448,38 @@ repo already has: a page keeps the trigger it was created with, so a bank seeded
 `"manual"` keeps refreshing on every consolidation. To move an existing page, change its trigger
 through the API (`PATCH /knowledge-base/nodes/{id}`), an SDK, or the control plane — or delete it
 and let the next session seed it again.
+
+### A bank you shape yourself — `manageBankConfig`
+
+Pointed at a bank, this plugin gives it the shape its ingestion needs: retain strategies for the
+kinds of document it writes (`git`, `gitlog`, `conversation`, `document`, `survey`), a `knowledge`
+entity-label group that routes facts to the knowledge pages, and — on a bank that has no missions of
+its own — the coding missions.
+
+**It only ever adds what is missing.** A strategy you defined, an edit you made to one of the
+plugin's, a reworded label group, a mission you rewrote in the control plane: each is left exactly
+as it is, on every session, forever. What the bank already says wins. The cost of that promise is
+that a plugin release which _rewords_ an existing strategy or label does not reach a bank that
+already has it. To take the current default back, clear that override on the bank (delete the
+strategy, or the whole `retain_strategies` entry, in the control plane): the next session finds the
+bank silent there and seeds it again.
+
+Set `manageBankConfig: false` to keep the plugin out of the bank's configuration altogether — the
+right setting for a bank you share with non-coding work, or one you configure yourself. That bank
+should then define the five strategies above itself. Note that the miss is **silent**: the server
+does not reject a retain naming a strategy the bank lacks, it logs a warning and extracts with the
+bank's own configuration — so a commit diff, a session transcript and a survey marker would all get
+the same generic treatment instead of the extraction each needs. Knowledge pages are seeded either
+way; `pageTriggerType` governs what they cost.
+
+Like every field here it can be set per bank, which is usually where it belongs:
+
+```json
+{
+  "bankId": "my-global-bank",
+  "banks": { "my-global-bank": { "manageBankConfig": false } }
+}
+```
 
 ### Per-repo opt-in/out — `banks.<bankId>`
 


### PR DESCRIPTION
Closes #3927.

`configureBank` runs on every session start, and it re-sent the plugin's five retain strategies and its `knowledge` entity-label group as whole values. The server stores each of those as ONE config value, so an import replaces the map outright: a strategy the user had defined was deleted, their edits to the plugin's own strategies (mission, extraction mode, chunk size) were reverted, and `retain_default_strategy` could be left naming a strategy that no longer existed — silently, once per session, on whatever bank the plugin was pointed at. Pointed at a global bank shared with non-coding work, the plugin took the bank over.

This is the third fix for one shape. #1270 covered OpenClaw's missions, #2492 this plugin's; each protected only the fields that had just been noticed, and everything else kept being stamped back. So the rule is now the whole surface rather than a list: read the bank's current OVERRIDES and write only where the bank is silent. `codingBankManifest()` returns the template fields still missing, or nothing at all — a settled bank now makes no import call.

The container fields merge per entry, which keeps the reason the re-apply exists: a strategy ADDED by a newer release still reaches an existing bank. What it gives up is deliberate — a release that REWORDS an existing strategy or label does not reach a bank that already has it; clearing that override takes the current default back on the next pass.

`manageBankConfig: false` keeps the plugin out of the bank's configuration entirely, for a bank whose owner shapes it themselves. That bank should then define the strategies this plugin retains under. The cost is documented, and it is a silent one: the server does not *reject* a retain naming a strategy the bank lacks — `apply_strategy` logs a warning and extracts with the bank's own config, so a commit diff, a session transcript and a survey marker would all get the same generic treatment. Like every other field it can be set per bank, which is where a global-bank user wants it.

Knowledge pages are seeded either way: they are not bank configuration, and `pageTriggerType` already governs what they cost.

## Fixes, against the reporter's own findings

| # | Finding | Now |
|---|---|---|
| 1 | a custom strategy is deleted, not merged | kept — the map merges per entry |
| 2 | `retain_default_strategy` left pointing at a deleted strategy | cannot happen; nothing is deleted, and the pointer is only written when the bank has none |
| 3 | customizations to `conversation` reverted (concise → verbose, 4000 → 12000) | left alone; an entry already present is never rewritten |
| 4 | pages seeded on a zero-fact bank | not addressed here — that is the page-seeding path, not bank config (see #3905) |

## Tests

- additive merge: a strategy added by a newer release reaches an old bank; a user's own strategy survives; edits to the plugin's own survive; a settled bank yields no manifest; the label group is added alongside the user's own and only once; the missions stay group-seeded (#2492)
- client level: no `/import` call at all once the bank carries the structure, and `manageBankConfig: false` makes no config calls (not even the probe) while pages still seed
- `codingBankManifest({})` is asserted equal to `CODING_BANK_TEMPLATE`, so the builder cannot drift from the declared template

683/683 package tests pass, `tsc` clean, `./scripts/hooks/lint.sh` clean. README updated and the skill + docs page regenerated from it.

https://claude.ai/code/session_01M9KwqWJZRrw7NjAaKuACzj
