### PR TITLE
fix(engine): authorize and provision banks before legacy mutations

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12582,12 +12582,24 @@ class MemoryEngine(MemoryEngineInterface):
         """
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
-            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+            from hindsight_api.extensions import (
+                BankReadContext,
+                BankReadOperation,
+                BankWriteContext,
+                BankWriteOperation,
+            )
 
             ctx = BankWriteContext(
                 bank_id=bank_id, operation=BankWriteOperation.UPDATE_BANK_DISPOSITION, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+
+            ctx_read = BankReadContext(
+                bank_id=bank_id, operation=BankReadOperation.GET_BANK_PROFILE, request_context=request_context
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx_read))
+
+        await self._ensure_bank_exists(bank_id, request_context)
         await self._get_backend()
         await bank_utils.update_bank_disposition(self._backend, bank_id, disposition)
 
@@ -12617,6 +12629,8 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankWriteOperation.SET_BANK_MISSION, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+
+        await self._ensure_bank_exists(bank_id, request_context)
         await self._get_backend()
         await bank_utils.set_bank_mission(self._backend, bank_id, mission)
         return {"bank_id": bank_id, "mission": mission}
@@ -12642,12 +12656,24 @@ class MemoryEngine(MemoryEngineInterface):
         """
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
-            from hindsight_api.extensions import BankWriteContext, BankWriteOperation
+            from hindsight_api.extensions import (
+                BankReadContext,
+                BankReadOperation,
+                BankWriteContext,
+                BankWriteOperation,
+            )
 
             ctx = BankWriteContext(
                 bank_id=bank_id, operation=BankWriteOperation.MERGE_BANK_MISSION, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_write(ctx))
+
+            ctx_read = BankReadContext(
+                bank_id=bank_id, operation=BankReadOperation.GET_BANK_PROFILE, request_context=request_context
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_read(ctx_read))
+
+        await self._ensure_bank_exists(bank_id, request_context)
         await self._get_backend()
         return await bank_utils.merge_bank_mission(self._backend, self._reflect_llm_config, bank_id, new_info)
 

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -25,6 +25,7 @@ def _make_operation_validator(
     reject_bank_write: BankWriteOperation | None = None,
     reject_bank_read: BankReadOperation | None = None,
     reject_mental_model_refresh: bool = False,
+    reject_create_bank: bool = False,
     reason: str = "operation is forbidden",
 ) -> MagicMock:
     """Build a complete async validator with one optional rejection."""
@@ -43,7 +44,9 @@ def _make_operation_validator(
         return_value=ValidationResult.reject(reason) if reject_mental_model_refresh else ValidationResult.accept()
     )
     validator.validate_mental_model_get = AsyncMock(return_value=ValidationResult.accept())
-    validator.validate_create_bank = AsyncMock(return_value=ValidationResult.accept())
+    validator.validate_create_bank = AsyncMock(
+        return_value=ValidationResult.reject(reason) if reject_create_bank else ValidationResult.accept()
+    )
     validator.on_mental_model_get_complete = AsyncMock()
     return validator
 
@@ -2268,3 +2271,127 @@ async def test_reflect_structured_output_llm_quality(api_client_real_llm):
 
     # Cleanup
     await api_client_real_llm.delete(f"/v1/default/banks/{test_bank_id}")
+
+
+@pytest.mark.asyncio
+async def test_put_bank_profile_denied_read_does_not_mutate_or_create_bank(
+    api_client,
+    memory,
+    monkeypatch,
+):
+    """PUT /profile when GET_BANK_PROFILE is denied must return 403 and leave no bank behind."""
+    from hindsight_api.engine.retain import bank_utils
+
+    bank_id = f"put_profile_denied_read_{datetime.now().timestamp()}"
+    validator = _make_operation_validator(reject_bank_read=BankReadOperation.GET_BANK_PROFILE)
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+
+    response = await api_client.put(
+        f"/v1/default/banks/{bank_id}/profile",
+        json={"disposition": {"skepticism": 5, "literalism": 5, "empathy": 5}},
+    )
+    assert response.status_code == 403, response.text
+
+    # Verify no bank row was created in the database
+    backend = await memory._get_backend()
+    exists = await bank_utils.bank_exists(backend, bank_id)
+    assert not exists, f"Bank '{bank_id}' should not exist after denied read authorization"
+
+
+@pytest.mark.asyncio
+async def test_merge_bank_mission_denied_read_does_not_call_llm_or_create_bank(
+    api_client,
+    memory,
+    monkeypatch,
+):
+    """POST /background when GET_BANK_PROFILE is denied must return 403, not call LLM, and leave no bank behind."""
+    from hindsight_api.engine.retain import bank_utils
+
+    bank_id = f"merge_mission_denied_read_{datetime.now().timestamp()}"
+    validator = _make_operation_validator(reject_bank_read=BankReadOperation.GET_BANK_PROFILE)
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+
+    mock_llm_merge = AsyncMock(return_value={"mission": "Merged mission"})
+    monkeypatch.setattr(bank_utils, "_llm_merge_mission", mock_llm_merge)
+
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/background",
+        json={"content": "New background info"},
+    )
+    assert response.status_code == 403, response.text
+    mock_llm_merge.assert_not_called()
+
+    backend = await memory._get_backend()
+    exists = await bank_utils.bank_exists(backend, bank_id)
+    assert not exists, f"Bank '{bank_id}' should not exist after denied read authorization"
+
+
+@pytest.mark.asyncio
+async def test_legacy_bank_writes_respect_validate_create_bank(
+    api_client,
+    memory,
+    monkeypatch,
+):
+    """Legacy write operations respect validate_create_bank rejection on new banks."""
+    from hindsight_api.engine.retain import bank_utils
+
+    validator = _make_operation_validator(reject_create_bank=True)
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+
+    # 1. PUT /profile
+    bank_id_1 = f"legacy_create_denied_profile_{datetime.now().timestamp()}"
+    response = await api_client.put(
+        f"/v1/default/banks/{bank_id_1}/profile",
+        json={"disposition": {"skepticism": 4, "literalism": 4, "empathy": 4}},
+    )
+    assert response.status_code == 403, response.text
+
+    # 2. POST /background
+    bank_id_2 = f"legacy_create_denied_background_{datetime.now().timestamp()}"
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id_2}/background",
+        json={"content": "Some mission"},
+    )
+    assert response.status_code == 403, response.text
+
+    # 3. set_bank_mission directly on engine
+    bank_id_3 = f"legacy_create_denied_set_mission_{datetime.now().timestamp()}"
+    with pytest.raises(OperationValidationError) as exc_info:
+        await memory.set_bank_mission(bank_id_3, "Mission text", request_context=RequestContext())
+    assert exc_info.value.status_code == 403
+
+    backend = await memory._get_backend()
+    for b in (bank_id_1, bank_id_2, bank_id_3):
+        exists = await bank_utils.bank_exists(backend, b)
+        assert not exists, f"Bank '{b}' should not exist after denied create authorization"
+
+
+@pytest.mark.asyncio
+async def test_legacy_bank_writes_apply_default_bank_template(
+    memory,
+    monkeypatch,
+):
+    """Legacy write operations on a new bank apply the default bank template."""
+    from hindsight_api.config import _get_raw_config
+
+    default_template = {
+        "version": "1",
+        "directives": [{"name": "Legacy default directive", "content": "Always be polite."}],
+    }
+    monkeypatch.setattr(_get_raw_config(), "default_bank_template", default_template)
+
+    bank_id = f"legacy_template_application_{datetime.now().timestamp()}"
+    request_context = RequestContext()
+
+    await memory.update_bank_disposition(
+        bank_id,
+        {"skepticism": 4, "literalism": 4, "empathy": 4},
+        request_context=request_context,
+    )
+
+    page = await memory.list_directives(bank_id, request_context=request_context)
+    directive_names = [d["name"] for d in page.items]
+    assert "Legacy default directive" in directive_names
+
+    # Cleanup
+    await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
Fixes #3958

## Overview

In Hindsight's authorization model, all operation validations (read, write, create) must occur strictly before database mutations, external side-effects (such as LLM calls), or resource provisioning. Furthermore, bank creation must uniformly invoke `_ensure_bank_exists` to enforce `validate_create_bank`, initialize bank storage, and apply `HINDSIGHT_API_DEFAULT_BANK_TEMPLATE`.

Previously, legacy bank write entry points (`update_bank_disposition`, `set_bank_mission`, and `merge_bank_mission`) bypassed `_ensure_bank_exists` by directly invoking low-level `bank_utils` helpers. This introduced two critical authorization and provisioning anomalies:
1. **Read authorization checked after mutation**: `PUT /v1/default/banks/{bank_id}/profile` executed the write mutation before validating `BankReadOperation.GET_BANK_PROFILE` when assembling the response; `merge_bank_mission` read existing missions and invoked the LLM with no read authorization check.
2. **Bypass of unified bank provisioning**: Missing banks were auto-created as bare database records by `bank_utils`, bypassing `validate_create_bank` rejection, storage initialization, and default bank template directives/mental models.

This PR aligns the three legacy engine methods with the canonical authorization and provisioning pattern established in `update_bank()`.

---

## Architectural Workflow: Before vs. After

### 1. `PUT /v1/default/banks/{bank_id}/profile` & `update_bank_disposition`

```mermaid
sequenceDiagram
    autonumber
    actor Client
    participant HTTP as HTTP Layer
    participant Engine as MemoryEngine
    participant Validator as OperationValidator
    participant DB as PostgreSQL / bank_utils

    Note over Client,DB: BEFORE (Vulnerable to 403-after-mutation & template bypass)
    Client->>HTTP: PUT /banks/{id}/profile
    HTTP->>Engine: update_bank_disposition(disposition)
    Engine->>Validator: validate_bank_write(UPDATE_BANK_DISPOSITION)
    Engine->>DB: update_bank_disposition (Auto-creates bare row, no template/storage)
    HTTP->>Engine: get_bank_profile()
    Engine->>Validator: validate_bank_read(GET_BANK_PROFILE)
    alt Read Denied (403)
        Validator-->>HTTP: Reject (403 Forbidden)
        HTTP-->>Client: 403 Forbidden (State already mutated in DB!)
    end

    Note over Client,DB: AFTER (Atomic pre-validation & unified provisioning)
    Client->>HTTP: PUT /banks/{id}/profile
    HTTP->>Engine: update_bank_disposition(disposition)
    Engine->>Validator: validate_bank_write(UPDATE_BANK_DISPOSITION)
    Engine->>Validator: validate_bank_read(GET_BANK_PROFILE)
    alt Any Validation Denied
        Validator-->>Client: 403 Forbidden (Zero mutation, zero creation)
    end
    Engine->>Engine: _ensure_bank_exists (validate_create_bank + template + storage)
    Engine->>DB: update_bank_disposition
    HTTP->>Engine: get_bank_profile()
    HTTP-->>Client: 200 OK (BankProfileResponse)
```

### 2. `POST /v1/default/banks/{bank_id}/background` & `merge_bank_mission`

```mermaid
sequenceDiagram
    autonumber
    actor Client
    participant Engine as MemoryEngine
    participant Validator as OperationValidator
    participant LLM as Reflect LLM
    participant DB as PostgreSQL

    Note over Client,DB: BEFORE (No read check, LLM side effects on unauthorized read)
    Client->>Engine: merge_bank_mission(new_info)
    Engine->>Validator: validate_bank_write(MERGE_BANK_MISSION)
    Engine->>DB: Read current mission via bank_utils (No read check!)
    Engine->>LLM: _llm_merge_mission(current, new_info)
    Engine->>DB: Update merged mission

    Note over Client,DB: AFTER (Pre-validated read, unified provisioning before LLM call)
    Client->>Engine: merge_bank_mission(new_info)
    Engine->>Validator: validate_bank_write(MERGE_BANK_MISSION)
    Engine->>Validator: validate_bank_read(GET_BANK_PROFILE)
    alt Any Validation Denied
        Validator-->>Client: 403 Forbidden (No LLM tokens spent, no DB mutation)
    end
    Engine->>Engine: _ensure_bank_exists
    Engine->>DB: Read mission
    Engine->>LLM: _llm_merge_mission
    Engine->>DB: Update merged mission
```

---

## Authorization & Provisioning Matrix

| Entry Point | Write Operation Validated | Read Operation Pre-Validated | Bank Provisioning (`_ensure_bank_exists`) | Default Template Applied |
| :--- | :--- | :--- | :--- | :--- |
| `update_bank_disposition` | `UPDATE_BANK_DISPOSITION` | `GET_BANK_PROFILE` | Yes (`validate_create_bank` + storage) | Yes (`HINDSIGHT_API_DEFAULT_BANK_TEMPLATE`) |
| `set_bank_mission` | `SET_BANK_MISSION` | N/A (Return value built from parameters) | Yes (`validate_create_bank` + storage) | Yes (`HINDSIGHT_API_DEFAULT_BANK_TEMPLATE`) |
| `merge_bank_mission` | `MERGE_BANK_MISSION` | `GET_BANK_PROFILE` | Yes (`validate_create_bank` + storage) | Yes (`HINDSIGHT_API_DEFAULT_BANK_TEMPLATE`) |

---

## Key Changes

- **Pre-validate `GET_BANK_PROFILE`**: In `update_bank_disposition` and `merge_bank_mission`, validate read authorization upfront alongside write authorization. If read access is denied, requests fail immediately before any database write or LLM invocation.
- **Unified Bank Provisioning**: In `update_bank_disposition`, `set_bank_mission`, and `merge_bank_mission`, call `await self._ensure_bank_exists(bank_id, request_context)` prior to mutating state. This guarantees execution of `validate_create_bank`, external storage initialization, and one-time `HINDSIGHT_API_DEFAULT_BANK_TEMPLATE` application.
- **Zero Interface Drift**: No public interface signatures or return types are modified; existing HTTP routes require zero code changes.

---

## Validation & Test Coverage

Automated integration tests added in `tests/test_http_api_integration.py`:
1. `test_put_bank_profile_denied_read_does_not_mutate_or_create_bank`: Confirms `PUT /profile` returns 403 when `GET_BANK_PROFILE` is denied and verifies zero database rows/mutations remain.
2. `test_merge_bank_mission_denied_read_does_not_call_llm_or_create_bank`: Confirms `POST /background` returns 403 when read access is denied, verifies `_llm_merge_mission` is never invoked, and verifies no bank is created.
3. `test_legacy_bank_writes_respect_validate_create_bank`: Confirms all three legacy paths reject creation with 403 when `validate_create_bank` is denied.
4. `test_legacy_bank_writes_apply_default_bank_template`: Confirms default directives from `HINDSIGHT_API_DEFAULT_BANK_TEMPLATE` are automatically provisioned when a bank is first touched via legacy write paths.
