### PR TITLE
fix(tests): isolate the worker claim tests in their own schema (#3963)

### DIFF
--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -12,6 +12,7 @@ Tests cover:
 
 import asyncio
 import json
+import os
 import uuid
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -36,16 +37,94 @@ async def _ensure_bank(pool, bank_id: str) -> None:
 pytestmark = pytest.mark.xdist_group("worker_tests")
 
 
+@pytest.fixture(scope="session")
+def isolated_ops_schema(pg0_db_url):
+    """A private, migrated Postgres schema for this file's claim tests.
+
+    ``WorkerPoller.claim_batch`` claims across the whole schema on the
+    connection's search_path, bounded by ``max_slots`` minus the reservations,
+    and ordered by ``created_at``. Sharing ``public`` with the rest of the suite
+    therefore makes an exact claim count unassertable: any concurrently running
+    test that leaves a claimable row (``status='pending'`` with a non-null
+    ``task_payload``) competes for the same batch, and older foreign rows
+    *displace* this file's own — filtering the result to our own bank sees the
+    shortfall but cannot prevent it (#3963).
+
+    That is not hypothetical. ``tests/test_operation_status.py`` writes exactly
+    such rows, and once ``pytest-split`` put it in the same shard the batch came
+    back one row short; with enough foreign rows it comes back with none of ours
+    at all.
+
+    So give this file its own schema, the way the claim-serialisation tests
+    already do (``test_claim_bank_serialization.py``): "the whole schema" is then
+    only its own rows. One schema per worker, created + migrated once and dropped
+    at session end. ``search_path`` is set on the pool in :func:`backend`, so
+    every unqualified table reference here resolves into it.
+    """
+    from hindsight_api.engine.db import create_database_backend
+    from hindsight_api.pg0 import resolve_database_url
+
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    schema = f"workerclaim_iso_{worker}"
+
+    async def _provision() -> str:
+        url = await resolve_database_url(pg0_db_url)
+        b = create_database_backend("postgresql")
+        await b.initialize(url, min_size=1, max_size=2)
+        try:
+            async with b.get_pool().acquire() as conn:
+                # Rebuild from scratch so a schema left by a crashed prior run
+                # can't carry stale state into this session.
+                await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+                await conn.execute(f'CREATE SCHEMA "{schema}"')
+            # run_migrations is sync; call it with the loop running (as elsewhere
+            # in the suite) — it builds banks/async_operations/etc. in the schema.
+            b.run_migrations(url, schema=schema)
+        finally:
+            await b.shutdown()
+        return url
+
+    async def _drop(url: str) -> None:
+        b = create_database_backend("postgresql")
+        await b.initialize(url, min_size=1, max_size=2)
+        try:
+            async with b.get_pool().acquire() as conn:
+                await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        finally:
+            await b.shutdown()
+
+    loop = asyncio.new_event_loop()
+    try:
+        url = loop.run_until_complete(_provision())
+    finally:
+        loop.close()
+
+    yield schema
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_drop(url))
+    finally:
+        loop.close()
+
+
 @pytest_asyncio.fixture
-async def backend(pg0_db_url):
-    """Create a DatabaseBackend for worker tests."""
+async def backend(pg0_db_url, isolated_ops_schema):
+    """Create a DatabaseBackend whose pool is pinned to this file's private schema."""
     from hindsight_api.engine.db import create_database_backend
     from hindsight_api.pg0 import resolve_database_url
 
     resolved_url = await resolve_database_url(pg0_db_url)
 
+    async def _use_isolated_schema(conn):
+        # init runs once per new connection, setup runs on every acquire (after
+        # asyncpg's release-time RESET ALL), so this pins search_path for the
+        # pool's whole lifetime — every unqualified table resolves into the
+        # private schema, so claims and cleanup never see the shared public one.
+        await conn.execute(f'SET search_path TO "{isolated_ops_schema}", public')
+
     b = create_database_backend("postgresql")
-    await b.initialize(resolved_url, min_size=2, max_size=10, command_timeout=30)
+    await b.initialize(resolved_url, min_size=2, max_size=10, command_timeout=30, init_callback=_use_isolated_schema)
     yield b
     await b.shutdown()
 
@@ -58,29 +137,26 @@ async def pool(backend):
 
 @pytest_asyncio.fixture
 async def clean_operations(pool):
-    """Clean up this file's async_operations rows before and after each test.
+    """Clear this file's async_operations rows before and after each test.
 
-    Scoped to the worker-test bank prefixes. This used to be a global
-    ``DELETE FROM async_operations WHERE status = 'pending'`` to keep the
-    whole-schema ``WorkerPoller.claim_batch`` from picking up rows other tests
-    left behind — but under pytest-xdist this file shares the ``public`` schema
-    with every test running in parallel, so that global delete removed *other
-    workers'* in-flight operations mid-run. A refresh op, for instance, sits
-    ``pending`` for the brief window between ``_submit_async_operation``
-    committing it and ``SyncTaskBackend`` marking it ``completed``; deleting it
-    in that window makes ``get_operation_status`` read back ``not_found`` and
-    flakes an unrelated test.
+    Safe to be broad now: the pool is pinned to this file's private schema
+    (:func:`isolated_ops_schema`), so this only ever touches its own rows. It
+    must also *be* broad — a delete scoped to the worker-test bank prefixes
+    leaves rows from any other id a test invents, and those stay claimable for
+    the next test's ``claim_batch``.
 
-    The claim tests here don't need a globally empty table: they filter claims to
-    their own bank or assert only against ``max_slots``, so foreign pending rows
-    are harmless. (The claim-*serialisation* tests, which do need an exact view,
-    isolate themselves in a private schema instead — see
-    test_graph_maintenance_claim_serialization.py.)
+    This deliberately no longer runs against ``public``. The scoped form it
+    replaced was itself a fix for a global ``DELETE FROM async_operations WHERE
+    status = 'pending'`` that, under pytest-xdist, removed *other* workers'
+    in-flight operations mid-run (a refresh op sits ``pending`` for the window
+    between ``_submit_async_operation`` committing it and ``SyncTaskBackend``
+    marking it ``completed``; deleting it there made ``get_operation_status``
+    read back ``not_found`` and flaked an unrelated test). Owning the schema
+    removes the conflict at its source instead of trading one flake for another.
     """
-    scoped_delete = "DELETE FROM async_operations WHERE bank_id LIKE 'test-worker-%' OR bank_id LIKE 'test_worker_%'"
-    await pool.execute(scoped_delete)
+    await pool.execute("DELETE FROM async_operations")
     yield
-    await pool.execute(scoped_delete)
+    await pool.execute("DELETE FROM async_operations")
 
 
 def test_metric_operation_label_normalises_retain_variants():
@@ -451,6 +527,55 @@ class TestWorkerPoller:
             assert row["worker_id"] == "test-worker-1"
 
     @pytest.mark.asyncio
+    async def test_claim_batch_cannot_see_rows_outside_this_files_schema(self, pool, clean_operations):
+        """Rows in ``public`` are invisible here, so they can never crowd out our claims (#3963).
+
+        ``claim_batch`` takes at most ``max_slots`` minus the reservations, oldest
+        first, across the whole schema on the connection's search_path. That makes
+        an exact claim count unassertable while this file shares ``public`` with
+        the rest of the suite: any concurrently running test that leaves a
+        claimable row (``status='pending'`` with a non-null ``task_payload``)
+        competes for the same batch, and older foreign rows *displace* ours.
+        Filtering the result to our own bank sees the shortfall but cannot prevent
+        it — the isolation has to come from owning the schema.
+
+        That is not hypothetical: ``tests/test_operation_status.py`` writes exactly
+        such rows, and once ``pytest-split`` moved it into this shard the batch
+        came back a row short.
+
+        The row planted below is deliberately unclaimable (``task_payload`` NULL)
+        so this test can never itself become the neighbour it is guarding against.
+        What it pins is visibility: unqualify the table and it must resolve into
+        this file's private schema, never ``public``.
+        """
+        marker = uuid.uuid4()
+        await pool.execute(
+            "INSERT INTO public.banks (bank_id, name) VALUES ($1, $1) ON CONFLICT DO NOTHING",
+            f"test-worker-public-{marker.hex[:8]}",
+        )
+        try:
+            await pool.execute(
+                """
+                INSERT INTO public.async_operations (operation_id, bank_id, operation_type, status)
+                VALUES ($1, $2, 'retain', 'pending')
+                """,
+                marker,
+                f"test-worker-public-{marker.hex[:8]}",
+            )
+
+            # Unqualified: resolves through search_path into the private schema.
+            visible = await pool.fetchval("SELECT count(*) FROM async_operations WHERE operation_id = $1", marker)
+            assert visible == 0, "public rows are visible here — the pool is not pinned to the private schema"
+
+            # And the row really does exist, so the count above is isolation, not a failed insert.
+            in_public = await pool.fetchval(
+                "SELECT count(*) FROM public.async_operations WHERE operation_id = $1", marker
+            )
+            assert in_public == 1
+        finally:
+            await pool.execute("DELETE FROM public.async_operations WHERE operation_id = $1", marker)
+            await pool.execute("DELETE FROM public.banks WHERE bank_id = $1", f"test-worker-public-{marker.hex[:8]}")
+
     async def test_claim_batch_respects_max_slots(self, pool, backend, clean_operations):
         """Test that claim_batch respects the max_slots limit."""
         from hindsight_api.worker import WorkerPoller


### PR DESCRIPTION
Fixes #3963. `test-api (3/3)` is currently red on main.

## Why it breaks

`WorkerPoller.claim_batch` claims across the whole schema on the connection's `search_path`, bounded by `max_slots` minus the reservations and ordered by `created_at`. While this file's pool ran against the shared `public` schema, that made its claim counts unassertable: any test running concurrently under xdist that leaves a claimable row — `status='pending'` with a non-null `task_payload` — competes for the same batch, and older foreign rows **displace** this file's own. Filtering the result to our own bank, which the tests already did, observes the shortfall but cannot prevent it.

`tests/test_operation_status.py::_insert_operation` writes exactly such rows. Once `pytest-split` moved that file into shard 3, `test_claim_batch_claims_pending_tasks` began failing with `Expected 3 claims for our bank, got 2`.

Reproduced directly, without any concurrency: plant 12 older foreign claimable rows, then the test's own three, and call `claim_batch` once —

```
total_claimed=8  mine=0  expected=3
```

The batch fills to its ceiling (`max_slots` 10 − 2 reserved) with foreign rows and takes none of ours. CI just sees a milder version of the same thing.

Nothing about the sharding is stable here: `--splits 3` is computed over all collected tests, so any PR that adds a couple of tests reshuffles which files share a shard. #3859 was merely the one that landed — a diff of shard 3's contents before and after it shows exactly two tests moved in, both from `test_operation_status.py`, and none moved out. The next such PR would hit a different pair.

## The fix

Give the file its own migrated schema and pin the pool's `search_path` to it, which is what the other claim tests already do for the same reason (`tests/test_claim_bank_serialization.py`). "The whole schema" is then only this file's rows, and the ordering that displaced them can't reach across.

`clean_operations` becomes a plain schema-wide delete. It has to be broad — scoping it to the worker-test bank prefixes left behind rows under any other id a test invented, and those stayed claimable for the next test. It is only *safe* to be broad because of the pinning; the scoped form it replaces was itself a fix for a global delete that, under xdist, removed other workers' in-flight operations mid-run.

## On the regression test

It pins **visibility isolation** — a row in `public` must be invisible here — rather than asserting that `claim_batch` resists displacement. That distinction is deliberate: `claim_batch` is bounded by design, so a test demanding it always return our rows would be asserting a property the production code does not and should not have. My first attempt did exactly that and failed correctly.

The planted row is deliberately unclaimable (`task_payload` NULL) so this test can never itself become the neighbour it guards against, and it is removed in a `finally`. Removing the `search_path` pinning makes it fail:

```
AssertionError: public rows are visible here — the pool is not pinned to the private schema
```

## Verification

- `tests/test_worker.py` — 110 passed
- `tests/test_worker.py` + `tests/test_operation_status.py` together (the pair that collided) — 126 passed
- regression test fails with the fix reverted, passes with it
- `ruff check`, `ruff format --check`, `ty check` clean

Test-only change; no production code touched.
