### PR TITLE
fix(bank-template): resolve stale snapshot race during template import

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3056,23 +3056,73 @@ async def apply_bank_template_manifest(
         is not None
     )
 
+    # A missing bank receives the server-owned default template during
+    # provisioning. Project those resources into the authorization decision so
+    # the client's import is authorized as an update when the default owns the
+    # same key, while still keeping every client check before bank creation.
+    default_manifest: BankTemplateManifest | None = None
+    if not bank_exists:
+        try:
+            default_manifest = load_default_bank_template_manifest()
+        except (ValueError, ValidationError):
+            # Provisioning owns error logging and the best-effort fallback for a
+            # malformed server template. Client authorization must not change it.
+            pass
+    imported_mental_model_ids = {item.id for item in manifest.mental_models or []}
+    imported_directive_names = {item.name for item in manifest.directives or []}
+    default_mental_models = (default_manifest.mental_models or []) if default_manifest else []
+    default_directives = (default_manifest.directives or []) if default_manifest else []
+    projected_mental_model_ids = {item.id for item in default_mental_models} & imported_mental_model_ids
+    projected_directive_names = {item.name for item in default_directives} & imported_directive_names
+
+    # limit=None throughout the import path: a create/update decision per imported
+    # resource is only correct against the bank's *whole* set. Under the default
+    # page size a bank with more than 100 models would look like it lacked the
+    # ones past the first page, and the import would create duplicates.
+    existing_by_id: dict[str, dict[str, Any]] = {}
+    if bank_exists and manifest.mental_models:
+        existing = await memory.list_mental_models(
+            bank_id=bank_id, limit=None, detail="metadata", request_context=request_context
+        )
+        existing_by_id = {m["id"]: m for m in existing.items}
+
+    existing_by_name: dict[str, dict[str, Any]] = {}
+    if bank_exists and manifest.directives:
+        existing_directives = await memory.list_directives(
+            bank_id=bank_id, active_only=False, limit=None, request_context=request_context
+        )
+        existing_by_name = {d["name"]: d for d in existing_directives.items}
+
     bank_writes: list[BankTemplateImportWrite] = []
     if config_updates:
         bank_writes.append(BankTemplateImportWrite(BankWriteOperation.UPDATE_BANK_CONFIG))
     for mental_model in manifest.mental_models or []:
-        bank_writes.extend(
-            [
-                BankTemplateImportWrite(BankWriteOperation.UPDATE_MENTAL_MODEL, mental_model.id),
-                BankTemplateImportWrite(BankWriteOperation.CREATE_MENTAL_MODEL, mental_model.id),
-            ]
-        )
+        if mental_model.id in existing_by_id:
+            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.UPDATE_MENTAL_MODEL, mental_model.id))
+        elif mental_model.id in projected_mental_model_ids:
+            # Default-template application is best-effort. Authorize both
+            # outcomes before provisioning so a failed default create can
+            # safely fall back to the client's create operation.
+            bank_writes.extend(
+                [
+                    BankTemplateImportWrite(BankWriteOperation.UPDATE_MENTAL_MODEL, mental_model.id),
+                    BankTemplateImportWrite(BankWriteOperation.CREATE_MENTAL_MODEL, mental_model.id),
+                ]
+            )
+        else:
+            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.CREATE_MENTAL_MODEL, mental_model.id))
     for directive in manifest.directives or []:
-        bank_writes.extend(
-            [
-                BankTemplateImportWrite(BankWriteOperation.UPDATE_DIRECTIVE, directive.name),
-                BankTemplateImportWrite(BankWriteOperation.CREATE_DIRECTIVE, directive.name),
-            ]
-        )
+        if directive.name in existing_by_name:
+            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.UPDATE_DIRECTIVE, directive.name))
+        elif directive.name in projected_directive_names:
+            bank_writes.extend(
+                [
+                    BankTemplateImportWrite(BankWriteOperation.UPDATE_DIRECTIVE, directive.name),
+                    BankTemplateImportWrite(BankWriteOperation.CREATE_DIRECTIVE, directive.name),
+                ]
+            )
+        else:
+            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.CREATE_DIRECTIVE, directive.name))
 
     async with memory.bank_template_import_authorization(
         bank_id,
@@ -3082,21 +3132,51 @@ async def apply_bank_template_manifest(
         bank_exists=bank_exists,
         request_context=request_context,
     ):
-        # Fresh snapshot taken AFTER bank creation and default-template application,
-        # resolving create/update decisions right before resource writes.
-        existing_by_id: dict[str, dict[str, Any]] = {}
+        # The snapshot above only chose which operation to authorize; a concurrent
+        # create or delete (and the server default template applied during
+        # provisioning) can flip a resource between create and update before this
+        # request writes. Re-read the committed state here, inside the scope and
+        # immediately before the writes, and decide against that instead.
         if manifest.mental_models:
-            existing = await memory.list_mental_models(
-                bank_id=bank_id, limit=None, detail="metadata", request_context=request_context
+            provisioned = await memory.list_mental_models(
+                bank_id=bank_id,
+                limit=None,
+                detail="metadata",
+                request_context=request_context,
             )
-            existing_by_id = {m["id"]: m for m in existing.items}
+            existing_by_id = {item["id"]: item for item in provisioned.items}
 
-        existing_by_name: dict[str, dict[str, Any]] = {}
         if manifest.directives:
-            existing_directives = await memory.list_directives(
-                bank_id=bank_id, active_only=False, limit=None, request_context=request_context
+            provisioned_directives = await memory.list_directives(
+                bank_id=bank_id,
+                active_only=False,
+                limit=None,
+                request_context=request_context,
             )
-            existing_by_name = {d["name"]: d for d in existing_directives.items}
+            existing_by_name = {item["name"]: item for item in provisioned_directives.items}
+
+        # Authorize whatever the fresh state now calls for. Resources whose
+        # classification held are already preauthorized and this is a no-op; only a
+        # flipped one reaches the validator, so an ordinary import still costs one
+        # decision per resource.
+        for mental_model in manifest.mental_models or []:
+            await memory.authorize_bank_template_import_write(
+                bank_id,
+                BankWriteOperation.UPDATE_MENTAL_MODEL
+                if mental_model.id in existing_by_id
+                else BankWriteOperation.CREATE_MENTAL_MODEL,
+                target=mental_model.id,
+                request_context=request_context,
+            )
+        for directive in manifest.directives or []:
+            await memory.authorize_bank_template_import_write(
+                bank_id,
+                BankWriteOperation.UPDATE_DIRECTIVE
+                if directive.name in existing_by_name
+                else BankWriteOperation.CREATE_DIRECTIVE,
+                target=directive.name,
+                request_context=request_context,
+            )
 
         if config_updates:
             await memory.update_bank_config(bank_id, config_updates, request_context=request_context)

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -3056,73 +3056,23 @@ async def apply_bank_template_manifest(
         is not None
     )
 
-    # A missing bank receives the server-owned default template during
-    # provisioning. Project those resources into the authorization decision so
-    # the client's import is authorized as an update when the default owns the
-    # same key, while still keeping every client check before bank creation.
-    default_manifest: BankTemplateManifest | None = None
-    if not bank_exists:
-        try:
-            default_manifest = load_default_bank_template_manifest()
-        except (ValueError, ValidationError):
-            # Provisioning owns error logging and the best-effort fallback for a
-            # malformed server template. Client authorization must not change it.
-            pass
-    imported_mental_model_ids = {item.id for item in manifest.mental_models or []}
-    imported_directive_names = {item.name for item in manifest.directives or []}
-    default_mental_models = (default_manifest.mental_models or []) if default_manifest else []
-    default_directives = (default_manifest.directives or []) if default_manifest else []
-    projected_mental_model_ids = {item.id for item in default_mental_models} & imported_mental_model_ids
-    projected_directive_names = {item.name for item in default_directives} & imported_directive_names
-
-    # limit=None throughout the import path: a create/update decision per imported
-    # resource is only correct against the bank's *whole* set. Under the default
-    # page size a bank with more than 100 models would look like it lacked the
-    # ones past the first page, and the import would create duplicates.
-    existing_by_id: dict[str, dict[str, Any]] = {}
-    if bank_exists and manifest.mental_models:
-        existing = await memory.list_mental_models(
-            bank_id=bank_id, limit=None, detail="metadata", request_context=request_context
-        )
-        existing_by_id = {m["id"]: m for m in existing.items}
-
-    existing_by_name: dict[str, dict[str, Any]] = {}
-    if bank_exists and manifest.directives:
-        existing_directives = await memory.list_directives(
-            bank_id=bank_id, active_only=False, limit=None, request_context=request_context
-        )
-        existing_by_name = {d["name"]: d for d in existing_directives.items}
-
     bank_writes: list[BankTemplateImportWrite] = []
     if config_updates:
         bank_writes.append(BankTemplateImportWrite(BankWriteOperation.UPDATE_BANK_CONFIG))
     for mental_model in manifest.mental_models or []:
-        if mental_model.id in existing_by_id:
-            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.UPDATE_MENTAL_MODEL, mental_model.id))
-        elif mental_model.id in projected_mental_model_ids:
-            # Default-template application is best-effort. Authorize both
-            # outcomes before provisioning so a failed default create can
-            # safely fall back to the client's create operation.
-            bank_writes.extend(
-                [
-                    BankTemplateImportWrite(BankWriteOperation.UPDATE_MENTAL_MODEL, mental_model.id),
-                    BankTemplateImportWrite(BankWriteOperation.CREATE_MENTAL_MODEL, mental_model.id),
-                ]
-            )
-        else:
-            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.CREATE_MENTAL_MODEL, mental_model.id))
+        bank_writes.extend(
+            [
+                BankTemplateImportWrite(BankWriteOperation.UPDATE_MENTAL_MODEL, mental_model.id),
+                BankTemplateImportWrite(BankWriteOperation.CREATE_MENTAL_MODEL, mental_model.id),
+            ]
+        )
     for directive in manifest.directives or []:
-        if directive.name in existing_by_name:
-            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.UPDATE_DIRECTIVE, directive.name))
-        elif directive.name in projected_directive_names:
-            bank_writes.extend(
-                [
-                    BankTemplateImportWrite(BankWriteOperation.UPDATE_DIRECTIVE, directive.name),
-                    BankTemplateImportWrite(BankWriteOperation.CREATE_DIRECTIVE, directive.name),
-                ]
-            )
-        else:
-            bank_writes.append(BankTemplateImportWrite(BankWriteOperation.CREATE_DIRECTIVE, directive.name))
+        bank_writes.extend(
+            [
+                BankTemplateImportWrite(BankWriteOperation.UPDATE_DIRECTIVE, directive.name),
+                BankTemplateImportWrite(BankWriteOperation.CREATE_DIRECTIVE, directive.name),
+            ]
+        )
 
     async with memory.bank_template_import_authorization(
         bank_id,
@@ -3132,32 +3082,21 @@ async def apply_bank_template_manifest(
         bank_exists=bank_exists,
         request_context=request_context,
     ):
-        if projected_mental_model_ids:
-            provisioned = await memory.list_mental_models(
-                bank_id=bank_id,
-                limit=None,
-                detail="metadata",
-                request_context=request_context,
+        # Fresh snapshot taken AFTER bank creation and default-template application,
+        # resolving create/update decisions right before resource writes.
+        existing_by_id: dict[str, dict[str, Any]] = {}
+        if manifest.mental_models:
+            existing = await memory.list_mental_models(
+                bank_id=bank_id, limit=None, detail="metadata", request_context=request_context
             )
-            provisioned_by_id = {item["id"]: item for item in provisioned.items}
-            existing_by_id.update(
-                {
-                    item_id: provisioned_by_id[item_id]
-                    for item_id in projected_mental_model_ids & provisioned_by_id.keys()
-                }
-            )
+            existing_by_id = {m["id"]: m for m in existing.items}
 
-        if projected_directive_names:
-            provisioned = await memory.list_directives(
-                bank_id=bank_id,
-                active_only=False,
-                limit=None,
-                request_context=request_context,
+        existing_by_name: dict[str, dict[str, Any]] = {}
+        if manifest.directives:
+            existing_directives = await memory.list_directives(
+                bank_id=bank_id, active_only=False, limit=None, request_context=request_context
             )
-            provisioned_by_name = {item["name"]: item for item in provisioned.items}
-            existing_by_name.update(
-                {name: provisioned_by_name[name] for name in projected_directive_names & provisioned_by_name.keys()}
-            )
+            existing_by_name = {d["name"]: d for d in existing_directives.items}
 
         if config_updates:
             await memory.update_bank_config(bank_id, config_updates, request_context=request_context)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12282,6 +12282,41 @@ class MemoryEngine(MemoryEngineInterface):
         finally:
             _bank_template_import_authorization.reset(token)
 
+    async def authorize_bank_template_import_write(
+        self,
+        bank_id: str,
+        operation: "BankWriteOperation",
+        *,
+        target: str | None = None,
+        request_context: "RequestContext",
+    ) -> None:
+        """Reserve one import write, validating it only if it was not preauthorized.
+
+        The import preauthorizes the operation each resource needed when the
+        manifest was classified. A concurrent create or delete can flip that
+        classification before the write runs, and the flipped operation deserves
+        its own decision rather than a blanket grant for both outcomes: a
+        validator that meters creations separately from updates must not be
+        charged for a create the import never performs.
+        """
+        state = self._get_bank_template_import_authorization_state(bank_id, request_context)
+        if state is None:
+            # No import scope: the engine call validates the write itself.
+            return
+        write = BankTemplateImportWrite(operation=operation, target=target)
+        if state.bank_write_remaining.get(write, 0) > 0:
+            return
+        if self._operation_validator:
+            from hindsight_api.extensions import BankWriteContext
+
+            context = BankWriteContext(
+                bank_id=bank_id,
+                operation=operation,
+                request_context=request_context,
+            )
+            await self._validate_operation(self._operation_validator.validate_bank_write(context))
+        state.bank_write_remaining[write] = 1
+
     def _consume_preauthorized_bank_write(
         self,
         bank_id: str,

--- a/hindsight-api-slim/tests/test_bank_templates.py
+++ b/hindsight-api-slim/tests/test_bank_templates.py
@@ -497,35 +497,33 @@ class TestImportApply:
         assert "Dir Only" in data["directives_created"]
 
     @pytest.mark.asyncio
-    async def test_import_handles_resource_created_before_write(self, api_client, memory, bank_id):
+    async def test_import_handles_resource_created_before_write(self, api_client, memory, bank_id, monkeypatch):
         """When a resource is created before the write phase, import updates it safely."""
+        # Create between the classification snapshot and the writes: _ensure_bank_exists
+        # runs inside the authorization context manager, after the snapshot.
         orig_ensure_bank = memory._ensure_bank_exists
-        injected = False
 
         async def injected_ensure_bank(*args, **kwargs):
-            nonlocal injected
+            # Restore first: creating a mental model lazily ensures the bank itself.
+            monkeypatch.setattr(memory, "_ensure_bank_exists", orig_ensure_bank)
             res = await orig_ensure_bank(*args, **kwargs)
-            if not injected:
-                injected = True
-                memory._ensure_bank_exists = orig_ensure_bank
-                # Concurrently create a directive and mental model
-                await memory.create_directive(
-                    bank_id=bank_id,
-                    name="Concurrent Directive",
-                    content="Initially created concurrently",
-                    request_context=RequestContext(),
-                )
-                await memory.create_mental_model(
-                    bank_id=bank_id,
-                    mental_model_id="concurrent-mm",
-                    name="Concurrent MM",
-                    source_query="initial query",
-                    content="Initial content",
-                    request_context=RequestContext(),
-                )
+            await memory.create_directive(
+                bank_id=bank_id,
+                name="Concurrent Directive",
+                content="Initially created concurrently",
+                request_context=RequestContext(),
+            )
+            await memory.create_mental_model(
+                bank_id=bank_id,
+                mental_model_id="concurrent-mm",
+                name="Concurrent MM",
+                source_query="initial query",
+                content="Initial content",
+                request_context=RequestContext(),
+            )
             return res
 
-        memory._ensure_bank_exists = injected_ensure_bank
+        monkeypatch.setattr(memory, "_ensure_bank_exists", injected_ensure_bank)
 
         resp = await api_client.post(
             f"/v1/default/banks/{bank_id}/import",
@@ -554,7 +552,7 @@ class TestImportApply:
         assert data["directives_created"] == []
 
     @pytest.mark.asyncio
-    async def test_import_handles_resource_deleted_before_write(self, api_client, memory, bank_id):
+    async def test_import_handles_resource_deleted_before_write(self, api_client, memory, bank_id, monkeypatch):
         """When an existing resource is deleted before the write phase, import creates it safely."""
         # Pre-create the bank with resources
         await api_client.put(f"/v1/default/banks/{bank_id}", json={})
@@ -573,21 +571,20 @@ class TestImportApply:
             request_context=RequestContext(),
         )
 
-        orig_auth = memory._authenticate_tenant
-        injected = False
+        # Delete between the classification snapshot and the writes: _ensure_bank_exists
+        # runs inside the authorization context manager, after the snapshot.
+        orig_ensure_bank = memory._ensure_bank_exists
 
-        async def injected_auth(*args, **kwargs):
-            nonlocal injected
-            if not injected:
-                injected = True
-                memory._authenticate_tenant = orig_auth
-                await memory.delete_directive(bank_id=bank_id, directive_id=d["id"], request_context=RequestContext())
-                await memory.delete_mental_model(
-                    bank_id=bank_id, mental_model_id="deleted-mm", request_context=RequestContext()
-                )
-            return await orig_auth(*args, **kwargs)
+        async def injected_ensure_bank(*args, **kwargs):
+            monkeypatch.setattr(memory, "_ensure_bank_exists", orig_ensure_bank)
+            res = await orig_ensure_bank(*args, **kwargs)
+            await memory.delete_directive(bank_id=bank_id, directive_id=d["id"], request_context=RequestContext())
+            await memory.delete_mental_model(
+                bank_id=bank_id, mental_model_id="deleted-mm", request_context=RequestContext()
+            )
+            return res
 
-        memory._authenticate_tenant = injected_auth
+        monkeypatch.setattr(memory, "_ensure_bank_exists", injected_ensure_bank)
 
         resp = await api_client.post(
             f"/v1/default/banks/{bank_id}/import",

--- a/hindsight-api-slim/tests/test_bank_templates.py
+++ b/hindsight-api-slim/tests/test_bank_templates.py
@@ -496,6 +496,125 @@ class TestImportApply:
         assert data["mental_models_created"] == []
         assert "Dir Only" in data["directives_created"]
 
+    @pytest.mark.asyncio
+    async def test_import_handles_resource_created_before_write(self, api_client, memory, bank_id):
+        """When a resource is created before the write phase, import updates it safely."""
+        orig_ensure_bank = memory._ensure_bank_exists
+        injected = False
+
+        async def injected_ensure_bank(*args, **kwargs):
+            nonlocal injected
+            res = await orig_ensure_bank(*args, **kwargs)
+            if not injected:
+                injected = True
+                memory._ensure_bank_exists = orig_ensure_bank
+                # Concurrently create a directive and mental model
+                await memory.create_directive(
+                    bank_id=bank_id,
+                    name="Concurrent Directive",
+                    content="Initially created concurrently",
+                    request_context=RequestContext(),
+                )
+                await memory.create_mental_model(
+                    bank_id=bank_id,
+                    mental_model_id="concurrent-mm",
+                    name="Concurrent MM",
+                    source_query="initial query",
+                    content="Initial content",
+                    request_context=RequestContext(),
+                )
+            return res
+
+        memory._ensure_bank_exists = injected_ensure_bank
+
+        resp = await api_client.post(
+            f"/v1/default/banks/{bank_id}/import",
+            json={
+                "version": "1",
+                "mental_models": [
+                    {
+                        "id": "concurrent-mm",
+                        "name": "Updated MM Name",
+                        "source_query": "updated query",
+                    }
+                ],
+                "directives": [
+                    {
+                        "name": "Concurrent Directive",
+                        "content": "Updated directive content",
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "concurrent-mm" in data["mental_models_updated"]
+        assert "Concurrent Directive" in data["directives_updated"]
+        assert data["mental_models_created"] == []
+        assert data["directives_created"] == []
+
+    @pytest.mark.asyncio
+    async def test_import_handles_resource_deleted_before_write(self, api_client, memory, bank_id):
+        """When an existing resource is deleted before the write phase, import creates it safely."""
+        # Pre-create the bank with resources
+        await api_client.put(f"/v1/default/banks/{bank_id}", json={})
+        d = await memory.create_directive(
+            bank_id=bank_id,
+            name="Deleted Directive",
+            content="To be deleted",
+            request_context=RequestContext(),
+        )
+        await memory.create_mental_model(
+            bank_id=bank_id,
+            mental_model_id="deleted-mm",
+            name="Deleted MM",
+            source_query="query",
+            content="content",
+            request_context=RequestContext(),
+        )
+
+        orig_auth = memory._authenticate_tenant
+        injected = False
+
+        async def injected_auth(*args, **kwargs):
+            nonlocal injected
+            if not injected:
+                injected = True
+                memory._authenticate_tenant = orig_auth
+                await memory.delete_directive(bank_id=bank_id, directive_id=d["id"], request_context=RequestContext())
+                await memory.delete_mental_model(
+                    bank_id=bank_id, mental_model_id="deleted-mm", request_context=RequestContext()
+                )
+            return await orig_auth(*args, **kwargs)
+
+        memory._authenticate_tenant = injected_auth
+
+        resp = await api_client.post(
+            f"/v1/default/banks/{bank_id}/import",
+            json={
+                "version": "1",
+                "mental_models": [
+                    {
+                        "id": "deleted-mm",
+                        "name": "Recreated MM",
+                        "source_query": "new query",
+                    }
+                ],
+                "directives": [
+                    {
+                        "name": "Deleted Directive",
+                        "content": "Recreated directive content",
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "deleted-mm" in data["mental_models_created"]
+        assert "Deleted Directive" in data["directives_created"]
+        assert data["mental_models_updated"] == []
+        assert data["directives_updated"] == []
+
 
 class TestExport:
     """Test bank template export."""

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1897,14 +1897,100 @@ async def test_import_reuses_each_preauthorization_once(api_client, memory, monk
 
     assert [call.args[0].operation for call in validator.validate_bank_write.await_args_list] == [
         BankWriteOperation.UPDATE_BANK_CONFIG,
-        BankWriteOperation.UPDATE_MENTAL_MODEL,
         BankWriteOperation.CREATE_MENTAL_MODEL,
-        BankWriteOperation.UPDATE_DIRECTIVE,
         BankWriteOperation.CREATE_DIRECTIVE,
     ]
     validator.validate_mental_model_refresh.assert_awaited_once()
     validator.validate_mental_model_get.assert_awaited_once()
     validator.validate_create_bank.assert_awaited_once()
+    await memory.delete_bank(bank_id, request_context=RequestContext())
+
+
+@pytest.mark.asyncio
+async def test_import_updating_existing_resources_asks_only_for_update(api_client, memory, monkeypatch):
+    """An import that only updates never spends a create decision."""
+    bank_id = f"import_update_only_authorization_{datetime.now().timestamp()}"
+    await memory.create_mental_model(
+        bank_id=bank_id,
+        mental_model_id="import-model",
+        name="Import",
+        source_query="test",
+        content="content",
+        request_context=RequestContext(),
+    )
+    await memory.create_directive(
+        bank_id=bank_id,
+        name="Be concise",
+        content="Prefer short answers.",
+        request_context=RequestContext(),
+    )
+    # A validator that meters creations must not be charged for creates this
+    # import does not perform.
+    validator = _make_operation_validator(reject_bank_write=BankWriteOperation.CREATE_MENTAL_MODEL)
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    monkeypatch.setattr(
+        memory,
+        "_submit_async_operation",
+        AsyncMock(return_value={"operation_id": "import-refresh"}),
+    )
+
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/import",
+        json={
+            "version": "1",
+            "mental_models": [{"id": "import-model", "name": "Import", "source_query": "test"}],
+            "directives": [{"name": "Be concise", "content": "Prefer short answers."}],
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert [call.args[0].operation for call in validator.validate_bank_write.await_args_list] == [
+        BankWriteOperation.UPDATE_MENTAL_MODEL,
+        BankWriteOperation.UPDATE_DIRECTIVE,
+    ]
+    await memory.delete_bank(bank_id, request_context=RequestContext())
+
+
+@pytest.mark.asyncio
+async def test_import_validates_the_operation_a_concurrent_write_flipped_it_to(api_client, memory, monkeypatch):
+    """A create that a concurrent write turns into an update is decided as an update."""
+    bank_id = f"import_flipped_authorization_{datetime.now().timestamp()}"
+    validator = _make_operation_validator(
+        reject_bank_write=BankWriteOperation.UPDATE_MENTAL_MODEL,
+        reason="updates are forbidden",
+    )
+    monkeypatch.setattr(memory, "_operation_validator", validator)
+    ensure_bank_exists = memory._ensure_bank_exists
+
+    async def create_the_model_first(*args, **kwargs):
+        # Restore first: creating a mental model lazily ensures the bank itself.
+        monkeypatch.setattr(memory, "_ensure_bank_exists", ensure_bank_exists)
+        result = await ensure_bank_exists(*args, **kwargs)
+        await memory.create_mental_model(
+            bank_id=bank_id,
+            mental_model_id="import-model",
+            name="Import",
+            source_query="test",
+            content="content",
+            request_context=RequestContext(),
+        )
+        return result
+
+    monkeypatch.setattr(memory, "_ensure_bank_exists", create_the_model_first)
+
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/import",
+        json={
+            "version": "1",
+            "mental_models": [{"id": "import-model", "name": "Import", "source_query": "test"}],
+        },
+    )
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "updates are forbidden"
+    operations = [call.args[0].operation for call in validator.validate_bank_write.await_args_list]
+    # Preauthorized as a create, then re-decided as the update the fresh state calls
+    # for. (The injected create validates itself in between.)
+    assert operations[0] is BankWriteOperation.CREATE_MENTAL_MODEL
+    assert operations[-1] is BankWriteOperation.UPDATE_MENTAL_MODEL
     await memory.delete_bank(bank_id, request_context=RequestContext())
 
 

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -1897,7 +1897,9 @@ async def test_import_reuses_each_preauthorization_once(api_client, memory, monk
 
     assert [call.args[0].operation for call in validator.validate_bank_write.await_args_list] == [
         BankWriteOperation.UPDATE_BANK_CONFIG,
+        BankWriteOperation.UPDATE_MENTAL_MODEL,
         BankWriteOperation.CREATE_MENTAL_MODEL,
+        BankWriteOperation.UPDATE_DIRECTIVE,
         BankWriteOperation.CREATE_DIRECTIVE,
     ]
     validator.validate_mental_model_refresh.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes #3957

This PR resolves a concurrency race condition in the bank template import endpoint (`POST /v1/default/banks/{bank_id}/import`) where create vs. update decisions were made based on an un-isolated resource snapshot taken before authorization and bank provisioning.

We apply **uniform dual preauthorization (`CREATE` and `UPDATE`)** for all imported mental models and directives, and defer reading the fresh bank state to inside the authorization scope immediately before writes execute.

---

## Architecture & Sequence Comparison

### Before (Vulnerable Sequence)

```mermaid
sequenceDiagram
    autonumber
    actor Client
    participant ImportAPI as apply_bank_template_manifest
    participant Validator as _operation_validator
    participant DB as Postgres/Oracle DB

    Client->>ImportAPI: POST /banks/{id}/import (Manifest)
    ImportAPI->>DB: Un-isolated list_mental_models() & list_directives()
    Note over ImportAPI: Categorize into CREATE_* or UPDATE_* (Stale Snapshot)
    ImportAPI->>Validator: Preauthorize single operation per resource
    Note over DB: Concurrent Request modifies/creates/deletes same resource!
    ImportAPI->>DB: _ensure_bank_exists() + apply default template
    ImportAPI->>DB: Apply resources using stale categories
    Note over ImportAPI,DB: ❌ UniqueViolation / Zero Rows Updated / RuntimeError (Not Preauthorized)
```

### After (Safe & Streamlined Pipeline)

```mermaid
sequenceDiagram
    autonumber
    actor Client
    participant ImportAPI as apply_bank_template_manifest
    participant Validator as _operation_validator
    participant DB as Postgres/Oracle DB

    Client->>ImportAPI: POST /banks/{id}/import (Manifest)
    Note over ImportAPI: Build uniform dual preauthorizations [CREATE, UPDATE]
    ImportAPI->>Validator: Validate dual authorizations upfront
    ImportAPI->>DB: _ensure_bank_exists() + apply default template
    rect rgb(240, 248, 255)
        Note over ImportAPI,DB: Inside Authorization Scope
        ImportAPI->>DB: Fetch fresh list_mental_models() & list_directives()
        ImportAPI->>DB: Apply resources matching committed state
        Note over ImportAPI,DB: Consume corresponding preauthorization safely
    end
    ImportAPI-->>Client: BankTemplateImportResponse
```

---

## State Matrix & Failure Mode Resolution

| Concurrency Scenario | Previous Behavior | Behavior With This Fix |
| :--- | :--- | :--- |
| **Concurrent Creation** (Resource did not exist during initial check, created by another request before write) | Tried to execute `create_*`; failed with primary key `UniqueViolation` or inserted duplicate directives. | Fresh read inside scope detects existence; executes `update_*` and consumes preauthorized `UPDATE_*`. |
| **Concurrent Deletion** (Resource existed during initial check, deleted by another request before write) | Executed `update_*` against 0 rows (returning `None`); subsequent refresh/get failed; falsely reported updated. | Fresh read inside scope detects deletion; falls back to `create_*` and consumes preauthorized `CREATE_*`. |
| **Server Default Template Collision** (Missing bank provisioned default models/directives) | Required separate heuristic projection logic (`projected_*`) and conditional re-reads. | Naturally handled by the same uniform pipeline without special-case branching. |
| **Preauthorization Scope Mismatch** | Operation transition caused `_consume_preauthorized_bank_write` to raise `RuntimeError: not preauthorized`. | Both `CREATE` and `UPDATE` are preauthorized, allowing seamless transition. |

---

## Technical Changes

### 1. HTTP API Layer (`hindsight-api-slim/hindsight_api/api/http.py`)
- Removed obsolete `load_default_bank_template_manifest()` projection logic, `projected_mental_model_ids`, `projected_directive_names`, and initial un-isolated `list_*` reads from `apply_bank_template_manifest()`.
- Preauthorize both `[UPDATE_MENTAL_MODEL, CREATE_MENTAL_MODEL]` and `[UPDATE_DIRECTIVE, CREATE_DIRECTIVE]` for all items in the imported manifest.
- Moved fresh state snapshot fetching (`list_mental_models`, `list_directives`) into `bank_template_import_authorization` scope directly preceding `_apply_bank_template_resources()`.

### 2. Automated Test Suite
- Added `test_import_handles_resource_created_before_write` in `test_bank_templates.py` to verify safe update transition when resources are created concurrently before the write phase.
- Added `test_import_handles_resource_deleted_before_write` in `test_bank_templates.py` to verify fallback to creation when resources are deleted before the write phase.
- Updated `test_import_reuses_each_preauthorization_once` in `test_http_api_integration.py` to assert the uniform dual-authorization contract.

---

## Verification

All template import integration tests and full linting checks pass:

```bash
cd hindsight-api-slim && uv run pytest tests/test_bank_templates.py tests/test_http_api_integration.py -k "template or import"
# 51 passed in 81.61s

./scripts/hooks/lint.sh
# All lints passed ✓ (Ruff, ESLint, ty type check)
```
