### PR TITLE
fix(monitoring): make Grafana dashboards importable on older Grafana

### DIFF
--- a/monitoring/grafana/dashboards/hindsight-api-service.json
+++ b/monitoring/grafana/dashboards/hindsight-api-service.json
@@ -17,10 +17,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -62,10 +59,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -107,10 +101,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -152,10 +143,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -199,10 +187,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -244,10 +229,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -322,10 +304,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -423,10 +402,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -527,10 +503,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -572,10 +545,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -618,10 +588,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -664,10 +631,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -709,10 +673,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -830,10 +791,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -875,10 +833,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -920,10 +875,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -965,10 +917,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1010,10 +959,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1088,10 +1034,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1180,10 +1123,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1278,16 +1218,27 @@
   "templating": {
     "list": [
       {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": ".*",
         "current": {
           "selected": true,
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(hindsight_http_requests_total, tenant)",
         "hide": 0,
         "includeAll": true,
@@ -1295,10 +1246,7 @@
         "multi": false,
         "name": "tenant",
         "options": [],
-        "query": {
-          "query": "label_values(hindsight_http_requests_total, tenant)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
+        "query": "label_values(hindsight_http_requests_total, tenant)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/monitoring/grafana/dashboards/hindsight-llm.json
+++ b/monitoring/grafana/dashboards/hindsight-llm.json
@@ -9,10 +9,7 @@
   "links": [],
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -54,10 +51,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -99,10 +93,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -145,10 +136,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -191,10 +179,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -269,10 +254,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -361,10 +343,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -439,10 +418,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -528,16 +504,27 @@
   "templating": {
     "list": [
       {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": ".*",
         "current": {
           "selected": true,
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(hindsight_llm_calls_total, tenant)",
         "hide": 0,
         "includeAll": true,
@@ -545,10 +532,7 @@
         "multi": false,
         "name": "tenant",
         "options": [],
-        "query": {
-          "query": "label_values(hindsight_llm_calls_total, tenant)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
+        "query": "label_values(hindsight_llm_calls_total, tenant)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/monitoring/grafana/dashboards/hindsight-operations.json
+++ b/monitoring/grafana/dashboards/hindsight-operations.json
@@ -9,10 +9,7 @@
   "links": [],
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -54,10 +51,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -99,10 +93,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -145,10 +136,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -191,10 +179,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -237,10 +222,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -328,10 +310,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -429,10 +408,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -507,10 +483,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -591,16 +564,27 @@
   "templating": {
     "list": [
       {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": ".*",
         "current": {
           "selected": true,
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(hindsight_operation_operations_total, tenant)",
         "hide": 0,
         "includeAll": true,
@@ -608,10 +592,7 @@
         "multi": false,
         "name": "tenant",
         "options": [],
-        "query": {
-          "query": "label_values(hindsight_operation_operations_total, tenant)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
+        "query": "label_values(hindsight_operation_operations_total, tenant)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
## Summary

Fixes #3968 — the three dashboards in `monitoring/grafana/dashboards/` could not be imported into an older Grafana (reproduced on **7.5.17**): variable init aborts with `Templating / Template variable service failed / e.replace is not a function` and every panel stays empty.

Two fields used save-model shapes that only exist in Grafana >= 8.3/9:

- `datasource` as an object ref — `{ "type": "prometheus", "uid": "prometheus" }` (schemaVersion 33+)
- the Prometheus variable query as the editor object — `{ "query": "label_values(...)", "refId": "PrometheusVariableQueryEditor-VariableQuery" }`

`DashboardMigrator` only ever migrates **up**, so with `"schemaVersion": 38` no migration runs on an older instance and both objects reach code that expects a string — `DatasourceSrv.get()` does `nameOrUid = this.templateSrv.replace(nameOrUid, ...)` and Prometheus `metricFindQuery()` does `templateSrv.replace(query, ...)`. `TemplateSrv.replace()` calls `target.replace(...)`, hence the `TypeError`.

## Changes

- Every panel now uses the string form `"datasource": "$datasource"`, backed by a new `datasource` template variable (`"query": "prometheus"`, `"current": {}`). This also removes the hardcoded `"uid": "prometheus"`, which only exists in the `grafana/otel-lgtm` image used by `scripts/dev/monitoring` — on any other instance the panels reported `Datasource prometheus was not found`.
- The `tenant` variable keeps its `label_values(...)` dropdown but as a plain string query, which 7.5 consumes directly and modern Grafana migrates via `migrateVariableQueryToEditor()`.

Both forms are still accepted by current Grafana, so the same files keep working for the dev stack and for manual import.

Alternatives considered and rejected:

- `${DS_PROMETHEUS}` + an `__inputs` block — fixes UI import but breaks `scripts/dev/monitoring`, since file provisioning does not substitute inputs.
- `"datasource": null` (org default) — breaks the dev stack, because `grafana/otel-lgtm` marks no datasource as `isDefault`.

## Testing

- `./scripts/hooks/lint.sh` — passes.
- Scripted check over all three files: JSON parses; no object-valued `datasource` remains (20/9/8 panel refs converted); every field that Grafana feeds into `templateSrv.replace()` (`expr`, `legendFormat`, `query`, `regex`, `allValue`, `definition`, `title`) is a string; `templating.list` is `[datasource(datasource), tenant(query)]` in each dashboard.
- Root cause traced against the Grafana `v7.5.17` sources (`public/app/features/plugins/datasource_srv.ts`, `migrations/variableMigration.ts`).
- **Not verified in a browser**: rendering on a live 7.5.17 instance is still being confirmed on the reporter's side in #3968, and I had no Grafana instance available locally.

## Known cosmetic gaps on 7.5 (silently ignored, not errors)

`timeseries` `stacking` (8.0+), `custom.lineStyle` dashes (8.x) and `legend.showLegend` (9+) — so the CPU panel does not stack and the pool `Max` line is solid. Left as-is to avoid regressing the modern dev stack.
