### PR TITLE
fix(retain): decouple bank display name from narrator

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -10654,12 +10654,13 @@ class MemoryEngine(MemoryEngineInterface):
         mutating the bank. Every prompt-affecting setting is overridable per call via ``overrides``
         (e.g. to test a candidate retain mission). ``agent_name`` is deprecated (describe the speaker
         in ``context`` instead) but still overrides the narrator when supplied, for backwards compatibility.
+        When it is omitted, no narrator is added: a bank's display name is not a speaker identity.
         Side-effect-free and idempotent.
         """
         from .response_models import ExtractedFact
-        from .retain import bank_utils, fact_extraction
+        from .retain import fact_extraction
 
-        # Resolve the tenant schema before touching any bank-scoped data (config, bank profile).
+        # Resolve the tenant schema before reading the bank-scoped config.
         await self._authenticate_tenant(request_context)
         resolved_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
         if self._llm_config.provider == "none":
@@ -10671,14 +10672,6 @@ class MemoryEngine(MemoryEngineInterface):
                     f"Unsupported extraction override '{key}'. Allowed: {sorted(self._EXTRACTION_OVERRIDE_FIELDS)}"
                 )
             setattr(resolved_config, key, value)
-
-        backend = await self._get_backend()
-        # Narrator primes the "Narrator:" line in the prompt. Dry-run must not
-        # create a bank just to resolve that optional display name.
-        if agent_name is None:
-            profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
-            profile_name = profile["name"] if profile is not None else bank_id
-            agent_name = None if profile_name == bank_id else profile_name
 
         retain_llm = self._retain_llm_config.with_config(resolved_config, bank_id=bank_id, operation="retain")
         facts, _chunks, usage = await fact_extraction.extract_facts_from_text(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -27,7 +27,6 @@ from ...metrics import get_metrics_collector
 from ...worker.stage import set_stage
 from ..db_utils import acquire_with_retry
 from ..memory_engine import count_tokens, fq_table
-from . import bank_utils
 
 
 @dataclass
@@ -343,32 +342,6 @@ async def _record_retain_document_outcome(pool: Any, bank_id: str, document_id: 
         get_metrics_collector().record_retain_document(bank_id=bank_id, memory_unit_count=total)
     except Exception:
         logger.debug("Failed to record retain document outcome metric", exc_info=True)
-
-
-#: "the narrator has not been resolved yet", which `None` cannot mean: `_resolve_narrator`
-#: returns None for a suppressed narrator, so None is a RESOLVED value. Using None as the
-#: sentinel made every recursive call re-resolve -- and re-read the bank row to do it -- for
-#: exactly the banks where the narrator is suppressed, which is the auto-created default.
-_NARRATOR_UNRESOLVED = object()
-
-
-def _resolve_narrator(profile_name: str, bank_id: str) -> str | None:
-    """Resolve the narrator (memory owner) used to prime fact extraction.
-
-    The narrator is injected as a "Narrator: {name}" line in fact extraction and
-    is stamped into the who-dimension of every first-person fact — and the
-    observations later consolidated from those facts. That is correct for a named
-    agent retaining its own logs, but harmful when ``name`` is just the bank_id:
-    on auto-create the bank ``name`` defaults to ``bank_id``, which is typically a
-    routing key (e.g. ``my-agent::channel-456::user-789``), not a speaker. Priming
-    extraction with a routing key embeds that string into stored fact text and
-    pollutes downstream observations (issue #1680). Suppress it in that case.
-
-    Returns the narrator name, or ``None`` to omit the Narrator line entirely.
-    """
-    if profile_name == bank_id:
-        return None
-    return profile_name
 
 
 # What a reprocess must NOT replay, because it supplies its own: `content` is the
@@ -1204,7 +1177,7 @@ async def retain_batch(
     document_body_hash: str | None = None,
     chunk_index_offset: int = 0,
     body_accum: "dict[str, DocumentBodyAccumulator] | None" = None,
-    agent_name: "str | None | object" = _NARRATOR_UNRESOLVED,
+    agent_name: str = "",
     retain_session=None,
     document_prefetch: "dict[str, dict] | asyncio.Task | None" = None,
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
@@ -1226,6 +1199,11 @@ async def retain_batch(
     a per-document offset each sub-batch would restart chunk_index at 0, so
     their chunk_ids collide and later sub-batches overwrite earlier chunks —
     leaving only one sub-batch's worth of chunks/memories behind (issue #1888).
+
+    ``agent_name`` is an explicit internal narrator override. It is deliberately
+    not inferred from the bank profile: ``banks.name`` is a display/management
+    label, not a speaker identity, and putting it in the extraction prompt leaks
+    project names into stored facts and entities (issue #3962).
 
     Returns a three-tuple of:
       * per-content-item unit ID lists
@@ -1252,20 +1230,6 @@ async def retain_batch(
     log_buffer.append(f"RETAIN_BATCH START: {bank_id}")
     log_buffer.append(f"Batch size: {len(contents_dicts)} content items, {total_chars:,} chars")
     log_buffer.append(f"{'=' * 60}")
-
-    # The bank profile is read for ONE value: the narrator name. A multi-document retain groups
-    # by document and re-enters this function per group (below), so reading it here made it one
-    # read -- and one pooled connection -- PER DOCUMENT rather than per retain. Resolved once by
-    # the outermost call and handed down.
-    #
-    # The sentinel is NOT None: `_resolve_narrator` returns None for a suppressed narrator, so
-    # None is a resolved value and testing for it would re-read on every recursion for precisely
-    # the auto-created banks where suppression applies.
-    if agent_name is _NARRATOR_UNRESOLVED:
-        profile = await bank_utils.get_bank_profile(pool, bank_id)
-        # Suppress the narrator when name == bank_id (auto-create default) — see
-        # _resolve_narrator for why a routing-key narrator pollutes extraction (#1680).
-        agent_name = _resolve_narrator(profile["name"], bank_id)
 
     # Convert dicts to RetainContent objects
     contents = _build_contents(contents_dicts, document_tags)

--- a/hindsight-api-slim/tests/test_bank_name_narrator_llm.py
+++ b/hindsight-api-slim/tests/test_bank_name_narrator_llm.py
@@ -1,0 +1,75 @@
+"""A bank display name must not become the fact-extraction narrator (#3962).
+
+Prompt isolation is pinned deterministically in ``test_narrator_resolution.py``.
+This test drives the real retain pipeline and asks the judge to verify the user-
+visible result: project/management metadata is not attributed as a participant.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api import MemoryEngine, RequestContext
+from tests.llm_judge import assert_meets_criteria
+
+pytestmark = pytest.mark.hs_llm_core
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=2, reruns_delay=2)
+async def test_bank_display_name_not_attributed_in_extracted_facts(memory_real_llm: MemoryEngine):
+    bank_id = f"bank-name-narrator-{uuid.uuid4().hex[:8]}"
+    document_id = f"dispatch-dialog-{uuid.uuid4().hex[:8]}"
+    display_name = "ReviewModelEval0825"
+    request_context = RequestContext()
+
+    try:
+        await memory_real_llm.update_bank(
+            bank_id,
+            name=display_name,
+            config_updates={"enable_observations": False},
+            request_context=request_context,
+        )
+        unit_ids = await memory_real_llm.retain_async(
+            bank_id,
+            (
+                "user: start\n"
+                "assistant: Hello, this is dispatch. I've scheduled a truck for you for next Wednesday morning.\n"
+                "user: Great, thank you."
+            ),
+            context="Conversation between a customer and an assistant named Dispatch.",
+            document_id=document_id,
+            request_context=request_context,
+        )
+
+        assert unit_ids, "Should extract at least one fact from the conversation"
+        listing = await memory_real_llm.list_memory_units(
+            bank_id,
+            fact_type=["world", "experience"],
+            document_id=document_id,
+            limit=100,
+            request_context=request_context,
+        )
+        units = listing["items"]
+        assert units, "Should persist the extracted conversation facts"
+        facts_summary = "\n".join(
+            f"- [{unit['fact_type']}] {unit['text']} | entities: {unit['entities']}" for unit in units
+        )
+        assert display_name not in facts_summary
+
+        await assert_meets_criteria(
+            response=facts_summary,
+            criteria=(
+                "The facts may attribute the scheduling action to Dispatch, the assistant, or a generic agent, "
+                "and may mention the customer/user. They must not mention or attribute any action to the bank's "
+                "internal display name 'ReviewModelEval0825', because that name was not part of the conversation."
+            ),
+            context=(
+                "A bank has the internal display name 'ReviewModelEval0825'. The retained content is a conversation "
+                "where an assistant named Dispatch schedules a truck for a customer. Bank display names are project "
+                "metadata, not conversation participants."
+            ),
+            msg=f"Bank display name leaked into extracted facts: {facts_summary}",
+        )
+    finally:
+        await memory_real_llm.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_narrator_resolution.py
+++ b/hindsight-api-slim/tests/test_narrator_resolution.py
@@ -1,32 +1,21 @@
-"""Narrator resolution + injection (issue #1680).
+"""Narrator injection and bank-name isolation (issues #1680 and #3962).
 
 The "Narrator: {name}" line in fact extraction is stamped into the who-dimension
-of every first-person fact and the observations derived from them. When the bank
-``name`` is just the bank_id (the auto-create default), that string is a routing
-key, not a speaker, and priming extraction with it pollutes stored fact text.
+of every first-person fact and the observations derived from them. A bank's
+``name`` is display/management metadata rather than a speaker identity, so neither
+normal retain nor dry-run extraction may inject it automatically.
 
-These are pure unit tests — no LLM, no DB. They pin the suppression decision and
-that the Narrator line is present/absent accordingly.
+The prompt assertions use MockLLM only to capture deterministic prompt assembly;
+model attribution behaviour is covered by the real-LLM test alongside this file.
 """
 
+import uuid
 from datetime import datetime
 
+import pytest
+
+from hindsight_api import MemoryEngine, RequestContext
 from hindsight_api.engine.retain.fact_extraction import _build_user_message
-from hindsight_api.engine.retain.orchestrator import _resolve_narrator
-
-
-class TestResolveNarrator:
-    def test_suppressed_when_name_equals_bank_id(self):
-        """Auto-create default (name == bank_id) → no narrator, routing key not injected."""
-        bank_id = "my-agent::channel-456::user-789"
-        assert _resolve_narrator(bank_id, bank_id) is None
-
-    def test_explicit_name_passes_through(self):
-        """A human-readable name decoupled from bank_id is used as the narrator."""
-        assert _resolve_narrator("Aria", "my-agent::channel-456::user-789") == "Aria"
-
-    def test_short_name_distinct_from_bank_id(self):
-        assert _resolve_narrator("Aria", "Aria-bank-1") == "Aria"
 
 
 class TestNarratorInjection:
@@ -41,8 +30,7 @@ class TestNarratorInjection:
             agent_name=agent_name,
         )
 
-    def test_no_narrator_line_when_suppressed(self):
-        """agent_name=None (the suppressed case) → no Narrator line, no leaked string."""
+    def test_no_narrator_line_without_explicit_override(self):
         msg = self._msg(None)
         assert "Narrator:" not in msg
 
@@ -59,9 +47,77 @@ class TestNarratorInjection:
         assert "Narrator: Aria" in without_context  # base narrator still present
         assert "Context above takes precedence" not in without_context
 
-    def test_routing_key_never_reaches_prompt_via_resolution(self):
-        """End-to-end of the fix: resolve then build → routing key absent from prompt."""
-        bank_id = "my-agent::channel-456::user-789"
-        msg = self._msg(_resolve_narrator(bank_id, bank_id))
-        assert bank_id not in msg
-        assert "Narrator:" not in msg
+
+def _fact_extraction_prompts(memory: MemoryEngine) -> list[str]:
+    return [
+        message["content"]
+        for call in memory._retain_llm_config.get_mock_calls()
+        if call["scope"] == "retain_extract_facts"
+        for message in call["messages"]
+        if message["role"] == "user"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bank_display_name_not_injected_by_retain(memory: MemoryEngine):
+    bank_id = f"narrator-retain-{uuid.uuid4().hex[:8]}"
+    display_name = "ReviewModelEval0825"
+    request_context = RequestContext()
+
+    try:
+        await memory.update_bank(bank_id, name=display_name, request_context=request_context)
+        memory._retain_llm_config.clear_mock_calls()
+
+        await memory.retain_async(
+            bank_id,
+            "assistant: I scheduled a truck for next Wednesday morning.",
+            context="Conversation between a user and a dispatch assistant.",
+            request_context=request_context,
+        )
+
+        prompts = _fact_extraction_prompts(memory)
+        assert prompts
+        assert all(display_name not in prompt for prompt in prompts)
+        assert all("Narrator:" not in prompt for prompt in prompts)
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_bank_display_name_not_injected_by_dry_run(memory: MemoryEngine):
+    bank_id = f"narrator-dry-run-{uuid.uuid4().hex[:8]}"
+    display_name = "crm_test_env"
+    request_context = RequestContext()
+
+    try:
+        await memory.update_bank(bank_id, name=display_name, request_context=request_context)
+        memory._retain_llm_config.clear_mock_calls()
+
+        await memory.extract_dry_run(
+            bank_id,
+            "assistant: I scheduled a truck for next Wednesday morning.",
+            context="Conversation between a user and a dispatch assistant.",
+            request_context=request_context,
+        )
+
+        prompts = _fact_extraction_prompts(memory)
+        assert prompts
+        assert all(display_name not in prompt for prompt in prompts)
+        assert all("Narrator:" not in prompt for prompt in prompts)
+
+        memory._retain_llm_config.clear_mock_calls()
+        await memory.extract_dry_run(
+            bank_id,
+            "assistant: I scheduled a truck for next Wednesday morning.",
+            context="Conversation between a user and a dispatch assistant.",
+            agent_name="Dispatch",
+            request_context=request_context,
+        )
+
+        explicit_prompts = _fact_extraction_prompts(memory)
+        assert explicit_prompts
+        assert all("Narrator: Dispatch" in prompt for prompt in explicit_prompts)
+        assert all(display_name not in prompt for prompt in explicit_prompts)
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION

## Summary

- Stop inferring the fact-extraction narrator from `banks.name`.
- Keep the deprecated explicit dry-run `agent_name` override working.
- Cover retain and dry-run prompt assembly plus the persisted real-LLM result.

## Validation

- `uv run pytest tests/test_narrator_resolution.py tests/test_extract_dry_run_http.py -q -n 1` (13 passed)
- `uv run pytest tests/test_bank_name_narrator_llm.py -q -n 1` (1 passed)
- `./scripts/hooks/lint.sh`
- `./scripts/hooks/check-unused.sh` (advisory findings only)

Closes https://github.com/vectorize-io/hindsight/issues/3962