### PR TITLE
fix(retain): decouple bank display name from fact extraction narrator

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -10660,7 +10660,7 @@ class MemoryEngine(MemoryEngineInterface):
         Side-effect-free and idempotent.
         """
         from .response_models import ExtractedFact
-        from .retain import bank_utils, fact_extraction
+        from .retain import fact_extraction
 
         # Resolve the tenant schema before touching any bank-scoped data (config, bank profile).
         await self._authenticate_tenant(request_context)
@@ -10674,14 +10674,6 @@ class MemoryEngine(MemoryEngineInterface):
                     f"Unsupported extraction override '{key}'. Allowed: {sorted(self._EXTRACTION_OVERRIDE_FIELDS)}"
                 )
             setattr(resolved_config, key, value)
-
-        backend = await self._get_backend()
-        # Narrator primes the "Narrator:" line in the prompt. Dry-run must not
-        # create a bank just to resolve that optional display name.
-        if agent_name is None:
-            profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
-            profile_name = profile["name"] if profile is not None else bank_id
-            agent_name = None if profile_name == bank_id else profile_name
 
         retain_llm = self._retain_llm_config.with_config(resolved_config, bank_id=bank_id, operation="retain")
         facts, _chunks, usage = await fact_extraction.extract_facts_from_text(

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -27,7 +27,6 @@ from ...metrics import get_metrics_collector
 from ...worker.stage import set_stage
 from ..db_utils import acquire_with_retry
 from ..memory_engine import count_tokens, fq_table
-from . import bank_utils
 
 
 @dataclass
@@ -343,32 +342,6 @@ async def _record_retain_document_outcome(pool: Any, bank_id: str, document_id: 
         get_metrics_collector().record_retain_document(bank_id=bank_id, memory_unit_count=total)
     except Exception:
         logger.debug("Failed to record retain document outcome metric", exc_info=True)
-
-
-#: "the narrator has not been resolved yet", which `None` cannot mean: `_resolve_narrator`
-#: returns None for a suppressed narrator, so None is a RESOLVED value. Using None as the
-#: sentinel made every recursive call re-resolve -- and re-read the bank row to do it -- for
-#: exactly the banks where the narrator is suppressed, which is the auto-created default.
-_NARRATOR_UNRESOLVED = object()
-
-
-def _resolve_narrator(profile_name: str, bank_id: str) -> str | None:
-    """Resolve the narrator (memory owner) used to prime fact extraction.
-
-    The narrator is injected as a "Narrator: {name}" line in fact extraction and
-    is stamped into the who-dimension of every first-person fact — and the
-    observations later consolidated from those facts. That is correct for a named
-    agent retaining its own logs, but harmful when ``name`` is just the bank_id:
-    on auto-create the bank ``name`` defaults to ``bank_id``, which is typically a
-    routing key (e.g. ``my-agent::channel-456::user-789``), not a speaker. Priming
-    extraction with a routing key embeds that string into stored fact text and
-    pollutes downstream observations (issue #1680). Suppress it in that case.
-
-    Returns the narrator name, or ``None`` to omit the Narrator line entirely.
-    """
-    if profile_name == bank_id:
-        return None
-    return profile_name
 
 
 # What a reprocess must NOT replay, because it supplies its own: `content` is the
@@ -1204,7 +1177,7 @@ async def retain_batch(
     document_body_hash: str | None = None,
     chunk_index_offset: int = 0,
     body_accum: "dict[str, DocumentBodyAccumulator] | None" = None,
-    agent_name: "str | None | object" = _NARRATOR_UNRESOLVED,
+    agent_name: str | None = None,
     retain_session=None,
     document_prefetch: "dict[str, dict] | asyncio.Task | None" = None,
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
@@ -1252,20 +1225,6 @@ async def retain_batch(
     log_buffer.append(f"RETAIN_BATCH START: {bank_id}")
     log_buffer.append(f"Batch size: {len(contents_dicts)} content items, {total_chars:,} chars")
     log_buffer.append(f"{'=' * 60}")
-
-    # The bank profile is read for ONE value: the narrator name. A multi-document retain groups
-    # by document and re-enters this function per group (below), so reading it here made it one
-    # read -- and one pooled connection -- PER DOCUMENT rather than per retain. Resolved once by
-    # the outermost call and handed down.
-    #
-    # The sentinel is NOT None: `_resolve_narrator` returns None for a suppressed narrator, so
-    # None is a resolved value and testing for it would re-read on every recursion for precisely
-    # the auto-created banks where suppression applies.
-    if agent_name is _NARRATOR_UNRESOLVED:
-        profile = await bank_utils.get_bank_profile(pool, bank_id)
-        # Suppress the narrator when name == bank_id (auto-create default) — see
-        # _resolve_narrator for why a routing-key narrator pollutes extraction (#1680).
-        agent_name = _resolve_narrator(profile["name"], bank_id)
 
     # Convert dicts to RetainContent objects
     contents = _build_contents(contents_dicts, document_tags)

--- a/hindsight-api-slim/tests/test_narrator_resolution.py
+++ b/hindsight-api-slim/tests/test_narrator_resolution.py
@@ -1,32 +1,17 @@
-"""Narrator resolution + injection (issue #1680).
+"""Narrator injection and bank name decoupling.
 
 The "Narrator: {name}" line in fact extraction is stamped into the who-dimension
-of every first-person fact and the observations derived from them. When the bank
-``name`` is just the bank_id (the auto-create default), that string is a routing
-key, not a speaker, and priming extraction with it pollutes stored fact text.
+of first-person facts when present. Bank profile ``name`` is a display/management
+label (e.g. project name "AuditProject_0825" or routing key "my-agent::123"), NOT an
+agent persona, and must not be injected as a Narrator by default.
 
-These are pure unit tests — no LLM, no DB. They pin the suppression decision and
-that the Narrator line is present/absent accordingly.
+These are pure unit tests — no LLM, no DB. They pin that the Narrator line is
+present/absent accordingly.
 """
 
 from datetime import datetime
 
 from hindsight_api.engine.retain.fact_extraction import _build_user_message
-from hindsight_api.engine.retain.orchestrator import _resolve_narrator
-
-
-class TestResolveNarrator:
-    def test_suppressed_when_name_equals_bank_id(self):
-        """Auto-create default (name == bank_id) → no narrator, routing key not injected."""
-        bank_id = "my-agent::channel-456::user-789"
-        assert _resolve_narrator(bank_id, bank_id) is None
-
-    def test_explicit_name_passes_through(self):
-        """A human-readable name decoupled from bank_id is used as the narrator."""
-        assert _resolve_narrator("Aria", "my-agent::channel-456::user-789") == "Aria"
-
-    def test_short_name_distinct_from_bank_id(self):
-        assert _resolve_narrator("Aria", "Aria-bank-1") == "Aria"
 
 
 class TestNarratorInjection:
@@ -41,12 +26,13 @@ class TestNarratorInjection:
             agent_name=agent_name,
         )
 
-    def test_no_narrator_line_when_suppressed(self):
-        """agent_name=None (the suppressed case) → no Narrator line, no leaked string."""
+    def test_no_narrator_line_by_default(self):
+        """agent_name=None (the default retain case) → no Narrator line."""
         msg = self._msg(None)
         assert "Narrator:" not in msg
 
-    def test_narrator_line_present_for_named_agent(self):
+    def test_narrator_line_present_when_explicitly_supplied(self):
+        """When an explicit agent_name is provided, Narrator line is injected."""
         msg = self._msg("Aria")
         assert "Narrator: Aria" in msg
 
@@ -59,9 +45,9 @@ class TestNarratorInjection:
         assert "Narrator: Aria" in without_context  # base narrator still present
         assert "Context above takes precedence" not in without_context
 
-    def test_routing_key_never_reaches_prompt_via_resolution(self):
-        """End-to-end of the fix: resolve then build → routing key absent from prompt."""
-        bank_id = "my-agent::channel-456::user-789"
-        msg = self._msg(_resolve_narrator(bank_id, bank_id))
-        assert bank_id not in msg
+    def test_project_or_routing_names_never_leak_when_unspecified(self):
+        """Display names (e.g. AuditProject_0825, routing keys) never reach the prompt by default."""
+        msg = self._msg(None, context="user interaction log")
         assert "Narrator:" not in msg
+        assert "AuditProject_0825" not in msg
+        assert "my-agent::channel-456::user-789" not in msg


### PR DESCRIPTION
## Summary

Fixes #3962

This PR decouples `banks.name` (a user-facing display and management label) from the retain extraction pipeline's `agent_name`/`Narrator`.

Previously, when a bank was created with an explicit display name (e.g., `"AuditProject_0825"` or `"crm_test_env"`), `_resolve_narrator` treated this display name as the `Narrator` (agent persona) during fact extraction. Consequently, the LLM was prompted that the agent was named after the bank project, leading it to attribute assistant actions to that project name in fact `who` fields (`Involving: AuditProject_0825 (dispatch), user`), permanently polluting stored memory units and graph entity links.

---

## Architecture & Data Flow Comparison

### Before (Conflated Bank Name & Extraction Narrator)

```mermaid
graph TD
    A["Client Retain Request"] --> B["orchestrator.retain_batch"]
    B --> C["Fetch banks.name via bank_utils.get_bank_profile"]
    C --> D{"name == bank_id ?"}
    D -- "Yes (Auto-created)" --> E["Suppress Narrator"]
    D -- "No (Explicit Display Name)" --> F["agent_name = profile['name']"]
    F --> G["Inject into Prompt:<br/>Narrator: AuditProject_0825 (the AI agent whose memory this is)..."]
    G --> H["LLM Fact Extraction"]
    H --> I["❌ Leakage:<br/>Involving: AuditProject_0825 (assistant_role), user"]
    I --> J["Polluted Memory Units & Knowledge Graph"]
```

### After (Clean Decoupling & Direct Contextual Attribution)

```mermaid
graph TD
    A["Client Retain Request"] --> B["orchestrator.retain_batch"]
    B --> C["agent_name: None by default (Zero DB queries)"]
    C --> D["Clean Prompt Assembly (No Narrator Line)<br/>Context: Specified via item.context"]
    D --> E["LLM Fact Extraction"]
    E --> F["✅ Clean Extraction:<br/>Involving: assistant_role, user"]
    F --> G["Pristine Memory Units & Knowledge Graph"]
```

---

## Technical Comparison Matrix

| Aspect | Before | After |
| :--- | :--- | :--- |
| **Bank Name Role** | Conflated as both a management display name and the prompt extraction Narrator persona. | Strictly a user-facing metadata and management label. |
| **Speaker Attribution** | Heuristic: if `banks.name != bank_id`, assumed `name` is the AI persona. | Canonical: determined by item-level `context` (or explicit caller `agent_name`). |
| **Database Overhead** | **1 DB query + pool connection** executed on every retain batch purely for narrator lookup. | **0 DB queries**: completely removed from the critical write path. |
| **State Complexity** | Required sentinel object `_NARRATOR_UNRESOLVED` and `_resolve_narrator` heuristics across recursion. | Streamlined: `agent_name: str | None = None` default throughout. |
| **Data Integrity** | Custom bank names (project/env names) leaked into stored memory units and entity graph. | 100% immune to bank display name leakage. |

---

## Technical Changes

### 1. Core Retain Orchestrator (`hindsight_api/engine/retain/orchestrator.py`)
- Removed `_NARRATOR_UNRESOLVED` sentinel object and `_resolve_narrator` heuristic function.
- Removed unused `from . import bank_utils` import.
- Changed default in `retain_batch` to `agent_name: str | None = None`.
- Removed `await bank_utils.get_bank_profile(pool, bank_id)` from `retain_batch`, eliminating unnecessary database I/O and connection slot usage.

### 2. Memory Engine Dry-Run (`hindsight_api/engine/memory_engine.py`)
- In `extract_dry_run`, removed the fallback that fetched `profile["name"]` when `agent_name is None`.
- Kept `agent_name` as an optional explicit parameter for callers who explicitly supply it.

### 3. Automated Test Suite (`tests/test_narrator_resolution.py`)
- Updated unit tests to assert:
  - Default retain (`agent_name=None`) produces no `Narrator:` line in prompt.
  - Explicit `agent_name="Aria"` injects `Narrator: Aria`.
  - Context precedence clause applies when context is present.
  - Display and routing names (e.g., `"AuditProject_0825"`, `"my-agent::123"`) never leak into prompt by default.

---

## Verification

- **Unit Tests**: `uv run pytest tests/test_narrator_resolution.py -v` (4 passed in 4.06s)
- **Dry-Run HTTP Tests**: `uv run pytest tests/test_extract_dry_run_http.py -v` (8 passed in 84.94s)
- **Linters & Formatters**: `ruff check`, `ruff format`, `ty check`, `./scripts/hooks/lint.sh` all passed cleanly.
