### PR TITLE
config: keep the hot path cached; freshness belongs to the caller that needs it

### DIFF
--- a/hindsight-api-slim/hindsight_api/config_resolver.py
+++ b/hindsight-api-slim/hindsight_api/config_resolver.py
@@ -230,7 +230,9 @@ class ConfigResolver:
         )
         return resolved_config
 
-    async def get_bank_config(self, bank_id: str, context: RequestContext | None = None) -> dict[str, Any]:
+    async def get_bank_config(
+        self, bank_id: str, context: RequestContext | None = None, *, cached: bool = True
+    ) -> dict[str, Any]:
         """
         Get fully resolved config for a bank (filtered by permissions).
 
@@ -239,11 +241,15 @@ class ConfigResolver:
         2. Tenant config overrides (from TenantExtension.get_tenant_config())
         3. Bank config overrides (from banks.config JSONB)
 
-        Note: the bank's stored overrides are read fresh on every call (``cached=False`` below),
-        not through the per-process cache, to ensure consistency across multiple API servers.
-        This is the endpoint a caller reads back after editing a bank's config, and the cache is
-        per process — so a cached read here answers a successful write with the values it just
-        replaced, on whichever pod did not serve the write.
+        ``cached`` defaults to True because this is ALSO on the hot path: ``recall_async`` and
+        ``retain_batch_async`` call it per request, and forcing a read there costs a pool acquire
+        each time — which is more than the query it carries, since the pool runs five
+        ``set_config`` calls on checkout and a ``RESET ALL`` on release.
+
+        The endpoint a user reads a bank's config back through passes ``cached=False``, and must:
+        the cache is per PROCESS, so a cached read there answers a successful write with the
+        values it just replaced, on whichever pod did not serve the write. Freshness is a property
+        of THAT caller, not of this method.
 
         SECURITY:
         - Only returns configurable fields (excludes static/infrastructure fields)
@@ -258,7 +264,7 @@ class ConfigResolver:
             Dict of allowed configurable fields only (never includes credentials or static fields)
         """
         # Resolve full config with all hierarchical overrides
-        resolved_config = await self.resolve_full_config(bank_id, context, cached=False)
+        resolved_config = await self.resolve_full_config(bank_id, context, cached=cached)
         config_dict = asdict(resolved_config)
 
         # SECURITY: drop static/infrastructure + credential fields, then permission-filter.

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -12178,10 +12178,11 @@ class MemoryEngine(MemoryEngineInterface):
         request_context: "RequestContext",
     ) -> BankConfigState:
         """Load config after the caller has established tenant and operation access."""
-        config = await self._config_resolver.get_bank_config(bank_id, request_context)
-        # Fresh, like the resolved config above: `overrides` is what the UI renders as "Bank
-        # override", so a cached read here answers a successful config edit with the values it
-        # replaced on any pod that did not serve the write.
+        # Both fresh: this is what the bank-config ENDPOINT answers with, and `overrides` is what
+        # the UI renders as "Bank override". A cached read here answers a successful config edit
+        # with the values it replaced, on any pod that did not serve the write. The hot-path
+        # callers (`recall_async`, `retain_batch_async`) take the cached default instead.
+        config = await self._config_resolver.get_bank_config(bank_id, request_context, cached=False)
         overrides = await self._config_resolver._load_bank_config(bank_id, cached=False)
         return BankConfigState(config=config, overrides=overrides)
 

--- a/hindsight-api-slim/tests/test_bank_info_cache_invalidation.py
+++ b/hindsight-api-slim/tests/test_bank_info_cache_invalidation.py
@@ -102,3 +102,42 @@ async def test_a_config_read_back_does_not_go_through_the_cache(memory: MemoryEn
         "value it replaced on any pod that did not serve the write"
     )
     assert state.config.get("retain_chunk_size") == 4321, "the resolved config came from the cache too"
+
+
+@pytest.mark.asyncio
+async def test_recall_reads_its_config_through_the_cache(memory: MemoryEngine, request_context):
+    """Freshness belongs to the caller that needs it, not to `get_bank_config` itself.
+
+    `recall_async` and `retain_batch_async` resolve the bank's config per request. Making the
+    method itself uncached to fix read-your-writes on the CONFIG ENDPOINT put a pool acquire on
+    both hot paths -- and an acquire costs more than the query it carries, because the pool runs
+    five `set_config` calls on checkout and a `RESET ALL` on release.
+
+    Asserted as the property (a warm second read issues no query) rather than by counting call
+    sites, so a new hot-path caller that forces a read fails here.
+    """
+    bank_id = _bank("cache_hot_path")
+    await memory.get_bank_profile(bank_id, request_context=request_context, create_if_missing=True)
+
+    resolver = memory._config_resolver
+    await resolver.get_bank_config(bank_id, request_context)  # warm
+
+    reads = 0
+    original = resolver._load_bank_config
+
+    async def _counting(bank, *, cached=True):
+        nonlocal reads
+        if not cached:
+            reads += 1
+        return await original(bank, cached=cached)
+
+    resolver._load_bank_config = _counting
+    try:
+        await resolver.get_bank_config(bank_id, request_context)
+    finally:
+        resolver._load_bank_config = original
+
+    assert reads == 0, (
+        "get_bank_config forced an uncached bank-config read; recall and retain call this per "
+        "request, so that is a pool acquire on every one of them"
+    )


### PR DESCRIPTION
Follow-up to #3952, which I got one level too high.

#3952 fixed read-your-writes on the bank-config endpoint by making `ConfigResolver.get_bank_config` read uncached. But that method is not only the endpoint's — **`recall_async` and `retain_batch_async` call it per request**. So every recall and every retain gained an uncached `SELECT config FROM banks WHERE bank_id = $1`.

That is not one cheap query. Each one takes a pool acquire, and an acquire costs more than the query it carries: the pool runs five `set_config` calls on checkout and a `RESET ALL` on release. Removing exactly that acquire is the reason the cache exists.

## Fix

`cached` defaults to True. Freshness is opted into by the caller that needs it — `_get_bank_config_authenticated`, which is what the endpoint answers with. Its `overrides` read was already explicit; now the resolved config beside it is too.

## Test

`test_recall_reads_its_config_through_the_cache` asserts the property (a warm read issues no query) rather than counting call sites, so a new hot-path caller that forces a read fails there.

Verified by mutation: restore the unconditional `cached=False` and the new test fails **while the read-your-writes test still passes** — that pair is what has to hold.

Found while answering how much the recall path spends in Postgres: measured on dev it is ~0 (`backend_acquisition=0ms`, `hydrate_results=0ms` across sampled `[phases]` lines), and #3952 would have changed that.

https://claude.ai/code/session_01V3ViCQDM6pPSCfntZam3Kg