### PR TITLE
metrics: time the operation-validator hooks, which run outside the operation's timer

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -2309,8 +2309,13 @@ class MemoryEngine(MemoryEngineInterface):
         # initialize encoding eagerly to avoid delaying the first time
         get_token_encoding()
 
-        # Store operation validator extension (optional)
-        self._operation_validator = operation_validator
+        # Store operation validator extension (optional). Wrapped so every hook is timed: the
+        # validator runs outside the operation's own timer, so nothing else can see what it costs.
+        # Done here, once, rather than at each call site -- the interface has nineteen hooks and a
+        # hand-instrumented one is a hook that silently loses its timing the next time one is added.
+        from ..extensions.validator_instrumentation import instrument_operation_validator
+
+        self._operation_validator = instrument_operation_validator(operation_validator)
 
         # Store tenant extension (always set, use default if none provided)
         if tenant_extension is None:

--- a/hindsight-api-slim/hindsight_api/extensions/validator_instrumentation.py
+++ b/hindsight-api-slim/hindsight_api/extensions/validator_instrumentation.py
@@ -47,6 +47,8 @@ _HOOK_PREFIXES = ("validate_", "on_", "precheck", "filter_")
 def _is_hook(name: str, attr: Any) -> bool:
     if name.startswith("_"):
         return False
+    if hasattr(attr, "__wrapped__"):  # already timed (a validator wrapped without being tracked)
+        return False
     if not any(name == p or name.startswith(p) for p in _HOOK_PREFIXES):
         return False
     return inspect.iscoroutinefunction(attr)
@@ -60,7 +62,14 @@ def instrument_operation_validator(validator: T) -> T:
     """
     if validator is None:
         return validator
-    if validator in _INSTRUMENTED:
+    # Instrumenting must never be the thing that breaks the engine it measures: the extension is
+    # loaded from an env var and is someone else's class, so an unhashable, weakref-less or
+    # slotted one degrades to "not timed" rather than failing construction.
+    try:
+        if validator in _INSTRUMENTED:
+            return validator
+    except TypeError:  # unhashable extension -- cannot be tracked, so cannot be wrapped safely
+        logger.debug("operation validator is not hashable; hooks left untimed")
         return validator
 
     wrapped = 0
@@ -71,10 +80,17 @@ def instrument_operation_validator(validator: T) -> T:
             continue
         if not _is_hook(name, attr):
             continue
-        setattr(validator, name, _timed(name, attr))
+        try:
+            setattr(validator, name, _timed(name, attr))
+        except (AttributeError, TypeError):  # __slots__ or a read-only attribute
+            logger.debug("could not instrument hook %s", name)
+            continue
         wrapped += 1
 
-    _INSTRUMENTED.add(validator)
+    try:
+        _INSTRUMENTED.add(validator)
+    except TypeError:  # not weak-referenceable: wrapping stands, idempotence is by __wrapped__
+        pass
     logger.debug("instrumented %d operation-validator hooks on %s", wrapped, type(validator).__name__)
     return validator
 
@@ -86,11 +102,11 @@ def _timed(hook_name: str, fn):
 
     @functools.wraps(fn)
     async def _wrapper(*args, **kwargs):
-        started = time.time()
+        started = time.perf_counter()
         try:
             return await fn(*args, **kwargs)
         finally:
-            _record(operation, hook, time.time() - started)
+            _record(operation, hook, time.perf_counter() - started)
 
     # `functools.wraps` sets `__wrapped__`, which is what makes a wrapped hook identifiable --
     # both to `inspect.signature` and to the test that asserts every hook is covered.

--- a/hindsight-api-slim/hindsight_api/extensions/validator_instrumentation.py
+++ b/hindsight-api-slim/hindsight_api/extensions/validator_instrumentation.py
@@ -1,0 +1,120 @@
+"""Time every operation-validator hook, without naming any of them.
+
+The validator runs OUTSIDE the operation's own timer: `validate_*` before the work starts,
+`on_*_complete` after it ends. A recall's ``[phases]`` line measures the inner search, so whatever
+the validator does is not in it — and the line reads as complete (``accounted=427ms of 433ms``),
+which is what makes the gap easy to miss rather than obvious.
+
+That is not a small omission. A validator may reach a database on every hook: the credits
+validator reads an org row and a pricing table on the control pool, uncached, before AND after,
+then writes the charge. All of it inline, none of it visible.
+
+**Wrapped once, here, rather than timed at each call site.** The interface has nineteen hooks and
+the engine calls them from many places; hand-instrumenting them means the next hook is added
+without timing and nobody notices, which is exactly how this gap appeared. Wrapping the instance
+means a new hook is covered the day it exists, and a hook the engine forgets to call is visible
+by its absence rather than by its silence.
+
+The wrapper is applied to the INSTANCE, not by subclassing or proxying, so `isinstance` checks,
+attribute access and any non-hook methods behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+import time
+import weakref
+from typing import Any, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+#: Which validators have been wrapped. A WeakSet rather than a flag ON the instance: the extension
+#: is someone else's object, and instrumentation should not leave an attribute on it that its own
+#: code (or a serializer, or a test asserting on its shape) can trip over. Weak, so wrapping does
+#: not keep a discarded extension alive.
+_INSTRUMENTED: "weakref.WeakSet[Any]" = weakref.WeakSet()
+
+#: Hooks are recognised by shape, not by a list: an async method whose name says it validates or
+#: reports completion. A list would be one more thing to update, which is the failure this module
+#: exists to prevent.
+_HOOK_PREFIXES = ("validate_", "on_", "precheck", "filter_")
+
+
+def _is_hook(name: str, attr: Any) -> bool:
+    if name.startswith("_"):
+        return False
+    if not any(name == p or name.startswith(p) for p in _HOOK_PREFIXES):
+        return False
+    return inspect.iscoroutinefunction(attr)
+
+
+def instrument_operation_validator(validator: T) -> T:
+    """Wrap every hook on ``validator`` so its duration is recorded. Returns the same object.
+
+    Safe to call on None (returns None) and idempotent: a validator already wrapped is left
+    alone, so constructing two engines over one extension does not double-count.
+    """
+    if validator is None:
+        return validator
+    if validator in _INSTRUMENTED:
+        return validator
+
+    wrapped = 0
+    for name in dir(validator):
+        try:
+            attr = getattr(validator, name)
+        except Exception:  # a property that raises is not a hook
+            continue
+        if not _is_hook(name, attr):
+            continue
+        setattr(validator, name, _timed(name, attr))
+        wrapped += 1
+
+    _INSTRUMENTED.add(validator)
+    logger.debug("instrumented %d operation-validator hooks on %s", wrapped, type(validator).__name__)
+    return validator
+
+
+def _timed(hook_name: str, fn):
+    """Wrap one hook. Timed in a `finally`, so a hook that REJECTS is measured too — that is the
+    402 path, and it is the whole cost the caller pays."""
+    operation, hook = _split(hook_name)
+
+    @functools.wraps(fn)
+    async def _wrapper(*args, **kwargs):
+        started = time.time()
+        try:
+            return await fn(*args, **kwargs)
+        finally:
+            _record(operation, hook, time.time() - started)
+
+    # `functools.wraps` sets `__wrapped__`, which is what makes a wrapped hook identifiable --
+    # both to `inspect.signature` and to the test that asserts every hook is covered.
+    return _wrapper
+
+
+def _split(hook_name: str) -> tuple[str, str]:
+    """``validate_recall`` -> ("recall", "pre"); ``on_recall_complete`` -> ("recall", "post").
+
+    The pair matters more than the name: a pre-check and a post-charge fail differently and are
+    fixed differently, so they must not share a series.
+    """
+    if hook_name.startswith("validate_"):
+        return hook_name[len("validate_") :], "pre"
+    if hook_name.startswith("on_") and hook_name.endswith("_complete"):
+        return hook_name[len("on_") : -len("_complete")], "post"
+    return hook_name, "other"
+
+
+def _record(operation: str, hook: str, seconds: float) -> None:
+    # Instrumentation must never be the thing that fails the request it measures.
+    try:
+        from ..metrics import get_metrics_collector
+
+        get_metrics_collector().record_validator_phase(operation, hook, seconds)
+    except Exception:
+        logger.debug("validator phase metrics not recorded", exc_info=True)

--- a/hindsight-api-slim/hindsight_api/metrics.py
+++ b/hindsight-api-slim/hindsight_api/metrics.py
@@ -304,6 +304,10 @@ class MetricsCollectorBase:
         """Record one phase of a retain."""
         raise NotImplementedError
 
+    def record_validator_phase(self, operation: str, hook: str, seconds: float):
+        """Record one operation-validator hook (`hook` is "pre" or "post")."""
+        raise NotImplementedError
+
     def record_loop_stall(self, stall_seconds: float):
         """Record a detected event-loop stall (blocked longer than the watchdog threshold)."""
         raise NotImplementedError
@@ -370,6 +374,9 @@ class NoOpMetricsCollector(MetricsCollectorBase):
         pass
 
     def record_retain_phase(self, phase: str, seconds: float, calls: int = 1, store: str = ""):
+        pass
+
+    def record_validator_phase(self, operation: str, hook: str, seconds: float):
         pass
 
     def record_loop_stall(self, stall_seconds: float):
@@ -491,6 +498,22 @@ class MetricsCollector(MetricsCollectorBase):
         self.retain_phase_calls = self.meter.create_counter(
             name="hindsight.retain.phase.calls",
             description="Number of times a retain phase ran -- the round-trip count per phase",
+            unit="calls",
+        )
+        # The operation validator runs OUTSIDE the recall/retain timers -- `validate_*` before the
+        # work starts and `on_*_complete` after it ends -- so whatever it does is invisible in the
+        # `[phases]` accounting, which measures only the inner search. A validator that reaches a
+        # database (billing does: an org row and a pricing table, uncached, on a small control
+        # pool) is then latency nobody can see. Labelled by hook so the pre-check and the
+        # post-charge are separable: they fail differently and are fixed differently.
+        self.validator_phase_duration = self.meter.create_histogram(
+            name="hindsight.validator.phase.duration",
+            description="Time in an operation-validator hook, which runs outside the operation's own timer",
+            unit="s",
+        )
+        self.validator_phase_calls = self.meter.create_counter(
+            name="hindsight.validator.phase.calls",
+            description="Number of operation-validator hook invocations",
             unit="calls",
         )
         self.event_loop_stalls = self.meter.create_counter(
@@ -752,6 +775,12 @@ class MetricsCollector(MetricsCollectorBase):
             attrs["store"] = store
         self.retain_phase_duration.record(seconds, attrs)
         self.retain_phase_calls.add(calls, attrs)
+
+    def record_validator_phase(self, operation: str, hook: str, seconds: float):
+        """Record one operation-validator hook. `hook` is "pre" or "post"."""
+        attrs = {"operation": operation, "hook": hook, "tenant": _get_tenant()}
+        self.validator_phase_duration.record(seconds, attrs)
+        self.validator_phase_calls.add(1, attrs)
 
     def record_loop_stall(self, stall_seconds: float):
         """Record a detected event-loop stall. Called from the watchdog thread."""

--- a/hindsight-api-slim/tests/test_validator_phase_instrumentation.py
+++ b/hindsight-api-slim/tests/test_validator_phase_instrumentation.py
@@ -1,0 +1,152 @@
+"""Every operation-validator hook is timed, and none of them had to be named to get there.
+
+The validator runs OUTSIDE the operation's own timer — `validate_*` before the work starts,
+`on_*_complete` after it ends — while a recall's ``[phases]`` line measures only the inner search.
+So a validator that reaches a database is latency nothing accounts for, and the ``[phases]`` line
+still reads as complete, which is what makes the gap easy to miss.
+
+The interface has nineteen hooks. These assert the STRUCTURAL property — every one is wrapped —
+rather than checking the handful that exist today, because the failure this guards against is a
+twentieth hook added later with no timing and nobody noticing.
+"""
+
+import inspect
+
+import pytest
+
+from hindsight_api.extensions.operation_validator import OperationValidatorExtension
+from hindsight_api.extensions.validator_instrumentation import instrument_operation_validator
+
+
+class _Collector:
+    def __init__(self):
+        self.recorded: list[tuple[str, str, float]] = []
+
+    def record_validator_phase(self, operation: str, hook: str, seconds: float) -> None:
+        self.recorded.append((operation, hook, seconds))
+
+
+@pytest.fixture
+def collector(monkeypatch):
+    c = _Collector()
+    import hindsight_api.metrics as m
+
+    monkeypatch.setattr(m, "get_metrics_collector", lambda: c)
+    return c
+
+
+class _Validator(OperationValidatorExtension):
+    """Implements only what the interface makes abstract and inherits the rest — the shape of a
+    real extension, which overrides a couple of hooks and leaves the other seventeen defaulted."""
+
+    name = "test-validator"
+
+    async def validate_retain(self, ctx):
+        return None
+
+    async def validate_recall(self, ctx):
+        return None
+
+    async def validate_reflect(self, ctx):
+        return None
+
+
+def test_every_hook_on_the_interface_is_instrumented():
+    """The property, not a list. A hook added to the interface is covered the day it exists.
+
+    "Hook" is defined HERE, independently: every public coroutine method the interface declares.
+    Asking the instrumentation's own predicate what counts would make this circular -- narrow the
+    predicate and the expectation narrows with it, so the test keeps passing while coverage
+    shrinks. It did exactly that until this was rewritten.
+    """
+    v = instrument_operation_validator(_Validator({}))
+
+    hooks = {
+        n
+        for n in dir(OperationValidatorExtension)
+        if not n.startswith("_") and inspect.iscoroutinefunction(getattr(OperationValidatorExtension, n, None))
+    }
+    assert len(hooks) > 10, f"only found {len(hooks)} hooks — has the interface moved?"
+
+    missed = [n for n in sorted(hooks) if not hasattr(getattr(v, n), "__wrapped__")]
+    assert missed == [], f"these hooks are not timed: {missed}"
+
+
+@pytest.mark.asyncio
+async def test_a_hook_records_its_operation_and_side(collector):
+    v = instrument_operation_validator(_Validator({}))
+
+    await v.validate_recall(None)
+    await v.on_recall_complete(None)
+
+    assert [(op, hook) for op, hook, _ in collector.recorded] == [
+        ("recall", "pre"),
+        ("recall", "post"),
+    ], "pre and post must not share a series: they fail differently and are fixed differently"
+
+
+@pytest.mark.asyncio
+async def test_a_rejecting_hook_is_still_timed(collector):
+    """The 402 path. A hook that refuses is the whole cost the caller pays, so leaving it
+    unmeasured hides exactly the request someone complains about."""
+
+    class _Rejects(_Validator):
+        async def validate_retain(self, ctx):
+            raise RuntimeError("insufficient credits")
+
+    v = instrument_operation_validator(_Rejects({}))
+    with pytest.raises(RuntimeError):
+        await v.validate_retain(None)
+
+    assert [(op, hook) for op, hook, _ in collector.recorded] == [("retain", "pre")]
+
+
+@pytest.mark.asyncio
+async def test_an_override_is_wrapped_not_bypassed(collector):
+    """A real extension overrides a couple of hooks. Wrapping must reach the OVERRIDE, not the
+    interface default it replaced, or the one hook that does work is the one not measured."""
+    calls = []
+
+    class _Overrides(_Validator):
+        async def validate_recall(self, ctx):
+            calls.append("mine")
+            return None
+
+    v = instrument_operation_validator(_Overrides({}))
+    await v.validate_recall(None)
+
+    assert calls == ["mine"], "the wrapper replaced the override instead of wrapping it"
+    assert [(op, hook) for op, hook, _ in collector.recorded] == [("recall", "pre")]
+
+
+def test_wrapping_is_idempotent():
+    """Two engines over one extension must not double-count."""
+    v = _Validator({})
+    instrument_operation_validator(v)
+    once = v.validate_recall
+    instrument_operation_validator(v)
+    assert v.validate_recall is once, "a second wrap would double-count every hook"
+
+
+def test_none_is_left_alone():
+    assert instrument_operation_validator(None) is None
+
+
+@pytest.mark.asyncio
+async def test_a_broken_collector_cannot_break_the_request(monkeypatch):
+    """Instrumentation must never be the thing that fails the operation it measures."""
+    import hindsight_api.metrics as m
+
+    monkeypatch.setattr(m, "get_metrics_collector", lambda: (_ for _ in ()).throw(RuntimeError("down")))
+
+    v = instrument_operation_validator(_Validator({}))
+    await v.validate_recall(None)  # must not raise
+
+
+def test_non_hooks_are_untouched():
+    """Only coroutine hooks are wrapped; ordinary attributes and sync helpers keep their identity."""
+    v = _Validator({})
+    before = v.name
+    instrument_operation_validator(v)
+    assert v.name == before
+    assert not inspect.iscoroutinefunction(getattr(v, "name", None))

--- a/hindsight-api-slim/tests/test_validator_phase_instrumentation.py
+++ b/hindsight-api-slim/tests/test_validator_phase_instrumentation.py
@@ -150,3 +150,18 @@ def test_non_hooks_are_untouched():
     instrument_operation_validator(v)
     assert v.name == before
     assert not inspect.iscoroutinefunction(getattr(v, "name", None))
+
+
+@pytest.mark.asyncio
+async def test_an_unwrappable_validator_does_not_break_construction(collector):
+    """The extension is loaded from an env var and is someone else's class. Instrumentation must
+    degrade to "not timed" rather than fail the engine that takes it."""
+
+    class _Unhashable(_Validator):
+        __hash__ = None  # type: ignore[assignment]
+
+    v = _Unhashable({})
+    assert instrument_operation_validator(v) is v
+
+    await v.validate_recall(None)  # still callable, simply untimed
+    assert collector.recorded == []


### PR DESCRIPTION
A recall's `[phases]` line accounts for its whole duration — `accounted=427ms of 433ms` is typical — and that is exactly what made this hard to see.

The line measures the **inner** search (`_search_with_retries`, which owns `recall_start`), while `validate_recall` and `on_recall_complete` run in `recall_async` on either side of it. So everything the validator does falls outside the number, and an instrument that reads as complete is covering a fraction of the request.

## Why it matters

Not hypothetical. The credits validator reaches the **control** database on both hooks, uncached:

| when | queries |
|---|---|
| `validate_recall` | org row + the whole `billing_config` table |
| `on_recall_complete` | the same two again, then the balance `UPDATE` + ledger `INSERT` |

Five queries on a `max_size=10` pool — the pool auth shares and caches for exactly this reason — all `await`ed inline, none of it visible in any existing instrument.

## Wrapped once, not timed per call site

The interface has **nineteen hooks**, called from many places in the engine. Hand-instrumenting the two that prompted this leaves the other seventeen dark, and guarantees the twentieth is added with no timing and nobody notices — which is how this gap appeared in the first place.

So the extension is wrapped once where the engine takes it. A new hook is covered the day it exists, and hooks are recognised by shape rather than from a list, for the same reason.

Details that matter:
- Applied to the **instance**, so `isinstance`, attribute access and non-hook methods are unchanged.
- Idempotence tracked in a `WeakSet`, not a flag on the extension — it's someone else's object and shouldn't carry an attribute its own code can trip over.
- Wraps an **override**, not the default it replaced. The overridden hook is the one doing work.
- Timed in a `finally`, so a **rejecting** hook is measured — the 402 path is the entire cost that caller pays.
- A metrics backend that is down cannot fail the request it measures.

## On the test

`test_every_hook_on_the_interface_is_instrumented` defines "hook" **independently** of the instrumentation's own predicate. Asking that predicate would be circular — narrow it and the expectation narrows with it, so the test passes while coverage silently shrinks.

It did exactly that until rewritten. Verified by mutation: drop `on_` from the wrapper's prefixes and the guard now names all nine hooks it would have missed.

https://claude.ai/code/session_01V3ViCQDM6pPSCfntZam3Kg