### PR TITLE
fix(retain): stop deriving the extraction narrator from the bank's display name (#3962)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -10680,9 +10680,9 @@ class MemoryEngine(MemoryEngineInterface):
             text=content,
             event_date=event_date,
             llm_config=retain_llm,
-            agent_name=agent_name or "",
             config=resolved_config,
             context=context,
+            agent_name=agent_name,
         )
 
         extracted = [

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -10657,9 +10657,9 @@ class MemoryEngine(MemoryEngineInterface):
         Side-effect-free and idempotent.
         """
         from .response_models import ExtractedFact
-        from .retain import bank_utils, fact_extraction
+        from .retain import fact_extraction
 
-        # Resolve the tenant schema before touching any bank-scoped data (config, bank profile).
+        # Resolve the tenant schema before touching any bank-scoped data (config).
         await self._authenticate_tenant(request_context)
         resolved_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
         if self._llm_config.provider == "none":
@@ -10672,14 +10672,9 @@ class MemoryEngine(MemoryEngineInterface):
                 )
             setattr(resolved_config, key, value)
 
-        backend = await self._get_backend()
-        # Narrator primes the "Narrator:" line in the prompt. Dry-run must not
-        # create a bank just to resolve that optional display name.
-        if agent_name is None:
-            profile = await bank_utils.get_bank_profile_if_exists(backend, bank_id)
-            profile_name = profile["name"] if profile is not None else bank_id
-            agent_name = None if profile_name == bank_id else profile_name
-
+        # No narrator unless the caller passed one. The bank's display `name` is deliberately
+        # NOT consulted: it leaked into extracted fact text (#3962), and retain no longer
+        # derives a narrator from it either, so a dry run must mirror what retain would do.
         retain_llm = self._retain_llm_config.with_config(resolved_config, bank_id=bank_id, operation="retain")
         facts, _chunks, usage = await fact_extraction.extract_facts_from_text(
             text=content,

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1559,7 +1559,7 @@ async def _extract_facts_from_chunk(
     context: str,
     llm_config: "LLMConfig",
     config,
-    agent_name: str = None,
+    agent_name: str | None = None,
     metadata: dict[str, str] | None = None,
 ) -> tuple[list[dict[str, str]], TokenUsage]:
     """
@@ -1963,7 +1963,7 @@ async def _extract_facts_with_auto_split(
     context: str,
     llm_config: LLMConfig,
     config,
-    agent_name: str = None,
+    agent_name: str | None = None,
     metadata: dict[str, str] | None = None,
 ) -> tuple[list[dict[str, str]], TokenUsage]:
     """
@@ -2069,10 +2069,10 @@ async def extract_facts_from_text(
     text: str,
     event_date: datetime | None,
     llm_config: LLMConfig,
-    agent_name: str,
     config,
     context: str = "",
     metadata: dict[str, str] | None = None,
+    agent_name: str | None = None,
 ) -> tuple[list[Fact], list[tuple[str, int]], TokenUsage]:
     """
     Extract semantic facts from conversational or narrative text using LLM.
@@ -2087,10 +2087,12 @@ async def extract_facts_from_text(
         text: Input text (conversation, article, etc.)
         event_date: Reference date for resolving relative times
         llm_config: LLM configuration to use
-        agent_name: Agent name (memory owner)
         config: Resolved HindsightConfig for this bank
         context: Context about the conversation/document
         metadata: Optional document metadata key-value pairs
+        agent_name: Optional narrator to prime the prompt with ("Narrator: {name}").
+            Retain never sets it — see the caller in retain/orchestrator.py — and the
+            dry-run endpoint's field that does is deprecated in favour of ``context``.
 
     Returns:
         Tuple of (facts, chunks, usage) where:
@@ -2248,7 +2250,6 @@ async def _write_batch_extraction_errors(
 async def extract_facts_from_contents_batch_api(
     contents: list[RetainContent],
     llm_config,
-    agent_name: str,
     config,
     pool=None,
     operation_id: str | None = None,
@@ -2263,7 +2264,6 @@ async def extract_facts_from_contents_batch_api(
     Args:
         contents: List of RetainContent objects to process
         llm_config: LLM configuration with batch API support
-        agent_name: Name of the agent
         config: Resolved HindsightConfig for this bank
         pool: Database connection pool (for storing batch state)
         operation_id: Async operation ID (for crash recovery)
@@ -2380,7 +2380,6 @@ async def extract_facts_from_contents_batch_api(
                 item.event_date,
                 item.context,
                 item.metadata or None,
-                agent_name,
                 mission_preamble=_retain_mission_preamble(config),
             )
 
@@ -2851,7 +2850,6 @@ def _extract_facts_chunks(
 async def extract_facts_from_contents(
     contents: list[RetainContent],
     llm_config,
-    agent_name: str,
     config,
     pool=None,
     operation_id: str | None = None,
@@ -2871,7 +2869,6 @@ async def extract_facts_from_contents(
     Args:
         contents: List of RetainContent objects to process
         llm_config: LLM configuration for fact extraction
-        agent_name: Name of the agent (for agent-related fact detection)
         config: Resolved HindsightConfig for this bank
         pool: Database connection pool (passed to batch API for state storage)
         operation_id: Async operation ID (passed to batch API for crash recovery)
@@ -2890,9 +2887,7 @@ async def extract_facts_from_contents(
 
     # Route to batch API if enabled
     if config.retain_batch_enabled:
-        return await extract_facts_from_contents_batch_api(
-            contents, llm_config, agent_name, config, pool, operation_id, schema
-        )
+        return await extract_facts_from_contents_batch_api(contents, llm_config, config, pool, operation_id, schema)
 
     # Step 1: Create parallel fact extraction tasks
     fact_extraction_tasks = []
@@ -2903,7 +2898,6 @@ async def extract_facts_from_contents(
             event_date=item.event_date,
             context=item.context,
             llm_config=llm_config,
-            agent_name=agent_name,
             config=config,
             metadata=item.metadata or None,
         )

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -27,7 +27,6 @@ from ...metrics import get_metrics_collector
 from ...worker.stage import set_stage
 from ..db_utils import acquire_with_retry
 from ..memory_engine import count_tokens, fq_table
-from . import bank_utils
 
 
 @dataclass
@@ -343,32 +342,6 @@ async def _record_retain_document_outcome(pool: Any, bank_id: str, document_id: 
         get_metrics_collector().record_retain_document(bank_id=bank_id, memory_unit_count=total)
     except Exception:
         logger.debug("Failed to record retain document outcome metric", exc_info=True)
-
-
-#: "the narrator has not been resolved yet", which `None` cannot mean: `_resolve_narrator`
-#: returns None for a suppressed narrator, so None is a RESOLVED value. Using None as the
-#: sentinel made every recursive call re-resolve -- and re-read the bank row to do it -- for
-#: exactly the banks where the narrator is suppressed, which is the auto-created default.
-_NARRATOR_UNRESOLVED = object()
-
-
-def _resolve_narrator(profile_name: str, bank_id: str) -> str | None:
-    """Resolve the narrator (memory owner) used to prime fact extraction.
-
-    The narrator is injected as a "Narrator: {name}" line in fact extraction and
-    is stamped into the who-dimension of every first-person fact — and the
-    observations later consolidated from those facts. That is correct for a named
-    agent retaining its own logs, but harmful when ``name`` is just the bank_id:
-    on auto-create the bank ``name`` defaults to ``bank_id``, which is typically a
-    routing key (e.g. ``my-agent::channel-456::user-789``), not a speaker. Priming
-    extraction with a routing key embeds that string into stored fact text and
-    pollutes downstream observations (issue #1680). Suppress it in that case.
-
-    Returns the narrator name, or ``None`` to omit the Narrator line entirely.
-    """
-    if profile_name == bank_id:
-        return None
-    return profile_name
 
 
 # What a reprocess must NOT replay, because it supplies its own: `content` is the
@@ -1057,7 +1030,6 @@ async def _delta_store_owned_write(
 async def _extract_and_embed(
     contents: list[RetainContent],
     llm_config,
-    agent_name: str,
     config,
     embeddings_model,
     format_date_fn,
@@ -1075,8 +1047,16 @@ async def _extract_and_embed(
     """
     set_stage("retain.extract_and_embed")
     step_start = time.time()
+    # No narrator. `agent_name` primes a "Narrator: {name}" line that extraction stamps
+    # into the who-dimension of every first-person fact, so whatever is passed here ends up
+    # verbatim in stored fact text. Retain used to pass the bank's `name` — a display label
+    # (#1680 already had to suppress it when it defaulted to the bank_id, itself typically a
+    # routing key), which leaked project/tenant names like "AuditProject_0825" into memories
+    # that never mentioned them (#3962). A caller that genuinely wants to name the speaker
+    # says so in the item's `context`, which extraction already reads and which the dry-run
+    # `agent_name` override is deprecated in favour of.
     extracted_facts, chunks, usage = await fact_extraction.extract_facts_from_contents(
-        contents, llm_config, agent_name, config, pool, operation_id, schema
+        contents, llm_config, None, config, pool, operation_id, schema
     )
     log_buffer.append(
         f"  Extract facts: {len(extracted_facts)} facts, {len(chunks)} chunks "
@@ -1204,7 +1184,6 @@ async def retain_batch(
     document_body_hash: str | None = None,
     chunk_index_offset: int = 0,
     body_accum: "dict[str, DocumentBodyAccumulator] | None" = None,
-    agent_name: "str | None | object" = _NARRATOR_UNRESOLVED,
     retain_session=None,
     document_prefetch: "dict[str, dict] | asyncio.Task | None" = None,
     progress_callback: "Callable[..., Awaitable[None]] | None" = None,
@@ -1252,20 +1231,6 @@ async def retain_batch(
     log_buffer.append(f"RETAIN_BATCH START: {bank_id}")
     log_buffer.append(f"Batch size: {len(contents_dicts)} content items, {total_chars:,} chars")
     log_buffer.append(f"{'=' * 60}")
-
-    # The bank profile is read for ONE value: the narrator name. A multi-document retain groups
-    # by document and re-enters this function per group (below), so reading it here made it one
-    # read -- and one pooled connection -- PER DOCUMENT rather than per retain. Resolved once by
-    # the outermost call and handed down.
-    #
-    # The sentinel is NOT None: `_resolve_narrator` returns None for a suppressed narrator, so
-    # None is a resolved value and testing for it would re-read on every recursion for precisely
-    # the auto-created banks where suppression applies.
-    if agent_name is _NARRATOR_UNRESOLVED:
-        profile = await bank_utils.get_bank_profile(pool, bank_id)
-        # Suppress the narrator when name == bank_id (auto-create default) — see
-        # _resolve_narrator for why a routing-key narrator pollutes extraction (#1680).
-        agent_name = _resolve_narrator(profile["name"], bank_id)
 
     # Convert dicts to RetainContent objects
     contents = _build_contents(contents_dicts, document_tags)
@@ -1366,7 +1331,6 @@ async def retain_batch(
                     # record write per document. Each of those is an append to the namespace's one
                     # WAL head, which concurrent appends contend for.
                     body_accum=body_accum,
-                    agent_name=agent_name,
                     retain_session=retain_session,
                     document_prefetch=document_prefetch,
                 )
@@ -1737,7 +1701,6 @@ async def retain_batch(
             effective_doc_id,
             fact_type_override,
             document_tags,
-            agent_name,
             log_buffer,
             start_time,
             operation_id,
@@ -1808,7 +1771,6 @@ async def retain_batch(
         is_first_batch=is_first_batch,
         fact_type_override=fact_type_override,
         document_tags=document_tags,
-        agent_name=agent_name,
         log_buffer=log_buffer,
         start_time=start_time,
         all_pre_chunks=all_pre_chunks,
@@ -2227,7 +2189,6 @@ async def _streaming_retain_batch(
     is_first_batch: bool,
     fact_type_override: str | None,
     document_tags: list[str] | None,
-    agent_name: str,
     log_buffer: list[str],
     start_time: float,
     all_pre_chunks: list[str],
@@ -2543,7 +2504,6 @@ async def _streaming_retain_batch(
                 extracted, processed, chunk_meta, usage = await _extract_and_embed(
                     [content],
                     llm_config,
-                    agent_name,
                     config,
                     coalescing_embedder,
                     format_date_fn,
@@ -3455,7 +3415,6 @@ async def _try_delta_retain(
     document_id,
     fact_type_override,
     document_tags,
-    agent_name,
     log_buffer,
     start_time,
     operation_id,
@@ -3776,7 +3735,6 @@ async def _try_delta_retain(
         extracted_facts, processed_facts, new_chunk_metadata, usage = await _extract_and_embed(
             delta_contents,
             llm_config,
-            agent_name,
             config,
             embeddings_model,
             format_date_fn,

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -1047,16 +1047,16 @@ async def _extract_and_embed(
     """
     set_stage("retain.extract_and_embed")
     step_start = time.time()
-    # No narrator. `agent_name` primes a "Narrator: {name}" line that extraction stamps
-    # into the who-dimension of every first-person fact, so whatever is passed here ends up
-    # verbatim in stored fact text. Retain used to pass the bank's `name` — a display label
-    # (#1680 already had to suppress it when it defaulted to the bank_id, itself typically a
-    # routing key), which leaked project/tenant names like "AuditProject_0825" into memories
-    # that never mentioned them (#3962). A caller that genuinely wants to name the speaker
-    # says so in the item's `context`, which extraction already reads and which the dry-run
+    # No narrator: extraction takes none from this path at all. A "Narrator: {name}" line is
+    # stamped into the who-dimension of every first-person fact, so whatever primes it ends up
+    # verbatim in stored fact text. Retain used to prime it with the bank's `name` — a display
+    # label (#1680 already had to suppress it when it defaulted to the bank_id, itself typically
+    # a routing key), which leaked project/tenant names like "AuditProject_0825" into memories
+    # that never mentioned them (#3962). A caller that genuinely wants to name the speaker says
+    # so in the item's `context`, which extraction already reads and which the dry-run
     # `agent_name` override is deprecated in favour of.
     extracted_facts, chunks, usage = await fact_extraction.extract_facts_from_contents(
-        contents, llm_config, None, config, pool, operation_id, schema
+        contents, llm_config, config, pool, operation_id, schema
     )
     log_buffer.append(
         f"  Extract facts: {len(extracted_facts)} facts, {len(chunks)} chunks "

--- a/hindsight-api-slim/tests/test_batch_api.py
+++ b/hindsight-api-slim/tests/test_batch_api.py
@@ -181,7 +181,6 @@ async def test_batch_api_normal_flow(mock_llm_config, test_contents, hindsight_c
         facts, chunks, usage = await extract_facts_from_contents_batch_api(
             contents=test_contents,
             llm_config=mock_llm_config,
-            agent_name="test_agent",
             config=hindsight_config,
             pool=None,  # No DB pool for this test
             operation_id=None,
@@ -269,7 +268,6 @@ async def test_batch_api_accepts_top_level_fact_list(mock_llm_config, test_conte
     facts, chunks, usage = await extract_facts_from_contents_batch_api(
         contents=[test_contents[0]],
         llm_config=mock_llm_config,
-        agent_name="test_agent",
         config=hindsight_config,
         pool=None,
         operation_id=None,
@@ -309,7 +307,6 @@ async def test_batch_api_rejects_top_level_non_fact_list(mock_llm_config, test_c
     facts, chunks, usage = await extract_facts_from_contents_batch_api(
         contents=[test_contents[0]],
         llm_config=mock_llm_config,
-        agent_name="test_agent",
         config=hindsight_config,
         pool=None,
         operation_id=None,
@@ -378,7 +375,6 @@ async def test_batch_api_records_schema_drifted_facts_as_extraction_errors(
         facts, chunks, _usage = await extract_facts_from_contents_batch_api(
             contents=[test_contents[0]],
             llm_config=mock_llm_config,
-            agent_name="test_agent",
             config=hindsight_config,
             pool=None,
             operation_id=None,
@@ -446,7 +442,6 @@ async def test_batch_api_recovers_fenced_and_control_char_json(mock_llm_config, 
     facts, chunks, usage = await extract_facts_from_contents_batch_api(
         contents=[test_contents[0]],
         llm_config=mock_llm_config,
-        agent_name="test_agent",
         config=hindsight_config,
         pool=None,
         operation_id=None,
@@ -495,7 +490,6 @@ async def test_batch_api_unparseable_json_still_records_error(mock_llm_config, t
     facts, chunks, usage = await extract_facts_from_contents_batch_api(
         contents=[test_contents[0]],
         llm_config=mock_llm_config,
-        agent_name="test_agent",
         config=hindsight_config,
         pool=None,
         operation_id=None,
@@ -622,7 +616,6 @@ async def test_batch_api_crash_recovery(mock_llm_config, test_contents, hindsigh
         facts, chunks, usage = await extract_facts_from_contents_batch_api(
             contents=test_contents,
             llm_config=mock_llm_config,
-            agent_name="test_agent",
             config=hindsight_config,
             pool=pool,
             operation_id=operation_id,  # Provides crash recovery context
@@ -723,7 +716,6 @@ async def test_batch_api_records_non_fatal_extraction_errors(
         facts, chunks, usage = await extract_facts_from_contents_batch_api(
             contents=test_contents,
             llm_config=mock_llm_config,
-            agent_name="test_agent",
             config=hindsight_config,
             pool=pool,
             operation_id=operation_id,
@@ -767,7 +759,6 @@ async def test_batch_api_raises_for_unsupported_provider(mock_llm_config, test_c
         await extract_facts_from_contents_batch_api(
             contents=test_contents,
             llm_config=mock_llm_config,
-            agent_name="test_agent",
             config=hindsight_config,
             pool=None,
             operation_id=None,
@@ -897,7 +888,6 @@ async def test_batch_api_via_extract_facts_from_contents(
         facts, chunks, usage = await extract_facts_from_contents(
             contents=test_contents,
             llm_config=mock_llm_config,
-            agent_name="test_agent",
             config=hindsight_config,
             pool=None,
             operation_id=None,
@@ -965,7 +955,6 @@ async def test_batch_api_sanitizes_model_authored_text(mock_llm_config, hindsigh
     facts, _chunks, _usage = await extract_facts_from_contents_batch_api(
         contents=[RetainContent(content="Alex laughed at the joke.")],
         llm_config=mock_llm_config,
-        agent_name="test_agent",
         config=hindsight_config,
         pool=None,
         operation_id=None,

--- a/hindsight-api-slim/tests/test_batch_api_integration.py
+++ b/hindsight-api-slim/tests/test_batch_api_integration.py
@@ -163,7 +163,6 @@ async def test_real_openai_batch_api(real_llm_config, test_contents_real, integr
         facts, chunks, usage = await extract_facts_from_contents_batch_api(
             contents=test_contents_real,
             llm_config=real_llm_config,
-            agent_name="test_agent",
             config=integration_config,
             pool=pool,
             operation_id=None,  # No crash recovery for this test

--- a/hindsight-api-slim/tests/test_batch_api_validation.py
+++ b/hindsight-api-slim/tests/test_batch_api_validation.py
@@ -73,7 +73,6 @@ async def test_runtime_raises_if_batch_unsupported() -> None:
         await extract_facts_from_contents_batch_api(
             contents=[RetainContent(content="Alice moved to Paris in 2023.")],
             llm_config=_provider("mock"),
-            agent_name="test_agent",
             config=_config(batch_enabled=True),
             pool=None,
             operation_id=None,

--- a/hindsight-api-slim/tests/test_causal_relation_offsets.py
+++ b/hindsight-api-slim/tests/test_causal_relation_offsets.py
@@ -36,7 +36,6 @@ async def test_causal_targets_are_offset_from_extraction_group_start(monkeypatch
     facts, _, _ = await fact_extraction.extract_facts_from_contents(
         [RetainContent(content="preceding"), RetainContent(content="causal group")],
         llm_config=None,
-        agent_name="test",
         config=config,
     )
 
@@ -70,7 +69,6 @@ async def test_each_chunk_uses_its_own_causal_index_base(monkeypatch):
     facts, _, _ = await fact_extraction.extract_facts_from_contents(
         [RetainContent(content="two chunks")],
         llm_config=None,
-        agent_name="test",
         config=config,
     )
 
@@ -170,7 +168,6 @@ async def test_batch_causal_targets_use_each_chunk_start(monkeypatch):
     facts, _, _ = await fact_extraction.extract_facts_from_contents_batch_api(
         [RetainContent(content="preceding"), RetainContent(content="first|second")],
         llm_config=llm_config,
-        agent_name="test",
         config=config,
     )
 

--- a/hindsight-api-slim/tests/test_experience_fact_type_passthrough.py
+++ b/hindsight-api-slim/tests/test_experience_fact_type_passthrough.py
@@ -48,7 +48,6 @@ async def test_extract_facts_preserves_experience_type():
         facts, _chunks, _usage = await extract_facts_from_contents(
             contents=contents,
             llm_config=None,
-            agent_name="TestAgent",
             config=_get_raw_config(),
         )
 

--- a/hindsight-api-slim/tests/test_fireworks_batch_integration.py
+++ b/hindsight-api-slim/tests/test_fireworks_batch_integration.py
@@ -106,7 +106,6 @@ async def test_real_fireworks_batch_end_to_end(fireworks_env):
     facts, chunks, usage = await extract_facts_from_contents_batch_api(
         contents=contents,
         llm_config=llm_config,
-        agent_name="test_agent",
         config=config,
         pool=None,
         operation_id=None,

--- a/hindsight-api-slim/tests/test_gemini_batch_integration.py
+++ b/hindsight-api-slim/tests/test_gemini_batch_integration.py
@@ -108,7 +108,6 @@ async def test_real_gemini_batch_end_to_end(gemini_env):
     facts, chunks, usage = await extract_facts_from_contents_batch_api(
         contents=contents,
         llm_config=llm_config,
-        agent_name="test_agent",
         config=config,
         pool=None,
         operation_id=None,

--- a/hindsight-api-slim/tests/test_multi_llm_batch.py
+++ b/hindsight-api-slim/tests/test_multi_llm_batch.py
@@ -180,7 +180,6 @@ async def test_batch_lifecycle_runs_entirely_on_the_batch_capable_member() -> No
     await extract_facts_from_contents_batch_api(
         contents=[RetainContent(content="Alice moved to Paris in 2023.")],
         llm_config=_chain(primary, secondary),
-        agent_name="test_agent",
         config=_batch_config(),
         pool=None,
         operation_id=None,
@@ -198,7 +197,6 @@ async def test_batch_request_body_carries_the_serving_members_settings() -> None
     await extract_facts_from_contents_batch_api(
         contents=[RetainContent(content="Alice moved to Paris in 2023.")],
         llm_config=_chain(_BatchMember("deepseek", False), secondary),
-        agent_name="test_agent",
         config=_batch_config(),
         pool=None,
         operation_id=None,
@@ -221,7 +219,6 @@ async def test_resume_polls_the_member_that_submitted_the_batch() -> None:
     await extract_facts_from_contents_batch_api(
         contents=[RetainContent(content="Alice moved to Paris in 2023.")],
         llm_config=_chain(_BatchMember("deepseek", False), secondary),
-        agent_name="test_agent",
         config=_batch_config(),
         pool=pool,
         operation_id=str(uuid.uuid4()),
@@ -246,7 +243,6 @@ async def test_resume_fails_loudly_when_the_chain_no_longer_serves_that_provider
         await extract_facts_from_contents_batch_api(
             contents=[RetainContent(content="Alice moved to Paris in 2023.")],
             llm_config=_chain(_BatchMember("deepseek", False), groq),
-            agent_name="test_agent",
             config=_batch_config(),
             pool=pool,
             operation_id=str(uuid.uuid4()),
@@ -283,7 +279,6 @@ async def test_submit_records_the_account_that_owns_the_batch() -> None:
     await extract_facts_from_contents_batch_api(
         contents=[RetainContent(content="Alice moved to Paris in 2023.")],
         llm_config=_chain(member),
-        agent_name="test_agent",
         config=_batch_config(),
         pool=pool,
         operation_id=str(uuid.uuid4()),
@@ -316,7 +311,6 @@ async def test_resume_polls_the_submitting_account_after_a_same_provider_reorder
     await extract_facts_from_contents_batch_api(
         contents=[RetainContent(content="Alice moved to Paris in 2023.")],
         llm_config=_chain(account_a, account_b),
-        agent_name="test_agent",
         config=_batch_config(),
         pool=pool,
         operation_id=str(uuid.uuid4()),
@@ -343,7 +337,6 @@ async def test_resume_fails_before_polling_when_the_submitting_account_is_gone()
         await extract_facts_from_contents_batch_api(
             contents=[RetainContent(content="Alice moved to Paris in 2023.")],
             llm_config=_chain(account_a),
-            agent_name="test_agent",
             config=_batch_config(),
             pool=pool,
             operation_id=str(uuid.uuid4()),

--- a/hindsight-api-slim/tests/test_narrator_resolution.py
+++ b/hindsight-api-slim/tests/test_narrator_resolution.py
@@ -64,28 +64,34 @@ def _fast_retain_env(monkeypatch):
     clear_config_cache()
 
 
-class _NarratorSpy:
-    """Records the ``agent_name`` retain hands to fact extraction."""
+class _PromptSpy:
+    """Captures every extraction prompt retain builds.
+
+    Asserting on the prompt rather than on an ``agent_name`` argument is deliberate:
+    retain no longer *has* a narrator parameter to inspect, and the prompt is the thing
+    that actually decides what ends up in a fact.
+    """
 
     def __init__(self) -> None:
-        self.narrators: list[object] = []
+        self.messages: list[str] = []
 
     def install(self, monkeypatch) -> None:
-        original = fact_extraction.extract_facts_from_contents
+        original = fact_extraction._build_user_message
 
-        async def _spy(contents, llm_config, agent_name, *args, **kwargs):
-            self.narrators.append(agent_name)
-            return await original(contents, llm_config, agent_name, *args, **kwargs)
+        def _spy(*args, **kwargs):
+            message = original(*args, **kwargs)
+            self.messages.append(message)
+            return message
 
-        monkeypatch.setattr(fact_extraction, "extract_facts_from_contents", _spy)
+        monkeypatch.setattr(fact_extraction, "_build_user_message", _spy)
 
 
 @pytest.mark.asyncio
-async def test_retain_passes_no_narrator_for_a_named_bank(memory, request_context, monkeypatch):
+async def test_retain_primes_no_narrator_for_a_named_bank(memory, request_context, monkeypatch):
     """#3962: a bank named after a project must not prime extraction with that name."""
     bank_id = f"test_narrator_named_bank_{datetime.now(timezone.utc).timestamp()}"
     project_name = "AuditProject_0825"
-    spy = _NarratorSpy()
+    spy = _PromptSpy()
     try:
         await memory.update_bank(bank_id, name=project_name, request_context=request_context)
         spy.install(monkeypatch)
@@ -96,8 +102,10 @@ async def test_retain_passes_no_narrator_for_a_named_bank(memory, request_contex
             request_context=request_context,
         )
 
-        assert spy.narrators, "fact extraction was never called — the test proves nothing"
-        assert all(n is None for n in spy.narrators), f"retain primed extraction with a narrator: {spy.narrators}"
+        assert spy.messages, "no extraction prompt was built — the test proves nothing"
+        for message in spy.messages:
+            assert "Narrator:" not in message, f"retain primed a narrator: {message}"
+            assert project_name not in message, "the bank's display name reached the prompt"
 
         units = await memory.list_memory_units(bank_id, limit=100, request_context=request_context)
         stored = "\n".join(str(u) for u in units["items"])

--- a/hindsight-api-slim/tests/test_narrator_resolution.py
+++ b/hindsight-api-slim/tests/test_narrator_resolution.py
@@ -1,35 +1,32 @@
-"""Narrator resolution + injection (issue #1680).
+"""The bank's display ``name`` never becomes the extraction narrator (issues #1680, #3962).
 
-The "Narrator: {name}" line in fact extraction is stamped into the who-dimension
-of every first-person fact and the observations derived from them. When the bank
-``name`` is just the bank_id (the auto-create default), that string is a routing
-key, not a speaker, and priming extraction with it pollutes stored fact text.
+The "Narrator: {name}" line primes fact extraction to read first-person statements
+as the narrator's own actions, and that name is stamped into the who-dimension of
+every fact it produces — and into the observations later consolidated from them.
 
-These are pure unit tests — no LLM, no DB. They pin the suppression decision and
-that the Narrator line is present/absent accordingly.
+Retain used to derive that narrator from ``banks.name``. But ``name`` is a display
+label: nothing but the bank selector reads it, and callers set it to whatever
+identifies the bank to *them* — a routing key on auto-create (#1680), or a project
+label like ``AuditProject_0825`` (#3962). Either way the string ends up verbatim in
+stored fact text that never mentioned it. Retain now passes no narrator at all; a
+caller who wants to name the speaker says so in the item's ``context``.
+
+``extract_facts_from_text`` still accepts an explicit ``agent_name`` (the dry-run
+endpoint's deprecated override), so the injection itself is still exercised here.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
+import pytest
+
+from hindsight_api.config import clear_config_cache
+from hindsight_api.engine.retain import fact_extraction
 from hindsight_api.engine.retain.fact_extraction import _build_user_message
-from hindsight_api.engine.retain.orchestrator import _resolve_narrator
-
-
-class TestResolveNarrator:
-    def test_suppressed_when_name_equals_bank_id(self):
-        """Auto-create default (name == bank_id) → no narrator, routing key not injected."""
-        bank_id = "my-agent::channel-456::user-789"
-        assert _resolve_narrator(bank_id, bank_id) is None
-
-    def test_explicit_name_passes_through(self):
-        """A human-readable name decoupled from bank_id is used as the narrator."""
-        assert _resolve_narrator("Aria", "my-agent::channel-456::user-789") == "Aria"
-
-    def test_short_name_distinct_from_bank_id(self):
-        assert _resolve_narrator("Aria", "Aria-bank-1") == "Aria"
 
 
 class TestNarratorInjection:
+    """Pure unit tests of the prompt line — no LLM, no DB."""
+
     def _msg(self, agent_name, context="agent log"):
         return _build_user_message(
             chunk="I shipped the fix.",
@@ -41,14 +38,12 @@ class TestNarratorInjection:
             agent_name=agent_name,
         )
 
-    def test_no_narrator_line_when_suppressed(self):
-        """agent_name=None (the suppressed case) → no Narrator line, no leaked string."""
-        msg = self._msg(None)
-        assert "Narrator:" not in msg
+    def test_no_narrator_line_without_a_name(self):
+        """What retain now always passes → no Narrator line, nothing to leak."""
+        assert "Narrator:" not in self._msg(None)
 
     def test_narrator_line_present_for_named_agent(self):
-        msg = self._msg("Aria")
-        assert "Narrator: Aria" in msg
+        assert "Narrator: Aria" in self._msg("Aria")
 
     def test_context_precedence_clause_only_when_context_set(self):
         """The 'Context above takes precedence' clause appears only with a context."""
@@ -59,9 +54,53 @@ class TestNarratorInjection:
         assert "Narrator: Aria" in without_context  # base narrator still present
         assert "Context above takes precedence" not in without_context
 
-    def test_routing_key_never_reaches_prompt_via_resolution(self):
-        """End-to-end of the fix: resolve then build → routing key absent from prompt."""
-        bank_id = "my-agent::channel-456::user-789"
-        msg = self._msg(_resolve_narrator(bank_id, bank_id))
-        assert bank_id not in msg
-        assert "Narrator:" not in msg
+
+@pytest.fixture(autouse=True)
+def _fast_retain_env(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION", "false")
+    monkeypatch.setenv("HINDSIGHT_API_ENABLE_OBSERVATIONS", "false")
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+class _NarratorSpy:
+    """Records the ``agent_name`` retain hands to fact extraction."""
+
+    def __init__(self) -> None:
+        self.narrators: list[object] = []
+
+    def install(self, monkeypatch) -> None:
+        original = fact_extraction.extract_facts_from_contents
+
+        async def _spy(contents, llm_config, agent_name, *args, **kwargs):
+            self.narrators.append(agent_name)
+            return await original(contents, llm_config, agent_name, *args, **kwargs)
+
+        monkeypatch.setattr(fact_extraction, "extract_facts_from_contents", _spy)
+
+
+@pytest.mark.asyncio
+async def test_retain_passes_no_narrator_for_a_named_bank(memory, request_context, monkeypatch):
+    """#3962: a bank named after a project must not prime extraction with that name."""
+    bank_id = f"test_narrator_named_bank_{datetime.now(timezone.utc).timestamp()}"
+    project_name = "AuditProject_0825"
+    spy = _NarratorSpy()
+    try:
+        await memory.update_bank(bank_id, name=project_name, request_context=request_context)
+        spy.install(monkeypatch)
+
+        await memory.retain_async(
+            bank_id=bank_id,
+            content="Dispatch scheduled a truck for the user for next Wednesday morning.",
+            request_context=request_context,
+        )
+
+        assert spy.narrators, "fact extraction was never called — the test proves nothing"
+        assert all(n is None for n in spy.narrators), f"retain primed extraction with a narrator: {spy.narrators}"
+
+        units = await memory.list_memory_units(bank_id, limit=100, request_context=request_context)
+        stored = "\n".join(str(u) for u in units["items"])
+        assert project_name not in stored, "the bank's display name leaked into stored memory"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_retain.py
+++ b/hindsight-api-slim/tests/test_retain.py
@@ -2647,7 +2647,6 @@ def test_chunks_extraction_mode():
             extract_facts_from_contents(
                 contents=contents,
                 llm_config=None,  # Must not be called
-                agent_name="TestAgent",
                 config=_get_raw_config(),
             )
         )
@@ -2714,7 +2713,6 @@ async def test_verbatim_extraction_mode():
         facts, chunks, _ = await extract_facts_from_contents(
             contents=contents,
             llm_config=llm_config,
-            agent_name="TestAgent",
             config=_get_raw_config(),
         )
 
@@ -2967,7 +2965,6 @@ def test_strategy_overrides_extraction_mode_for_chunks():
         extract_facts_from_contents(
             contents=contents,
             llm_config=None,  # chunks must not call the LLM
-            agent_name="TestAgent",
             config=strategy_config,
         )
     )

--- a/hindsight-api-slim/tests/test_retain_pipeline_cancellation.py
+++ b/hindsight-api-slim/tests/test_retain_pipeline_cancellation.py
@@ -92,7 +92,6 @@ async def test_consumer_failure_cancels_in_flight_extractions(monkeypatch):
             is_first_batch=True,
             fact_type_override=None,
             document_tags=None,
-            agent_name="agent",
             log_buffer=[],
             start_time=0.0,
             all_pre_chunks=list(chunks),


### PR DESCRIPTION
Closes #3962.

## The bug

Retain primed fact extraction with a `Narrator: {name}` line built from `banks.name`. That line tells the model that first-person statements are the narrator's own actions, and the name it carries is stamped into the who-dimension of every fact it produces — and into the observations later consolidated from them. A bank created with a project label ends up with that label inside memories that never mentioned it:

```
Dispatch has arranged a truck for the user for Wednesday morning.
  | Involving: AuditProject_0825 (dispatch), user
```

## Why the coupling was wrong, not just the edge case

`name` is a display label:

- the only thing that renders it is the bank selector (`bank.name || bank.bank_id`), plus the `?q=` substring filter;
- the update-profile field already documents it as *"Deprecated: display label only, not advertised"*;
- the control plane has no UI to set it, so it is only ever set through the API/CLI — to whatever identifies the bank to the caller.

Nothing in the docs mentions a narrator at all, so the prompt side effect was invisible. #1680 already hit the same coupling from the other side and suppressed the narrator when `name` defaulted to the bank_id (typically a routing key); a project name is the same defect with a different string.

Retain now passes no narrator. A caller who genuinely wants to name the speaker says so in the item's `context`, which extraction already reads and prefers over the narrator — the same channel the dry-run endpoint's deprecated `agent_name` override already points people to.

## Changes

- `retain_batch` no longer resolves a narrator, so `_resolve_narrator`, the `_NARRATOR_UNRESOLVED` sentinel and the `agent_name` plumbing through `_streaming_retain_batch` / `_try_delta_retain` / `_extract_and_embed` are gone. This also drops a bank-profile read (and its pooled connection) from every retain — the bank is already created by `retain_batch_async` → `_ensure_bank_exists`, so nothing depended on that read's auto-create side effect.
- `extract_dry_run` mirrors retain: no narrator unless the caller passes one. The deprecated `agent_name` request field still overrides it.
- `extract_facts_from_text` keeps its `agent_name` parameter — it is the dry-run override, and the Narrator line still works when explicitly asked for.

**No API change**: no request/response schema was touched, so no OpenAPI or client regeneration.

## Tests

`test_narrator_resolution.py` keeps the prompt-assembly unit tests and replaces the `_resolve_narrator` cases with a retain-level regression test: a bank named `AuditProject_0825`, a spy on the narrator handed to extraction, and an assertion that the name is absent from stored units. Verified it fails when a narrator is reintroduced (`AssertionError: retain primed extraction with a narrator: ['AuditProject_0825']`).

Run locally on an isolated pg0: `test_narrator_resolution` (4), `test_delta_removed_chunks` + `test_delta_oversized_replacement` (9, the positional-argument paths), `test_async_batch_retain` (36).
