### PR TITLE
fix(worker): rotate slots across banks so bulk ingest stops starving them (#3861)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -182,6 +182,26 @@ def bank_serialization_sql(table: str, alias: str, operation_type: str | None = 
 
 
 @dataclass
+class ClaimedOperations:
+    """One claim cycle's rows, plus where the bank rotation got to.
+
+    ``claim_tasks`` picks the bank whose turn it is *inside* the claim query, so
+    the caller cannot know which bank that was from the rows alone — the
+    rotation row is not distinguishable from the ones claimed by age. Handing
+    the cursor back keeps the rotation's state in the poller (where the tenant
+    rotation already lives) without costing a second statement to ask.
+    """
+
+    rows: list[ResultRow]
+    """Claimed rows, rotation row first, then oldest-first."""
+
+    next_bank_cursor: str
+    """Bank served by the rotation, to claim past next time. Empty string starts
+    a new round — which is what an empty rotation tier means: no bank sorts after
+    the cursor any more."""
+
+
+@dataclass
 class TagListingParts:
     """Backend-specific SQL fragments for the tag listing query."""
 
@@ -791,8 +811,9 @@ class DataAccessOps(ABC):
         reserved_limits: dict[str, int],
         shared_limit: int,
         *,
+        bank_cursor: str = "",
         consolidation_bank_priority: dict[str, int] | None = None,
-    ) -> list[ResultRow]:
+    ) -> ClaimedOperations:
         """Claim pending tasks from the async_operations table.
 
         Implementations must apply :func:`bank_serialization_sql` to every query
@@ -801,7 +822,20 @@ class DataAccessOps(ABC):
         :func:`document_serialization_sql` to every query that can return a
         ``retain`` row, so at most one retain per document is ever in flight.
 
+        The shared pool must additionally be claimed with one row taken for the
+        bank after ``bank_cursor`` — deficit round robin with a quantum of one
+        slot, the rest of the pool still filled oldest-first. Without it,
+        claiming is a global FIFO and one bank mid-backfill holds every slot
+        until its queue drains, so a bank with a single queued write waits
+        behind the whole backlog (#3861). Both tiers belong in *one* statement:
+        the rotation is a bounded index seek, the backfill is the query that was
+        always there, and a separate seek would cost a round trip on every claim.
+
         Args:
+            bank_cursor: Bank the rotation served last; the claim takes one row for
+                the first bank sorting after it. The empty string starts a round
+                from the beginning, and is also what a caller with no rotation
+                state passes.
             consolidation_bank_priority: Per-bank priority for consolidation scheduling.
                 Maps bank name patterns to integer priorities (higher = claimed first).
                 Patterns support ``*`` as wildcard (converted to SQL ``%`` for LIKE).
@@ -809,9 +843,9 @@ class DataAccessOps(ABC):
                 When set, consolidation tasks are claimed in priority tiers.
                 None preserves current behavior (pure created_at ordering).
 
-        Returns claimed rows with operation_id, operation_type, task_payload,
-        retry_count, bank_id and serialization_key. The caller is responsible for
-        building ClaimedTask objects.
+        Returns the claimed rows — operation_id, operation_type, task_payload,
+        retry_count, bank_id and serialization_key — together with the rotation's
+        next cursor. The caller is responsible for building ClaimedTask objects.
         """
         ...
 

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 
 from .base import DatabaseConnection
 from .ops import (
+    ClaimedOperations,
     DataAccessOps,
     LinkExpansionRows,
     TagListingParts,
@@ -1352,6 +1353,81 @@ class OracleOps(DataAccessOps):
             *params,
         )
 
+    async def _claim_reserved_tasks(self, conn, table, limit, op_type) -> list:
+        """Claim rows of one operation type against that type's reserved pool."""
+        return await conn.fetch(
+            f"""
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+            FROM {table} o
+            WHERE o.status = 'pending'
+              AND o.task_payload IS NOT NULL
+              AND o.operation_type = $1
+              AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+              AND {bank_serialization_sql(table, "o")}
+              AND {document_serialization_sql(table, "o")}
+            ORDER BY o.created_at
+            LIMIT $2
+            FOR UPDATE SKIP LOCKED
+            """,
+            op_type,
+            limit,
+        )
+
+    async def _claim_shared_tasks(self, conn, table, claimed_ids, limit) -> list:
+        """Claim the shared pool oldest-first.
+
+        No bank rotation, unlike PostgreSQL (#3861). Two things rule the
+        rotation query out here rather than it being an oversight:
+
+        * Oracle rejects ``FETCH FIRST`` with ``FOR UPDATE`` (ORA-02014), so
+          ``db/oracle.py`` rewrites a limited claim into ``WHERE ROWNUM <= n``.
+          Oracle applies ``ROWNUM`` *before* ``ORDER BY``, so an ordered claim
+          returns an arbitrary n rows — a rotation ordered by ``bank_id`` would
+          land on whichever bank happens to be scanned first, which under bulk
+          ingest is overwhelmingly the bank the rotation exists to rotate away
+          from.
+        * That rewrite injects into the first ``WHERE`` it finds, which in a
+          CTE-based claim is the rotation branch, not the outer query.
+
+        Fixing that means reworking the ROWNUM rewrite, which the existing
+        ``created_at`` claim depends on just as much.
+        """
+        if claimed_ids:
+            return await conn.fetch(
+                f"""
+                SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+                FROM {table} o
+                WHERE o.status = 'pending'
+                  AND o.task_payload IS NOT NULL
+                  AND o.operation_type != 'consolidation'
+                  AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+                  AND o.operation_id != ALL($1::uuid[])
+                  AND {bank_serialization_sql(table, "o")}
+                  AND {document_serialization_sql(table, "o")}
+                ORDER BY o.created_at
+                LIMIT $2
+                FOR UPDATE SKIP LOCKED
+                """,
+                claimed_ids,
+                limit,
+            )
+        return await conn.fetch(
+            f"""
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+            FROM {table} o
+            WHERE o.status = 'pending'
+              AND o.task_payload IS NOT NULL
+              AND o.operation_type != 'consolidation'
+              AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+              AND {bank_serialization_sql(table, "o")}
+              AND {document_serialization_sql(table, "o")}
+            ORDER BY o.created_at
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+            """,
+            limit,
+        )
+
     async def claim_tasks(
         self,
         conn,
@@ -1360,10 +1436,18 @@ class OracleOps(DataAccessOps):
         reserved_limits,
         shared_limit,
         *,
+        bank_cursor="",
         consolidation_bank_priority=None,
     ):
         all_rows = []
         claimed_ids = []
+
+        def _collect(rows) -> int:
+            """Record a claim query's rows, and report how many it returned."""
+            for row in rows:
+                claimed_ids.append(row["operation_id"])
+                all_rows.append(row)
+            return len(rows)
 
         # --- Phase 1: claim from reserved pools ---
         for op_type, limit in reserved_limits.items():
@@ -1371,35 +1455,17 @@ class OracleOps(DataAccessOps):
                 continue
 
             if op_type == "consolidation":
-                rows = await self._claim_consolidation_tasks(
-                    conn,
-                    table,
-                    claimed_ids,
-                    limit,
-                    consolidation_bank_priority,
+                _collect(
+                    await self._claim_consolidation_tasks(
+                        conn,
+                        table,
+                        claimed_ids,
+                        limit,
+                        consolidation_bank_priority,
+                    )
                 )
             else:
-                rows = await conn.fetch(
-                    f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
-                    FROM {table} o
-                    WHERE o.status = 'pending'
-                      AND o.task_payload IS NOT NULL
-                      AND o.operation_type = $1
-                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
-                      AND {bank_serialization_sql(table, "o")}
-                      AND {document_serialization_sql(table, "o")}
-                    ORDER BY o.created_at
-                    LIMIT $2
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    op_type,
-                    limit,
-                )
-
-            for row in rows:
-                claimed_ids.append(row["operation_id"])
-                all_rows.append(row)
+                _collect(await self._claim_reserved_tasks(conn, table, limit, op_type))
 
         # --- Phase 2: claim from shared pool ---
         remaining_shared = shared_limit
@@ -1407,70 +1473,28 @@ class OracleOps(DataAccessOps):
             # 2a. Non-consolidation tasks. graph_maintenance stays in this
             # created_at-ordered query — see bank_serialization_sql
             # for why it is a predicate rather than a phase of its own.
-            if claimed_ids:
-                rows = await conn.fetch(
-                    f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
-                    FROM {table} o
-                    WHERE o.status = 'pending'
-                      AND o.task_payload IS NOT NULL
-                      AND o.operation_type != 'consolidation'
-                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
-                      AND o.operation_id != ALL($1::uuid[])
-                      AND {bank_serialization_sql(table, "o")}
-                      AND {document_serialization_sql(table, "o")}
-                    ORDER BY o.created_at
-                    LIMIT $2
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    claimed_ids,
-                    remaining_shared,
-                )
-            else:
-                rows = await conn.fetch(
-                    f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
-                    FROM {table} o
-                    WHERE o.status = 'pending'
-                      AND o.task_payload IS NOT NULL
-                      AND o.operation_type != 'consolidation'
-                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
-                      AND {bank_serialization_sql(table, "o")}
-                      AND {document_serialization_sql(table, "o")}
-                    ORDER BY o.created_at
-                    LIMIT $1
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    remaining_shared,
-                )
-
-            for row in rows:
-                claimed_ids.append(row["operation_id"])
-                all_rows.append(row)
-            remaining_shared -= len(rows)
+            remaining_shared -= _collect(await self._claim_shared_tasks(conn, table, claimed_ids, remaining_shared))
 
             # 2b. Consolidation tasks (with bank-serialization + optional priority)
             if remaining_shared > 0:
-                rows = await self._claim_consolidation_tasks(
-                    conn,
-                    table,
-                    claimed_ids,
-                    remaining_shared,
-                    consolidation_bank_priority,
+                _collect(
+                    await self._claim_consolidation_tasks(
+                        conn,
+                        table,
+                        claimed_ids,
+                        remaining_shared,
+                        consolidation_bank_priority,
+                    )
                 )
 
-                for row in rows:
-                    claimed_ids.append(row["operation_id"])
-                    all_rows.append(row)
-
         if not all_rows:
-            return []
+            return ClaimedOperations(rows=[], next_bank_cursor=bank_cursor)
 
         # Mark all claimed rows as processing
         operation_ids = [row["operation_id"] for row in all_rows]
         await self.mark_operations_processing(conn, table, worker_id, operation_ids)
 
-        return all_rows
+        return ClaimedOperations(rows=all_rows, next_bank_cursor=bank_cursor)
 
     async def mark_operations_processing(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from .base import DatabaseConnection
 from .ops import (
+    ClaimedOperations,
     DataAccessOps,
     LinkExpansionRows,
     TagListingParts,
@@ -1553,6 +1554,129 @@ class PostgreSQLOps(DataAccessOps):
             *params,
         )
 
+    async def _claim_reserved_tasks(self, conn, table, limit, op_type) -> list:
+        """Claim rows of one operation type against that type's reserved pool.
+
+        No bank rotation here: reservations are a floor for an operation *type*,
+        and every non-consolidation type defaults to 0 (``WORKER_SLOT_TYPE_DEFAULTS``),
+        so retains are claimed from the shared pool where the rotation lives. An
+        operator who reserves the whole of ``WORKER_MAX_SLOTS`` by type leaves no
+        shared pool for it to rotate in — deliberate, and the reason the defaults
+        keep a shared pool.
+        """
+        return await conn.fetch(
+            f"""
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
+            FROM {table} o
+            WHERE o.status = 'pending'
+              AND o.task_payload IS NOT NULL
+              AND o.operation_type = $1
+              AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+              AND {bank_serialization_sql(table, "o")}
+              AND {document_serialization_sql(table, "o")}
+            ORDER BY o.created_at
+            LIMIT $2
+            FOR UPDATE SKIP LOCKED
+            """,
+            op_type,
+            limit,
+        )
+
+    async def _claim_shared_tasks(self, conn, table, claimed_ids, limit, bank_cursor) -> list:
+        """Claim the shared pool: one row for the bank whose turn it is, rest by age.
+
+        Deficit round robin (Shreedhar & Varghese) with a quantum of one slot.
+        Every operation costs exactly one slot, so the deficit counter the
+        algorithm carries for variable-size packets is always zero and drops out
+        — what is left is the round-robin walk. ``bank_id > $1`` *is* that walk:
+        a cursor over the bank id space, advanced by an index seek rather than by
+        maintaining a list of active queues. A list could not do it anyway — the
+        starved bank is the one this worker has never claimed for, so only a
+        range can discover it.
+
+        Both tiers are one statement on purpose. ``rot`` is a bounded seek and
+        ``fifo`` is the claim query that was always here, so the fairness costs
+        no extra round trip; measured at 50k pending rows, 0.10 ms against
+        0.02 ms for the bare FIFO claim. Splitting them cost a statement on every
+        claim, for every schema, on every poll.
+
+        ``fifo`` is also what makes the rotation safe at both ends:
+
+        * It is the wrap. Once the cursor passes the last bank with work, ``rot``
+          matches nothing and ``fifo`` claims the whole pool by itself — no
+          second query, no reset round-trip, and a single-bank deployment (where
+          the cursor is *always* past the only bank) pays nothing but the empty
+          seek.
+        * It is what keeps this work-conserving. The rotation can never hold a
+          slot open for an idle bank, because ``fifo`` always offers a full
+          pool's worth of candidates behind it. A bank alone with work still
+          takes every slot.
+
+        The predicates are repeated in the outer query, not just in the CTEs:
+        the CTEs read rows unlocked, and re-checking under ``FOR UPDATE`` is what
+        makes a row another worker claimed in between fall out instead of being
+        claimed twice.
+
+        Two ways that re-check costs a little precision, both self-correcting on
+        the next poll and both preferred to a second statement: a candidate lost
+        to ``SKIP LOCKED`` makes this return fewer rows than the pool has free
+        even though other rows are claimable, and losing the *rotation* row that
+        way reads as an empty tier, so the cursor restarts the round early.
+
+        ``tier`` comes back in the rows so the caller can read the rotation's new
+        cursor off the result. Within the rotated bank the row is index-ordered
+        rather than that bank's oldest — sorting by ``created_at`` there would
+        need an index on ``(bank_id, created_at)`` and cost 12 s without one, and
+        per-document order is held by ``document_serialization_sql`` regardless.
+        """
+        params: list = [bank_cursor]
+        exclusion = ""
+        idx = 2
+
+        if claimed_ids:
+            exclusion = f" AND o.operation_id != ALL(${idx}::uuid[])"
+            params.append(claimed_ids)
+            idx += 1
+
+        params.append(limit)
+        claimable = f"""o.status = 'pending'
+              AND o.task_payload IS NOT NULL
+              AND o.operation_type != 'consolidation'
+              AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
+              AND {bank_serialization_sql(table, "o")}
+              AND {document_serialization_sql(table, "o")}{exclusion}"""
+
+        return await conn.fetch(
+            f"""
+            WITH rot AS (
+                SELECT o.operation_id, 0 AS tier, o.created_at
+                FROM {table} o
+                WHERE {claimable}
+                  AND o.bank_id > $1
+                ORDER BY o.bank_id
+                LIMIT 1
+            ), fifo AS (
+                SELECT o.operation_id, 1 AS tier, o.created_at
+                FROM {table} o
+                WHERE {claimable}
+                  AND NOT EXISTS (SELECT 1 FROM rot WHERE rot.operation_id = o.operation_id)
+                ORDER BY o.created_at
+                LIMIT ${idx}
+            ), cand AS (
+                SELECT * FROM rot UNION ALL SELECT * FROM fifo
+            )
+            SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count,
+                   o.serialization_key, o.bank_id, c.tier
+            FROM cand c
+            JOIN {table} o ON o.operation_id = c.operation_id
+            WHERE {claimable}
+            ORDER BY c.tier, c.created_at
+            LIMIT ${idx}
+            FOR UPDATE OF o SKIP LOCKED
+            """,
+            *params,
+        )
+
     async def claim_tasks(
         self,
         conn,
@@ -1561,10 +1685,19 @@ class PostgreSQLOps(DataAccessOps):
         reserved_limits,
         shared_limit,
         *,
+        bank_cursor="",
         consolidation_bank_priority=None,
     ):
         all_rows = []
         claimed_ids = []
+        next_bank_cursor = bank_cursor
+
+        def _collect(rows) -> int:
+            """Record a claim query's rows, and report how many it returned."""
+            for row in rows:
+                claimed_ids.append(row["operation_id"])
+                all_rows.append(row)
+            return len(rows)
 
         # --- Phase 1: claim from reserved pools ---
         for op_type, limit in reserved_limits.items():
@@ -1572,106 +1705,52 @@ class PostgreSQLOps(DataAccessOps):
                 continue
 
             if op_type == "consolidation":
-                rows = await self._claim_consolidation_tasks(
-                    conn,
-                    table,
-                    claimed_ids,
-                    limit,
-                    consolidation_bank_priority,
+                _collect(
+                    await self._claim_consolidation_tasks(
+                        conn,
+                        table,
+                        claimed_ids,
+                        limit,
+                        consolidation_bank_priority,
+                    )
                 )
             else:
-                rows = await conn.fetch(
-                    f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
-                    FROM {table} o
-                    WHERE o.status = 'pending'
-                      AND o.task_payload IS NOT NULL
-                      AND o.operation_type = $1
-                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
-                      AND {bank_serialization_sql(table, "o")}
-                      AND {document_serialization_sql(table, "o")}
-                    ORDER BY o.created_at
-                    LIMIT $2
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    op_type,
-                    limit,
-                )
-
-            for row in rows:
-                claimed_ids.append(row["operation_id"])
-                all_rows.append(row)
+                _collect(await self._claim_reserved_tasks(conn, table, limit, op_type))
 
         # --- Phase 2: claim from shared pool ---
         remaining_shared = shared_limit
         if remaining_shared > 0:
-            # 2a. Non-consolidation tasks. graph_maintenance stays in this
-            # created_at-ordered query — see bank_serialization_sql
-            # for why it is a predicate rather than a phase of its own.
-            if claimed_ids:
-                rows = await conn.fetch(
-                    f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
-                    FROM {table} o
-                    WHERE o.status = 'pending'
-                      AND o.task_payload IS NOT NULL
-                      AND o.operation_type != 'consolidation'
-                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
-                      AND o.operation_id != ALL($1::uuid[])
-                      AND {bank_serialization_sql(table, "o")}
-                      AND {document_serialization_sql(table, "o")}
-                    ORDER BY o.created_at
-                    LIMIT $2
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    claimed_ids,
-                    remaining_shared,
-                )
-            else:
-                rows = await conn.fetch(
-                    f"""
-                    SELECT o.operation_id, o.operation_type, o.task_payload, o.retry_count, o.serialization_key, o.bank_id
-                    FROM {table} o
-                    WHERE o.status = 'pending'
-                      AND o.task_payload IS NOT NULL
-                      AND o.operation_type != 'consolidation'
-                      AND (o.next_retry_at IS NULL OR o.next_retry_at <= NOW())
-                      AND {bank_serialization_sql(table, "o")}
-                      AND {document_serialization_sql(table, "o")}
-                    ORDER BY o.created_at
-                    LIMIT $1
-                    FOR UPDATE SKIP LOCKED
-                    """,
-                    remaining_shared,
-                )
-
-            for row in rows:
-                claimed_ids.append(row["operation_id"])
-                all_rows.append(row)
-            remaining_shared -= len(rows)
+            # 2a. Non-consolidation tasks: one row for the bank the rotation is
+            # up to (#3861), the rest oldest-first, in one statement.
+            # graph_maintenance stays in this created_at-ordered query — see
+            # bank_serialization_sql for why it is a predicate rather than a
+            # phase of its own.
+            shared_rows = await self._claim_shared_tasks(conn, table, claimed_ids, remaining_shared, bank_cursor)
+            # An empty rotation tier means no bank sorts after the cursor: the
+            # round is over, so the next claim starts from the beginning.
+            next_bank_cursor = next((row["bank_id"] for row in shared_rows if row["tier"] == 0), "")
+            remaining_shared -= _collect(shared_rows)
 
             # 2b. Consolidation tasks (with bank-serialization + optional priority)
             if remaining_shared > 0:
-                rows = await self._claim_consolidation_tasks(
-                    conn,
-                    table,
-                    claimed_ids,
-                    remaining_shared,
-                    consolidation_bank_priority,
+                _collect(
+                    await self._claim_consolidation_tasks(
+                        conn,
+                        table,
+                        claimed_ids,
+                        remaining_shared,
+                        consolidation_bank_priority,
+                    )
                 )
 
-                for row in rows:
-                    claimed_ids.append(row["operation_id"])
-                    all_rows.append(row)
-
         if not all_rows:
-            return []
+            return ClaimedOperations(rows=[], next_bank_cursor=next_bank_cursor)
 
         # Mark all claimed rows as processing
         operation_ids = [row["operation_id"] for row in all_rows]
         await self.mark_operations_processing(conn, table, worker_id, operation_ids)
 
-        return all_rows
+        return ClaimedOperations(rows=all_rows, next_bank_cursor=next_bank_cursor)
 
     async def mark_operations_processing(
         self,

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -374,6 +374,15 @@ class WorkerPoller:
         # Rotation offset for per-tenant fair claiming. Advances past the last
         # schema we serviced so a busy tenant can't monopolize the poll order.
         self._next_schema_idx: int = 0
+        # The same rotation one level down, per schema: the bank the claim
+        # served last, so the next one takes a row for the bank after it.
+        # Claiming is otherwise a global FIFO on created_at, which lets one bank
+        # mid-bulk-ingest hold every slot until its queue drains while other
+        # banks' writes wait behind the backlog (#3861). A cursor over the bank
+        # id space rather than a set of known banks: the starved bank is the one
+        # this worker has never claimed for, so only a range can discover it.
+        # Empty string starts a round; claim_tasks resets to it at the end of one.
+        self._next_bank_cursor: dict[str | None, str] = {}
         # Retention cleanup runs outside the claim loop. Keep one task per
         # poller so maintenance cannot overlap with itself or block slot refill.
 
@@ -669,14 +678,20 @@ class WorkerPoller:
         table = fq_table("async_operations", schema)
 
         async with conn.transaction():
-            all_rows = await self._backend.ops.claim_tasks(
+            claimed = await self._backend.ops.claim_tasks(
                 conn,
                 table,
                 self._worker_id,
                 reserved_limits,
                 shared_limit,
+                bank_cursor=self._next_bank_cursor.get(schema, ""),
                 consolidation_bank_priority=self._consolidation_bank_priority,
             )
+            # Where the rotation got to. Carried across claims per schema, the
+            # way _next_schema_idx is across tenants; the claim query itself
+            # picks the bank, so this costs no extra statement to learn.
+            self._next_bank_cursor[schema] = claimed.next_bank_cursor
+            all_rows = claimed.rows
 
             if not all_rows:
                 return []

--- a/hindsight-api-slim/tests/test_claim_bank_fairness.py
+++ b/hindsight-api-slim/tests/test_claim_bank_fairness.py
@@ -1,0 +1,394 @@
+"""Per-bank rotation of the worker's slots (#3861).
+
+Claiming used to be a strict global FIFO on ``created_at``, so a bank under
+sustained bulk ingest held every slot for as long as its queue lasted: measured
+on a six-bank instance, one bulk bank owned 17 of 17 retain slots in 90.6% of
+daily samples, and a write to a bank with an *empty* queue timed out behind it.
+
+The claim query now takes one row for the bank after a cursor the poller keeps
+per schema — deficit round robin with a quantum of one slot, one level below the
+tenant rotation the poller already had — and fills the rest of the pool
+oldest-first exactly as before. So no bank is throttled (a bank alone with work
+still takes every slot) and no slot is held open for an idle bank; all the
+rotation decides is *which* row wins a slot being handed out anyway.
+
+Both tiers are one statement. The tests below pin the three properties that
+depend on that: the rotation tier reaches a starved bank, the FIFO tier still
+fills the pool behind it, and the FIFO tier doubles as the wrap so the end of a
+round costs neither a second query nor an empty claim.
+
+The cursor is a *range* over bank ids, not a set of known banks, because the
+starved bank is by definition one this worker has never claimed for.
+
+These call ``ops`` directly rather than ``WorkerPoller.claim_batch`` so the slot
+limits under test are exact and not a function of ambient in-flight work in the
+shared test database; the poller's own cursor bookkeeping is driven through
+``WorkerPoller`` in ``test_poller_cycles_banks_across_claims``.
+"""
+
+import asyncio
+import json
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+
+# Use loadgroup to ensure these tests run in the same worker
+# since they share database state
+pytestmark = pytest.mark.xdist_group("worker_tests")
+
+_TABLE = "async_operations"
+
+
+@pytest.fixture(scope="session")
+def isolated_ops_schema(pg0_db_url):
+    """A private, migrated Postgres schema for this file's claim tests.
+
+    ``ops.claim_tasks`` scans the whole schema on the connection's search_path,
+    and every test here asserts on an *exact* claim, so another pytest-xdist
+    worker's pending rows would make them meaningless. One schema per worker,
+    created + migrated once and dropped at session end — the same isolation
+    ``test_claim_bank_serialization.py`` uses, under its own name so the two
+    files never share rows.
+    """
+    from hindsight_api.engine.db import create_database_backend
+    from hindsight_api.pg0 import resolve_database_url
+
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    schema = f"bankfair_iso_{worker}"
+
+    async def _provision() -> str:
+        url = await resolve_database_url(pg0_db_url)
+        b = create_database_backend("postgresql")
+        await b.initialize(url, min_size=1, max_size=2)
+        try:
+            async with b.get_pool().acquire() as conn:
+                # Rebuild from scratch so a schema left by a crashed prior run
+                # can't carry stale state into this session.
+                await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+                await conn.execute(f'CREATE SCHEMA "{schema}"')
+            b.run_migrations(url, schema=schema)
+        finally:
+            await b.shutdown()
+        return url
+
+    async def _drop(url: str) -> None:
+        b = create_database_backend("postgresql")
+        await b.initialize(url, min_size=1, max_size=2)
+        try:
+            async with b.get_pool().acquire() as conn:
+                await conn.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        finally:
+            await b.shutdown()
+
+    loop = asyncio.new_event_loop()
+    try:
+        url = loop.run_until_complete(_provision())
+    finally:
+        loop.close()
+
+    yield schema
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_drop(url))
+    finally:
+        loop.close()
+
+
+@pytest_asyncio.fixture
+async def backend(pg0_db_url, isolated_ops_schema):
+    """Create a DatabaseBackend whose pool is pinned to this file's private schema."""
+    from hindsight_api.engine.db import create_database_backend
+    from hindsight_api.pg0 import resolve_database_url
+
+    resolved_url = await resolve_database_url(pg0_db_url)
+
+    async def _use_isolated_schema(conn):
+        await conn.execute(f'SET search_path TO "{isolated_ops_schema}", public')
+
+    b = create_database_backend("postgresql")
+    await b.initialize(resolved_url, min_size=2, max_size=10, command_timeout=30, init_callback=_use_isolated_schema)
+    yield b
+    await b.shutdown()
+
+
+@pytest_asyncio.fixture
+async def pool(backend):
+    """Expose the raw asyncpg pool from the backend for direct DB access in tests."""
+    yield backend.get_pool()
+
+
+@pytest_asyncio.fixture
+async def clean_operations(pool):
+    """Clear leftovers from a prior test in this group.
+
+    Safe to be broad: the pool is pinned to this file's private schema, so this
+    only ever touches its own rows.
+    """
+    await pool.execute(f"DELETE FROM {_TABLE}")
+    yield
+    await pool.execute(f"DELETE FROM {_TABLE} WHERE bank_id LIKE 'test-bankfair-%'")
+
+
+async def _make_bank(pool) -> str:
+    """Create a bank with a unique id so concurrent runs can't collide."""
+    bank_id = f"test-bankfair-{uuid.uuid4().hex[:8]}"
+    await pool.execute(
+        "INSERT INTO banks (bank_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        bank_id,
+        bank_id,
+    )
+    return bank_id
+
+
+async def _insert_op(
+    pool,
+    bank_id: str,
+    op_type: str = "retain",
+    status: str = "pending",
+    *,
+    age_seconds: float = 0.0,
+    worker_id: str | None = None,
+    retry_in_seconds: float | None = None,
+    serialization_key: str | None = None,
+) -> uuid.UUID:
+    """Insert one claimable operation row, ``age_seconds`` old."""
+    op_id = uuid.uuid4()
+    created_at = datetime.now(UTC) - timedelta(seconds=age_seconds)
+    payload = json.dumps({"type": op_type, "bank_id": bank_id, "operation_id": str(op_id)})
+    claimed_at = created_at if status == "processing" else None
+    next_retry_at = datetime.now(UTC) + timedelta(seconds=retry_in_seconds) if retry_in_seconds else None
+    await pool.execute(
+        f"""
+        INSERT INTO {_TABLE}
+            (operation_id, bank_id, operation_type, status, task_payload, worker_id,
+             created_at, claimed_at, next_retry_at, serialization_key, updated_at)
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, now())
+        """,
+        op_id,
+        bank_id,
+        op_type,
+        status,
+        payload,
+        worker_id,
+        created_at,
+        claimed_at,
+        next_retry_at,
+        serialization_key,
+    )
+    return op_id
+
+
+async def _claim(
+    backend,
+    *,
+    shared: int = 10,
+    reserved: dict[str, int] | None = None,
+    cursor: str = "",
+):
+    """Run one claim cycle. Returns the ClaimedOperations as-is."""
+    async with backend.acquire() as conn:
+        async with conn.transaction():
+            return await backend.ops.claim_tasks(
+                conn,
+                _TABLE,
+                "test-bankfair-worker",
+                reserved or {},
+                shared,
+                bank_cursor=cursor,
+            )
+
+
+def _ids(claimed) -> list[str]:
+    """Claimed operation ids, in claim order (rotation row first)."""
+    return [str(row["operation_id"]) for row in claimed.rows]
+
+
+@pytest.mark.asyncio
+async def test_rotation_reaches_a_bank_buried_behind_a_backlog(pool, backend, clean_operations):
+    """#3861 itself: the starved bank's write wins the free slot.
+
+    ``bulk`` is mid-backfill with a queue of older work; ``quiet`` submitted one
+    write a moment ago. Under a global FIFO every freed slot went back to
+    ``bulk`` until its queue drained, so ``quiet`` waited behind the whole
+    backlog. With the cursor on ``bulk``, the rotation tier takes ``quiet``.
+    """
+    bulk, quiet = sorted([await _make_bank(pool), await _make_bank(pool)])
+
+    backlog = [await _insert_op(pool, bulk, age_seconds=300 - i) for i in range(5)]
+    quiet_write = await _insert_op(pool, quiet, age_seconds=1)
+
+    claimed = await _claim(backend, shared=1, cursor=bulk)
+
+    assert _ids(claimed) == [str(quiet_write)]
+    assert not {str(op) for op in backlog} & set(_ids(claimed))
+
+
+@pytest.mark.asyncio
+async def test_backfill_behind_the_rotation_is_still_oldest_first(pool, backend, clean_operations):
+    """One slot to the bank whose turn it is, the rest by age — in one claim.
+
+    The rotation is a quantum of one. Everything behind it is the claim query
+    that was always there, so the backlog still drains oldest-first.
+    """
+    bulk, quiet = sorted([await _make_bank(pool), await _make_bank(pool)])
+
+    backlog = [await _insert_op(pool, bulk, age_seconds=300 - i) for i in range(5)]
+    quiet_write = await _insert_op(pool, quiet, age_seconds=1)
+
+    claimed = await _claim(backend, shared=3, cursor=bulk)
+
+    assert _ids(claimed)[0] == str(quiet_write)
+    assert _ids(claimed)[1:] == [str(op) for op in backlog[:2]]
+
+
+@pytest.mark.asyncio
+async def test_a_bank_alone_with_work_is_never_throttled(pool, backend, clean_operations):
+    """Rotation is a tier, not a cap: with no one else waiting, one bank takes it all."""
+    bulk = await _make_bank(pool)
+    backlog = [await _insert_op(pool, bulk, age_seconds=300 - i) for i in range(5)]
+
+    claimed = await _claim(backend, shared=3, cursor=bulk)
+
+    assert _ids(claimed) == [str(op) for op in backlog[:3]]
+
+
+@pytest.mark.asyncio
+async def test_end_of_a_round_costs_neither_a_query_nor_an_empty_claim(pool, backend, clean_operations):
+    """A cursor past the last bank still fills the pool, and resets to start a round.
+
+    This is what lets both tiers live in one statement: the FIFO tier *is* the
+    wrap, so nothing has to notice the round ended and re-ask. A single-bank
+    deployment sits in this state permanently — every claim has a cursor past
+    its only bank — and must not pay an empty claim for it.
+    """
+    bank = await _make_bank(pool)
+    queue = [await _insert_op(pool, bank, age_seconds=300 - i) for i in range(4)]
+
+    claimed = await _claim(backend, shared=3, cursor="zzz-past-every-bank")
+
+    assert _ids(claimed) == [str(op) for op in queue[:3]]
+    assert claimed.next_bank_cursor == ""
+
+
+@pytest.mark.asyncio
+async def test_cursor_reports_the_bank_the_rotation_served(pool, backend, clean_operations):
+    """The new cursor rides back with the rows, so learning it costs no query."""
+    first, second = sorted([await _make_bank(pool), await _make_bank(pool)])
+    await _insert_op(pool, first, age_seconds=300)
+    await _insert_op(pool, second, age_seconds=1)
+
+    assert (await _claim(backend, shared=1, cursor="")).next_bank_cursor == first
+    assert (await _claim(backend, shared=1, cursor=first)).next_bank_cursor == second
+
+
+@pytest.mark.asyncio
+async def test_poller_cycles_banks_across_claims(pool, backend, clean_operations):
+    """Through the poller: successive claims serve each bank, then start over.
+
+    The cursor is the poller's state, carried between claims the way
+    ``_next_schema_idx`` is between tenants.
+    """
+    from hindsight_api.worker import WorkerPoller
+
+    # Staggered so a plain FIFO would take both of the first bank's rows before
+    # touching the second — otherwise same-age queues make FIFO and the rotation
+    # visit banks in the same order, and the test passes either way.
+    banks = sorted([await _make_bank(pool) for _ in range(3)])
+    for offset, bank in enumerate(banks):
+        for age in (300 - offset * 100, 290 - offset * 100):
+            await _insert_op(pool, bank, age_seconds=age)
+
+    poller = WorkerPoller(backend=backend, worker_id="test-bankfair-rotation", executor=lambda task: None)
+
+    served = []
+    async with backend.acquire() as conn:
+        for _ in range(len(banks) + 1):
+            tasks = await poller._claim_batch_for_schema(conn, None, {}, 1)
+            served.append(tasks[0].task_dict["bank_id"])
+
+    # Three banks, then the round restarts at the first.
+    assert served == [*banks, banks[0]]
+
+
+@pytest.mark.asyncio
+async def test_rotation_row_is_not_claimed_twice(pool, backend, clean_operations):
+    """The rotation's row is also the oldest, so both tiers select it.
+
+    The tiers are unioned, so without the FIFO tier excluding what the rotation
+    took, one operation would come back as two claimed tasks and be executed
+    twice.
+    """
+    first, second = sorted([await _make_bank(pool), await _make_bank(pool)])
+    oldest = await _insert_op(pool, second, age_seconds=900)
+    await _insert_op(pool, first, age_seconds=10)
+
+    claimed = await _claim(backend, shared=10, cursor=first)
+
+    assert _ids(claimed)[0] == str(oldest)
+    assert len(_ids(claimed)) == len(set(_ids(claimed)))
+
+
+@pytest.mark.asyncio
+async def test_rotation_skips_banks_with_nothing_claimable(pool, backend, clean_operations):
+    """A bank is only owed a turn if it has a claimable row.
+
+    Rows that are processing, deferred, or consolidation don't count —
+    consolidation is claimed by its own phase against its own reserved slots.
+    An empty or blocked queue leaving the circle is what stops the rotation
+    spending visits on banks it cannot serve.
+    """
+    processing, deferred, consolidating, real = sorted([await _make_bank(pool) for _ in range(4)])
+
+    await _insert_op(pool, processing, status="processing", age_seconds=10, worker_id="other")
+    await _insert_op(pool, deferred, age_seconds=10, retry_in_seconds=600)
+    await _insert_op(pool, consolidating, op_type="consolidation", age_seconds=10)
+    real_row = await _insert_op(pool, real, age_seconds=10)
+
+    claimed = await _claim(backend, shared=1, cursor="")
+
+    assert _ids(claimed) == [str(real_row)]
+    assert claimed.next_bank_cursor == real
+
+
+@pytest.mark.asyncio
+async def test_rotation_spans_operation_types(pool, backend, clean_operations):
+    """A slot is a slot: the turn goes to the bank, whatever type it queued.
+
+    ``file_convert_retain`` and ``refresh_mental_model`` compete for the same
+    shared pool as ``retain``, so the rotation is over banks rather than over
+    one type's queue.
+    """
+    bulk, quiet = sorted([await _make_bank(pool), await _make_bank(pool)])
+
+    bulk_convert = await _insert_op(pool, bulk, op_type="file_convert_retain", age_seconds=300)
+    quiet_refresh = await _insert_op(pool, quiet, op_type="refresh_mental_model", age_seconds=1)
+
+    claimed = await _claim(backend, shared=1, cursor=bulk)
+
+    assert _ids(claimed) == [str(quiet_refresh)]
+    assert str(bulk_convert) not in _ids(claimed)
+
+
+@pytest.mark.asyncio
+async def test_rotation_does_not_break_document_serialization(pool, backend, clean_operations):
+    """A bank's turn cannot hand out a retain for a document already in flight.
+
+    The rotation tier carries the same predicates as the FIFO tier; appends to
+    one document stay serialised, so the bank's turn passes to its next
+    claimable row rather than racing the in-flight retain.
+    """
+    bulk, quiet = sorted([await _make_bank(pool), await _make_bank(pool)])
+
+    await _insert_op(pool, bulk, age_seconds=300)
+    await _insert_op(pool, quiet, status="processing", age_seconds=100, worker_id="other", serialization_key="doc-1")
+    blocked = await _insert_op(pool, quiet, age_seconds=50, serialization_key="doc-1")
+    free = await _insert_op(pool, quiet, age_seconds=40, serialization_key="doc-2")
+
+    claimed = await _claim(backend, shared=1, cursor=bulk)
+
+    assert _ids(claimed) == [str(free)]
+    assert str(blocked) not in _ids(claimed)

--- a/hindsight-api-slim/tests/test_claim_bank_serialization.py
+++ b/hindsight-api-slim/tests/test_claim_bank_serialization.py
@@ -202,7 +202,7 @@ async def _claim(
     """Run one claim cycle and return the claimed operation ids as strings."""
     async with backend.acquire() as conn:
         async with conn.transaction():
-            rows = await backend.ops.claim_tasks(
+            claimed = await backend.ops.claim_tasks(
                 conn,
                 _TABLE,
                 "test-bankclaim-worker",
@@ -210,7 +210,7 @@ async def _claim(
                 shared,
                 consolidation_bank_priority=consolidation_bank_priority,
             )
-    return {str(row["operation_id"]) for row in rows}
+    return {str(row["operation_id"]) for row in claimed.rows}
 
 
 async def _status_of(pool, op_id: uuid.UUID) -> str:

--- a/hindsight-api-slim/tests/test_retain_document_serialization.py
+++ b/hindsight-api-slim/tests/test_retain_document_serialization.py
@@ -381,6 +381,17 @@ async def bank(backend):
         await conn.execute("DELETE FROM banks WHERE bank_id = $1", bank_id)
 
 
+async def _claim_rows(backend, conn, worker_id):
+    """Claim, and hand back just the rows.
+
+    ``claim_tasks`` also reports where the per-bank rotation got to (#3861);
+    these tests are about per-document serialisation, which the rotation does
+    not touch, so they only look at the rows.
+    """
+    claimed = await backend.ops.claim_tasks(conn, "async_operations", worker_id, {}, _UNBOUNDED_CLAIM)
+    return claimed.rows
+
+
 @pytest.mark.asyncio
 async def test_claim_takes_only_one_retain_per_document(backend, bank):
     """Three queued appends to one document: only the oldest is claimable."""
@@ -388,9 +399,7 @@ async def test_claim_takes_only_one_retain_per_document(backend, bank):
     await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "two"}])
     await _insert_retain_op(backend, bank, "doc-a", contents=[{"content": "three"}])
 
-    rows = await _claiming(
-        backend, lambda conn: backend.ops.claim_tasks(conn, "async_operations", "w1", {}, _UNBOUNDED_CLAIM)
-    )
+    rows = await _claiming(backend, lambda conn: _claim_rows(backend, conn, "w1"))
 
     claimed = _own(rows, bank)
     assert claimed == [first], f"expected only the oldest same-document retain, got {claimed}"
@@ -403,9 +412,7 @@ async def test_claim_does_not_serialize_across_documents(backend, bank):
     b = await _insert_retain_op(backend, bank, "doc-b", contents=[{"content": "b1"}])
     c = await _insert_retain_op(backend, bank, None, contents=[{"content": "c1"}])
 
-    rows = await _claiming(
-        backend, lambda conn: backend.ops.claim_tasks(conn, "async_operations", "w1", {}, _UNBOUNDED_CLAIM)
-    )
+    rows = await _claiming(backend, lambda conn: _claim_rows(backend, conn, "w1"))
 
     assert set(_own(rows, bank)) == {a, b, c}
 
@@ -421,9 +428,7 @@ async def test_claim_waits_for_a_processing_peer(backend, bank):
             uuid.UUID(first),
         )
 
-    rows = await _claiming(
-        backend, lambda conn: backend.ops.claim_tasks(conn, "async_operations", "w2", {}, _UNBOUNDED_CLAIM)
-    )
+    rows = await _claiming(backend, lambda conn: _claim_rows(backend, conn, "w2"))
 
     assert _own(rows, bank) == [], "a document with a retain in flight must yield nothing"
 
@@ -485,7 +490,7 @@ async def _claim_own(backend, bank_id: str, worker_id: str) -> "_ClaimOutcome":
     observed: dict = {}
 
     async def _body(conn):
-        rows = await backend.ops.claim_tasks(conn, "async_operations", worker_id, {}, _UNBOUNDED_CLAIM)
+        rows = await _claim_rows(backend, conn, worker_id)
         tasks = []
         for row in rows:
             if row["bank_id"] != bank_id:

--- a/hindsight-api-slim/tests/test_worker_claim_connection_reuse.py
+++ b/hindsight-api-slim/tests/test_worker_claim_connection_reuse.py
@@ -47,9 +47,11 @@ class _StubOps:
         self._recorder = recorder
 
     async def claim_tasks(self, conn, table, worker_id, reserved_limits, shared_limit, **kwargs):
+        from hindsight_api.engine.db.ops import ClaimedOperations
+
         self._recorder.claimed_tables.append(table)
         self._recorder.claim_conns.append(conn)
-        return [
+        rows = [
             {
                 "operation_id": uuid.uuid4(),
                 "operation_type": "test",
@@ -61,6 +63,9 @@ class _StubOps:
                 "bank_id": "test-bank",
             }
         ]
+        # The bank rotation's cursor rides back with the rows (#3861); this stub
+        # claims for one bank, so it reports that bank as where it got to.
+        return ClaimedOperations(rows=rows, next_bank_cursor="test-bank")
 
 
 class _StubBackend:

--- a/hindsight-docs/docs/developer/api/operations.mdx
+++ b/hindsight-docs/docs/developer/api/operations.mdx
@@ -240,6 +240,8 @@ Each worker has a single concurrency budget (`HINDSIGHT_API_WORKER_MAX_SLOTS`, d
 
 For most deployments the defaults are fine. Reserve slots for an operation type if you've seen it starved by a flood of another type (e.g., a long file_convert_retain blocking graph_maintenance on a deletion-heavy workload).
 
+Slots are also rotated across banks. Each claim serves the next bank in turn — one operation — then fills the rest of the pool oldest-first from anywhere. So a bank ingesting in bulk cannot own the whole pool while another bank's single write waits behind its backlog, and it is not throttled either: when no one else is waiting it still takes every slot.
+
 ## Next Steps
 
 - [**Documents**](./documents) — Track document sources

--- a/skills/hindsight-docs/references/developer/api/operations.md
+++ b/skills/hindsight-docs/references/developer/api/operations.md
@@ -347,6 +347,8 @@ Each worker has a single concurrency budget (`HINDSIGHT_API_WORKER_MAX_SLOTS`, d
 
 For most deployments the defaults are fine. Reserve slots for an operation type if you've seen it starved by a flood of another type (e.g., a long file_convert_retain blocking graph_maintenance on a deletion-heavy workload).
 
+Slots are also rotated across banks. Each claim serves the next bank in turn — one operation — then fills the rest of the pool oldest-first from anywhere. So a bank ingesting in bulk cannot own the whole pool while another bank's single write waits behind its backlog, and it is not throttled either: when no one else is waiting it still takes every slot.
+
 ## Next Steps
 
 - [**Documents**](./documents) — Track document sources


### PR DESCRIPTION
Closes #3861.

## The problem

Claiming is a strict global FIFO on `created_at`, so a bank under sustained bulk ingest holds every worker slot for as long as its queue lasts. From the issue's measurements on a six-bank instance: one bulk bank owned **17 of 17** retain slots in **90.6%** of daily samples, and a write to a bank with an *empty* queue timed out at 300s behind the backlog. The queue drains correctly once ingest stops — this is fairness, not correctness.

## The fix

**Deficit round robin with a quantum of one slot.** Every operation costs exactly one slot, so DRR's deficit counter is always zero and drops out; what's left is the round-robin walk. The poller keeps a cursor over the bank id space per schema — one level below the tenant rotation it already had — and the claim takes one row for the first bank sorting after it.

Both tiers are **one statement**, so the fairness costs no extra round trip:

```sql
WITH rot AS (                      -- the visit: quantum = 1, bounded index seek
    SELECT ... WHERE <claimable> AND o.bank_id > $cursor ORDER BY o.bank_id LIMIT 1
), fifo AS (                       -- the claim that was always here
    SELECT ... WHERE <claimable> AND o.operation_id NOT IN (SELECT operation_id FROM rot)
    ORDER BY o.created_at LIMIT $n
), cand AS (SELECT * FROM rot UNION ALL SELECT * FROM fifo)
SELECT o.<cols>, c.tier FROM cand c JOIN async_operations o USING (operation_id)
WHERE <claimable>                  -- re-checked under the lock
ORDER BY c.tier, c.created_at LIMIT $n FOR UPDATE OF o SKIP LOCKED
```

Two design points worth stating:

- **The cursor is a range, not a set of known banks.** The starved bank is by definition one this worker has never claimed for, so a remembered list can never discover it — only `bank_id > $cursor` can.
- **`fifo` is what makes the rotation safe at both ends.** It is the wrap: once the cursor passes the last bank, `rot` matches nothing and `fifo` claims the whole pool, so the end of a round costs neither a second query nor an empty claim — and a single-bank deployment sits in that state permanently. It is also what keeps this work-conserving: **a bank alone with work still takes every slot**, so nothing is throttled and no slot is ever held open for an idle bank. The rotation only decides *which* row wins a slot that is being handed out anyway.

`claim_tasks` now returns `ClaimedOperations` (rows + the rotation's next cursor) instead of a bare row list, so learning where the rotation got to costs no second statement. Callers updated.

## Cost

Measured at 50k pending rows, and both alternatives were built and rejected on measurements rather than argument:

| approach | cost | verdict |
|---|---|---|
| **this** — rotation + backfill in one statement | **0.10 ms** | same query count as before |
| bare FIFO claim (before) | 0.02 ms | the baseline |
| ordering predicate, re-scanning the bank's queue per candidate row | **11,078 ms** at 10k rows, timeout at 50k | quadratic — abandoned |
| separate seek before the claim | 0.019 ms + a round trip on every claim, every schema, every poll | abandoned |

No new index: `idx_async_operations_bank_status` and `idx_async_operations_bank_created_desc` already serve both branches. An index migration written for this turned out to be redundant — the planner never chose it, and the existing one was faster — so it was dropped.

## Oracle

Keeps the plain FIFO claim, deliberately and with the reason in the code. Its `ROWNUM` rewrite for `FOR UPDATE` + `LIMIT` (ORA-02014 forbids `FETCH FIRST` there) applies before `ORDER BY`, so a rotation would land on whichever bank is scanned first — under bulk ingest, the one it exists to rotate away from.

## Tests

`tests/test_claim_bank_fairness.py`, 10 tests: the starved bank winning the slot, the backfill still oldest-first, a lone bank taking the whole pool, the end-of-round case, the cursor value, the poller cycling banks across claims, the rotation row not being claimed twice, banks with nothing claimable skipped, fairness spanning operation types, and document serialization still holding.

They were checked to discriminate by neutralizing only the rotation tier (`LIMIT 1` → `LIMIT 0`): **7 fail, 3 are deliberate no-regression guards**. That check also caught a test that passed either way because same-age queues made FIFO and the rotation visit banks in the same order; its queues are staggered now.

Full local run of the worker, claim, retain-serialization and batch-retain suites: **402 passed, 101 skipped**, plus one fixture error in `test_worker.py::test_pending_breakdown_explains_unclaimable_rows` that is present on main and unrelated.

## Not addressed here

The issue's 300s timeout was measured on a **synchronous** write, which never touches worker slots — that path is gated by the global LLM semaphore (`llm_wrapper.py`, `HINDSIGHT_API_LLM_MAX_CONCURRENT`, default 32) and the per-op retain semaphore, neither of which is bank-aware. This fixes slot ownership, which is what the issue's title and suggestion are about, but that measurement will not move with it.

https://claude.ai/code/session_017ufCz6qrNxn36Stug7ek8A
