### PR TITLE
fix(coding-agents): stop a failed git probe from forking a worktree into its own bank

### DIFF
--- a/hindsight-integrations/coding-agents/src/antigravity-statusline.ts
+++ b/hindsight-integrations/coding-agents/src/antigravity-statusline.ts
@@ -6,7 +6,7 @@
  * changes, and a network request here would make rendering depend on server latency.
  */
 import { applyBankConfig, loadConfig, type Config } from "./core/config";
-import { deriveBankId } from "./core/bank";
+import { deriveBankIdOrSkip } from "./core/bank";
 import { brandWord } from "./core/brand";
 
 export interface AntigravityStatusLineState {
@@ -24,7 +24,9 @@ export function buildAntigravityStatusLine(state: AntigravityStatusLineState, cf
   // the directory the agent navigated to while the hooks keep writing to the session's own bank
   // (#3563). It is a display-only divergence — this command never calls the API, so nothing is
   // retained or created under the name shown.
-  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, "antigravity-cli"), cwd);
+  const bankId = deriveBankIdOrSkip(cfg, cwd, "antigravity-cli");
+  if (bankId === null) return brandWord(); // unidentifiable repo: name no bank rather than the wrong one
+  const resolved = applyBankConfig(cfg, bankId, cwd);
   return resolved.cfg.disabled ? "" : `${brandWord()} · ${resolved.bankId}`;
 }
 

--- a/hindsight-integrations/coding-agents/src/core/bank-bare-hub.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank-bare-hub.test.ts
@@ -3,9 +3,15 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { getProjectRootFromGit, projectNameOf } from "./bank";
+import { projectNameOf, resolveProjectRoot } from "./bank";
 
 const fixtures: string[] = [];
+
+/** The resolved root, or "" — these fixtures are all real repositories, so anything else fails. */
+function rootOf(directory: string): string {
+  const projectRoot = resolveProjectRoot(directory);
+  return projectRoot.status === "resolved" ? projectRoot.root : "";
+}
 
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
@@ -39,8 +45,8 @@ describe("bare-hub project resolution", () => {
     const { hub, worktree } = createBareHub(root, bareName);
     const canonicalHub = realpathSync(hub);
 
-    expect(getProjectRootFromGit(hub)).toBe(canonicalHub);
-    expect(getProjectRootFromGit(worktree)).toBe(canonicalHub);
+    expect(rootOf(hub)).toBe(canonicalHub);
+    expect(rootOf(worktree)).toBe(canonicalHub);
     expect(projectNameOf(join(worktree, "nested"))).toBe(basename(canonicalHub));
   });
 
@@ -50,7 +56,7 @@ describe("bare-hub project resolution", () => {
     const bare = join(root, "myproject.git");
     git(root, ["init", "--bare", "-q", bare]);
 
-    expect(getProjectRootFromGit(bare)).toBe(realpathSync(bare));
+    expect(rootOf(bare)).toBe(realpathSync(bare));
     expect(projectNameOf(bare)).toBe("myproject.git");
   });
 
@@ -65,7 +71,7 @@ describe("bare-hub project resolution", () => {
     const worktree = join(root, "feature");
     git(repo, ["worktree", "add", "-q", "-b", "feature", worktree]);
 
-    expect(getProjectRootFromGit(repo)).toBe(realpathSync(repo));
-    expect(getProjectRootFromGit(worktree)).toBe(realpathSync(repo));
+    expect(rootOf(repo)).toBe(realpathSync(repo));
+    expect(rootOf(worktree)).toBe(realpathSync(repo));
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/bank-probe-failure.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank-probe-failure.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./git-layout", () => ({ probeGitLayout: vi.fn() }));
+
+import { BankResolutionError, deriveBankId, deriveBankIdOrSkip, isOptedIn } from "./bank";
+import { probeGitLayout } from "./git-layout";
+
+const mockProbe = vi.mocked(probeGitLayout);
+
+/**
+ * #3950: a probe that FAILS is not a probe that says "no repository here". Reading the two the
+ * same way is what silently retained a linked worktree's session into `coding-agent::<repo>-wt1`,
+ * a bank nobody ever reads back, permanently and with no log line.
+ */
+describe("a git probe that could not complete", () => {
+  const WORKTREE = "/home/me/dev/myrepo-wt1";
+  let diagDir: string;
+
+  beforeEach(() => {
+    mockProbe.mockReturnValue({ status: "failed", reason: "EAGAIN" });
+    diagDir = mkdtempSync(join(tmpdir(), "hs-diag-"));
+    process.env.HINDSIGHT_DIAG_FILE = join(diagDir, "diag.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(diagDir, { recursive: true, force: true });
+    delete process.env.HINDSIGHT_DIAG_FILE;
+    vi.clearAllMocks();
+  });
+
+  it("never falls back to the worktree's own basename", () => {
+    expect(() => deriveBankId({}, WORKTREE)).toThrow(BankResolutionError);
+  });
+
+  it("skips the session instead, and says so in the diagnostics", () => {
+    expect(deriveBankIdOrSkip({}, WORKTREE, "claude-code")).toBeNull();
+    const events = readFileSync(process.env.HINDSIGHT_DIAG_FILE as string, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ event: "bank_unresolved", directory: WORKTREE });
+  });
+
+  it("still honours a static bank id — nothing was guessed there", () => {
+    expect(deriveBankIdOrSkip({ bankId: "pinned" }, WORKTREE)).toBe("pinned");
+  });
+
+  it("still honours an explicit mapPathToBank entry for the directory itself", () => {
+    expect(deriveBankIdOrSkip({ mapPathToBank: { [WORKTREE]: "mapped" } }, WORKTREE)).toBe(
+      "mapped"
+    );
+  });
+
+  it("leaves opt-in approval fail-closed rather than throwing", () => {
+    expect(isOptedIn({ optInOnly: true, optInPaths: ["/home/me/dev"] }, WORKTREE)).toBe(true);
+    expect(isOptedIn({ optInOnly: true, optInPaths: ["/elsewhere"] }, WORKTREE)).toBe(false);
+  });
+});
+
+/**
+ * The family guard. Bank resolution happens once per entrypoint, and #3950 was one entrypoint's
+ * worth of a wrong answer becoming permanent — so the rule has to hold for ALL of them, including
+ * the next harness added. A per-entrypoint test cannot catch this: the entrypoint that forgets is
+ * by definition the one whose test nobody wrote.
+ */
+describe("every entrypoint resolves banks through the skip path", () => {
+  const SRC = fileURLToPath(new URL("..", import.meta.url));
+
+  /** The only module allowed to call the throwing form: it IS the throwing form's home. */
+  const OWNER = "core/bank.ts";
+
+  function sourceFiles(dir: string, prefix = ""): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory())
+        return entry.name === "e2e" ? [] : sourceFiles(join(dir, entry.name), rel);
+      return entry.name.endsWith(".ts") && !entry.name.includes(".test.") ? [rel] : [];
+    });
+  }
+
+  /** Comment lines are excluded: prose naming the function is documentation, not a call. */
+  const callsDirectly = (src: string): boolean =>
+    src
+      .split("\n")
+      .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+      .some((line) => /\bderiveBankId\s*\(/.test(line));
+
+  it("has no module calling deriveBankId( directly", () => {
+    const direct = sourceFiles(SRC).filter(
+      (rel) => rel !== OWNER && callsDirectly(readFileSync(join(SRC, rel), "utf8"))
+    );
+    expect(direct).toEqual([]);
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/bank.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank.test.ts
@@ -1,18 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+// The git LAYOUT probe is the seam, not `child_process`: resolution reads the repository layout
+// off disk (see git-layout.ts), so these unit tests state what the layout says and assert the bank
+// id derived from it. Real repositories are covered by bank-bare-hub / bank-missing-dir.
+vi.mock("./git-layout", () => ({ probeGitLayout: vi.fn() }));
 
-import { execFileSync } from "node:child_process";
 import { deriveBankId } from "./bank";
+import { probeGitLayout } from "./git-layout";
 
-const mockExec = vi.mocked(execFileSync);
-const NOT_A_REPO = () => {
-  throw new Error("fatal: not a git repository");
-};
+const mockProbe = vi.mocked(probeGitLayout);
+const inRepo = (commonDir: string, bare = false) =>
+  ({ status: "resolved", commonDir, bare }) as const;
 
 describe("deriveBankId", () => {
   beforeEach(() => {
-    mockExec.mockImplementation(NOT_A_REPO); // default: not in a git repo
+    mockProbe.mockReturnValue({ status: "absent" }); // default: not in a git repo
   });
   afterEach(() => {
     vi.clearAllMocks();
@@ -25,40 +27,31 @@ describe("deriveBankId", () => {
   });
 
   it("resolves the MAIN worktree root inside git (worktrees share one bank)", () => {
-    mockExec.mockReturnValue("/home/me/dev/myrepo/.git\n");
+    mockProbe.mockReturnValue(inRepo("/home/me/dev/myrepo/.git"));
     expect(deriveBankId({}, "/home/me/dev/myrepo-feature-wt")).toBe("coding-agent::myrepo");
   });
 
   it("uses the bare-repo directory name when common-dir is not .git", () => {
-    mockExec.mockReturnValue("/srv/git/myrepo.git\n");
+    mockProbe.mockReturnValue(inRepo("/srv/git/myrepo.git", true));
     expect(deriveBankId({}, "/srv/git/myrepo.git")).toBe("coding-agent::myrepo.git");
   });
 
   it("uses the hub name for a hidden bare repository shared by worktrees", () => {
-    mockExec.mockImplementation((_command, args) => {
-      if (args?.includes("--git-common-dir")) return "/home/me/myrepo/.bare\n";
-      if (args?.includes("--is-bare-repository")) return "true\n";
-      throw new Error("unexpected git command");
-    });
+    mockProbe.mockReturnValue(inRepo("/home/me/myrepo/.bare", true));
     expect(deriveBankId({}, "/home/me/myrepo/main")).toBe("coding-agent::myrepo");
-    expect(mockExec).toHaveBeenCalledTimes(2);
   });
 
   it("keeps a hidden non-bare common directory unchanged", () => {
-    mockExec.mockImplementation((_command, args) => {
-      if (args?.includes("--git-common-dir")) return "/home/me/project/.git-bare\n";
-      if (args?.includes("--is-bare-repository")) return "false\n";
-      throw new Error("unexpected git command");
-    });
+    mockProbe.mockReturnValue(inRepo("/home/me/project/.git-bare", false));
     expect(deriveBankId({}, "/home/me/project")).toBe("coding-agent::.git-bare");
   });
 
   it("resolveWorktrees=false skips git and uses the directory basename", () => {
-    mockExec.mockReturnValue("/home/me/dev/myrepo/.git\n");
+    mockProbe.mockReturnValue(inRepo("/home/me/dev/myrepo/.git"));
     expect(deriveBankId({ resolveWorktrees: false }, "/home/me/dev/myrepo-wt")).toBe(
       "coding-agent::myrepo-wt"
     );
-    expect(mockExec).not.toHaveBeenCalled();
+    expect(mockProbe).not.toHaveBeenCalled();
   });
 
   it("the default bank is harness-neutral — same id regardless of the harness arg", () => {
@@ -94,7 +87,7 @@ describe("deriveBankId", () => {
     });
 
     it("{project} is the plain directory basename even inside git", () => {
-      mockExec.mockReturnValue("/home/me/dev/myrepo/.git\n");
+      mockProbe.mockReturnValue(inRepo("/home/me/dev/myrepo/.git"));
       expect(deriveBankId({ bankIdTemplate: "{project}" }, "/home/me/dev/myrepo-wt")).toBe(
         "myrepo-wt"
       );

--- a/hindsight-integrations/coding-agents/src/core/bank.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank.ts
@@ -20,11 +20,19 @@
  *        {user}        $HINDSIGHT_USER_ID or "anonymous"
  *      e.g. "hindsight-{gitProject}" or "{harness}-{gitProject}" to split per agent. The default
  *      is harness-neutral "coding-agent::{gitProject}" so every coding agent shares ONE memory per repo.
+ *
+ * The repository probe (core/git-layout.ts) reads the repository layout off disk and answers one
+ * of three things: this repo, no repo, or "could not tell". Only "no repo" reaches the basename
+ * fallback — a probe that FAILED makes resolution throw `BankResolutionError`, and the lifecycle
+ * hooks skip the session (`deriveBankIdOrSkip`). Guessing there is how a linked worktree ended up
+ * with a permanent bank of its own (#3950): a skipped session is recoverable, a scattered one is not.
  */
-import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, normalize, sep } from "node:path";
+import { diag } from "./diag";
+import { probeGitLayout } from "./git-layout";
+import { log } from "./log";
 import { applyTemplate } from "./template";
 
 export interface BankConfig {
@@ -44,52 +52,45 @@ const DEFAULT_BANK_NAME = "coding";
 // split memory per agent, defeating cross-agent sharing).
 const DEFAULT_TEMPLATE = "coding-agent::{gitProject}";
 
-/** Main-worktree root for a directory inside a git repo (worktree- and bare-repo-aware), else null. */
-export function getProjectRootFromGit(directory: string): string | null {
-  if (!directory) return null;
-  try {
-    const commonDir = execFileSync(
-      "git",
-      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-      {
-        cwd: directory,
-        encoding: "utf-8",
-        stdio: ["ignore", "pipe", "ignore"],
-        timeout: 1000,
-        windowsHide: true,
-      }
-    ).trim();
-    if (!commonDir) return null;
-    // Clones + `git worktree add`: common-dir is `<main root>/.git`.
-    if (basename(commonDir) === ".git") return dirname(commonDir);
+/**
+ * The repository a directory belongs to — or WHY there is no answer.
+ *
+ * "This is not a repository" and "the probe did not complete" are different answers and only the
+ * first may reach a fallback: mapping both to `null` is what forked linked worktrees into their
+ * own banks (#3950).
+ */
+export type ProjectRoot =
+  | { status: "resolved"; root: string }
+  | { status: "absent" }
+  | { status: "failed"; reason: string };
 
-    // A bare-hub keeps its bare repository in a hidden plumbing directory (usually `.bare`),
-    // while a standalone bare clone uses its directory name as the project identity. Check the
-    // common dir itself because a linked worktree reports `false` for --is-bare-repository.
-    if (basename(commonDir).startsWith(".") && isBareRepository(commonDir)) {
-      return dirname(commonDir);
-    }
-
-    // Preserve the historical name for standalone bare repositories such as `myrepo.git`.
-    return commonDir;
-  } catch {
-    return null;
+/** Thrown when a repository could not be identified because the PROBE failed. Callers on the
+ *  retain path skip the session rather than invent a bank: a skipped session is recoverable, a
+ *  session scattered into a bank nobody reads is not. */
+export class BankResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BankResolutionError";
   }
 }
 
-function isBareRepository(commonDir: string): boolean {
-  try {
-    return (
-      execFileSync("git", ["-C", commonDir, "rev-parse", "--is-bare-repository"], {
-        encoding: "utf-8",
-        stdio: ["ignore", "pipe", "ignore"],
-        timeout: 1000,
-        env: { ...process.env, GIT_DIR: undefined, GIT_WORK_TREE: undefined },
-      }).trim() === "true"
-    );
-  } catch {
-    return false;
+/** Main-worktree root for a directory inside a git repo (worktree- and bare-repo-aware). */
+export function resolveProjectRoot(directory: string): ProjectRoot {
+  if (!directory) return { status: "absent" };
+  const layout = probeGitLayout(directory);
+  if (layout.status !== "resolved") return layout;
+  const commonDir = layout.commonDir;
+  // Clones + `git worktree add`: common-dir is `<main root>/.git`.
+  if (basename(commonDir) === ".git") return { status: "resolved", root: dirname(commonDir) };
+
+  // A bare-hub keeps its bare repository in a hidden plumbing directory (usually `.bare`), while a
+  // standalone bare clone uses its directory name as the project identity.
+  if (basename(commonDir).startsWith(".") && layout.bare) {
+    return { status: "resolved", root: dirname(commonDir) };
   }
+
+  // Preserve the historical name for standalone bare repositories such as `myrepo.git`.
+  return { status: "resolved", root: commonDir };
 }
 
 /** Worktree-aware repo name for DOCUMENT IDS (gitlog:<name>, commit context): all worktrees of a
@@ -153,23 +154,37 @@ function dirName(directory: string): string {
  * exported roots are a last rescue, not a new source of truth — and both name the CURRENT
  * session's own project, so neither can reach a repo this session was not already working in.
  */
-function mainWorktreeRoot(directory: string, sessionRoot = ""): string | null {
+function mainWorktreeRoot(directory: string, sessionRoot = ""): ProjectRoot {
   const candidates = [
     nearestExistingDir(directory),
     sessionRoot,
     ...PROJECT_ROOT_ENV.map((v) => process.env[v] || ""),
   ];
+  // A failure anywhere in the cascade is remembered but not returned early: a later candidate may
+  // still answer, and only when NONE does does the difference between "no repository here" and
+  // "could not tell" matter.
+  let failure: ProjectRoot | null = null;
   for (const candidate of candidates) {
-    const root = candidate ? getProjectRootFromGit(candidate) : null;
-    if (root) return root;
+    if (!candidate) continue;
+    const projectRoot = resolveProjectRoot(candidate);
+    if (projectRoot.status === "resolved") return projectRoot;
+    if (projectRoot.status === "failed") failure = projectRoot;
   }
-  return null;
+  return failure ?? { status: "absent" };
 }
 
 function gitProjectName(directory: string, resolveWorktrees: boolean, sessionRoot = ""): string {
   if (resolveWorktrees) {
-    const root = mainWorktreeRoot(directory, sessionRoot);
-    if (root) return basename(root);
+    const projectRoot = mainWorktreeRoot(directory, sessionRoot);
+    if (projectRoot.status === "resolved") return basename(projectRoot.root);
+    // The fallback below is right for a directory outside any repository and WRONG for a failed
+    // probe inside one — for a linked worktree it names the worktree instead of the repo, forking
+    // it into a bank of its own, forever and silently (#3950). Refuse to guess instead.
+    if (projectRoot.status === "failed") {
+      throw new BankResolutionError(
+        `git probe failed for ${directory} (${projectRoot.reason}) — refusing to guess a bank id`
+      );
+    }
   }
   // Nothing git can name. `directory` is the agent's LIVE working directory and it moves during
   // normal work; inside a repo that was harmless because every subdirectory resolved back to the
@@ -212,8 +227,10 @@ function mapLookup(map: Record<string, string>, directory: string): string | und
 function lookupDirectories(config: BankConfig, directory: string, sessionRoot = ""): string[] {
   const directories = [normalize(directory)];
   if (config.resolveWorktrees ?? true) {
-    const root = mainWorktreeRoot(directory, sessionRoot);
-    const normalizedRoot = root ? normalize(root) : "";
+    // Deliberately failure-tolerant, unlike bank naming: approval and mapping fall back to the
+    // literal directory, which can only ever be narrower than the repo-wide answer.
+    const projectRoot = mainWorktreeRoot(directory, sessionRoot);
+    const normalizedRoot = projectRoot.status === "resolved" ? normalize(projectRoot.root) : "";
     if (normalizedRoot && normalizedRoot !== directories[0]) directories.push(normalizedRoot);
   }
   return directories;
@@ -283,4 +300,31 @@ export function deriveBankId(
     user: () => process.env.HINDSIGHT_USER_ID || "anonymous",
   };
   return applyTemplate(config.bankIdTemplate || DEFAULT_TEMPLATE, resolvers, "bankIdTemplate");
+}
+
+/**
+ * `deriveBankId`, or null when the repository could not be identified — with a `warn` and a diag
+ * event so the miss is diagnosable in minutes rather than by cross-referencing bank creation
+ * timestamps against a log file.
+ *
+ * The lifecycle hooks (SessionStart, prompt, retain) use this: skipping a session loses one
+ * session's memory and heals on the next hook, while guessing a bank id scatters it permanently.
+ */
+export function deriveBankIdOrSkip(
+  config: BankConfig,
+  directory: string,
+  harness = "coding",
+  sessionRoot?: string
+): string | null {
+  try {
+    return deriveBankId(config, directory, harness, sessionRoot);
+  } catch (error) {
+    if (!(error instanceof BankResolutionError)) throw error;
+    log.warn(harness, "bank unresolved: skipping (repository could not be identified)", {
+      directory,
+      error: error.message,
+    });
+    diag(harness, "bank_unresolved", { directory, error: error.message });
+    return null;
+  }
 }

--- a/hindsight-integrations/coding-agents/src/core/config.ts
+++ b/hindsight-integrations/coding-agents/src/core/config.ts
@@ -190,7 +190,7 @@ export interface Config {
   daemonProfile: string;
   embedVersion?: string;
   embedPackagePath?: string;
-  bankId?: string; // resolved per-directory via deriveBankId(cfg, dir) — see core/bank.ts
+  bankId?: string; // resolved per-directory via deriveBankIdOrSkip — see core/bank.ts
   dynamicBankId?: boolean;
   bankIdTemplate?: string;
   mapPathToBank?: Record<string, string>;
@@ -560,7 +560,7 @@ export function applyBankConfig(
   cfg: Config,
   resolvedId: string,
   /** The directory the bank was resolved FROM. Supplying it enforces `optInOnly`; every entry
-   *  point already has it to hand, having just passed it to `deriveBankId`. */
+   *  point already has it to hand, having just passed it to bank resolution. */
   directory?: string
 ): { cfg: Config; bankId: string } {
   // Rides the `disabled` gate every entry point already checks after bank resolution, rather than

--- a/hindsight-integrations/coding-agents/src/core/git-layout-retry.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/git-layout-retry.test.ts
@@ -1,0 +1,48 @@
+import type { Stats } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const lstatSync = vi.fn();
+vi.mock("node:fs", async () => ({
+  ...(await vi.importActual<typeof import("node:fs")>("node:fs")),
+  lstatSync,
+}));
+
+const { probeGitLayout } = await import("./git-layout");
+
+function transient(code: string): Error {
+  return Object.assign(new Error(code), { code });
+}
+
+describe("transient probe failures", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("retries, then answers normally once the pressure clears", () => {
+    lstatSync
+      .mockImplementationOnce(() => {
+        throw transient("EAGAIN"); // spawn-pressure's filesystem twin — the #3950 condition
+      })
+      .mockImplementation(() => ({ isDirectory: () => true }) as Stats);
+
+    const layout = probeGitLayout("/home/me/dev/myrepo-wt1");
+    expect(layout.status).toBe("resolved");
+  });
+
+  it("reports failure — never absence — when every attempt is starved", () => {
+    lstatSync.mockImplementation(() => {
+      throw transient("EMFILE");
+    });
+
+    expect(probeGitLayout("/home/me/dev/myrepo-wt1")).toEqual({
+      status: "failed",
+      reason: "EMFILE",
+    });
+  });
+
+  it("treats an ordinary missing path as absence, with no retry", () => {
+    lstatSync.mockImplementation(() => {
+      throw transient("ENOENT");
+    });
+
+    expect(probeGitLayout("/nowhere/at/all")).toEqual({ status: "absent" });
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/git-layout.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/git-layout.test.ts
@@ -1,0 +1,108 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deriveBankId, resolveProjectRoot } from "./bank";
+import { probeGitLayout } from "./git-layout";
+
+/** Real git, real worktrees — the layout reader has to agree with the tool that wrote the layout. */
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
+}
+
+describe("git layout resolution", () => {
+  let root: string;
+  let repo: string;
+  let worktree: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "hs-layout-"));
+    repo = join(root, "myrepo");
+    git(root, ["init", "-q", "-b", "main", repo]);
+    git(repo, ["config", "user.email", "test@example.invalid"]);
+    git(repo, ["config", "user.name", "Test"]);
+    git(repo, ["commit", "--allow-empty", "-qm", "seed"]);
+    worktree = join(root, "myrepo-wt1"); // a SIBLING directory, as `git worktree add` makes them
+    git(repo, ["worktree", "add", "-q", "-b", "wt1", worktree]);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("reports the repository's own git directory for a checkout", () => {
+    expect(probeGitLayout(repo)).toEqual({
+      status: "resolved",
+      commonDir: join(realpathSync(repo), ".git"),
+      bare: false,
+    });
+  });
+
+  it("follows a linked worktree to the MAIN worktree's git directory", () => {
+    expect(probeGitLayout(worktree)).toEqual({
+      status: "resolved",
+      commonDir: join(realpathSync(repo), ".git"),
+      bare: false,
+    });
+  });
+
+  it("answers the same from a nested subdirectory", () => {
+    const nested = join(worktree, "a", "b");
+    mkdirSync(nested, { recursive: true });
+    expect(resolveProjectRoot(nested)).toEqual({ status: "resolved", root: realpathSync(repo) });
+  });
+
+  it("reports absence — not failure — outside any repository", () => {
+    const plain = mkdtempSync(join(tmpdir(), "hs-plain-"));
+    try {
+      expect(probeGitLayout(plain)).toEqual({ status: "absent" });
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves a worktree with no `git` binary reachable at all", () => {
+    // The point of reading the layout: #3950 was a SPAWN failing (timeout, EAGAIN under load) and
+    // being read as "not a repository". With no subprocess there is no such failure to have — an
+    // empty PATH is the strongest available proof that none is attempted.
+    const path = process.env.PATH;
+    process.env.PATH = "";
+    try {
+      expect(deriveBankId({}, worktree)).toBe(`coding-agent::${basename(realpathSync(repo))}`);
+    } finally {
+      process.env.PATH = path;
+    }
+  });
+
+  it("does not mistake a `.git` file with no gitdir pointer for a repository", () => {
+    const junk = mkdtempSync(join(tmpdir(), "hs-junk-"));
+    try {
+      writeFileSync(join(junk, ".git"), "not a pointer\n");
+      expect(probeGitLayout(junk)).toEqual({ status: "absent" });
+    } finally {
+      rmSync(junk, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("a worktree whose administrative directory was pruned", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "hs-pruned-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("does not name the dangling gitdir (that basename IS the worktree)", () => {
+    // `git worktree prune` after the checkout survived: the `.git` pointer still names
+    // `<repo>/.git/worktrees/wt1`, whose basename is exactly the wrong bank id.
+    const stale = join(root, "myrepo-wt1");
+    mkdirSync(stale);
+    writeFileSync(join(stale, ".git"), `gitdir: ${join(root, "myrepo/.git/worktrees/wt1")}\n`);
+    expect(probeGitLayout(stale)).toEqual({ status: "absent" });
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/git-layout.ts
+++ b/hindsight-integrations/coding-agents/src/core/git-layout.ts
@@ -1,0 +1,173 @@
+/**
+ * Where does this directory's git repository keep its common directory? — answered by READING the
+ * repository layout, never by spawning `git`.
+ *
+ * This is the probe bank identity is built on, and bank identity is the one value in the plugin
+ * that must not degrade silently: a wrong id is not a degraded session, it is a *different*
+ * memory. The previous implementation shelled out to `git rev-parse --git-common-dir` with a
+ * 1000 ms budget and mapped every failure to `null` — indistinguishable from "not a repository",
+ * which is the answer that sends a linked worktree to the basename fallback and forks it into its
+ * own bank (#3950). Both failure modes were load-dependent and silent: the timeout elapsing on a
+ * busy machine, and `execFileSync` failing to spawn at all (`EAGAIN` under process pressure).
+ *
+ * Reading the layout removes the failure rather than widening its budget: no subprocess, no
+ * timeout, no spawn. It is also what git itself does — `.git` is either the git directory or a
+ * one-line pointer to it, and a linked worktree's git directory carries a `commondir` file naming
+ * the repository it belongs to:
+ *
+ *   <main>/.git/                                  ordinary checkout   -> common dir <main>/.git
+ *   <wt>/.git                 "gitdir: <main>/.git/worktrees/<name>"  -> commondir "../.." -> <main>/.git
+ *   <hub>/.git                "gitdir: ./.bare"                       -> common dir <hub>/.bare
+ *   <repo>.git/               bare clone (HEAD + objects + refs)      -> common dir <repo>.git
+ *
+ * A pure-JS git library was considered and rejected: isomorphic-git models objects and refs, not
+ * worktree discovery, so it answers a different question — and this file is ~100 lines of fs reads
+ * against a format git itself guarantees, in a package that is bundled into every hook process.
+ *
+ * Environment (`GIT_DIR`, `GIT_COMMON_DIR`) is deliberately ignored: a hook can inherit a stale
+ * one from whatever spawned it, and discovery from the directory is the question actually being
+ * asked ("which repo is this path in?").
+ */
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+export type GitLayout =
+  /** The directory is inside a repository whose common directory is `commonDir`. */
+  | { status: "resolved"; commonDir: string; bare: boolean }
+  /** The directory is definitively NOT inside a repository — the walk reached the filesystem root. */
+  | { status: "absent" }
+  /** The probe could not complete. NOT the same as absent: callers must not guess an identity. */
+  | { status: "failed"; reason: string };
+
+/** Errors worth another attempt: resource pressure, not an answer about the filesystem. */
+const TRANSIENT = new Set(["EAGAIN", "EMFILE", "ENFILE", "EBUSY", "EINTR", "EIO", "ETIMEDOUT"]);
+
+const ATTEMPTS = 3;
+const BACKOFF_MS = 20;
+
+function errorCode(error: unknown): string {
+  return (error as NodeJS.ErrnoException | undefined)?.code ?? "";
+}
+
+/** Synchronous backoff — the whole resolution path is sync (hooks call it before any await). */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+class TransientProbeError extends Error {}
+
+/** `lstat` reduced to the three answers the walk cares about; transient failures propagate. */
+function entryKind(path: string): "dir" | "file" | "none" {
+  try {
+    const st = lstatSync(path);
+    return st.isDirectory() ? "dir" : "file";
+  } catch (error) {
+    if (TRANSIENT.has(errorCode(error))) throw new TransientProbeError(errorCode(error));
+    return "none"; // ENOENT, ENOTDIR, and unreadable paths: nothing discoverable here
+  }
+}
+
+function readTextOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (error) {
+    if (TRANSIENT.has(errorCode(error))) throw new TransientProbeError(errorCode(error));
+    return null;
+  }
+}
+
+/** `gitdir: <path>` from a `.git` FILE (linked worktree, submodule, bare hub), resolved against
+ *  the directory holding it — the pointer is allowed to be relative (`gitdir: ./.bare`). */
+function gitDirFromPointer(text: string, holder: string): string | null {
+  const match = /^\s*gitdir:\s*(.+?)\s*$/m.exec(text);
+  if (!match) return null;
+  const target = match[1];
+  return isAbsolute(target) ? target : resolve(holder, target);
+}
+
+/** The repository-wide directory for a git directory: a linked worktree's own git directory names
+ *  it in `commondir`, everything else IS it. This single hop is what makes worktrees share a bank. */
+function commonDirOf(gitDir: string): string {
+  const pointer =
+    entryKind(join(gitDir, "commondir")) === "file"
+      ? readTextOrNull(join(gitDir, "commondir"))?.trim()
+      : null;
+  if (!pointer) return gitDir;
+  return isAbsolute(pointer) ? pointer : resolve(gitDir, pointer);
+}
+
+/** `core.bare = true` in the repository's own config. */
+function isBare(commonDir: string): boolean {
+  const config = readTextOrNull(join(commonDir, "config"));
+  return config !== null && /^\s*bare\s*=\s*true\s*$/im.test(config);
+}
+
+/** A directory that IS a repository (no worktree, no `.git`): `git init --bare` output. */
+function looksLikeBareRepository(directory: string): boolean {
+  return (
+    entryKind(join(directory, "HEAD")) === "file" &&
+    entryKind(join(directory, "objects")) === "dir" &&
+    entryKind(join(directory, "refs")) === "dir"
+  );
+}
+
+function canonical(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path; // a path we cannot canonicalise is still the right answer, just not resolved
+  }
+}
+
+/** A resolved answer, or null when the layout points at a directory that is no longer there — a
+ *  worktree whose administrative directory has been pruned. Naming THAT path would hand the bank
+ *  the worktree's own name, the exact outcome this file exists to prevent, so the walk goes on. */
+function resolved(commonDir: string): GitLayout | null {
+  if (entryKind(commonDir) !== "dir") return null;
+  const canonicalDir = canonical(commonDir);
+  return { status: "resolved", commonDir: canonicalDir, bare: isBare(canonicalDir) };
+}
+
+function probeOnce(directory: string): GitLayout {
+  let current = resolve(directory);
+  for (;;) {
+    const dotGit = join(current, ".git");
+    const kind = entryKind(dotGit);
+    if (kind === "dir") {
+      const layout = resolved(commonDirOf(dotGit));
+      if (layout) return layout;
+    } else if (kind === "file") {
+      const text = readTextOrNull(dotGit);
+      const gitDir = text ? gitDirFromPointer(text, current) : null;
+      const layout = gitDir ? resolved(commonDirOf(gitDir)) : null;
+      if (layout) return layout;
+    }
+    if (looksLikeBareRepository(current)) {
+      const layout = resolved(current);
+      if (layout) return layout;
+    }
+    const parent = dirname(current);
+    if (parent === current) return { status: "absent" };
+    current = parent;
+  }
+}
+
+/**
+ * The common directory for `directory`, distinguishing "not a repository" from "could not tell".
+ *
+ * Retries a transient failure (the class the old spawn hit constantly) before giving up, because
+ * giving up here is what costs a session its memory.
+ */
+export function probeGitLayout(directory: string): GitLayout {
+  if (!directory) return { status: "absent" };
+  let last = "";
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+    if (attempt) sleepSync(BACKOFF_MS * attempt);
+    try {
+      return probeOnce(directory);
+    } catch (error) {
+      last = error instanceof TransientProbeError ? error.message : errorCode(error) || "unknown";
+    }
+  }
+  return { status: "failed", reason: last };
+}

--- a/hindsight-integrations/coding-agents/src/core/hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/hook.ts
@@ -18,7 +18,7 @@
  * without stdin/stdout; `runHook` is thin plumbing around it, with a `makeClient` seam for tests.
  */
 import { existsSync, readFileSync } from "node:fs";
-import { deriveBankId } from "./bank";
+import { deriveBankIdOrSkip } from "./bank";
 import type { Config } from "./config";
 import { applyBankConfig, loadConfig } from "./config";
 import { diag, diagFilePath } from "./diag";
@@ -241,7 +241,9 @@ export async function runHook(
     process.stdout.write(JSON.stringify(spec.emit(context ?? "", notice, ev)));
 
   const sessionRoot = sessionRootDir(spec.harness, sessionId, cwd);
-  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, spec.harness, sessionRoot), cwd);
+  const derived = deriveBankIdOrSkip(cfg, cwd, spec.harness, sessionRoot);
+  if (derived === null) return; // repository unidentifiable: stay silent rather than invent a bank
+  const resolved = applyBankConfig(cfg, derived, cwd);
   cfg = resolved.cfg;
   const bankId = resolved.bankId;
   if (cfg.disabled) {

--- a/hindsight-integrations/coding-agents/src/core/host-client.ts
+++ b/hindsight-integrations/coding-agents/src/core/host-client.ts
@@ -15,7 +15,7 @@
  * can rotate under them.
  */
 import { applyBankConfig, loadConfig, type Config } from "./config";
-import { deriveBankId } from "./bank";
+import { deriveBankIdOrSkip } from "./bank";
 import { HindsightClient } from "./hindsight";
 
 /** A host's resolved memory: the config for THIS workspace, the bank it resolved to, and a client
@@ -33,12 +33,15 @@ export function resolveHostConfig(
   directory: string
 ): { cfg: Config; bankId: string } {
   const cfg0 = loadConfig({ harness });
-  // A globally disabled plugin stops HERE, before bank derivation: that path shells out to git,
-  // and `disabled` exists to be a zero-overhead baseline — the same agent with no memory — not
-  // merely a silent one. Callers return early on `cfg.disabled`, so the empty bank id never
-  // reaches a request.
+  // A globally disabled plugin stops HERE, before bank derivation: `disabled` exists to be a
+  // zero-overhead baseline — the same agent with no memory — not merely a silent one. Callers
+  // return early on `cfg.disabled`, so the empty bank id never reaches a request.
   if (cfg0.disabled) return { cfg: cfg0, bankId: "" };
-  return applyBankConfig(cfg0, deriveBankId(cfg0, directory, harness), directory);
+  const bankId = deriveBankIdOrSkip(cfg0, directory, harness);
+  // An unidentifiable repository takes the same exit: no bank id is safer than a guessed one, and
+  // `disabled` is the signal every caller already handles (#3950).
+  if (bankId === null) return { cfg: { ...cfg0, disabled: true }, bankId: "" };
+  return applyBankConfig(cfg0, bankId, directory);
 }
 
 /**

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -14,7 +14,7 @@
  * in core/hook.ts.
  */
 import { readFileSync } from "node:fs";
-import { deriveBankId } from "./bank";
+import { deriveBankIdOrSkip } from "./bank";
 import { retainLiveSession } from "./chat";
 import { applyBankConfig, loadConfig } from "./config";
 import { DAEMON_WAIT_RETAIN_MS, ensureDaemon } from "./daemon";
@@ -167,7 +167,11 @@ export async function runRetainHook(
   if (!transcriptPath) return;
 
   const sessionRoot = sessionRootDir(spec.harness, sessionId, cwd);
-  const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, spec.harness, sessionRoot), cwd);
+  const derived = deriveBankIdOrSkip(cfg, cwd, spec.harness, sessionRoot);
+  // Skipping the write-back loses this session; retaining it into a guessed bank loses it AND
+  // pollutes the server with a bank nothing ever reads back (#3950).
+  if (derived === null) return;
+  const resolved = applyBankConfig(cfg, derived, cwd);
   cfg = resolved.cfg;
   const bankId = resolved.bankId;
   if (cfg.disabled) return; // per-bank opt-out (banks.<id> override)

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -28,7 +28,7 @@ import { SURVEY_DOC_IDS, startCodebaseSurvey, type SurveyHarness } from "./surve
 import { applyBankConfig, loadConfig } from "./config";
 import { DAEMON_WAIT_SESSION_START_MS, ensureDaemon } from "./daemon";
 import type { Config } from "./config";
-import { deriveBankId } from "./bank";
+import { deriveBankIdOrSkip } from "./bank";
 import { brandWord } from "./brand";
 import { diag } from "./diag";
 import { setLogLevel } from "./log";
@@ -363,7 +363,9 @@ export async function runSessionStartHook(
     // Recorded HERE, on the session's first hook, so every later hook of this session resolves the
     // same bank however far the agent navigates (#3563).
     const sessionRoot = sessionRootDir(harness, sessionId, cwd);
-    const resolved = applyBankConfig(cfg, deriveBankId(cfg, cwd, harness, sessionRoot), cwd);
+    const derived = deriveBankIdOrSkip(cfg, cwd, harness, sessionRoot);
+    if (derived === null) return; // repository unidentifiable: no bank, no seed, no injection
+    const resolved = applyBankConfig(cfg, derived, cwd);
     cfg = resolved.cfg;
     const bankId = resolved.bankId;
     if (cfg.disabled) return; // per-bank opt-out (banks.<id> override)

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -23,7 +23,7 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { deriveBankId } from "./core/bank";
+import { deriveBankIdOrSkip } from "./core/bank";
 import { ingestChats } from "./core/chat";
 import { applyBankConfig, loadConfig } from "./core/config";
 import { commitsSince, repoNameOf, retainCommit, syncGitLog } from "./core/git";
@@ -50,7 +50,9 @@ function arg(name: string, def?: string): string | undefined {
 const REPO = arg("repo");
 const cfg0 = loadConfig({ harness: arg("harness") ?? undefined, path: arg("config") });
 const BANK =
-  arg("bank") ?? (REPO ? deriveBankId(cfg0, REPO, arg("harness") ?? cfg0.harness) : cfg0.bankId);
+  arg("bank") ??
+  (REPO ? deriveBankIdOrSkip(cfg0, REPO, arg("harness") ?? cfg0.harness) : cfg0.bankId) ??
+  undefined;
 const resolved0 = BANK
   ? applyBankConfig(cfg0, BANK, REPO ?? undefined)
   : { cfg: cfg0, bankId: BANK };

--- a/hindsight-integrations/coding-agents/src/hindsight-seed.ts
+++ b/hindsight-integrations/coding-agents/src/hindsight-seed.ts
@@ -12,7 +12,7 @@
  * need a real `--harness` flag, not added here.
  */
 import { loadConfig } from "./core/config";
-import { deriveBankId } from "./core/bank";
+import { deriveBankIdOrSkip } from "./core/bank";
 import { seedControl } from "./core/seed";
 
 function arg(name: string): string | undefined {
@@ -23,7 +23,13 @@ function arg(name: string): string | undefined {
 const command = process.argv[2] || "";
 const repo = arg("repo") || process.cwd();
 const cfg = loadConfig({ harness: "claude-code" });
-const bankId = deriveBankId(cfg, repo, "claude-code");
+const bankId = deriveBankIdOrSkip(cfg, repo, "claude-code");
+if (bankId === null) {
+  console.error(
+    `seed: cannot identify the repository at ${repo} — refusing to seed a guessed bank`
+  );
+  process.exit(1);
+}
 const result = seedControl(command, { repo, bankId });
 console.log(result.message);
 process.exit(result.ok ? 0 : 1);

--- a/hindsight-integrations/coding-agents/src/status.ts
+++ b/hindsight-integrations/coding-agents/src/status.ts
@@ -6,7 +6,7 @@
  *
  * usage: node status.js --repo <path> [--bank <id>] [--harness <name>] [--api-url U] [--api-token X] [--config path]
  */
-import { deriveBankId } from "./core/bank";
+import { deriveBankIdOrSkip } from "./core/bank";
 import { applyBankConfig, loadConfig } from "./core/config";
 import { HindsightClient } from "./core/hindsight";
 import { syncStatus } from "./core/status";
@@ -20,7 +20,9 @@ function arg(name: string): string | undefined {
 const REPO = arg("repo");
 const cfg0 = loadConfig({ harness: arg("harness") ?? undefined, path: arg("config") });
 const BANK =
-  arg("bank") ?? (REPO ? deriveBankId(cfg0, REPO, arg("harness") ?? cfg0.harness) : cfg0.bankId);
+  arg("bank") ??
+  (REPO ? deriveBankIdOrSkip(cfg0, REPO, arg("harness") ?? cfg0.harness) : cfg0.bankId) ??
+  undefined;
 if (!BANK) {
   console.error("usage: node status.js --repo <path> [--bank <id>] [--api-url U]");
   process.exit(1);


### PR DESCRIPTION
Fixes #3950.

## The bug

A transient failure of the single `git rev-parse --git-common-dir` probe silently changed a repository's bank identity. `getProjectRootFromGit` mapped **every** failure to `null` — indistinguishable from "not a git repository" — so `gitProjectName` took the basename fallback and a linked worktree was retained into a brand-new bank. Permanently, with no log line, no diag event and no retry. One repository in the wild accumulated eight stray `coding-agent::<repo>-wtN` banks; the user's first symptom is "my memory is missing", days later.

Both triggers were load-dependent and silent: the 1000 ms `timeout` elapsing under machine load, and `execFileSync` failing to spawn at all (`EAGAIN` under process pressure). The spawn-failure path ignored the timeout entirely, so raising it would not have helped.

## The fix: read the layout, don't spawn git

New `core/git-layout.ts` resolves the common directory with `fs` reads instead of a subprocess — no spawn, no timeout, nothing to fail transiently. It is what git itself does: `.git` is either the git directory or a one-line pointer to it, and a linked worktree's git directory names its repository in `commondir`.

```
<main>/.git/                                  ordinary checkout  -> common dir <main>/.git
<wt>/.git     "gitdir: <main>/.git/worktrees/x" -> commondir "../.." -> <main>/.git
<hub>/.git    "gitdir: ./.bare"                                   -> common dir <hub>/.bare
<repo>.git/   bare clone (HEAD + objects + refs)                  -> common dir <repo>.git
```

A pure-JS git library was considered and rejected: `isomorphic-git` models objects and refs, not worktree discovery, so it answers a different question at a much larger cost in a package bundled into every hook process. `core/git.ts` deliberately keeps the git CLI — it needs real `git log` output, and a wrong answer there is not identity.

## The rest of the issue's asks

- **Failure ≠ absence** — the probe answers `resolved` / `absent` / `failed`; only `absent` may reach the basename fallback.
- **Retry** — transient codes (`EAGAIN`, `EMFILE`, `ENFILE`, `EBUSY`, `EINTR`, `EIO`, `ETIMEDOUT`) retry with backoff; `ENOENT`/`ENOTDIR` are answers, not failures, and don't.
- **Never guess** — a failed probe throws `BankResolutionError`, and every entrypoint now resolves through `deriveBankIdOrSkip`: the three lifecycle hooks return silently, `resolveHostConfig` returns the `disabled` shape its callers already handle, the statusline names no bank, the CLIs exit 1. A skipped session is recoverable and heals on the next hook; a scattered one is not. Static `bankId` and `mapPathToBank` still resolve — nothing was guessed there.
- **Log it** — `log.warn` plus a `bank_unresolved` diag event carrying the directory and reason.
- Raising the 1000 ms budget is moot: there is no subprocess left.

Found on the way: a **pruned** worktree whose `.git` still points at a deleted `…/.git/worktrees/wt1` could be named `wt1` — the same wrong id by another route. The walk now rejects a common directory that no longer exists and keeps climbing.

## Tests

- `git-layout.test.ts` — real repos, linked worktrees, bare hubs, nested dirs, and resolution with `PATH` emptied (the strongest available proof that nothing spawns); plus the pruned-worktree case.
- `git-layout-retry.test.ts` — a starved probe retries, then reports `failed`, never `absent`.
- `bank-probe-failure.test.ts` — no basename fallback, skip + diag event, static/mapped ids survive, opt-in stays fail-closed.
- A **family guard** in the style of `daemon.test.ts`: no module outside `core/bank.ts` may call the throwing `deriveBankId(` directly, so the next entrypoint added can't quietly reintroduce the guess.
- `bank.test.ts` now mocks the layout probe rather than `child_process` — that's the real seam.

## Not in scope

The issue's "Cleanup" section — folding an already-created stray bank back into the real one. That's server-side surgery and deserves its own issue; #3950 can stay open for it or a follow-up can track it.

https://claude.ai/code/session_011n8KQc8sCe4cJJCd8Cv69n
