### PR TITLE
fix(reflect): name the sections array the document schema requires

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/prompts.py
@@ -444,6 +444,17 @@ def build_system_prompt_for_tools(
                 "## Output Format: Structured Document",
                 "Call done() with a 'document' field. Do NOT write a markdown document — "
                 "state its structure and the markdown is generated from it.",
+                # Name the wrapper and show it. Every field of a *section* was spelled out
+                # here — heading, level, blocks — and the array holding them never was, so
+                # the prose described a section while the tool schema described a document
+                # containing sections. Models resolved that disagreement in favour of the
+                # prose and emitted the bare section, which parsed to zero sections, an
+                # empty render, and a failed refresh. A shape stated in one place and shown
+                # in another is a shape that gets filled correctly.
+                "- 'document' holds a 'sections' array — one entry per section, in order. "
+                'Shape: {"sections": [{"heading": "Overview", "level": 2, "blocks": '
+                '["First paragraph.", "- a list item\\n- another"]}]}',
+                "- Even a one-section document uses the 'sections' array; never emit a bare section",
                 "- Each section carries its heading text (no '#') and a level; the heading is NOT a block",
                 "- 'blocks' holds the section's content, ONE block per paragraph, list, table or code fence",
                 "- Never put two paragraphs in one block, and never put a heading inside a block",

--- a/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/structured_doc.py
@@ -334,7 +334,20 @@ def document_from_sections(payload: dict) -> StructuredDocument:
     rejected. A block holding several blank-line-separated fragments is split
     into one block each, so the document keeps the granularity delta operations
     address even when the model packs a whole section into one string.
+
+    That tolerance now extends to the wrapper itself. A one-section document is
+    the shape a model most often flattens — it emits the section *as* the
+    document, ``{"heading": …, "level": …, "blocks": […]}``, with no ``sections``
+    array around it. Every fact it was asked for is present and correctly
+    structured; only the wrapper is missing. Read literally that payload has no
+    sections at all, so it rendered to an empty string and reflect raised
+    ReflectNoAnswerError — a whole refresh thrown away, and retried against the
+    same prompt, over one absent key (observed from Gemini on the mental-model
+    refresh path). Take it as the single section it plainly is.
     """
+    if "sections" not in payload and isinstance(payload.get("blocks"), list):
+        payload = {"sections": [payload]}
+
     sections: list[Section] = []
     used_ids: set[str] = set()
     block_ids: set[str] = set()

--- a/hindsight-api-slim/tests/test_reflect_document_answer.py
+++ b/hindsight-api-slim/tests/test_reflect_document_answer.py
@@ -5,12 +5,17 @@ structure, and reading markdown back is where #3361 destroyed tables. In
 document mode the model states the structure and the markdown is rendered from
 it, so nothing the model writes is ever parsed to find out what it meant.
 
-These are pure-Python tests of the schema and the parsing of the tool call —
-the mechanics. Whether a real model fills the shape correctly is covered by the
-``hs_llm_core`` refresh evals in ``test_mental_model_delta.py``.
+Most of these are pure-Python tests of the schema, the prompt text and the
+parsing of the tool call — the mechanics. ``TestRealModelFillsTheDocumentShape``
+is the exception: whether a real model actually fills the shape is the thing
+that broke, and no amount of schema testing can answer it.
 """
 
 from __future__ import annotations
+
+import uuid
+
+import pytest
 
 from hindsight_api.engine.reflect.structured_doc import (
     document_from_sections,
@@ -119,6 +124,88 @@ class TestDocumentFromSections:
         assert render_document(document_from_sections({"sections": []})) == ""
 
 
+class TestBareSectionIsReadAsOne:
+    """A one-section document the model emitted without its wrapper.
+
+    The most common near-miss on this schema: the model states the section *as*
+    the document — heading, level and blocks at the top level, no ``sections``
+    array. Every fact is present and correctly structured; only the wrapper is
+    absent. Read literally it has no sections, which rendered to "" and made
+    reflect raise ReflectNoAnswerError — the whole refresh discarded, and retried
+    against the same prompt, over one missing key.
+    """
+
+    def test_a_bare_section_is_taken_as_the_document(self):
+        doc = document_from_sections(
+            {"heading": "Team Information Summary", "level": 2, "blocks": ["Alice leads.", "Bob reviews."]}
+        )
+        assert [s.heading for s in doc.sections] == ["Team Information Summary"]
+        rendered = render_document(doc)
+        assert "## Team Information Summary" in rendered
+        # The content is what was nearly thrown away — assert it survives, not just the shape.
+        assert "Alice leads." in rendered
+        assert "Bob reviews." in rendered
+
+    def test_a_bare_section_keeps_the_block_granularity(self):
+        """Blocks must not be folded together on this path — delta operations address
+        them individually, so a document imported here has to be as addressable as one
+        that arrived wrapped."""
+        doc = document_from_sections({"heading": "H", "level": 2, "blocks": ["One.", "- a\n- b"]})
+        assert len(doc.sections[0].blocks) == 2
+
+    def test_a_wrapped_document_is_unaffected(self):
+        """The normalisation triggers on the absence of ``sections``, so a correct
+        payload — including one whose section happens to carry no blocks — takes the
+        ordinary path."""
+        doc = document_from_sections({"sections": [{"heading": "H", "level": 2, "blocks": ["x"]}]})
+        assert [s.heading for s in doc.sections] == ["H"]
+        assert document_from_sections({"sections": []}).sections == []
+
+    def test_a_payload_that_is_neither_stays_empty(self):
+        """Not a licence to guess: something with no sections and no blocks is not a
+        document, and inventing one from it would be the silent overwrite #2959 fixed."""
+        assert document_from_sections({"heading": "H", "level": 2}).sections == []
+        assert document_from_sections({"blocks": "not a list"}).sections == []
+
+
+class TestDocumentPromptStatesTheShape:
+    """The prompt has to name the field the schema requires.
+
+    It described every field of a *section* — heading, level, blocks — and never
+    named the ``sections`` array holding them, so the prose described a section
+    while the tool schema described a document containing sections. Models
+    resolved that disagreement in favour of the prose. These are direct asserts,
+    not judged: whether the text reaches the prompt is mechanical.
+    """
+
+    @staticmethod
+    def _document_block() -> str:
+        from hindsight_api.engine.reflect.prompts import build_system_prompt_for_tools
+
+        prompt = build_system_prompt_for_tools(bank_profile={"name": "T", "mission": ""}, answer_as_document=True)
+        return prompt[prompt.index("## Output Format: Structured Document") :]
+
+    def test_the_sections_array_is_named(self):
+        assert "'sections' array" in self._document_block()
+
+    def test_an_example_of_the_shape_is_shown(self):
+        """A nested shape stated but never shown is the gap that caused this: the
+        example is the part a model copies."""
+        block = self._document_block()
+        assert '{"sections": [{"heading"' in block
+
+    def test_the_single_section_case_is_called_out(self):
+        """The failure only ever showed up on one-section documents — that is the case
+        where flattening looks harmless to the model."""
+        assert "never emit a bare section" in self._document_block()
+
+    def test_markdown_mode_does_not_carry_the_document_shape(self):
+        from hindsight_api.engine.reflect.prompts import build_system_prompt_for_tools
+
+        prompt = build_system_prompt_for_tools(bank_profile={"name": "T", "mission": ""})
+        assert "'sections' array" not in prompt
+
+
 class TestOverBudgetRewrite:
     """A document too long for its budget is trimmed as a document, not as prose.
 
@@ -163,3 +250,58 @@ class TestOverBudgetRewrite:
         ):
             trimmed = _document_from_rewrite(rewritten, "## Kept\n\nbody\n")
             assert trimmed.markdown.strip() == render_document(trimmed.structure).strip()
+
+
+@pytest.mark.hs_llm_core
+@pytest.mark.asyncio
+class TestRealModelFillsTheDocumentShape:
+    """A real model, asked for a document, produces one that renders.
+
+    The schema tests above all pass while the pipeline is broken: they check the
+    shape we *accept*, not the shape a model *sends*. What actually happened is
+    that the model sent a bare section, the parse yielded zero sections, and
+    reflect raised ReflectNoAnswerError — so the assertion that matters is that a
+    real document-mode reflect comes back with content in it.
+
+    Structural asserts, not a judge: section count and non-empty text are
+    deterministic properties of any usable answer, whatever the model wrote.
+    """
+
+    async def test_document_mode_reflect_returns_a_rendered_document(self, memory_real_llm, request_context):
+        bank_id = f"test-doc-shape-{uuid.uuid4().hex[:8]}"
+        await memory_real_llm.get_bank_profile(bank_id, request_context=request_context)
+        await memory_real_llm.retain_batch_async(
+            bank_id=bank_id,
+            contents=[
+                {"content": "Alice is the team lead and owns quarterly project planning."},
+                {"content": "Bob is a senior engineer who reviews every database migration."},
+            ],
+            request_context=request_context,
+        )
+        await memory_real_llm.wait_for_background_tasks()
+
+        # A narrow question, because a one-section answer is where the model flattens
+        # the wrapper away — a broad one would produce several sections and hide it.
+        result = await memory_real_llm.reflect_async(
+            bank_id=bank_id,
+            query="Who is the team lead?",
+            answer_as_document=True,
+            request_context=request_context,
+        )
+
+        assert result.text.strip(), (
+            "document-mode reflect returned no text: the model's 'document' did not parse into "
+            "anything renderable, which is the failure this covers (an empty render makes the "
+            "mental-model refresh raise and discard the run)"
+        )
+        # ``document`` is not guaranteed: a model that answers in prose without calling
+        # done sends reflect down the forced-synthesis path, which returns text and no
+        # structure — legitimate, and handled downstream by splitting the markdown. What
+        # is guaranteed is that a document it *did* state parses into something.
+        if result.document is not None:
+            assert len(result.document.sections) >= 1, (
+                "the model stated a document and it parsed to nothing — the shape it sent is not the shape being read"
+            )
+            assert render_document(result.document).strip()
+
+        await memory_real_llm.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
Follow-up to #3943, where this surfaced.

## The bug

Document mode's output-format block (`prompts.py`) spelled out every field of a *section* and never named the array that holds them:

```
"Call done() with a 'document' field. Do NOT write a markdown document…"
- Each section carries its heading text (no '#') and a level; the heading is NOT a block
- 'blocks' holds the section's content, ONE block per paragraph, list, table or code fence
```

`document`, `heading`, `level`, `blocks` — everything except **`sections`**, which the word never appears as in this block. So the prose describes a section while the tool schema (correctly) describes a document *containing* sections, and a model resolving that disagreement in favour of the prose sends:

```json
{"document": {"heading": "Team Information Summary", "level": 2, "blocks": ["Alice leads.", "Bob reviews."]}}
```

That is a real payload captured from gemini-2.5-flash-lite on the mental-model refresh path. `document_from_sections` reads `payload["sections"]`, finds nothing, and returns an empty document:

```
sections parsed: 0
rendered: ''
```

Empty render → `ReflectNoAnswerError` → the refresh fails, preserves the old content, and the worker retries against the same prompt. Every fact the model was asked for was present and correctly structured; only the wrapper was missing.

## The fix, at both ends

**Prompt** — name the array and show the shape. This was the only output-format block in the file that described a nested shape without an example of it, and the example is the part a model copies. Also calls out the one-section case explicitly, since that is where flattening looks harmless.

**Parser** — take a bare section as the single section it plainly is. `document_from_sections` is already documented as tolerant of model output (it coerces a missing heading, an out-of-range level, a non-string block); a payload that *is* one section is the same class of near-miss, and the only one that currently costs the entire refresh instead of one field of it.

Not a licence to guess: a payload with neither `sections` nor `blocks` still yields an empty document, so an answer is never invented from something that is not one (#2959).

## Verification

- **Real Gemini, locally:** 12 document-mode refresh runs (6 with the new prompt, 6 with the old one for comparison) plus the new `hs_llm_core` reflect test — all green. **The flattening did not reproduce in that window.** It is rare, and 12 runs cannot measure a change in its rate, so the prompt half is argued from the text rather than from these runs; what they show is that the corrected prompt and the normalisation break nothing a real model does.
- **The parser half is pinned deterministically** by a unit test carrying the exact payload captured from the failing run, asserting the content survives — not just the shape.
- Prompt asserts are direct, not judged: whether the text reaches the prompt is mechanical.
- 335 tests green across the reflect / structured-doc / delta / dry-run suites; lint and `ty` clean.

https://claude.ai/code/session_01UBcDzagMhuXsYZDp63i7aB
