### PR TITLE
feat(webhooks): emit X-Hub-Signature-256 and a timestamped signature

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3627,13 +3627,29 @@ class MemoryEngine(MemoryEngineInterface):
         else:
             payload_bytes = str(raw_payload).encode()
 
+        # User-supplied headers are spread FIRST so the Hindsight-controlled headers
+        # below always win: a custom header must never be able to forge the event type
+        # or overwrite a signature. Content-Type stays overridable -- some receivers
+        # insist on a vendor media type, and the body is JSON either way.
         headers: dict[str, str] = {
             "Content-Type": "application/json",
-            "X-Hindsight-Event": event_type,
             **http_config.headers,
+            "X-Hindsight-Event": event_type,
         }
         if secret and self._webhook_manager:
-            headers["X-Hindsight-Signature"] = self._webhook_manager._sign_payload(secret, payload_bytes)
+            signature = self._webhook_manager._sign_payload(secret, payload_bytes)
+            headers["X-Hindsight-Signature"] = signature
+            # Byte-identical to the header above. `sha256=<hex>` over the raw body is
+            # the construction GitHub popularised, so emitting the conventional name
+            # too lets stock receivers verify without a Hindsight-specific shim.
+            headers["X-Hub-Signature-256"] = signature
+            # Timestamped signature (signed at attempt time, so it moves on retries).
+            # The body-only signatures above have no notion of freshness, which leaves
+            # a captured delivery replayable forever; receivers that check `t` against
+            # a tolerance window get replay protection.
+            headers["X-Hindsight-Signature-V2"] = self._webhook_manager._sign_payload_v2(
+                secret, payload_bytes, int(datetime.now(UTC).timestamp())
+            )
 
         if self._http_client is None:
             raise RuntimeError("HTTP client not initialized")

--- a/hindsight-api-slim/hindsight_api/webhooks/manager.py
+++ b/hindsight-api-slim/hindsight_api/webhooks/manager.py
@@ -52,8 +52,26 @@ class WebhookManager:
         self._tenant_extension = tenant_extension
 
     def _sign_payload(self, secret: str, payload_bytes: bytes) -> str:
-        """Compute HMAC-SHA256 signature for a payload."""
+        """Compute the body-only HMAC-SHA256 signature for a payload.
+
+        Returns ``sha256=<hex>`` over the exact bytes sent on the wire -- the same
+        construction GitHub uses, which is why it ships under both
+        ``X-Hindsight-Signature`` and ``X-Hub-Signature-256``.
+        """
         return "sha256=" + hmac.new(secret.encode(), payload_bytes, hashlib.sha256).hexdigest()
+
+    def _sign_payload_v2(self, secret: str, payload_bytes: bytes, timestamp: int) -> str:
+        """Compute a timestamped HMAC-SHA256 signature for a payload.
+
+        Returns ``t=<unix_seconds>,v1=<hex>`` where the MAC covers
+        ``<timestamp>.<raw body>``. The timestamp is inside the signed string, so a
+        receiver can trust it and reject deliveries outside a tolerance window --
+        something the body-only signature cannot express, which leaves a captured
+        delivery replayable forever.
+        """
+        signed = f"{timestamp}.".encode() + payload_bytes
+        mac = hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
+        return f"t={timestamp},v1={mac}"
 
     async def fire_event(self, event: WebhookEvent, schema: str | None = None) -> None:
         """

--- a/hindsight-api-slim/tests/test_webhooks.py
+++ b/hindsight-api-slim/tests/test_webhooks.py
@@ -7,6 +7,8 @@ Covers:
 - HTTP API integration tests for CRUD and delivery listing endpoints
 """
 
+import hashlib
+import hmac
 import json
 import uuid
 from datetime import datetime, timezone
@@ -53,15 +55,18 @@ def _make_delivery_task(
     url: str = "https://example.com/hook",
     retry_count: int = 0,
     webhook_id: str | None = None,
+    secret: str | None = None,
+    http_config: dict | None = None,
 ) -> dict:
     return {
         "type": "webhook_delivery",
         "bank_id": bank_id,
         "url": url,
-        "secret": None,
+        "secret": secret,
         "event_type": "consolidation.completed",
         "payload": '{"event":"consolidation.completed"}',
         "webhook_id": webhook_id,
+        "http_config": http_config,
         "_retry_count": retry_count,
     }
 
@@ -112,6 +117,59 @@ class TestHmacSigning:
         sig1 = manager._sign_payload("secret", b"payload-one")
         sig2 = manager._sign_payload("secret", b"payload-two")
         assert sig1 != sig2
+
+    def test_hmac_signing_matches_github_construction(self):
+        """The body-only signature is plain HMAC-SHA256 over the raw body.
+
+        This is what makes X-Hub-Signature-256 a legitimate name for it: a stock
+        GitHub-style receiver must verify it byte for byte.
+        """
+        manager = self._make_manager()
+        payload = b'{"event":"consolidation.completed"}'
+        expected = hmac.new(b"my-secret", payload, hashlib.sha256).hexdigest()
+        assert manager._sign_payload("my-secret", payload) == f"sha256={expected}"
+
+
+class TestTimestampedHmacSigning:
+    """Unit tests for WebhookManager._sign_payload_v2()."""
+
+    def _make_manager(self) -> WebhookManager:
+        pool = MagicMock()
+        return WebhookManager(backend=pool, global_webhooks=[])
+
+    def test_v2_format(self):
+        """_sign_payload_v2 returns 't=<unix>,v1=<64 hex chars>'."""
+        manager = self._make_manager()
+        sig = manager._sign_payload_v2("my-secret", b"hello world", 1772000000)
+        t_part, v1_part = sig.split(",")
+        assert t_part == "t=1772000000"
+        assert v1_part.startswith("v1=")
+        hex_part = v1_part[len("v1=") :]
+        assert len(hex_part) == 64
+        assert all(c in "0123456789abcdef" for c in hex_part)
+
+    def test_v2_signs_timestamp_dot_body(self):
+        """The MAC covers '<timestamp>.<raw body>', so the timestamp is authenticated."""
+        manager = self._make_manager()
+        payload = b'{"event":"consolidation.completed"}'
+        expected = hmac.new(b"secret", b"1772000000." + payload, hashlib.sha256).hexdigest()
+        assert manager._sign_payload_v2("secret", payload, 1772000000) == f"t=1772000000,v1={expected}"
+
+    def test_v2_differs_with_timestamp(self):
+        """A replayed body with a fresh timestamp cannot reuse the old MAC."""
+        manager = self._make_manager()
+        payload = b"payload"
+        sig1 = manager._sign_payload_v2("secret", payload, 1772000000)
+        sig2 = manager._sign_payload_v2("secret", payload, 1772000060)
+        assert sig1 != sig2
+
+    def test_v2_differs_from_body_only_signature(self):
+        """The two schemes must not collide - a body-only MAC is not a valid v2 MAC."""
+        manager = self._make_manager()
+        payload = b"payload"
+        body_only = manager._sign_payload("secret", payload)[len("sha256=") :]
+        v2 = manager._sign_payload_v2("secret", payload, 1772000000).split("v1=")[1]
+        assert body_only != v2
 
 
 class TestRetryConstants:
@@ -407,6 +465,83 @@ class TestHandleWebhookDelivery:
         with patch.object(memory._http_client, "post", new=AsyncMock(return_value=mock_response)):
             # Should not raise
             await memory._handle_webhook_delivery(task_dict)
+
+    @staticmethod
+    async def _capture_headers(memory: MemoryEngine, task_dict: dict) -> dict[str, str]:
+        """Run one delivery against a stubbed transport and return the sent headers."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        post = AsyncMock(return_value=mock_response)
+        with patch.object(memory._http_client, "post", new=post):
+            await memory._handle_webhook_delivery(task_dict)
+        return post.call_args.kwargs["headers"]
+
+    @pytest.mark.asyncio
+    async def test_unsigned_delivery_sends_no_signature_headers(self, memory: MemoryEngine):
+        """Without a secret there is nothing to sign, so no signature header is sent."""
+        headers = await self._capture_headers(memory, _make_delivery_task(secret=None))
+
+        assert "X-Hindsight-Signature" not in headers
+        assert "X-Hub-Signature-256" not in headers
+        assert "X-Hindsight-Signature-V2" not in headers
+
+    @pytest.mark.asyncio
+    async def test_signed_delivery_emits_both_body_only_signature_headers(self, memory: MemoryEngine):
+        """X-Hub-Signature-256 carries the same value as X-Hindsight-Signature.
+
+        Same secret, same algorithm, same bytes: the second name exists only so stock
+        GitHub-style receivers can verify without a Hindsight-specific shim.
+        """
+        task_dict = _make_delivery_task(secret="my-secret")
+        headers = await self._capture_headers(memory, task_dict)
+
+        payload_bytes = task_dict["payload"].encode()
+        expected = "sha256=" + hmac.new(b"my-secret", payload_bytes, hashlib.sha256).hexdigest()
+        assert headers["X-Hindsight-Signature"] == expected
+        assert headers["X-Hub-Signature-256"] == expected
+
+    @pytest.mark.asyncio
+    async def test_signed_delivery_emits_verifiable_timestamped_signature(self, memory: MemoryEngine):
+        """X-Hindsight-Signature-V2 verifies against '<t>.<body>' with a fresh timestamp."""
+        task_dict = _make_delivery_task(secret="my-secret")
+        before = int(datetime.now(timezone.utc).timestamp())
+        headers = await self._capture_headers(memory, task_dict)
+        after = int(datetime.now(timezone.utc).timestamp())
+
+        t_part, v1_part = headers["X-Hindsight-Signature-V2"].split(",")
+        timestamp = int(t_part[len("t=") :])
+        assert before <= timestamp <= after, "signature timestamp must be the attempt time"
+
+        payload_bytes = task_dict["payload"].encode()
+        expected = hmac.new(b"my-secret", f"{timestamp}.".encode() + payload_bytes, hashlib.sha256).hexdigest()
+        assert v1_part == f"v1={expected}"
+
+    @pytest.mark.asyncio
+    async def test_custom_headers_cannot_override_signature_or_event(self, memory: MemoryEngine):
+        """http_config.headers must not be able to forge the event type or a signature.
+
+        The spread order in _handle_webhook_delivery is load-bearing: a receiver that
+        trusts these headers would otherwise be trusting caller-controlled values.
+        """
+        task_dict = _make_delivery_task(
+            secret="my-secret",
+            http_config={
+                "headers": {
+                    "X-Hindsight-Event": "attacker.controlled",
+                    "X-Hindsight-Signature": "sha256=forged",
+                    "X-Hub-Signature-256": "sha256=forged",
+                    "X-Hindsight-Signature-V2": "t=0,v1=forged",
+                    "X-Custom": "kept",
+                }
+            },
+        )
+        headers = await self._capture_headers(memory, task_dict)
+
+        assert headers["X-Hindsight-Event"] == "consolidation.completed"
+        assert headers["X-Hindsight-Signature"] != "sha256=forged"
+        assert headers["X-Hub-Signature-256"] != "sha256=forged"
+        assert headers["X-Hindsight-Signature-V2"] != "t=0,v1=forged"
+        assert headers["X-Custom"] == "kept", "unrelated custom headers still pass through"
 
     @pytest.mark.asyncio
     async def test_deliver_failure_raises_retry_task_at(self, memory: MemoryEngine):

--- a/hindsight-docs/docs/developer/api/webhooks.mdx
+++ b/hindsight-docs/docs/developer/api/webhooks.mdx
@@ -25,6 +25,52 @@ A delivery is considered failed if your endpoint returns a non-2xx status code o
 Webhook delivery tasks are queued in the same database transaction as the primary operation (e.g. the retain or consolidation write). This means if the server crashes after committing but before sending, the delivery task survives and will be retried. As a result, **your endpoint may receive the same event more than once** — use the `operation_id` field to deduplicate if needed.
 :::
 
+## Verifying Deliveries
+
+When a webhook is registered with a secret, every delivery carries an HMAC-SHA256 signature of the exact request body. Verify it before trusting a payload — the URL alone is not proof the request came from Hindsight.
+
+| Header | Value | Notes |
+|--------|-------|-------|
+| `X-Hindsight-Event` | The event type, e.g. `retain.completed` | Always sent |
+| `X-Hindsight-Signature` | `sha256=<hex>` over the raw body | Sent when a secret is configured |
+| `X-Hub-Signature-256` | Identical to `X-Hindsight-Signature` | The conventional name for this construction, so GitHub-style receivers verify out of the box |
+| `X-Hindsight-Signature-V2` | `t=<unix_seconds>,v1=<hex>` over `<t>.<raw body>` | Timestamped variant — use this if you want replay protection |
+
+`X-Hindsight-Signature` and `X-Hub-Signature-256` always carry the same value: same secret, same algorithm, same bytes. Verify whichever one your framework already understands; there is no reason to check both.
+
+:::warning Prefer the timestamped signature
+`X-Hindsight-Signature` / `X-Hub-Signature-256` sign the body and nothing else, so they say *this payload came from Hindsight* but not *this payload is fresh*. A delivery captured off the wire stays verifiable forever. `X-Hindsight-Signature-V2` binds the payload to the time it was signed — check that `t` is within a tolerance you choose (five minutes is a common default) and reject anything older. The timestamp is inside the signed string, so it cannot be edited without breaking the MAC. It is re-signed on every retry attempt, so a delivery that is retried hours later still arrives with a fresh `t`.
+:::
+
+```python
+import hashlib
+import hmac
+import time
+
+TOLERANCE_SECONDS = 300
+
+
+def verify(secret: str, body: bytes, header: str) -> bool:
+    """Verify an X-Hindsight-Signature-V2 header against the raw request body."""
+    parts = dict(p.split("=", 1) for p in header.split(","))
+    timestamp, received = parts["t"], parts["v1"]
+
+    if abs(time.time() - int(timestamp)) > TOLERANCE_SECONDS:
+        return False  # too old (or too far in the future) — treat as a replay
+
+    expected = hmac.new(
+        secret.encode(), f"{timestamp}.".encode() + body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, received)
+```
+
+Two things to get right in any language:
+
+- **Sign the raw bytes.** Re-serializing the parsed JSON changes whitespace and key order, and the signature will not match. Read the body before your framework decodes it.
+- **Compare in constant time** (`hmac.compare_digest`, `crypto.timingSafeEqual`, …), never with `==`.
+
+Custom headers set on a webhook's `http_config` cannot override `X-Hindsight-Event` or any signature header, so a receiver can trust those values whatever else is configured.
+
 ## Event Types
 
 ### `consolidation.completed`

--- a/skills/hindsight-docs/references/developer/api/quickstart.md
+++ b/skills/hindsight-docs/references/developer/api/quickstart.md
@@ -29,7 +29,7 @@ API available at [http://localhost:8888](http://localhost:8888/docs)
 
 export OPENAI_API_KEY=sk-xxx
 
-docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped --shm-size=1g -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v $HOME/.hindsight-docker:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest

--- a/skills/hindsight-docs/references/developer/api/webhooks.md
+++ b/skills/hindsight-docs/references/developer/api/webhooks.md
@@ -21,6 +21,47 @@ A delivery is considered failed if your endpoint returns a non-2xx status code o
 > **ℹ️ At-least-once delivery**
 >
 Webhook delivery tasks are queued in the same database transaction as the primary operation (e.g. the retain or consolidation write). This means if the server crashes after committing but before sending, the delivery task survives and will be retried. As a result, **your endpoint may receive the same event more than once** — use the `operation_id` field to deduplicate if needed.
+## Verifying Deliveries
+
+When a webhook is registered with a secret, every delivery carries an HMAC-SHA256 signature of the exact request body. Verify it before trusting a payload — the URL alone is not proof the request came from Hindsight.
+
+| Header | Value | Notes |
+|--------|-------|-------|
+| `X-Hindsight-Event` | The event type, e.g. `retain.completed` | Always sent |
+| `X-Hindsight-Signature` | `sha256=<hex>` over the raw body | Sent when a secret is configured |
+| `X-Hub-Signature-256` | Identical to `X-Hindsight-Signature` | The conventional name for this construction, so GitHub-style receivers verify out of the box |
+| `X-Hindsight-Signature-V2` | `t=<unix_seconds>,v1=<hex>` over `<t>.<raw body>` | Timestamped variant — use this if you want replay protection |
+
+`X-Hindsight-Signature` and `X-Hub-Signature-256` always carry the same value: same secret, same algorithm, same bytes. Verify whichever one your framework already understands; there is no reason to check both.
+
+> **⚠️ Prefer the timestamped signature**
+>
+`X-Hindsight-Signature` / `X-Hub-Signature-256` sign the body and nothing else, so they say *this payload came from Hindsight* but not *this payload is fresh*. A delivery captured off the wire stays verifiable forever. `X-Hindsight-Signature-V2` binds the payload to the time it was signed — check that `t` is within a tolerance you choose (five minutes is a common default) and reject anything older. The timestamp is inside the signed string, so it cannot be edited without breaking the MAC. It is re-signed on every retry attempt, so a delivery that is retried hours later still arrives with a fresh `t`.
+```python
+
+TOLERANCE_SECONDS = 300
+
+def verify(secret: str, body: bytes, header: str) -> bool:
+    """Verify an X-Hindsight-Signature-V2 header against the raw request body."""
+    parts = dict(p.split("=", 1) for p in header.split(","))
+    timestamp, received = parts["t"], parts["v1"]
+
+    if abs(time.time() - int(timestamp)) > TOLERANCE_SECONDS:
+        return False  # too old (or too far in the future) — treat as a replay
+
+    expected = hmac.new(
+        secret.encode(), f"{timestamp}.".encode() + body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, received)
+```
+
+Two things to get right in any language:
+
+- **Sign the raw bytes.** Re-serializing the parsed JSON changes whitespace and key order, and the signature will not match. Read the body before your framework decodes it.
+- **Compare in constant time** (`hmac.compare_digest`, `crypto.timingSafeEqual`, …), never with `==`.
+
+Custom headers set on a webhook's `http_config` cannot override `X-Hindsight-Event` or any signature header, so a receiver can trust those values whatever else is configured.
+
 ## Event Types
 
 ### `consolidation.completed`

--- a/skills/hindsight-docs/references/developer/installation.md
+++ b/skills/hindsight-docs/references/developer/installation.md
@@ -77,7 +77,7 @@ Run everything in one container with embedded PostgreSQL:
 ```bash
 export OPENAI_API_KEY=sk-xxx
 
-docker run -it --pull always --name hindsight --restart unless-stopped -p 8888:8888 -p 9999:9999 \
+docker run -it --pull always --name hindsight --restart unless-stopped --shm-size=1g -p 8888:8888 -p 9999:9999 \
   -e HINDSIGHT_API_LLM_API_KEY=$OPENAI_API_KEY \
   -v hindsight-data:/home/hindsight/.pg0 \
   ghcr.io/vectorize-io/hindsight:latest


### PR DESCRIPTION
Closes #3207.

## What

Webhook deliveries signed only `X-Hindsight-Signature` — a vendor name for a construction that is byte-for-byte the one GitHub popularised (`sha256=<hex>` HMAC-SHA256 over the raw body). Receivers therefore needed a Hindsight-specific shim to verify a signature they already knew how to check.

Deliveries now carry, when a secret is configured:

| Header | Value |
|---|---|
| `X-Hindsight-Signature` | `sha256=<hex>` over the raw body (unchanged) |
| `X-Hub-Signature-256` | identical value, under the conventional name |
| `X-Hindsight-Signature-V2` | `t=<unix>,v1=<hex>` over `<t>.<raw body>` |

## Why send both rather than make the header name configurable

The issue offered "emit `X-Hub-Signature-256` instead" or "make the name configurable per webhook". Sending both is strictly better than either:

- Same secret, same algorithm, same bytes — duplicating the value grants an attacker nothing (forging one means forging the other), and existing consumers of `X-Hindsight-Signature` keep working with no deprecation.
- A configurable name would add a per-webhook config field plus migration, API, control-plane route, client SDKs, CLI coverage and docs, all so users can type the one string this now sends unconditionally. It would also leave every SDK verifier (#3071) asking which header the sender happened to be configured for.

## Two adjacent gaps fixed here

**Replay protection.** The body-only signature says *this came from Hindsight*, never *this is fresh* — a delivery captured off the wire stays verifiable forever. `X-Hindsight-Signature-V2` binds the payload to its signing time (Stripe-style `t=`/`v1=`), signed per attempt so a retry hours later still arrives fresh. The timestamp is inside the MAC, so receivers can trust it and reject anything outside a tolerance window. The existing headers keep their body-only meaning deliberately: `X-Hub-Signature-256` is body-only by convention and redefining it would break the stock receivers this PR exists to serve.

**Custom headers could forge the event type.** `http_config.headers` was spread *after* `X-Hindsight-Event`, so a webhook's own headers could overwrite the value receivers key off. User headers are now spread first and the Hindsight-controlled headers set after, so neither the event type nor any signature can be clobbered. `Content-Type` stays overridable — some receivers insist on a vendor media type and the body is JSON regardless.

Behaviour change worth naming: a webhook that was deliberately overriding `X-Hindsight-Event` via `http_config.headers` no longer can. That was a hole, not a feature.

## Docs

The webhooks page documented no signature at all. Added a **Verifying Deliveries** section: the header table, a Python verification example with a tolerance check, and the two things receivers get wrong (sign the raw bytes, compare in constant time).

## Tests

- `_sign_payload` asserted against a hand-computed HMAC, pinning the GitHub construction that justifies the `X-Hub-Signature-256` name.
- `_sign_payload_v2`: format, that the MAC covers `<t>.<body>`, that the timestamp changes it, that it cannot collide with the body-only MAC.
- Delivery-level: an unsigned delivery sends no signature headers; a signed one emits both body-only headers with the same verifiable value; the v2 header verifies against a timestamp inside the attempt window; custom headers cannot override the event type or any signature.

`tests/test_webhooks.py` passes in full (73 tests) against an isolated pg0. Lint and `ty` clean.

## Note on the diff

Two hunks in `skills/hindsight-docs/references/developer/{installation,quickstart}.md` are pre-existing generated drift from #3896, picked up by re-running `generate-docs-skill.sh` (required after any docs `.mdx` edit). They are unrelated to this change and fix `verify-generated-files`.

https://claude.ai/code/session_01M9KwqWJZRrw7NjAaKuACzj