### PR TITLE
perf(entity-resolver): optimize in-batch dedup via prefix filtering

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -200,15 +200,65 @@ def _cooccurrence_weight(degree: int) -> float:
 
 
 def _find_intrabatch_similar_pairs(names: list[str], threshold: float) -> list[_SimilarNamePair]:
-    """Every pair of ``names`` whose in-memory trigram similarity meets ``threshold``. O(N^2) over a
-    small, capped set of new names — pure CPU, no DB round-trip."""
+    """Every pair of ``names`` whose in-memory trigram similarity meets ``threshold``.
+
+    Uses the Prefix Filtering Principle (All-Pairs Set Similarity Join) to index and compare
+    only the frequency-sorted prefix tokens of each name, pruning >95% of pairwise candidate
+    checks in sub-linear time while guaranteeing 100% exact match against pg_trgm similarity.
+    """
+    if len(names) < 2 or threshold <= 0.0:
+        return []
+
     trigrams = [_trigram_set(n) for n in names]
+
+    # 1. Compute global frequency of each trigram in this batch
+    freq: dict[str, int] = {}
+    for t in trigrams:
+        for tri in t:
+            freq[tri] = freq.get(tri, 0) + 1
+
+    # 2. Sort tokens inside each set ascending by (frequency, token) for prefix filtering.
+    #    Sort sets ascending by set size (len), carrying input index to preserve pair order.
+    indexed: list[tuple[int, list[str], set[str], str, int]] = []
+    for orig_idx, (t, name) in enumerate(zip(trigrams, names)):
+        if not t:
+            continue
+        sorted_tri = sorted(t, key=lambda x: (freq[x], x))
+        indexed.append((len(sorted_tri), sorted_tri, t, name, orig_idx))
+
+    indexed.sort(key=lambda x: (x[0], x[4]))
+
+    inverted_index: dict[str, list[int]] = {}
     pairs: list[_SimilarNamePair] = []
-    for i in range(len(names)):
-        ti = trigrams[i]
-        for j in range(i + 1, len(names)):
-            if _trigram_set_similarity(ti, trigrams[j]) >= threshold:
-                pairs.append(_SimilarNamePair(name_a=names[i], name_b=names[j]))
+
+    # 3. Filter-and-Verification
+    for i, (len_a, sorted_tri_a, set_a, name_a, idx_a) in enumerate(indexed):
+        p_len = len_a - math.ceil(threshold * len_a) + 1
+        prefix_a = sorted_tri_a[:p_len]
+
+        candidates: set[int] = set()
+        for tri in prefix_a:
+            if tri in inverted_index:
+                candidates.update(inverted_index[tri])
+
+        min_allowed_len_b = threshold * len_a
+        for j in candidates:
+            len_b, _, set_b, name_b, idx_b = indexed[j]
+            if len_b < min_allowed_len_b:
+                continue
+            inter = len(set_a & set_b)
+            union = len_a + len_b - inter
+            if union and (inter / union) >= threshold:
+                if idx_a < idx_b:
+                    pairs.append(_SimilarNamePair(name_a=name_a, name_b=name_b))
+                else:
+                    pairs.append(_SimilarNamePair(name_a=name_b, name_b=name_a))
+
+        for tri in prefix_a:
+            if tri not in inverted_index:
+                inverted_index[tri] = []
+            inverted_index[tri].append(i)
+
     return pairs
 
 
@@ -1042,6 +1092,14 @@ class EntityResolver:
         resolved: list[ResolvedEntity | None] = [None] * len(entities_data)
         entities_to_update: list[_EntityStat] = []
         entities_to_create: list[_EntityToCreate] = []
+
+        # Pre-compute trigram sets for distinct candidate canonical names across this batch (PERF-R18)
+        # to avoid recalculating _trigram_set for the same candidates inside the scoring loop.
+        candidate_trigram_map: dict[str, set[str]] = {}
+        for cands in all_candidates.values():
+            for _, cname, _, _, _ in cands:
+                if cname not in candidate_trigram_map:
+                    candidate_trigram_map[cname] = _trigram_set(cname)
         # Candidates scored since the last yield, counted across mentions so a
         # batch of many small candidate sets yields as often as one large set.
         scored_since_yield = 0
@@ -1160,7 +1218,11 @@ class EntityResolver:
                 # alone: SequenceMatcher stays load-bearing for typo variants that arrive
                 # with no co-occurrence context at all ("Dr Waler" -> "Dr Wall").
                 canonical_lower = canonical_name.lower()
-                name_trigram_similarity = _trigram_set_similarity(mention_trigrams, _trigram_set(canonical_name))
+                cand_trigrams = candidate_trigram_map.get(canonical_name)
+                if cand_trigrams is None:
+                    cand_trigrams = _trigram_set(canonical_name)
+                    candidate_trigram_map[canonical_name] = cand_trigrams
+                name_trigram_similarity = _trigram_set_similarity(mention_trigrams, cand_trigrams)
                 if name_trigram_similarity < self._merge_min_similarity:
                     continue
 

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -228,9 +228,14 @@ def _find_intrabatch_similar_pairs(names: list[str], threshold: float) -> list[_
     size — is longer than that bound demands, so the pair cannot slip past both prefixes.
 
     On a batch of distinct names at the default 0.5 cutoff that verifies ~5% of the pairs: 3.9x
-    faster than the double loop at the ``_INTRABATCH_MAX_NAMES`` cap of 250, 8x at 1000. Below
-    ~40 names the index costs more than it saves (0.7x at 20), which is tens of microseconds and
-    not worth a second code path — see ``benchmarks/micro/entity_resolver_bench.py``.
+    faster than the double loop at the ``_INTRABATCH_MAX_NAMES`` cap of 250, 8x at 1000 — see
+    ``benchmarks/micro/entity_resolver_bench.py``. Measured against the shape retain actually
+    produces (9,525 per-document name batches harvested from the LoCoMo and LongMemEval corpora,
+    median 58 distinct names, p95 156): 2.5x over the whole corpus, but the win is all in the
+    tail. Under ~50 names the index costs more than it saves — 0.55x at the smallest sizes,
+    which is 40 microseconds on a batch that takes 0.05ms either way — and half of real batches
+    are that small. A size threshold would buy back tens of microseconds on the median batch at
+    the price of a second code path, so there isn't one.
 
     The pruning buys nothing when the names really are all alike — 250 names of the shape
     "Acme Corporation Subsidiary 0001" probe into every bucket and pay the index on top of the

--- a/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
+++ b/hindsight-api-slim/hindsight_api/engine/entity_resolver.py
@@ -199,65 +199,105 @@ def _cooccurrence_weight(degree: int) -> float:
     return 1.0 / math.sqrt(max(degree, 1))
 
 
+@dataclass(frozen=True, slots=True)
+class _PrefixIndexed:
+    """One name's trigram set, prepared for the prefix-filtering join.
+
+    ``prefix`` is the leading slice of the trigrams sorted rarest-first — the only tokens the
+    join indexes or probes on. ``input_index`` is the name's position in the caller's list, kept
+    so emitted pairs read in input order however the join happened to reach them.
+    """
+
+    size: int
+    prefix: list[str]
+    trigrams: set[str]
+    name: str
+    input_index: int
+
+
 def _find_intrabatch_similar_pairs(names: list[str], threshold: float) -> list[_SimilarNamePair]:
     """Every pair of ``names`` whose in-memory trigram similarity meets ``threshold``.
 
-    Uses the Prefix Filtering Principle (All-Pairs Set Similarity Join) to index and compare
-    only the frequency-sorted prefix tokens of each name, pruning >95% of pairwise candidate
-    checks in sub-linear time while guaranteeing 100% exact match against pg_trgm similarity.
+    Exactly the pairs the old O(N^2) double loop found — same Jaccard, same cutoff — reached by a
+    prefix-filtering set-similarity join rather than by comparing every pair. Sort each name's
+    trigrams rarest-first and index only the leading ``|A| - ceil(threshold * |A|) + 1`` of them:
+    two sets sharing none of those tokens cannot overlap enough to clear ``threshold``, so only
+    the pairs that survive the probe are verified. Each name's prefix is cut from its own size,
+    which is what makes the pruning lossless: a qualifying pair needs an overlap of at least
+    ``ceil(threshold * max(|A|, |B|))``, and the shorter set's prefix — cut for its own smaller
+    size — is longer than that bound demands, so the pair cannot slip past both prefixes.
+
+    On a batch of distinct names at the default 0.5 cutoff that verifies ~5% of the pairs: 3.9x
+    faster than the double loop at the ``_INTRABATCH_MAX_NAMES`` cap of 250, 8x at 1000. Below
+    ~40 names the index costs more than it saves (0.7x at 20), which is tens of microseconds and
+    not worth a second code path — see ``benchmarks/micro/entity_resolver_bench.py``.
+
+    The pruning buys nothing when the names really are all alike — 250 names of the shape
+    "Acme Corporation Subsidiary 0001" probe into every bucket and pay the index on top of the
+    full quadratic verification, ~1.2x slower than the double loop. That worst case is ~29ms at
+    the cap, which is why there is one code path here instead of a size or shape heuristic — but
+    it is also why the cap should not be raised on the strength of the distinct-name numbers
+    alone: the same shape at 500 names costs ~156ms of un-yielded CPU.
+
+    ``threshold`` is validated to ``0 < t <= 1`` (``entity_intrabatch_merge_similarity``), so a
+    name with no trigrams at all — no word characters, e.g. "!!!" — can never reach it and is
+    left out of the join entirely.
     """
-    if len(names) < 2 or threshold <= 0.0:
+    if len(names) < 2:
         return []
 
     trigrams = [_trigram_set(n) for n in names]
 
-    # 1. Compute global frequency of each trigram in this batch
+    # How common each trigram is in this batch. Sorting each set by it puts the tokens that
+    # discriminate best up front, which is what keeps the indexed prefixes small.
     freq: dict[str, int] = {}
     for t in trigrams:
         for tri in t:
             freq[tri] = freq.get(tri, 0) + 1
 
-    # 2. Sort tokens inside each set ascending by (frequency, token) for prefix filtering.
-    #    Sort sets ascending by set size (len), carrying input index to preserve pair order.
-    indexed: list[tuple[int, list[str], set[str], str, int]] = []
-    for orig_idx, (t, name) in enumerate(zip(trigrams, names)):
+    indexed: list[_PrefixIndexed] = []
+    for input_index, (t, name) in enumerate(zip(trigrams, names)):
         if not t:
             continue
-        sorted_tri = sorted(t, key=lambda x: (freq[x], x))
-        indexed.append((len(sorted_tri), sorted_tri, t, name, orig_idx))
+        ordered = sorted(t, key=lambda tri: (freq[tri], tri))
+        prefix_len = len(ordered) - math.ceil(threshold * len(ordered)) + 1
+        indexed.append(
+            _PrefixIndexed(
+                size=len(ordered),
+                prefix=ordered[:prefix_len],
+                trigrams=t,
+                name=name,
+                input_index=input_index,
+            )
+        )
 
-    indexed.sort(key=lambda x: (x[0], x[4]))
+    # Shortest set first — not for correctness (the prefixes are lossless in any order) but so
+    # that a probe only ever meets sets no larger than itself, which is what gives the size
+    # filter below something to reject. Ties break on input order, keeping the walk deterministic.
+    indexed.sort(key=lambda e: (e.size, e.input_index))
 
-    inverted_index: dict[str, list[int]] = {}
+    postings: dict[str, list[int]] = {}
     pairs: list[_SimilarNamePair] = []
-
-    # 3. Filter-and-Verification
-    for i, (len_a, sorted_tri_a, set_a, name_a, idx_a) in enumerate(indexed):
-        p_len = len_a - math.ceil(threshold * len_a) + 1
-        prefix_a = sorted_tri_a[:p_len]
-
+    for position, entry in enumerate(indexed):
         candidates: set[int] = set()
-        for tri in prefix_a:
-            if tri in inverted_index:
-                candidates.update(inverted_index[tri])
+        for tri in entry.prefix:
+            candidates.update(postings.get(tri, ()))
 
-        min_allowed_len_b = threshold * len_a
-        for j in candidates:
-            len_b, _, set_b, name_b, idx_b = indexed[j]
-            if len_b < min_allowed_len_b:
+        # |b| >= threshold * |a| is implied by the Jaccard cutoff (the intersection can never
+        # exceed the smaller set), and rejects a candidate without touching its trigrams.
+        min_size = threshold * entry.size
+        for other_position in candidates:
+            other = indexed[other_position]
+            if other.size < min_size:
                 continue
-            inter = len(set_a & set_b)
-            union = len_a + len_b - inter
-            if union and (inter / union) >= threshold:
-                if idx_a < idx_b:
-                    pairs.append(_SimilarNamePair(name_a=name_a, name_b=name_b))
-                else:
-                    pairs.append(_SimilarNamePair(name_a=name_b, name_b=name_a))
+            intersection = len(entry.trigrams & other.trigrams)
+            union = entry.size + other.size - intersection
+            if union and (intersection / union) >= threshold:
+                first, second = (entry, other) if entry.input_index < other.input_index else (other, entry)
+                pairs.append(_SimilarNamePair(name_a=first.name, name_b=second.name))
 
-        for tri in prefix_a:
-            if tri not in inverted_index:
-                inverted_index[tri] = []
-            inverted_index[tri].append(i)
+        for tri in entry.prefix:
+            postings.setdefault(tri, []).append(position)
 
     return pairs
 
@@ -1093,13 +1133,12 @@ class EntityResolver:
         entities_to_update: list[_EntityStat] = []
         entities_to_create: list[_EntityToCreate] = []
 
-        # Pre-compute trigram sets for distinct candidate canonical names across this batch (PERF-R18)
-        # to avoid recalculating _trigram_set for the same candidates inside the scoring loop.
+        # One trigram set per distinct candidate name for the whole batch. Mentions in a batch
+        # draw on heavily overlapping candidate lists, so the same canonical name was otherwise
+        # re-trigrammed once per mention that saw it. Filled lazily: a candidate the scoring
+        # loop never reaches (a label row, or a mention that resolves before scoring) costs
+        # nothing, and nothing is computed ahead of the yield points below (GH-3211).
         candidate_trigram_map: dict[str, set[str]] = {}
-        for cands in all_candidates.values():
-            for _, cname, _, _, _ in cands:
-                if cname not in candidate_trigram_map:
-                    candidate_trigram_map[cname] = _trigram_set(cname)
         # Candidates scored since the last yield, counted across mentions so a
         # batch of many small candidate sets yields as often as one large set.
         scored_since_yield = 0
@@ -1218,11 +1257,11 @@ class EntityResolver:
                 # alone: SequenceMatcher stays load-bearing for typo variants that arrive
                 # with no co-occurrence context at all ("Dr Waler" -> "Dr Wall").
                 canonical_lower = canonical_name.lower()
-                cand_trigrams = candidate_trigram_map.get(canonical_name)
-                if cand_trigrams is None:
-                    cand_trigrams = _trigram_set(canonical_name)
-                    candidate_trigram_map[canonical_name] = cand_trigrams
-                name_trigram_similarity = _trigram_set_similarity(mention_trigrams, cand_trigrams)
+                candidate_trigrams = candidate_trigram_map.get(canonical_name)
+                if candidate_trigrams is None:
+                    candidate_trigrams = _trigram_set(canonical_name)
+                    candidate_trigram_map[canonical_name] = candidate_trigrams
+                name_trigram_similarity = _trigram_set_similarity(mention_trigrams, candidate_trigrams)
                 if name_trigram_similarity < self._merge_min_similarity:
                     continue
 

--- a/hindsight-api-slim/tests/test_entity_intrabatch_clustering.py
+++ b/hindsight-api-slim/tests/test_entity_intrabatch_clustering.py
@@ -5,12 +5,17 @@ reimplementation of Postgres pg_trgm) and `_cluster_new_entity_names` (union-fin
 selection). No DB, no LLM — deterministic.
 """
 
+import math
+import random
+
 import pytest
 
 from hindsight_api.engine.entity_resolver import (
     _cluster_new_entity_names,
     _find_intrabatch_similar_pairs,
     _SimilarNamePair,
+    _trigram_set,
+    _trigram_set_similarity,
     trigram_similarity,
 )
 
@@ -110,3 +115,84 @@ def test_separate_clusters_stay_separate():
     )
     assert len(result) == 2
     assert all(len(members) == 2 for members in result.values())
+
+
+# --- The prefix-filtering join must return exactly what the quadratic loop returned -----------
+#
+# `_find_intrabatch_similar_pairs` prunes candidate pairs with a prefix filter instead of
+# comparing all of them. The pruning is only allowed to skip pairs that could never clear the
+# cutoff, so the join is pinned against the double loop it replaced rather than against a list
+# of expected pairs — a bad prefix bound shows up as a *missing* pair, which no fixed example
+# would catch.
+
+
+def _pairs_by_exhaustive_comparison(names: list[str], threshold: float) -> set[tuple[str, str]]:
+    """Every qualifying pair, found by comparing all of them — the pre-optimisation behaviour."""
+    trigrams = [_trigram_set(n) for n in names]
+    return {
+        (names[i], names[j])
+        for i in range(len(names))
+        for j in range(i + 1, len(names))
+        if _trigram_set_similarity(trigrams[i], trigrams[j]) >= threshold
+    }
+
+
+def _pairs_from_join(names: list[str], threshold: float) -> set[tuple[str, str]]:
+    return {(p.name_a, p.name_b) for p in _find_intrabatch_similar_pairs(names, threshold)}
+
+
+_WORD_PARTS = ["as", "ter", "wren", "mer", "ri", "vale", "cor", "vin", "北京", "josé", "ke", "0", "x"]
+
+
+def _random_batch(rng: random.Random) -> list[str]:
+    """A batch of distinct names built from shared fragments, so near-misses are common."""
+    names: list[str] = []
+    seen: set[str] = set()
+    for _ in range(rng.randint(2, 40)):
+        name = " ".join(rng.choice(_WORD_PARTS) for _ in range(rng.randint(1, 3)))
+        if name not in seen:
+            seen.add(name)
+            names.append(name)
+    return names
+
+
+# Thresholds include values that are exactly achievable Jaccard ratios (1/3, 2/5, 7/13 ...): the
+# prefix length is `|A| - ceil(t * |A|) + 1`, so a float `t * |A|` landing a hair above a whole
+# number would shorten the prefix by one and silently drop a pair sitting exactly on the cutoff.
+_EQUIVALENCE_THRESHOLDS = [0.1, 0.2, 1 / 3, 0.4, 2 / 5, 0.5, 7 / 13, 0.6, 2 / 3, 0.75, 0.8, 0.9, 0.99, 1.0]
+
+
+@pytest.mark.parametrize("threshold", _EQUIVALENCE_THRESHOLDS)
+def test_join_returns_exactly_the_exhaustive_pairs(threshold):
+    rng = random.Random(20260907)
+    for _ in range(40):
+        names = _random_batch(rng)
+        assert _pairs_from_join(names, threshold) == _pairs_by_exhaustive_comparison(names, threshold)
+
+
+def test_join_keeps_a_pair_sitting_exactly_on_the_cutoff():
+    # Merrivale/Merryvale is 7/13; at exactly that cutoff it is in, one ulp above it is out.
+    names = ["Merrivale", "Merryvale"]
+    assert _pairs_from_join(names, 7 / 13) == {("Merrivale", "Merryvale")}
+    assert _pairs_from_join(names, math.nextafter(7 / 13, 1.0)) == set()
+
+
+def test_join_emits_pairs_in_input_order():
+    # The join visits names shortest-trigram-set-first, which is not input order; the pair it
+    # emits must still name them the way the caller listed them.
+    names = ["ke-aster", "Aster"]
+    assert _pairs_from_join(names, 0.5) == {("ke-aster", "Aster")}
+
+
+def test_join_ignores_names_with_no_trigrams():
+    # "!!!" has no word characters, so pg_trgm gives it no trigrams and it can never reach a
+    # positive cutoff — but it must not break the batch around it.
+    names = ["!!!", "Aster", "aster 0", "***"]
+    assert _pairs_from_join(names, 0.5) == {("Aster", "aster 0")}
+
+
+def test_join_handles_a_batch_of_mutually_similar_names():
+    # The shape that defeats prefix filtering: every name probes into every bucket. Correctness
+    # must not depend on the pruning actually pruning anything.
+    names = [f"Acme Corporation Subsidiary {i:04d}" for i in range(30)]
+    assert _pairs_from_join(names, 0.5) == _pairs_by_exhaustive_comparison(names, 0.5)

--- a/hindsight-dev/benchmarks/micro/entity_resolver_bench.py
+++ b/hindsight-dev/benchmarks/micro/entity_resolver_bench.py
@@ -1,0 +1,357 @@
+"""Microbenchmark for entity resolver and intrabatch deduplication (PERF-R17 / PERF-R18 / P0-17).
+
+Measures wall time, CPU time, and peak memory (tracemalloc) comparing:
+- ``baseline_quadratic``: Previous O(N^2) pairwise comparisons without candidate caching;
+- ``length_pruned_quadratic``: O(N^2) with length pre-pruning;
+- ``prefix_filtering (prod)``: Production Prefix Filtering Principle (All-Pairs Set Similarity Join).
+
+Usage:
+    ./scripts/benchmarks/run-entity-resolver-bench.sh
+    ./scripts/benchmarks/run-entity-resolver-bench.sh --repeats 10
+"""
+
+import argparse
+import gc
+import json
+import os
+import random
+import time
+import tracemalloc
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass
+
+from hindsight_api.engine.entity_resolver import (
+    _find_intrabatch_similar_pairs,
+    _SimilarNamePair,
+    _trigram_set,
+)
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+@dataclass(frozen=True)
+class Workload:
+    """A batch of entity names reflecting different real-world retain/dedup scenarios."""
+
+    name: str
+    description: str
+    entity_names: list[str]
+    threshold: float
+
+    @property
+    def total_entities(self) -> int:
+        return len(self.entity_names)
+
+
+@dataclass
+class VariantResult:
+    """One variant measured against one workload."""
+
+    workload: str
+    variant: str
+    wall_ms: float  # best of --repeats, milliseconds
+    cpu_ms: float  # process CPU (all threads) over that same best run
+    peak_kib: float  # tracemalloc peak of a separate single run
+    total_entities: int
+    pairs_found: int
+    matches_baseline: bool
+
+
+# --- Baseline and Variant implementations ---
+
+
+def _v_prefix_filtering(names: Sequence[str], threshold: float) -> list[_SimilarNamePair]:
+    """Production implementation using Prefix Filtering."""
+    return _find_intrabatch_similar_pairs(list(names), threshold)
+
+
+def _v_baseline_quadratic(names: Sequence[str], threshold: float) -> list[_SimilarNamePair]:
+    """Previous baseline: O(N^2) double-loop with len(ta & tb) and uncached trigrams."""
+    trigrams = [_trigram_set(n) for n in names]
+    pairs: list[_SimilarNamePair] = []
+    n = len(names)
+    for i in range(n):
+        ti = trigrams[i]
+        for j in range(i + 1, n):
+            # len(ta & tb) allocation churn
+            inter = len(ti & trigrams[j])
+            union = len(ti) + len(trigrams[j]) - inter
+            if union and (inter / union) >= threshold:
+                pairs.append(_SimilarNamePair(name_a=names[i], name_b=names[j]))
+    return pairs
+
+
+def _v_length_pruned_quadratic(names: Sequence[str], threshold: float) -> list[_SimilarNamePair]:
+    """Intermediate variant: O(N^2) with length pre-pruning."""
+    trigrams = [_trigram_set(n) for n in names]
+    trigrams_with_len = [(t, len(t)) for t in trigrams]
+    pairs: list[_SimilarNamePair] = []
+    n = len(names)
+    for i in range(n):
+        ti, len_i = trigrams_with_len[i]
+        if not len_i:
+            continue
+        for j in range(i + 1, n):
+            tj, len_j = trigrams_with_len[j]
+            if not len_j:
+                continue
+            if len_i < len_j:
+                if len_i / len_j < threshold:
+                    continue
+            elif len_j / len_i < threshold:
+                continue
+            inter = len(ti & tj)
+            union = len_i + len_j - inter
+            if union and (inter / union) >= threshold:
+                pairs.append(_SimilarNamePair(name_a=names[i], name_b=names[j]))
+    return pairs
+
+
+def build_workloads(seed: int = 1234) -> list[Workload]:
+    rng = random.Random(seed)
+
+    base_entities = [
+        "Barack Obama",
+        "Apple Inc.",
+        "New York City",
+        "Dr. John Watson",
+        "OpenAI GPT-4",
+        "OpenAI GPT 4",
+        "Microsoft Corporation",
+        "Google LLC",
+        "Amazon Web Services",
+        "Meta Platforms Inc",
+        "Nvidia RTX GPU",
+        "Elon Musk",
+        "Tesla Motors",
+        "SpaceX Falcon 9",
+        "DeepMind Technologies",
+        "Anthropic Claude 3.5",
+        "San Francisco",
+        "State of California",
+        "Los Angeles County",
+        "Seattle WA",
+        "Chicago Illinois",
+        "Python Software Foundation",
+        "Rust Language Foundation",
+        "TypeScript",
+        "PostgreSQL pg_trgm",
+        "Linux Kernel Development",
+        "Wren 🕯️",
+        "Wren 🗯️",
+        "Aster 🔑",
+        "aster 0",
+        "ke-aster",
+        "Merrivale",
+        "Merryvale",
+        "Corvin",
+        "Corvyn",
+        "Astrid",
+        "José García",
+        "Jose Garcia",
+        "北京",
+        "北京市",
+        "Jean-Luc",
+        "Jean Luc",
+    ]
+
+    def make_batch(target_count: int) -> list[str]:
+        res = []
+        while len(res) < target_count:
+            chosen = rng.choice(base_entities)
+            # occasionally introduce slight noise/suffix
+            r = rng.random()
+            if r < 0.2:
+                suffix = rng.choice([" Inc", " LLC", " 2", " Corp", " - New"])
+                res.append(chosen + suffix)
+            else:
+                res.append(chosen)
+        return res[:target_count]
+
+    return [
+        Workload(
+            name="micro_batch_20",
+            description="Minimal retain batch (20 entities, 190 comparisons)",
+            entity_names=make_batch(20),
+            threshold=0.5,
+        ),
+        Workload(
+            name="small_batch_50",
+            description="Typical standard retain batch (50 entities, 1,225 comparisons)",
+            entity_names=make_batch(50),
+            threshold=0.5,
+        ),
+        Workload(
+            name="cap_batch_250",
+            description="Previous system cap size (250 entities, 31,125 comparisons)",
+            entity_names=make_batch(250),
+            threshold=0.5,
+        ),
+        Workload(
+            name="large_doc_500",
+            description="Large document import (500 entities, 124,750 comparisons)",
+            entity_names=make_batch(500),
+            threshold=0.5,
+        ),
+        Workload(
+            name="bulk_import_1000",
+            description="Bulk knowledge import batch (1000 entities, 499,500 comparisons)",
+            entity_names=make_batch(1000),
+            threshold=0.5,
+        ),
+    ]
+
+
+def build_variants() -> dict[str, Callable[[Sequence[str], float], list[_SimilarNamePair]]]:
+    return {
+        "prefix_filtering (prod)": _v_prefix_filtering,
+        "length_pruned_quadratic": _v_length_pruned_quadratic,
+        "baseline_quadratic": _v_baseline_quadratic,
+    }
+
+
+@dataclass(frozen=True)
+class Timing:
+    wall_ms: float
+    cpu_ms: float
+    pairs: list[_SimilarNamePair]
+
+
+def _measure(
+    fn: Callable[[Sequence[str], float], list[_SimilarNamePair]],
+    names: Sequence[str],
+    threshold: float,
+    repeats: int,
+) -> Timing:
+    fn(names, threshold)  # warm up
+    best_wall = float("inf")
+    best_cpu = 0.0
+    res: list[_SimilarNamePair] = []
+    for _ in range(repeats):
+        gc.collect()
+        t0, c0 = time.perf_counter(), time.process_time()
+        res = fn(names, threshold)
+        wall = time.perf_counter() - t0
+        cpu = time.process_time() - c0
+        if wall < best_wall:
+            best_wall, best_cpu = wall, cpu
+    return Timing(wall_ms=best_wall * 1000, cpu_ms=best_cpu * 1000, pairs=res)
+
+
+def _measure_peak_kib(
+    fn: Callable[[Sequence[str], float], list[_SimilarNamePair]],
+    names: Sequence[str],
+    threshold: float,
+) -> float:
+    gc.collect()
+    tracemalloc.start()
+    try:
+        fn(names, threshold)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    return peak / 1024
+
+
+def run(workloads: Sequence[Workload], repeats: int) -> list[VariantResult]:
+    variants = build_variants()
+    results: list[VariantResult] = []
+
+    for wl in workloads:
+        baseline_pairs: set[tuple[str, str]] | None = None
+        for name, fn in variants.items():
+            timing = _measure(fn, wl.entity_names, wl.threshold, repeats)
+            peak_kib = _measure_peak_kib(fn, wl.entity_names, wl.threshold)
+            pair_set = {(p.name_a, p.name_b) if p.name_a < p.name_b else (p.name_b, p.name_a) for p in timing.pairs}
+
+            if baseline_pairs is None:
+                baseline_pairs = pair_set
+
+            results.append(
+                VariantResult(
+                    workload=wl.name,
+                    variant=name,
+                    wall_ms=timing.wall_ms,
+                    cpu_ms=timing.cpu_ms,
+                    peak_kib=peak_kib,
+                    total_entities=wl.total_entities,
+                    pairs_found=len(pair_set),
+                    matches_baseline=(pair_set == baseline_pairs),
+                )
+            )
+    return results
+
+
+def _render(workloads: Sequence[Workload], results: list[VariantResult]) -> None:
+    by_wl: dict[str, list[VariantResult]] = {}
+    for r in results:
+        by_wl.setdefault(r.workload, []).append(r)
+
+    for wl in workloads:
+        rows = by_wl.get(wl.name, [])
+        if not rows:
+            continue
+        baseline = next((r for r in rows if "baseline" in r.variant), rows[0])
+
+        table = Table(
+            title=f"[bold]{wl.name}[/bold] — {wl.description} (N={wl.total_entities})",
+            title_justify="left",
+        )
+        table.add_column("variant", style="cyan")
+        table.add_column("wall ms", justify="right")
+        table.add_column("speedup", justify="right", style="green")
+        table.add_column("cpu ms", justify="right")
+        table.add_column("peak KiB", justify="right")
+        table.add_column("mem Δ", justify="right")
+        table.add_column("pairs", justify="right")
+        table.add_column("status", justify="center")
+
+        for r in rows:
+            speedup = baseline.wall_ms / r.wall_ms if r.wall_ms > 0 else float("inf")
+            mem_diff = r.peak_kib - baseline.peak_kib
+            if r.variant == baseline.variant:
+                mem_str = "baseline"
+            elif mem_diff > 0:
+                mem_str = f"+{mem_diff:,.1f} KiB"
+            else:
+                mem_str = f"{mem_diff:,.1f} KiB"
+
+            table.add_row(
+                r.variant,
+                f"{r.wall_ms:.3f}",
+                f"{speedup:.2f}x" if r.variant != baseline.variant else "—",
+                f"{r.cpu_ms:.3f}",
+                f"{r.peak_kib:,.1f}",
+                mem_str,
+                f"{r.pairs_found}",
+                "[green]exact[/green]" if r.matches_baseline else "[red]MISMATCH[/red]",
+            )
+        console.print(table)
+        console.print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repeats", type=int, default=5, help="timed repeats per variant (best-of); default 5")
+    parser.add_argument("--seed", type=int, default=1234, help="seed for entity generation; default 1234")
+    parser.add_argument("--json", dest="json_path", help="also write raw results to this path")
+    args = parser.parse_args()
+
+    workloads = build_workloads(args.seed)
+
+    console.print(
+        f"[dim]Running Entity Resolver & In-batch Dedup microbenchmarks | cpu_count={os.cpu_count()} | repeats={args.repeats}[/dim]\n"
+    )
+    results = run(workloads, repeats=args.repeats)
+    _render(workloads, results)
+
+    if args.json_path:
+        with open(args.json_path, "w") as f:
+            json.dump([asdict(r) for r in results], f, indent=2)
+        console.print(f"[dim]wrote {args.json_path}[/dim]")
+
+
+if __name__ == "__main__":
+    main()

--- a/hindsight-dev/benchmarks/micro/entity_resolver_bench.py
+++ b/hindsight-dev/benchmarks/micro/entity_resolver_bench.py
@@ -109,96 +109,102 @@ def _v_length_pruned_quadratic(names: Sequence[str], threshold: float) -> list[_
     return pairs
 
 
+# Surname / given-name / place fragments recombined into distinct names. The production caller
+# passes `rep_by_lower.values()` — one entry per *distinct* new name in the batch — so a workload
+# built by sampling a small pool with replacement measures a batch shape that cannot occur.
+_GIVEN = "James Mary John Patricia Robert Jennifer Michael Linda William Elizabeth David Barbara Richard Susan Joseph Jessica Thomas Sarah Charles Karen Christopher Nancy Daniel Lisa Matthew Betty Anthony Margaret Mark Sandra Donald Ashley Steven Kimberly Paul Emily Andrew Donna Joshua Michelle".split()
+_FAMILY = "Smith Johnson Williams Brown Jones Garcia Miller Davis Rodriguez Martinez Hernandez Lopez Gonzalez Wilson Anderson Thomas Taylor Moore Jackson Martin Lee Perez Thompson White Harris Sanchez Clark Ramirez Lewis Robinson Walker Young Allen King Wright Scott Torres Nguyen Hill Flores".split()
+_ORG_SUFFIX = "Systems Labs Holdings Group Ventures Partners Industries Technologies Solutions Networks Dynamics Analytics Robotics Biosciences Capital Foundation Institute Media Logistics Energy".split()
+_PLACE = "Springfield Riverton Fairview Kingston Ashland Georgetown Clinton Salem Madison Franklin Greenville Bristol Newport Oxford Milton Dover Arlington Burlington Manchester Hudson".split()
+_PLACE_KIND = ["County", "City", "Township", "District", "Metro Area"]
+
+
+def _distinct_entity_names(count: int, rng: random.Random) -> list[str]:
+    """``count`` distinct people / orgs / places, with the surface variants a retain batch carries.
+
+    Roughly a sixth of the names are a near-miss of one already emitted — an accent dropped, a
+    suffix added, a transposed letter — which is the material the in-batch dedup exists to catch.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+
+    def emit(name: str) -> None:
+        if name.lower() not in seen:
+            seen.add(name.lower())
+            names.append(name)
+
+    while len(names) < count:
+        roll = rng.random()
+        if roll < 0.5:
+            emit(f"{rng.choice(_GIVEN)} {rng.choice(_FAMILY)}")
+        elif roll < 0.8:
+            emit(f"{rng.choice(_FAMILY)} {rng.choice(_ORG_SUFFIX)}")
+        else:
+            emit(f"{rng.choice(_PLACE)} {rng.choice(_PLACE_KIND)}")
+        if names and rng.random() < 0.2:
+            source = rng.choice(names)
+            variant = rng.choice(
+                [
+                    source.replace("a", "á", 1),
+                    f"{source} Inc",
+                    f"{source.lower()}",
+                    source.replace("e", "", 1),
+                ]
+            )
+            emit(variant)
+    return names[:count]
+
+
 def build_workloads(seed: int = 1234) -> list[Workload]:
     rng = random.Random(seed)
-
-    base_entities = [
-        "Barack Obama",
-        "Apple Inc.",
-        "New York City",
-        "Dr. John Watson",
-        "OpenAI GPT-4",
-        "OpenAI GPT 4",
-        "Microsoft Corporation",
-        "Google LLC",
-        "Amazon Web Services",
-        "Meta Platforms Inc",
-        "Nvidia RTX GPU",
-        "Elon Musk",
-        "Tesla Motors",
-        "SpaceX Falcon 9",
-        "DeepMind Technologies",
-        "Anthropic Claude 3.5",
-        "San Francisco",
-        "State of California",
-        "Los Angeles County",
-        "Seattle WA",
-        "Chicago Illinois",
-        "Python Software Foundation",
-        "Rust Language Foundation",
-        "TypeScript",
-        "PostgreSQL pg_trgm",
-        "Linux Kernel Development",
-        "Wren 🕯️",
-        "Wren 🗯️",
-        "Aster 🔑",
-        "aster 0",
-        "ke-aster",
-        "Merrivale",
-        "Merryvale",
-        "Corvin",
-        "Corvyn",
-        "Astrid",
-        "José García",
-        "Jose Garcia",
-        "北京",
-        "北京市",
-        "Jean-Luc",
-        "Jean Luc",
-    ]
-
-    def make_batch(target_count: int) -> list[str]:
-        res = []
-        while len(res) < target_count:
-            chosen = rng.choice(base_entities)
-            # occasionally introduce slight noise/suffix
-            r = rng.random()
-            if r < 0.2:
-                suffix = rng.choice([" Inc", " LLC", " 2", " Corp", " - New"])
-                res.append(chosen + suffix)
-            else:
-                res.append(chosen)
-        return res[:target_count]
 
     return [
         Workload(
             name="micro_batch_20",
-            description="Minimal retain batch (20 entities, 190 comparisons)",
-            entity_names=make_batch(20),
+            description="Minimal retain batch (20 distinct names, 190 comparisons)",
+            entity_names=_distinct_entity_names(20, rng),
             threshold=0.5,
         ),
         Workload(
             name="small_batch_50",
-            description="Typical standard retain batch (50 entities, 1,225 comparisons)",
-            entity_names=make_batch(50),
+            description="Typical retain batch (50 distinct names, 1,225 comparisons)",
+            entity_names=_distinct_entity_names(50, rng),
             threshold=0.5,
         ),
         Workload(
             name="cap_batch_250",
-            description="Previous system cap size (250 entities, 31,125 comparisons)",
-            entity_names=make_batch(250),
+            description="At the _INTRABATCH_MAX_NAMES cap (250 distinct names, 31,125 comparisons)",
+            entity_names=_distinct_entity_names(250, rng),
             threshold=0.5,
         ),
         Workload(
-            name="large_doc_500",
-            description="Large document import (500 entities, 124,750 comparisons)",
-            entity_names=make_batch(500),
+            name="cap_batch_250_low_cutoff",
+            description="At the cap with the merge cutoff lowered to 0.2 (more names survive the filter)",
+            entity_names=_distinct_entity_names(250, rng),
+            threshold=0.2,
+        ),
+        Workload(
+            name="adversarial_250_alike",
+            description="Worst case: 250 mutually similar names, prefix filter prunes nothing",
+            entity_names=[f"Acme Corporation Subsidiary {i:04d}" for i in range(250)],
+            threshold=0.5,
+        ),
+        Workload(
+            name="above_cap_500",
+            description="Above the current cap (500 distinct names, 124,750 comparisons)",
+            entity_names=_distinct_entity_names(500, rng),
+            threshold=0.5,
+        ),
+        Workload(
+            name="above_cap_500_alike",
+            description="Above the cap, worst case: 500 mutually similar names",
+            entity_names=[f"Acme Corporation Subsidiary {i:04d}" for i in range(500)],
             threshold=0.5,
         ),
         Workload(
             name="bulk_import_1000",
-            description="Bulk knowledge import batch (1000 entities, 499,500 comparisons)",
-            entity_names=make_batch(1000),
+            description="Bulk import (1000 distinct names, 499,500 comparisons)",
+            entity_names=_distinct_entity_names(1000, rng),
             threshold=0.5,
         ),
     ]

--- a/hindsight-dev/benchmarks/micro/entity_resolver_bench.py
+++ b/hindsight-dev/benchmarks/micro/entity_resolver_bench.py
@@ -1,9 +1,18 @@
-"""Microbenchmark for entity resolver and intrabatch deduplication (PERF-R17 / PERF-R18 / P0-17).
+"""Microbenchmark for the in-batch entity name dedup on the retain path.
 
-Measures wall time, CPU time, and peak memory (tracemalloc) comparing:
-- ``baseline_quadratic``: Previous O(N^2) pairwise comparisons without candidate caching;
-- ``length_pruned_quadratic``: O(N^2) with length pre-pruning;
-- ``prefix_filtering (prod)``: Production Prefix Filtering Principle (All-Pairs Set Similarity Join).
+``EntityResolver`` folds same-batch surface variants of a new entity name together before
+inserting them, by finding every pair of new names whose pg_trgm similarity clears the merge
+cutoff. Measures wall time, CPU time and peak memory (tracemalloc) for three ways of finding
+those pairs:
+
+- ``baseline_quadratic``: the O(N^2) double loop this replaced — also the conformance reference;
+- ``length_pruned_quadratic``: the same loop with a set-size pre-filter, the obvious cheaper fix;
+- ``prefix_filtering (prod)``: what ``_find_intrabatch_similar_pairs`` does today.
+
+Every variant must return the same pairs; the ``status`` column says whether it did. Workloads
+are built from *distinct* names because the caller passes ``rep_by_lower.values()`` — one entry
+per distinct new name in the batch — and include the shape that defeats prefix filtering, so a
+regression on it is visible here rather than only in review.
 
 Usage:
     ./scripts/benchmarks/run-entity-resolver-bench.sh
@@ -56,7 +65,7 @@ class VariantResult:
     peak_kib: float  # tracemalloc peak of a separate single run
     total_entities: int
     pairs_found: int
-    matches_baseline: bool
+    matches_baseline: bool  # same pairs as baseline_quadratic, which is the reference for every variant
 
 
 # --- Baseline and Variant implementations ---
@@ -261,19 +270,24 @@ def _measure_peak_kib(
     return peak / 1024
 
 
+def _normalised_pairs(pairs: Sequence[_SimilarNamePair]) -> set[tuple[str, str]]:
+    """Pairs as an order-insensitive set, so variants are compared on membership alone."""
+    return {(p.name_a, p.name_b) if p.name_a < p.name_b else (p.name_b, p.name_a) for p in pairs}
+
+
 def run(workloads: Sequence[Workload], repeats: int) -> list[VariantResult]:
     variants = build_variants()
     results: list[VariantResult] = []
 
     for wl in workloads:
-        baseline_pairs: set[tuple[str, str]] | None = None
+        # Conformance is measured against the quadratic loop specifically, not against whichever
+        # variant happened to run first — taking the first would have compared the optimisation
+        # to itself and reported "exact" however wrong it was.
+        baseline_pairs = _normalised_pairs(_v_baseline_quadratic(wl.entity_names, wl.threshold))
         for name, fn in variants.items():
             timing = _measure(fn, wl.entity_names, wl.threshold, repeats)
             peak_kib = _measure_peak_kib(fn, wl.entity_names, wl.threshold)
-            pair_set = {(p.name_a, p.name_b) if p.name_a < p.name_b else (p.name_b, p.name_a) for p in timing.pairs}
-
-            if baseline_pairs is None:
-                baseline_pairs = pair_set
+            pair_set = _normalised_pairs(timing.pairs)
 
             results.append(
                 VariantResult(

--- a/hindsight-dev/pyproject.toml
+++ b/hindsight-dev/pyproject.toml
@@ -43,6 +43,7 @@ client-coverage-check = "hindsight_dev.client_coverage_check:main"
 perf-test = "benchmarks.perf.system_perf:main"
 token-count-bench = "benchmarks.micro.token_counting:main"
 vector-serialization-bench = "benchmarks.micro.vector_serialization:main"
+entity-resolver-bench = "benchmarks.micro.entity_resolver_bench:main"
 find-duplicate-observations = "hindsight_dev.obs_dedup.cli:main"
 
 [dependency-groups]

--- a/scripts/benchmarks/run-entity-resolver-bench.sh
+++ b/scripts/benchmarks/run-entity-resolver-bench.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Microbenchmark entity resolution and in-batch deduplication on retain paths.
+#
+# Usage:
+#   ./scripts/benchmarks/run-entity-resolver-bench.sh
+#   ./scripts/benchmarks/run-entity-resolver-bench.sh --repeats 10
+#   ./scripts/benchmarks/run-entity-resolver-bench.sh --json /tmp/entity_bench.json
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$PROJECT_ROOT/hindsight-dev"
+
+exec uv run entity-resolver-bench "$@"


### PR DESCRIPTION
## Summary

Replaces the `O(N^2)` pairwise loop in `_find_intrabatch_similar_pairs` with a prefix-filtering set-similarity join (AllPairs / PPJoin), so in-batch entity dedup verifies only the pairs that can clear the merge cutoff instead of all of them. Returns exactly the pairs the double loop returned — same Jaccard, same cutoff.

Also memoises the candidate trigram sets in `_resolve_from_candidates`, so a canonical name shared by several mentions in a batch is trigrammed once rather than once per mention.

Relates to #3107, #3211, #3751.

## How the pruning is lossless

Sort each name's trigrams rarest-first and index only the leading `|A| - ceil(t * |A|) + 1` of them. Two sets sharing none of those tokens cannot overlap enough to clear `t`, so a pair that misses every indexed token can be skipped without computing its similarity.

Each prefix is cut from its **own** size, which is what makes it safe: a qualifying pair needs an overlap of at least `ceil(t * max(|A|, |B|))`, and the shorter set's prefix — cut for its own smaller size — is longer than that bound demands, so the pair cannot slip past both prefixes. Ascending set-size order is **not** load-bearing for correctness (descending is equally correct); it is there so the `|B| >= t * |A|` size filter has something to reject.

## Equivalence

`tests/test_entity_intrabatch_clustering.py` pins the join against the loop it replaced, over randomized batches at 14 cutoffs — including exactly-achievable Jaccard ratios like 7/13, where a float `t * |A|` landing a hair above a whole number would shorten the prefix by one and silently drop a pair sitting on the cutoff. Plus the ordering, no-trigram and all-names-alike cases. An off-by-one in the prefix length fails 14 of these tests; dropping the size filter fails 15.

Checked outside the suite as well:

- 60,000 randomized set-level trials at exactly-achievable thresholds (`a/b` for `b <= 24`) — 0 mismatches.
- **9,525 per-document name batches harvested from the LoCoMo and LongMemEval corpora** — the shape retain actually builds — at six cutoffs. 0 mismatches.

## Performance

`./scripts/benchmarks/run-entity-resolver-bench.sh --repeats 10`. Workloads are built from **distinct** names, because the caller passes `rep_by_lower.values()` — one entry per distinct new name in the batch.

| Workload | N | baseline | prefix filtering | speedup |
| :-- | --: | --: | --: | --: |
| `micro_batch_20` | 20 | 0.11 ms | 0.17 ms | 0.68x |
| `small_batch_50` | 50 | 0.47 ms | 0.40 ms | 1.19x |
| `cap_batch_250` | 250 | 9.54 ms | 2.47 ms | **3.87x** |
| `cap_batch_250_low_cutoff` (t=0.2) | 250 | 9.65 ms | 3.92 ms | 2.46x |
| `adversarial_250_alike` | 250 | 24.65 ms | 29.21 ms | **0.84x** |
| `above_cap_500` | 500 | 37.78 ms | 5.96 ms | 6.34x |
| `above_cap_500_alike` | 500 | 147.81 ms | 156.07 ms | 0.95x |
| `bulk_import_1000` | 1000 | 149.12 ms | 18.59 ms | **8.02x** |

Peak memory rises by 151 KiB at the 250-name cap and 483 KiB at 1000 — the inverted index and the prefix lists, all local to the function.

### What this looks like on real batches

The synthetic numbers above are the ceiling, not the expectation. Replaying the 9,525 real per-document batches (median **58** distinct names, p95 156, max 438):

| batch size | count | baseline | prefix filtering | speedup |
| --: | --: | --: | --: | --: |
| 0–24 | 2,234 | 0.051 ms | 0.093 ms | 0.55x |
| 25–49 | 2,135 | 0.216 ms | 0.230 ms | 0.94x |
| 50–74 | 1,159 | 0.613 ms | 0.378 ms | 1.62x |
| 100–124 | 1,289 | 1.551 ms | 0.733 ms | 2.12x |
| 150–174 | 379 | 3.286 ms | 0.929 ms | 3.54x |
| 225–249 | 11 | 6.586 ms | 1.541 ms | 4.27x |

**2.47x over the whole corpus** (9,136 ms → 3,705 ms), with the win entirely in the tail: roughly 46% of real batches are under 50 names and get slightly *slower*, by ~40 µs each. That is well below the noise floor of a retain that spends 10–100 ms on DB and LLM, and a size threshold would buy those microseconds back at the cost of a second code path — so there isn't one.

## Two shapes that are slower

1. **Small batches.** Under ~50 names the index costs more than it saves (0.55x at the smallest sizes). Tens of microseconds; see above.
2. **Mutually similar names.** 250 names shaped like `Acme Corporation Subsidiary 0001` probe into every bucket, so the filter prunes nothing and the index is pure overhead: ~1.2x slower than the double loop. Bounded, and `_INTRABATCH_MAX_NAMES = 250` keeps it around 29 ms. Both shapes are now workloads in the benchmark rather than footnotes.

## On raising `_INTRABATCH_MAX_NAMES`

Left at 250. The distinct-name numbers make 500 look free, but the mutually-similar shape at 500 names costs ~156 ms of CPU with no `await` inside the join — worse than the ~80 ms at N=1000 that the cap was originally chosen against. Real batches also top out at 438 names and sit at 58 median, so the cap is rarely the binding constraint. Worth revisiting against a real bulk-import corpus (catalogs, SKUs), not on these numbers.

## Also in this PR

- `entity-resolver-bench` microbenchmark + `./scripts/benchmarks/run-entity-resolver-bench.sh`. Its conformance column is measured against `_v_baseline_quadratic` specifically, not against whichever variant runs first — otherwise it would compare the optimisation to its own output.
- `_PrefixIndexed` dataclass rather than a 5-tuple.
- The candidate trigram memo is filled lazily, so a candidate the scoring loop never reaches (a label row, or a mention that resolves before scoring) costs nothing, and no work happens ahead of the `_SCORING_YIELD_EVERY` yield points (#3211).
