### PR TITLE
fix(coding-agents): the runtime auto-update never fired — registry 406 on the /latest media type

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/auto-update.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/auto-update.test.ts
@@ -63,8 +63,17 @@ describe("maybeAutoUpdate", () => {
     const runtime = tmp();
     writeFileSync(join(runtime, "package.json"), JSON.stringify({ version }));
     const spawn = spawnMock();
+    // Answers like the real registry, which is the point: the previous stub returned `ok: true`
+    // whatever was asked of it, so it happily served a request npmjs.org rejects with 406 —
+    // `accept: application/vnd.npm.install-v1+json` is only valid on the packument (`/<pkg>`), not
+    // on `/<pkg>/latest`. That shipped in 0.5.0 as a silent permanent no-op: the 406 became "" and
+    // read as "no newer version". A stub that encodes the caller's assumption cannot catch that.
     const fetchOk = (latest: string) =>
-      vi.fn(async () => ({ ok: true, json: async () => ({ version: latest }) }));
+      vi.fn(async (_url: string, init?: { headers?: Record<string, string> }) => {
+        const accept = init?.headers?.accept ?? "";
+        if (accept.includes("vnd.npm.install-v1+json")) return { ok: false, status: 406 };
+        return { ok: true, json: async () => ({ version: latest }) };
+      });
     return { runtime, spawn, fetchOk };
   };
 

--- a/hindsight-integrations/coding-agents/src/core/auto-update.ts
+++ b/hindsight-integrations/coding-agents/src/core/auto-update.ts
@@ -255,9 +255,14 @@ function stampCheck(file: string, now: number, latest: string): void {
 /** Ask the registry for the published version, or "" if it cannot be determined. */
 async function latestVersion(fetchImpl: typeof fetch): Promise<string> {
   try {
+    // No `application/vnd.npm.install-v1+json` accept header. That abbreviated-packument media
+    // type is only served for the PACKUMENT (`/<pkg>`); asking for it on `/<pkg>/latest` gets a
+    // hard 406, which this function turned into "" — indistinguishable from "no newer version", so
+    // the runtime silently never updated (the stub in the tests answered `ok: true` regardless of
+    // what was requested, so nothing caught it). `/latest` is the smaller response anyway: one
+    // version's metadata rather than every version's.
     const r = await fetchImpl(`https://registry.npmjs.org/${PACKAGE_NAME}/latest`, {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      headers: { accept: "application/vnd.npm.install-v1+json" },
     });
     if (!r.ok) return "";
     const body = (await r.json()) as { version?: string };


### PR DESCRIPTION
Found while smoke-testing the published **v0.5.0**, which is where the auto-update feature shipped.

## The defect

A staged runtime pinned below the published version never updated — three attempts in a row, stamp always `{"lastCheck":…,"latest":""}` — while a plain `fetch` of the same URL from the same container returned `0.5.0` instantly.

`latestVersion` requested `https://registry.npmjs.org/<pkg>/latest` with `accept: application/vnd.npm.install-v1+json`. That abbreviated-packument media type is only served for the **packument** (`/<pkg>`); on `/<pkg>/latest` the registry answers **406 Not Acceptable**:

```
no accept header  -> 200 {"bin":{...
with npm accept   -> 406
```

`!r.ok` returns `""`, and `""` is indistinguishable from "no newer version", so `maybeAutoUpdate` stamped "checked, nothing to do" and returned. The feature was inert for every user, permanently and silently — no error, no log line, and the once-a-day stamp meant it looked like it had run.

## The fix

Drop the header. `/latest` is the smaller response anyway: one version's metadata rather than every version's.

## Why the tests passed

The fetch stub returned `ok: true` regardless of URL or headers, so it happily served a request the registry rejects — the mock encoded the caller's assumption instead of the contract. It now answers 406 to that media type like the real registry. With the stub fixed, **four existing tests fail on the 0.5.0 code** (verified by restoring it), and pass with the fix.

Verified end to end after the fix: a runtime staged from npx and pinned to 0.4.9 updates itself to the published version on the next session start.