### PR TITLE
blog: date the Cloud roundup 2026-09-01

### DIFF
--- a/hindsight-docs/blog/2026-09-01-cloud-june-august-updates.md
+++ b/hindsight-docs/blog/2026-09-01-cloud-june-august-updates.md
@@ -1,8 +1,8 @@
 ---
 title: "What's New in Hindsight Cloud: June–August Updates"
 authors: [benfrank241]
-slug: "2026/08/31/hindsight-cloud-june-august-updates"
-date: 2026-08-31T12:00
+slug: "2026/09/01/hindsight-cloud-june-august-updates"
+date: 2026-09-01T12:00
 tags: [hindsight-cloud, release, knowledge-pages, mental-models, ui, enterprise, sso, mfa, security]
 description: "Three months of Hindsight Cloud: a client-managed knowledge base, scheduled mental model refreshes, a rebuilt console, plus enterprise SSO, MFA enforcement, audit logging, and Memory Defense."
 image: /img/blog/hindsight-cloud-june-august-updates.png


### PR DESCRIPTION
Follow-up to #3951.

The Cloud roundup merged carrying **2026-08-31**, a day before it actually went out. This moves it to **2026-09-01** so the published date matches the publish.

Three things move together, since Docusaurus derives the URL from all of them:

- filename → `2026-09-01-cloud-june-august-updates.md`
- `date:` → `2026-09-01T12:00`
- `slug:` → `2026/09/01/hindsight-cloud-june-august-updates`

**This does change the live URL.** When this PR was opened the 08-31 path was still 404 because the deploy was in flight; it has since gone live. Merging this moves the post to the 09-01 path and the 08-31 path will 404. That is judged acceptable: the URL has been live for minutes, isn't linked from anywhere, and hasn't been shared or indexed, whereas an incorrect publish date is permanent.

The title and cover still read "June–August", which stays correct: that's the window the post covers, not its publish date.

Content is untouched — this is a rename plus two frontmatter lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AE4NCnCKXUzNDF3N9FaQja
