### PR TITLE
fix(reflect): fail the run when a retrieval tool fails, and record refused refreshes

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -179,7 +179,7 @@ from hindsight_api.engine.mental_model_refresh import (
     RefreshMentalModelOperationDetails,
 )
 from hindsight_api.engine.providers.none_llm import LLMNotAvailableError
-from hindsight_api.engine.reflect import ReflectNoAnswerError, ReflectToolCallError
+from hindsight_api.engine.reflect import ReflectNoAnswerError, ReflectToolCallError, ReflectToolExecutionError
 from hindsight_api.engine.response_models import (
     VALID_RECALL_FACT_TYPES,
     DryRunExtractionResult,
@@ -5131,6 +5131,13 @@ def _register_routes(app: FastAPI):
             # The request itself is fine, so this is a server-side (500) failure, not a
             # 4xx -- but log at warning, not error: it's a misconfiguration, not a bug.
             logger.warning("Reflect tool-calling failure in bank %s: %s", bank_id, e)
+            raise HTTPException(status_code=500, detail=str(e))
+        except ReflectToolExecutionError as e:
+            # A retrieval tool raised, so the loop could not finish gathering the
+            # evidence it was asked for. Answering anyway would return a confident
+            # reply built on a partial (often empty) evidence set, which callers
+            # store as a real answer (#2894). Returning the failure lets them retry.
+            logger.warning("Reflect retrieval failure in bank %s: %s", bank_id, e)
             raise HTTPException(status_code=500, detail=str(e))
         except TimeoutError as e:
             logger.error("Timeout in /v1/default/banks/%s/reflect: %s", bank_id, e)

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -142,6 +142,12 @@ def _authorize_nested_operations() -> "Iterator[None]":
 
 MENTAL_MODEL_PENDING_CONTENT = "Generating content..."
 
+# ``mental_model_history`` holds two kinds of row in one JSONB blob: the version
+# snapshots a successful refresh writes, and the failure records a refused one
+# writes. Rows written before failure records existed carry no ``kind`` at all, so
+# absent means version — no backfill needed.
+_MM_HISTORY_KIND_FAILURE = "refresh_failed"
+
 #: Marks a queued ``refresh_mental_model`` operation as *automatically* triggered — by
 #: consolidation or by the cron scan — and therefore subject to the minimum-interval
 #: floor. Explicit refreshes omit it and always run at once.
@@ -532,7 +538,7 @@ from .mental_model_refresh import (
 )
 from .multi_llm import MultiLLMProvider
 from .query_analyzer import QueryAnalyzer
-from .reflect import run_reflect_agent
+from .reflect import ReflectNoAnswerError, ReflectToolExecutionError, run_reflect_agent
 from .reflect.retractions import (
     RetractedGrounding,
     based_on_fact_ids,
@@ -3185,6 +3191,35 @@ class MemoryEngine(MemoryEngineInterface):
             # fails the operation, and once it does nothing else writes to the
             # row except the prose error_message (#3274).
             await self._write_refresh_failure_metadata(task_dict.get("operation_id"), e)
+            raise
+        except OperationCancelledError:
+            # Not a failed refresh: the caller went away. It records no outcome and
+            # no history, exactly like the deferral above.
+            raise
+        except Exception as e:
+            # Anything else that escaped the refresh — a provider error the reflect
+            # loop gave up on, a store that went away mid-run. The refresh failed, so
+            # it leaves the same record every refusal does; without this the model
+            # would look as though it had simply never been refreshed, which is the
+            # whole defect this path exists to close (#2894).
+            #
+            # The ORIGINAL exception is re-raised, not a MentalModelRefreshError
+            # wrapping it: the worker classifies retryability by exception class, and
+            # burying, say, a ProviderContentPolicyError would turn a permanent
+            # refusal back into three retries of the same doomed call (#3690).
+            failure = MentalModelRefreshError(
+                f"Refresh failed for mental_model_id={mental_model_id}: {type(e).__name__}: {e}",
+                outcome="refresh_failed_error",
+                reason="unexpected_error",
+            )
+            await self._write_refresh_failure_metadata(task_dict.get("operation_id"), failure)
+            await self._record_mental_model_refresh_failure(
+                bank_id,
+                mental_model_id,
+                outcome="refresh_failed_error",
+                failure_reason="unexpected_error",
+                error_message=f"{type(e).__name__}: {e}",
+            )
             raise
         if refreshed is None:
             raise ValueError(f"Mental model {mental_model_id} not found in bank {bank_id}")
@@ -14349,9 +14384,13 @@ class MemoryEngine(MemoryEngineInterface):
     ) -> list[dict] | None:
         """Get the refresh history of a mental model.
 
-        Returns None if the mental model is not found.
-        Returns a list of history entries (most recent first), each with previous_content and changed_at.
-
+        Returns None if the mental model is not found, otherwise the entries most
+        recent first. Two kinds share the list: version snapshots, carrying
+        ``previous_content`` and ``previous_reflect_response``, and failure records
+        for refreshes that refused to write, carrying ``kind="refresh_failed"`` plus
+        ``outcome``/``failure_reason``/``error_message``. Both carry ``changed_at``.
+        A failure produced no version, so its ``previous_content`` is always None —
+        read ``kind`` to tell them apart.
         """
         await self._authenticate_tenant(request_context)
         # Suppressed under _authorize_nested_operations: export_knowledge_base reads
@@ -14395,13 +14434,22 @@ class MemoryEngine(MemoryEngineInterface):
                     content = json.loads(content) if content else {}
                 content = content or {}
                 changed_at = r["changed_at"]
-                result.append(
-                    {
-                        "previous_content": content.get("previous_content"),
-                        "previous_reflect_response": content.get("previous_reflect_response"),
-                        "changed_at": changed_at.isoformat() if hasattr(changed_at, "isoformat") else changed_at,
-                    }
-                )
+                entry = {
+                    "previous_content": content.get("previous_content"),
+                    "previous_reflect_response": content.get("previous_reflect_response"),
+                    "changed_at": changed_at.isoformat() if hasattr(changed_at, "isoformat") else changed_at,
+                }
+                # A failure record is not a version: it has no content to diff.
+                # It reports why the refresh refused to write, so a reader of the
+                # history can tell "this document is unchanged because nothing
+                # changed" from "this document is unchanged because the refresh
+                # broke" (#2894).
+                if content.get("kind") == _MM_HISTORY_KIND_FAILURE:
+                    entry["kind"] = _MM_HISTORY_KIND_FAILURE
+                    entry["outcome"] = content.get("outcome")
+                    entry["failure_reason"] = content.get("failure_reason")
+                    entry["error_message"] = content.get("error_message")
+                result.append(entry)
             return result
 
     async def _mental_model_embedding_vector(self, name: str, content: str) -> list[float] | None:
@@ -15707,9 +15755,12 @@ class MemoryEngine(MemoryEngineInterface):
         Raises:
             MentalModelRefreshError: The refresh could not produce a document that is
                 safe to store — it came back empty, its delta operations never reached
-                the document, or structured-output extraction failed. In every case the
-                previous content and the watermark are left untouched, so a retry reads
-                the same window again.
+                the document, structured-output extraction failed, or reflect itself
+                failed before there was a candidate at all (a retrieval tool raised, or
+                the agent produced no answer). In every case the previous content and
+                the watermark are left untouched, so a retry reads the same window
+                again, and the reason is recorded on the operation and in the model's
+                history.
         """
         await self._authenticate_tenant(request_context)
 
@@ -15720,7 +15771,33 @@ class MemoryEngine(MemoryEngineInterface):
 
         # Create parent span for mental model refresh operation
         with create_operation_span("mental_model_refresh", bank_id):
-            run = await self._execute_mental_model_refresh(bank_id, mental_model, request_context=request_context)
+            try:
+                run = await self._execute_mental_model_refresh(bank_id, mental_model, request_context=request_context)
+            except (ReflectToolExecutionError, ReflectNoAnswerError) as exc:
+                # Reflect failed before there was a run: a retrieval tool raised
+                # (#2894) or the agent produced no answer (#2959). Nothing was
+                # written — content, structured document and watermark all stand —
+                # but the failure must still be recorded, or the model looks like it
+                # was simply never refreshed. Re-raised as a MentalModelRefreshError
+                # so it reaches the operation's typed ``details`` through the same
+                # ``_write_refresh_failure_metadata`` hook every other refusal uses.
+                failure_reason: RefreshFailureReason = (
+                    "retrieval_failed" if isinstance(exc, ReflectToolExecutionError) else "no_answer"
+                )
+                detail = f"{type(exc).__name__}: {exc}"
+                await self._record_mental_model_refresh_failure(
+                    bank_id,
+                    mental_model_id,
+                    outcome="refresh_failed_error",
+                    failure_reason=failure_reason,
+                    error_message=detail,
+                )
+                raise MentalModelRefreshError(
+                    f"Refresh failed for mental_model_id={mental_model_id}: {detail} "
+                    f"Previous content preserved in DB; recorded in the model's history for audit.",
+                    outcome="refresh_failed_error",
+                    reason=failure_reason,
+                ) from exc
             if run is None:
                 return None
 
@@ -15800,6 +15877,16 @@ class MemoryEngine(MemoryEngineInterface):
                     reflect_response=reflect_response_payload,
                     last_refreshed_source_query=run.source_query,
                     request_context=request_context,
+                )
+                # ``refresh_skipped`` above is only readable until the next refresh
+                # overwrites the reflect_response. The history row is the durable
+                # copy, and the one a reader of the model's own timeline sees.
+                await self._record_mental_model_refresh_failure(
+                    bank_id,
+                    mental_model_id,
+                    outcome=outcome,
+                    failure_reason=reason,
+                    error_message=detail,
                 )
                 raise MentalModelRefreshError(
                     f"Refresh failed for mental_model_id={mental_model_id}: {detail} "
@@ -16282,6 +16369,27 @@ class MemoryEngine(MemoryEngineInterface):
         content = json.dumps(
             {"previous_content": previous_content, "previous_reflect_response": previous_reflect_response}
         )
+        await self._insert_mental_model_history_row(
+            conn, bank_id, mental_model_id, content, max_entries, is_failure=False
+        )
+
+    async def _insert_mental_model_history_row(
+        self,
+        conn: Any,
+        bank_id: str,
+        mental_model_id: str,
+        content_json: str,
+        max_entries: int,
+        *,
+        is_failure: bool,
+    ) -> None:
+        """Insert one history row and trim that row's KIND back to ``max_entries``.
+
+        Retention is per kind — version snapshots and failure records are capped
+        independently. A single overall cap would let a broken retriever's run of
+        failures evict every content version the model ever had, which is the
+        opposite of what the history is for.
+        """
         await conn.execute(
             f"""
             INSERT INTO {fq_table("mental_model_history")} (mental_model_id, bank_id, content, changed_at)
@@ -16289,16 +16397,32 @@ class MemoryEngine(MemoryEngineInterface):
             """,
             mental_model_id,
             bank_id,
-            content,
+            content_json,
         )
         if max_entries and max_entries > 0:
+            # ``content->>'kind'`` is NULL on every row written before failure
+            # records existed, and those are all version snapshots — so the
+            # version predicate matches them without a backfill migration.
+            #
+            # Spelled out as ``IS NULL OR <>`` rather than ``IS DISTINCT FROM``:
+            # the ``->>`` operator is rewritten to JSON_VALUE for Oracle, but
+            # ``IS DISTINCT FROM`` is not, and Oracle 23ai does not accept it —
+            # migration d1e2f3a4b5c6 writes the same predicate out longhand for
+            # the same reason. Every trim would otherwise throw on Oracle.
+            kind_predicate = (
+                f"content->>'kind' = '{_MM_HISTORY_KIND_FAILURE}'"
+                if is_failure
+                else f"(content->>'kind' IS NULL OR content->>'kind' <> '{_MM_HISTORY_KIND_FAILURE}')"
+            )
             await conn.execute(
                 f"""
                 DELETE FROM {fq_table("mental_model_history")}
                 WHERE mental_model_id = $1 AND bank_id = $2
+                  AND {kind_predicate}
                   AND id NOT IN (
                       SELECT id FROM {fq_table("mental_model_history")}
                       WHERE mental_model_id = $1 AND bank_id = $2
+                        AND {kind_predicate}
                       ORDER BY changed_at DESC, id DESC
                       LIMIT $3
                   )
@@ -16307,6 +16431,51 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id,
                 max_entries,
             )
+
+    async def _record_mental_model_refresh_failure(
+        self,
+        bank_id: str,
+        mental_model_id: str,
+        *,
+        outcome: "RefreshOperationOutcome",
+        failure_reason: "RefreshFailureReason",
+        error_message: str,
+    ) -> None:
+        """Record a refusal to write in the model's own history.
+
+        A failed refresh writes no content, so before this it left no trace on the
+        model at all: the History tab kept rendering the last SUCCESSFUL trace as
+        though it were current, and the only record of the failure was prose on an
+        async-operation row that a mental-model view never reads (#2894).
+
+        Best-effort by design — the refresh has already failed and is about to
+        raise; losing the audit row must not also swallow that exception, and the
+        operation still carries the same reason in its typed ``details``.
+        """
+        config = get_config()
+        if not config.enable_mental_model_history:
+            return
+        content = json.dumps(
+            {
+                "kind": _MM_HISTORY_KIND_FAILURE,
+                "outcome": outcome,
+                "failure_reason": failure_reason,
+                "error_message": error_message,
+            }
+        )
+        try:
+            backend = await self._get_backend()
+            async with acquire_with_retry(backend) as conn:
+                await self._insert_mental_model_history_row(
+                    conn,
+                    bank_id,
+                    mental_model_id,
+                    content,
+                    config.mental_model_history_max_entries,
+                    is_failure=True,
+                )
+        except Exception as e:
+            logger.warning(f"Failed to record refresh failure history for mental model {mental_model_id}: {e}")
 
     async def clear_mental_model(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/mental_model_refresh.py
+++ b/hindsight-api-slim/hindsight_api/engine/mental_model_refresh.py
@@ -47,7 +47,10 @@ RefreshOutcome = Literal[
 
 # What a refresh did, as recorded on the operation. A superset of RefreshOutcome:
 # the persist path can still refuse a document the executor accepted, when
-# structured-output extraction fails against a configured response_schema. Kept
+# structured-output extraction fails against a configured response_schema, and
+# a refresh can also die on an error rather than refuse to write a document
+# (``refresh_failed_error`` — a retrieval tool raised, the agent produced no
+# answer, or something unforeseen escaped). Kept
 # separate rather than widening RefreshOutcome, so the dry run does not advertise
 # an outcome it can never return — it never extracts structured output. Spelled
 # out rather than unioned because a union of Literals renders as an ``anyOf`` of
@@ -60,12 +63,19 @@ RefreshOperationOutcome = Literal[
     "refresh_failed_empty_candidate",
     "refresh_failed_delta_not_applied",
     "refresh_failed_structured_output",
+    "refresh_failed_error",
 ]
 
 # Why a refresh refused to write, matching the ``reflect_response.refresh_skipped``
 # value persisted alongside the preserved document. Finer-grained than the outcome:
 # ``refresh_failed_delta_not_applied`` alone does not say whether the op call failed,
 # every op was rejected, or the baseline document could not be read.
+# ``retrieval_failed``, ``no_answer`` and ``unexpected_error`` are errors rather
+# than refusals, so they have no ``refresh_skipped`` counterpart on the model — the
+# run died before there was a ``reflect_response`` to write one into. They are
+# recorded on the operation and in ``mental_model_history`` instead.
+# ``unexpected_error`` is the catch-all: whatever escaped is not something the
+# pipeline models, but the refresh still failed and still has to leave a record.
 RefreshFailureReason = Literal[
     "empty_candidate",
     "structured_doc_unreadable",
@@ -73,6 +83,9 @@ RefreshFailureReason = Literal[
     "delta_ops_all_skipped",
     "delta_not_applied",
     "structured_output_failed",
+    "retrieval_failed",
+    "no_answer",
+    "unexpected_error",
 ]
 
 

--- a/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
+++ b/hindsight-api-slim/hindsight_api/engine/operation_metadata.py
@@ -194,17 +194,22 @@ class RefreshMentalModelOutcomeMetadata:
     failure_reason: "RefreshFailureReason | None" = None
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert to dict for JSON serialization, omitting unrecorded fields.
+        """Convert to dict for JSON serialization, omitting an unrecorded outcome.
 
-        ``outcome``/``failure_reason`` are dropped when unset rather than written
-        as null: the metadata is merged into whatever the operation already
-        carries, and a null would overwrite a recorded value with "unknown".
+        ``outcome`` is dropped when unset rather than written as null: the metadata
+        is merged into whatever the operation already carries, and a null would
+        overwrite a recorded value with "unknown".
+
+        ``failure_reason`` is the opposite — it is written as null when unset, and
+        must be. A refresh is retried on the SAME operation row, so an attempt that
+        failed leaves its reason behind; merging a success over it without clearing
+        the reason produced the nonsense pairing ``outcome=content_written`` with
+        ``failure_reason=no_answer``. This writer only ever runs on a refresh that
+        finished, so "no reason" is a fact about it, not a gap.
         """
         data = asdict(self)
         if data.get("outcome") is None:
             data.pop("outcome", None)
-        if data.get("failure_reason") is None:
-            data.pop("failure_reason", None)
         return data
 
 

--- a/hindsight-api-slim/hindsight_api/engine/reflect/__init__.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/__init__.py
@@ -7,7 +7,13 @@ The reflect agent uses an iterative loop with tools to:
 3. Expand memories (get chunk/document context)
 """
 
-from .agent import ReflectAgentResult, ReflectNoAnswerError, ReflectToolCallError, run_reflect_agent
+from .agent import (
+    ReflectAgentResult,
+    ReflectNoAnswerError,
+    ReflectToolCallError,
+    ReflectToolExecutionError,
+    run_reflect_agent,
+)
 from .models import ReflectAction, ReflectActionBatch
 
 __all__ = [
@@ -15,6 +21,7 @@ __all__ = [
     "ReflectAgentResult",
     "ReflectToolCallError",
     "ReflectNoAnswerError",
+    "ReflectToolExecutionError",
     "ReflectAction",
     "ReflectActionBatch",
 ]

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -13,6 +13,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
+from ...cancellation import OperationCancelledError
 from ...config import get_config
 from ..llm_interface import LLM_TOOL_CHOICE_AUTO, LLMToolChoice
 from .models import DirectiveInfo, LLMCall, ReflectAgentResult, StructuredOutputResult, TokenUsageSummary, ToolCall
@@ -88,6 +89,27 @@ class ReflectToolCallError(RuntimeError):
     mimic a ``done`` payload. Rather than salvage that untooled text -- and risk
     surfacing raw tool-call JSON as the answer -- we fail loudly so the caller can
     switch to a tool-calling-capable model/transport.
+    """
+
+
+class ReflectToolExecutionError(RuntimeError):
+    """A retrieval tool raised, so the run's evidence set is incomplete.
+
+    Reflect used to hand the exception text back to the model as a tool result and
+    let the loop continue. The model then answered from whatever it happened to
+    have -- often nothing -- and that answer was indistinguishable from a run over
+    a bank that genuinely holds nothing on the topic. A mental-model refresh wrote
+    it, replacing a document built across months with "I don't have information
+    about that" and recording the operation as ``completed`` (#2894).
+
+    A failed tool is an infrastructure failure (the database, the embedder, the
+    reranker), not something the model can fix by rephrasing, so the run fails
+    instead: callers that write what reflect returns never reach the write, and
+    the refresh preserves its document and its watermark.
+
+    This covers tools that *raised*. A tool that returns ``{"error": ...}`` for a
+    malformed or unavailable call is the model's mistake, is fixable by retrying
+    with different arguments, and is still fed back to it as before.
     """
 
 
@@ -903,25 +925,34 @@ async def _run_reflect_agent_inner(
                 }
             )
 
+        except OperationCancelledError:
+            # A cancellation is not a provider failure: never retried, never
+            # synthesized around, and it must reach the HTTP layer as itself so a
+            # client disconnect stays a 499 (issue #2122).
+            raise
         except Exception as e:
             err_duration = int((time.time() - llm_start) * 1000)
             consecutive_errors += 1
             logger.warning(f"[REFLECT {reflect_id}] LLM error on iteration {iteration + 1}: {e} ({err_duration}ms)")
             llm_trace.append({"scope": f"agent_{iteration + 1}_err", "duration_ms": err_duration})
-            has_gathered_evidence = (
-                bool(available_memory_ids) or bool(available_mental_model_ids) or bool(available_observation_ids)
-            )
             # Context overflow errors must never be retried — retrying would only make them worse.
-            # Skip straight to final synthesis with whatever evidence we have.
+            # Skip straight to final synthesis with whatever evidence we have: the
+            # prompt was too big for the model, which is a budgeting problem, not a
+            # broken dependency, and the evidence gathered so far is intact.
             if _is_context_overflow_error(e):
                 logger.warning(
                     f"[REFLECT {reflect_id}] Context window exceeded on iteration {iteration + 1}, "
                     "forcing final synthesis from gathered evidence."
                 )
-            # For other errors: retry if no evidence yet (but cap consecutive errors to avoid long hangs)
-            elif not has_gathered_evidence and iteration < max_iterations - 1 and consecutive_errors < 2:
+                return await _forced_final_synthesis(iteration + 1)
+            # Any other error: retry (capped, so a persistently failing provider does
+            # not hang the run), then give up. Synthesizing an answer here instead
+            # would be built on an evidence set the failed turn never finished
+            # gathering, and callers cannot tell that from a complete one (#2894).
+            # The provider's own retries (429/5xx) already ran inside the call.
+            if iteration < max_iterations - 1 and consecutive_errors < 2:
                 continue
-            return await _forced_final_synthesis(iteration + 1)
+            raise
 
         # No tool calls this turn.
         if not result.tool_calls:
@@ -1085,13 +1116,23 @@ async def _run_reflect_agent_inner(
 
             # Process results and add to messages
             for position, tc, result_data in zip(allowed_positions, other_tools, tool_results):
+                if isinstance(result_data, OperationCancelledError):
+                    # The client went away mid-tool (recall propagates this — see
+                    # issue #2122). Let it through untouched so the HTTP layer still
+                    # returns 499; wrapping it would report a cancellation as a 500.
+                    raise result_data
                 if isinstance(result_data, Exception):
-                    # Tool execution failed - send error back to LLM so it can try again
+                    # A tool that raised is an infrastructure failure, not something
+                    # the model can retry its way out of. Feeding it back as a tool
+                    # result let the loop answer from an evidence set it knows is
+                    # incomplete, and nothing downstream could tell that answer from
+                    # one over an empty bank -- see ReflectToolExecutionError (#2894).
                     logger.warning(f"[REFLECT {reflect_id}] Tool {tc.name} failed with exception: {result_data}")
-                    output = {"error": f"Tool execution failed: {result_data}"}
-                    duration_ms = 0
-                else:
-                    output, duration_ms = result_data
+                    raise ReflectToolExecutionError(
+                        f"Reflect tool '{_normalize_tool_name(tc.name)}' failed on iteration {iteration + 1}: "
+                        f"{result_data}"
+                    ) from result_data
+                output, duration_ms = result_data
 
                 # Normalize tool name for consistent tracking
                 normalized_tool_name = _normalize_tool_name(tc.name)

--- a/hindsight-api-slim/hindsight_api/mcp_tools.py
+++ b/hindsight-api-slim/hindsight_api/mcp_tools.py
@@ -1363,7 +1363,10 @@ def _register_reflect(mcp: FastMCP, memory: MemoryEngine, config: MCPToolsConfig
                 return json.dumps({"error": str(e)})
             except Exception as e:
                 logger.error(f"Error reflecting: {e}", exc_info=True)
-                return f'{{"error": "{e}", "text": ""}}'
+                # Built with json.dumps, not an f-string: error text carries provider
+                # messages with quotes and newlines in them, which hand-rolled JSON
+                # turns into a payload the client cannot parse.
+                return json.dumps({"error": str(e), "text": ""})
 
     else:
 

--- a/hindsight-api-slim/tests/test_mental_model_no_answer_preserved.py
+++ b/hindsight-api-slim/tests/test_mental_model_no_answer_preserved.py
@@ -11,13 +11,18 @@ no failure signal anywhere to alert on.
 Reflect now raises instead of inventing text, so the refresh never reaches its
 write. These tests assert that end of it: the exception propagates and the
 stored document is byte-identical afterwards.
+
+The refresh re-raises it as a ``MentalModelRefreshError`` carrying
+``failure_reason="no_answer"``, so the failure also reaches the operation's typed
+details and the model's own history rather than only a prose error_message
+(#2894); the reflect error stays as ``__cause__``.
 """
 
 import uuid
 
 import pytest
 
-from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.memory_engine import MemoryEngine, MentalModelRefreshError
 from hindsight_api.engine.reflect import ReflectNoAnswerError
 from tests.conftest import stub_refresh_has_sources
 
@@ -49,7 +54,7 @@ async def test_refresh_preserves_content_when_reflect_has_no_answer(memory, requ
         monkeypatch.setattr(memory, "reflect_async", no_answer)
         stub_refresh_has_sources(monkeypatch, memory)
 
-        with pytest.raises(ReflectNoAnswerError):
+        with pytest.raises(MentalModelRefreshError):
             await memory.refresh_mental_model(
                 bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
             )
@@ -84,7 +89,7 @@ async def test_refresh_does_not_advance_the_watermark_on_no_answer(memory, reque
         monkeypatch.setattr(memory, "reflect_async", no_answer)
         stub_refresh_has_sources(monkeypatch, memory)
 
-        with pytest.raises(ReflectNoAnswerError):
+        with pytest.raises(MentalModelRefreshError):
             await memory.refresh_mental_model(
                 bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
             )

--- a/hindsight-api-slim/tests/test_mental_model_tool_failure_preserved.py
+++ b/hindsight-api-slim/tests/test_mental_model_tool_failure_preserved.py
@@ -1,0 +1,236 @@
+"""A refresh whose retrieval failed must not touch the stored document (#2894).
+
+When a reflect tool raised, reflect handed the exception text back to the model
+as a tool result and let the loop continue. The model answered from whatever it
+had — usually nothing — and that answer was indistinguishable from a run over a
+bank that genuinely holds nothing on the topic: non-empty prose, so every
+emptiness guard on the write path let it through. A mental model built across
+months of refreshes was replaced by "I don't have information about that", and
+the operation was recorded as completed.
+
+Reflect now fails the run instead (``ReflectToolExecutionError``), so the refresh
+never reaches its write. These tests assert that end of it.
+
+The distinction that matters is against a *successful* empty retrieval: a bank
+that really has nothing to say on the query must still be allowed to rewrite the
+document, so that case is asserted here too.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api.engine.memory_engine import MemoryEngine, MentalModelRefreshError
+from hindsight_api.engine.reflect import ReflectToolExecutionError
+from tests.conftest import stub_refresh_has_sources
+
+EXISTING = "# Team\n\nAlice leads platform. Bob owns ingest.\n"
+
+
+async def _model_with_content(memory: MemoryEngine, request_context, bank_id: str) -> dict:
+    await memory.get_bank_profile(bank_id, request_context=request_context)
+    return await memory.create_mental_model(
+        bank_id=bank_id,
+        name="Team Info",
+        source_query="Tell me about the team",
+        content=EXISTING,
+        trigger={"mode": "full"},
+        request_context=request_context,
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_preserves_content_when_a_tool_failed(memory, request_context, monkeypatch):
+    """The reported production case: retrieval broke, the model answered anyway."""
+    bank_id = f"test-mm-tool-fail-{uuid.uuid4().hex[:8]}"
+    try:
+        mm = await _model_with_content(memory, request_context, bank_id)
+
+        async def tool_failed(**kwargs):
+            raise ReflectToolExecutionError(
+                "Reflect tool 'recall' failed on iteration 1: connection to the embedding service was refused"
+            )
+
+        monkeypatch.setattr(memory, "reflect_async", tool_failed)
+        stub_refresh_has_sources(monkeypatch, memory)
+
+        with pytest.raises(MentalModelRefreshError) as exc_info:
+            await memory.refresh_mental_model(
+                bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+            )
+
+        # Reported as a typed refresh failure, so the operation records an outcome
+        # rather than only prose — and the reflect error stays the cause.
+        assert exc_info.value.outcome == "refresh_failed_error"
+        assert exc_info.value.reason == "retrieval_failed"
+        assert isinstance(exc_info.value.__cause__, ReflectToolExecutionError)
+
+        preserved = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert preserved is not None
+        assert preserved["content"] == EXISTING, "A failed retrieval overwrote the stored document (#2894)"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_advance_the_watermark_on_tool_failure(memory, request_context, monkeypatch):
+    """The failed run must stay repeatable.
+
+    ``last_refreshed_at`` bounds the next delta refresh's window. Moving it for a
+    run whose retrieval never completed would put the facts this refresh was
+    triggered by permanently behind the watermark.
+    """
+    bank_id = f"test-mm-tool-fail-wm-{uuid.uuid4().hex[:8]}"
+    try:
+        mm = await _model_with_content(memory, request_context, bank_id)
+        before = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+
+        async def tool_failed(**kwargs):
+            raise ReflectToolExecutionError("Reflect tool 'search_observations' failed on iteration 2: index missing")
+
+        monkeypatch.setattr(memory, "reflect_async", tool_failed)
+        stub_refresh_has_sources(monkeypatch, memory)
+
+        with pytest.raises(MentalModelRefreshError):
+            await memory.refresh_mental_model(
+                bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+            )
+
+        after = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert after is not None and before is not None
+        assert after["last_refreshed_at"] == before["last_refreshed_at"]
+        assert after["last_memory_seen_at"] == before["last_memory_seen_at"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_refresh_still_writes_when_retrieval_genuinely_found_nothing(memory, request_context, monkeypatch):
+    """A working retrieval that returns nothing is an answer, and must be written.
+
+    This is the line the guard draws. The failure mode above is "we could not
+    look"; this is "we looked and there is nothing there" — a legitimate result
+    that the document is supposed to reflect, so the refresh proceeds normally.
+    """
+    bank_id = f"test-mm-empty-ok-{uuid.uuid4().hex[:8]}"
+    try:
+        mm = await _model_with_content(memory, request_context, bank_id)
+
+        answer = "There is no information about the team in this memory bank."
+
+        async def empty_but_successful(**kwargs):
+            from hindsight_api.engine.response_models import ReflectResult
+
+            return ReflectResult(text=answer, based_on={})
+
+        monkeypatch.setattr(memory, "reflect_async", empty_but_successful)
+        stub_refresh_has_sources(monkeypatch, memory)
+
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+
+        updated = await memory.get_mental_model(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert updated is not None
+        assert answer in updated["content"], "A successful empty retrieval must still update the document"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_is_recorded_in_the_model_history(memory, request_context, monkeypatch):
+    """The failure must be visible on the model itself, not only on the operation.
+
+    A refresh that writes nothing used to leave the model looking as though it had
+    simply never been refreshed: the History tab kept rendering the last successful
+    trace as current, and the only record was prose on an async-operation row that
+    no mental-model view reads (#2894).
+    """
+    bank_id = f"test-mm-fail-history-{uuid.uuid4().hex[:8]}"
+    try:
+        mm = await _model_with_content(memory, request_context, bank_id)
+
+        async def tool_failed(**kwargs):
+            raise ReflectToolExecutionError("Reflect tool 'recall' failed on iteration 1: pgvector index missing")
+
+        monkeypatch.setattr(memory, "reflect_async", tool_failed)
+        stub_refresh_has_sources(monkeypatch, memory)
+
+        with pytest.raises(MentalModelRefreshError):
+            await memory.refresh_mental_model(
+                bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+            )
+
+        history = await memory.get_mental_model_history(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert history, "the failed refresh left no history entry"
+        entry = history[0]
+        assert entry["kind"] == "refresh_failed"
+        assert entry["outcome"] == "refresh_failed_error"
+        assert entry["failure_reason"] == "retrieval_failed"
+        assert "pgvector index missing" in entry["error_message"]
+        # A failure is an event, not a version: there is no content to diff.
+        assert entry["previous_content"] is None
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_failure_records_do_not_evict_content_versions(memory, request_context, monkeypatch):
+    """Retention is per kind, so a run of failures cannot erase the version history.
+
+    A single overall cap would let a broken retriever push every real version out of
+    the table — losing the document's actual history to the noise of the outage that
+    stopped it changing.
+    """
+    bank_id = f"test-mm-fail-retention-{uuid.uuid4().hex[:8]}"
+    try:
+        mm = await _model_with_content(memory, request_context, bank_id)
+
+        # One successful refresh, so there is a version snapshot to protect.
+        async def wrote_content(**kwargs):
+            from hindsight_api.engine.response_models import ReflectResult
+
+            return ReflectResult(text="# Team\n\nAlice leads platform.\n", based_on={})
+
+        monkeypatch.setattr(memory, "reflect_async", wrote_content)
+        stub_refresh_has_sources(monkeypatch, memory)
+        await memory.refresh_mental_model(bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context)
+        versions_before = [
+            e
+            for e in (
+                await memory.get_mental_model_history(
+                    bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+                )
+                or []
+            )
+            if e.get("kind") != "refresh_failed"
+        ]
+        assert versions_before, "no version snapshot to protect"
+
+        async def tool_failed(**kwargs):
+            raise ReflectToolExecutionError("Reflect tool 'recall' failed on iteration 1: still broken")
+
+        monkeypatch.setattr(memory, "reflect_async", tool_failed)
+        stub_refresh_has_sources(monkeypatch, memory)
+        for _ in range(12):
+            with pytest.raises(MentalModelRefreshError):
+                await memory.refresh_mental_model(
+                    bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+                )
+
+        history = await memory.get_mental_model_history(
+            bank_id=bank_id, mental_model_id=mm["id"], request_context=request_context
+        )
+        assert history is not None
+        versions_after = [e for e in history if e.get("kind") != "refresh_failed"]
+        assert len(versions_after) == len(versions_before), "failure records evicted the version history"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -13,10 +13,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from hindsight_api.cancellation import OperationCancelledError
 from hindsight_api.engine.llm_interface import LLM_TOOL_CHOICE_AUTO, LLMToolChoice
 from hindsight_api.engine.reflect.agent import (
     ReflectNoAnswerError,
     ReflectToolCallError,
+    ReflectToolExecutionError,
     _all_mental_models_are_usable_and_fresh,
     _cache_cleanup_tasks,
     _count_messages_tokens,
@@ -719,22 +721,91 @@ class TestReflectAgentMocked:
         assert mock_llm.call_with_tools.call_count == 3
 
     @pytest.mark.asyncio
-    async def test_recovery_from_tool_execution_error(self, mock_llm, mock_functions):
-        """Test that LLM can recover after a tool execution fails."""
-        # Make recall fail the first time, succeed the second time
-        mock_functions["recall_fn"].side_effect = [
-            Exception("Database connection failed"),
-            {"memories": [{"id": "mem-1", "content": "test memory"}]},
-        ]
+    async def test_tool_execution_error_fails_the_run(self, mock_llm, mock_functions):
+        """A tool that raises fails the whole run — the loop must not answer around it.
+
+        Reflect used to feed the exception back as a tool result and let the model
+        try again. Whatever it answered was then indistinguishable from a run over
+        a bank that genuinely holds nothing, and a mental-model refresh wrote that
+        answer over a real document (#2894). A raising tool is a broken dependency,
+        so the run fails and the caller never reaches its write.
+        """
+        mock_functions["recall_fn"].side_effect = Exception("Database connection failed")
 
         mock_llm.call_with_tools.side_effect = [
             LLMToolCallResult(
                 tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "test"})],
                 finish_reason="tool_calls",
             ),
-            # LLM tries again after seeing error
             LLMToolCallResult(
-                tool_calls=[LLMToolCall(id="2", name="recall", arguments={"query": "test retry"})],
+                tool_calls=[
+                    LLMToolCall(
+                        id="2",
+                        name="done",
+                        arguments={"answer": "I don't have information about that.", "memory_ids": []},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        with pytest.raises(ReflectToolExecutionError) as exc_info:
+            await run_reflect_agent(
+                llm_config=mock_llm,
+                bank_id="test-bank",
+                query="test query",
+                bank_profile={"name": "Test", "mission": "Testing"},
+                **mock_functions,
+            )
+
+        assert "recall" in str(exc_info.value)
+        assert "Database connection failed" in str(exc_info.value)
+        # The failure is immediate: the model is never asked to carry on without it.
+        assert mock_llm.call_with_tools.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_one_failing_tool_fails_a_parallel_batch(self, mock_llm, mock_functions):
+        """Even one failure in a parallel batch fails the run, however much the others returned."""
+        mock_functions["search_observations_fn"].side_effect = Exception("pgroonga index unavailable")
+
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(id="1", name="recall", arguments={"query": "test"}),
+                    LLMToolCall(id="2", name="search_observations", arguments={"query": "test"}),
+                ],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        with pytest.raises(ReflectToolExecutionError) as exc_info:
+            await run_reflect_agent(
+                llm_config=mock_llm,
+                bank_id="test-bank",
+                query="test query",
+                bank_profile={"name": "Test", "mission": "Testing"},
+                **mock_functions,
+            )
+
+        assert "search_observations" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_tool_argument_errors_are_still_fed_back(self, mock_llm, mock_functions):
+        """A malformed call is the model's mistake, not a broken dependency.
+
+        ``_execute_tool`` returns ``{"error": ...}`` for a missing argument or a
+        hallucinated tool name. Those are fixable by calling again with different
+        arguments, so they keep going back to the model — only tools that *raise*
+        fail the run.
+        """
+        mock_llm.call_with_tools.side_effect = [
+            # No query argument: the dispatcher answers with an error dict.
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="1", name="recall", arguments={})],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="2", name="recall", arguments={"query": "test"})],
                 finish_reason="tool_calls",
             ),
             LLMToolCallResult(
@@ -742,7 +813,7 @@ class TestReflectAgentMocked:
                     LLMToolCall(
                         id="3",
                         name="done",
-                        arguments={"answer": "Recovered from error", "memory_ids": ["mem-1"]},
+                        arguments={"answer": "Recovered from a bad call", "memory_ids": ["mem-1"]},
                     )
                 ],
                 finish_reason="tool_calls",
@@ -757,8 +828,111 @@ class TestReflectAgentMocked:
             **mock_functions,
         )
 
-        assert result.text == "Recovered from error"
+        assert result.text == "Recovered from a bad call"
         assert mock_llm.call_with_tools.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_persistent_llm_error_fails_instead_of_synthesizing(self, mock_llm, mock_functions):
+        """A provider that keeps failing fails the run, rather than answering around it.
+
+        The loop used to fall through to a forced final synthesis on any LLM error.
+        With retrieval never completed, that synthesis had nothing to work from and
+        produced a confident "no information" answer that callers stored (#2894).
+        The provider's own 429/5xx retries already ran inside the call, so reaching
+        here twice means the failure is not transient.
+        """
+        mock_llm.call_with_tools.side_effect = RuntimeError("provider unavailable")
+
+        with pytest.raises(RuntimeError, match="provider unavailable"):
+            await run_reflect_agent(
+                llm_config=mock_llm,
+                bank_id="test-bank",
+                query="test query",
+                bank_profile={"name": "Test", "mission": "Testing"},
+                **mock_functions,
+            )
+
+        # Retried once (capped at 2 consecutive errors), then gave up.
+        assert mock_llm.call_with_tools.call_count == 2
+        mock_llm.call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_transient_llm_error_is_still_retried(self, mock_llm, mock_functions):
+        """One failed turn followed by a good one is a normal run, not a failure."""
+        mock_llm.call_with_tools.side_effect = [
+            RuntimeError("connection reset"),
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "test"})],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[
+                    LLMToolCall(
+                        id="2",
+                        name="done",
+                        arguments={"answer": "Recovered after a blip", "memory_ids": ["mem-1"]},
+                    )
+                ],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        result = await run_reflect_agent(
+            llm_config=mock_llm,
+            bank_id="test-bank",
+            query="test query",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            **mock_functions,
+        )
+
+        assert result.text == "Recovered after a blip"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_from_a_tool_is_not_wrapped(self, mock_llm, mock_functions):
+        """A client disconnect must stay a cancellation, not become a tool failure.
+
+        ``recall`` re-raises ``OperationCancelledError`` so the HTTP layer can
+        answer 499 (issue #2122). Wrapping it in ``ReflectToolExecutionError``
+        would report a client that went away as a server-side retrieval failure.
+        """
+        mock_functions["recall_fn"].side_effect = OperationCancelledError("client disconnected")
+
+        mock_llm.call_with_tools.side_effect = [
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "test"})],
+                finish_reason="tool_calls",
+            ),
+        ]
+
+        with pytest.raises(OperationCancelledError):
+            await run_reflect_agent(
+                llm_config=mock_llm,
+                bank_id="test-bank",
+                query="test query",
+                bank_profile={"name": "Test", "mission": "Testing"},
+                **mock_functions,
+            )
+
+    @pytest.mark.asyncio
+    async def test_cancellation_from_the_llm_call_is_not_retried(self, mock_llm, mock_functions):
+        """A cancellation raised by the LLM call is not a provider failure.
+
+        It must not be retried and must not be synthesized around — it reaches the
+        HTTP layer as itself, so a client disconnect stays a 499 (issue #2122).
+        """
+        mock_llm.call_with_tools.side_effect = OperationCancelledError("client disconnected")
+
+        with pytest.raises(OperationCancelledError):
+            await run_reflect_agent(
+                llm_config=mock_llm,
+                bank_id="test-bank",
+                query="test query",
+                bank_profile={"name": "Test", "mission": "Testing"},
+                **mock_functions,
+            )
+
+        assert mock_llm.call_with_tools.call_count == 1
+        mock_llm.call.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_normalizes_tool_names_in_other_tools(self, mock_llm, mock_functions):

--- a/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
+++ b/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
@@ -16,6 +16,14 @@ import pytest
 
 from hindsight_api.api.http import OperationResponse, OperationStatusResponse
 from hindsight_api.engine.memory_engine import MemoryEngine
+
+# Imported at module scope on purpose. test_reflect_tokenizer_lazy_load purges
+# ``hindsight_api.engine.reflect*`` from sys.modules, so a late import inside a
+# test can hand back a FRESHLY imported class whose identity no longer matches
+# the one memory_engine bound at its own import time — the ``except`` in
+# refresh_mental_model then misses, and the failure is recorded as
+# ``unexpected_error``. Importing here binds before any test can purge.
+from hindsight_api.engine.reflect import ReflectNoAnswerError, ReflectToolExecutionError
 from hindsight_api.worker.exceptions import RetryTaskAt
 from tests.conftest import stub_refresh_has_sources
 
@@ -244,8 +252,11 @@ async def test_preserved_and_rewritten_differ_only_by_outcome(memory: MemoryEngi
     # ...and only the outcome tells them apart.
     assert preserved["outcome"] == "content_preserved_no_new_facts"
     assert rewritten["outcome"] == "content_written"
-    assert "failure_reason" not in preserved
-    assert "failure_reason" not in rewritten
+    # A finished refresh has no failure reason, and says so explicitly rather than
+    # leaving the field out: a retry runs on the same operation row, so a reason an
+    # earlier attempt wrote would otherwise survive into the attempt that succeeded.
+    assert preserved["failure_reason"] is None
+    assert rewritten["failure_reason"] is None
 
 
 def test_operation_outcome_is_a_superset_of_executor_outcome():
@@ -264,7 +275,7 @@ def test_operation_outcome_is_a_superset_of_executor_outcome():
     assert executor <= operation, f"executor outcomes missing from the operation vocabulary: {executor - operation}"
     # The persist path is the only source of the extra values; if that changes,
     # the comment on RefreshOperationOutcome needs to change with it.
-    assert operation - executor == {"refresh_failed_structured_output"}
+    assert operation - executor == {"refresh_failed_structured_output", "refresh_failed_error"}
 
 
 def test_unknown_outcome_reports_no_details_instead_of_raising():
@@ -360,6 +371,10 @@ class _OutcomeCase:
     expect_failure_reason: str | None = None
     expect_ops_applied: int = 0
     expect_ops_skipped: int = 0
+    # Reflect itself fails, before there is an executor run at all: the tool-failure
+    # (#2894) and no-answer (#2959) paths, which the refresh re-raises as a typed
+    # MentalModelRefreshError so they reach the operation like every other refusal.
+    reflect_raises: str | None = None
 
 
 _OUTCOME_CASES = [
@@ -462,6 +477,33 @@ _OUTCOME_CASES = [
         expect_failure_reason="structured_output_failed",
         why="the persist path refuses a document the executor already accepted — the one outcome a dry run cannot reach",
     ),
+    _OutcomeCase(
+        id="reflect_retrieval_failed",
+        mode="full",
+        reflect_text="",
+        reflect_raises="tool",
+        expect_outcome="refresh_failed_error",
+        expect_failure_reason="retrieval_failed",
+        why="a retrieval tool raised, so the run never gathered the evidence it was asked for (#2894)",
+    ),
+    _OutcomeCase(
+        id="unexpected_error",
+        mode="full",
+        reflect_text="",
+        reflect_raises="unexpected",
+        expect_outcome="refresh_failed_error",
+        expect_failure_reason="unexpected_error",
+        why="anything that escapes the refresh still has to leave a record (#2894)",
+    ),
+    _OutcomeCase(
+        id="reflect_produced_no_answer",
+        mode="full",
+        reflect_text="",
+        reflect_raises="answer",
+        expect_outcome="refresh_failed_error",
+        expect_failure_reason="no_answer",
+        why="reflect finished without an answer, so there is nothing to write (#2959)",
+    ),
 ]
 
 
@@ -483,7 +525,28 @@ async def test_refresh_outcome_matrix(case: _OutcomeCase, memory: MemoryEngine, 
         request_context=request_context,
     )
 
-    _patch_reflect(monkeypatch, memory, text=case.reflect_text, facts=case.facts)
+    if case.reflect_raises:
+        if case.reflect_raises == "tool":
+            exc: Exception = ReflectToolExecutionError(
+                "Reflect tool 'recall' failed on iteration 1: the store is unreachable"
+            )
+        elif case.reflect_raises == "unexpected":
+            # Not a shape the pipeline models — a provider that gave up, a store
+            # that went away. It is still a failed refresh.
+            exc = RuntimeError("the provider returned 503 three times")
+        else:
+            exc = ReflectNoAnswerError("Reflect's done tool returned no answer.")
+
+        async def reflect_fails(**kwargs):
+            raise exc
+
+        monkeypatch.setattr(memory, "reflect_async", reflect_fails)
+        # These cases are about what reflect does when it runs, so the bank has to
+        # look non-empty — otherwise the empty-scope short-circuit (#3875) skips the
+        # loop and the stub never raises.
+        stub_refresh_has_sources(monkeypatch, memory)
+    else:
+        _patch_reflect(monkeypatch, memory, text=case.reflect_text, facts=case.facts)
     _patch_delta_llm(monkeypatch, memory, returns=case.delta_returns)
     if case.unparseable_baseline:
         from hindsight_api.engine.reflect import structured_doc
@@ -562,3 +625,46 @@ def test_outcome_matrix_covers_every_outcome_and_reason():
     # delta-not-applied guard sets a more specific reason. It is covered by
     # test_delta_failure_reason_narrows_the_fallback_vocabulary instead.
     assert covered_reasons == set(get_args(RefreshFailureReason)) - {"delta_not_applied"}
+
+
+@pytest.mark.asyncio
+async def test_a_retry_that_succeeds_clears_the_earlier_failure_reason(bank_with_model, request_context, monkeypatch):
+    """A refresh is retried on the same operation row, so its reason must not stick.
+
+    Observed live: an operation that failed with ``no_answer`` and then succeeded on
+    retry reported ``outcome=content_written`` alongside ``failure_reason=no_answer``.
+    Both writers merge into ``result_metadata``, so the success has to overwrite the
+    earlier reason rather than simply not write one.
+
+    Driven through the two writers directly: the worker's real retry only fires
+    after ``next_retry_at``, and a second submit folds into the pending row (#3487)
+    without re-running it, so neither reproduces a second attempt in-process.
+    """
+    memory, bank_id, mm = bank_with_model
+    from hindsight_api.engine.memory_engine import MentalModelRefreshError
+
+    operation_id = await _submit_with_fake_refresh(
+        memory, monkeypatch, bank_id, mm, request_context, _fake_refreshed("first attempt", {})
+    )
+
+    # Attempt 1 failed.
+    await memory._write_refresh_failure_metadata(
+        operation_id,
+        MentalModelRefreshError("no answer", outcome="refresh_failed_error", reason="no_answer"),
+    )
+    failed = await memory.get_operation_status(
+        bank_id=bank_id, operation_id=operation_id, request_context=request_context
+    )
+    assert failed["result_metadata"]["failure_reason"] == "no_answer"
+
+    # Attempt 2, on the same row, wrote a document.
+    await memory._write_refresh_outcome_metadata(
+        operation_id, _fake_refreshed("a real document", {}) | {"reflect_response": {"outcome": "content_written"}}
+    )
+    succeeded = await memory.get_operation_status(
+        bank_id=bank_id, operation_id=operation_id, request_context=request_context
+    )
+    assert succeeded["result_metadata"]["outcome"] == "content_written"
+    assert succeeded["result_metadata"]["failure_reason"] is None, (
+        "the earlier attempt's failure reason survived into the successful one"
+    )

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -9826,6 +9826,7 @@ components:
           - refresh_failed_empty_candidate
           - refresh_failed_delta_not_applied
           - refresh_failed_structured_output
+          - refresh_failed_error
           title: Outcome
           type: string
         failure_reason:
@@ -9836,6 +9837,9 @@ components:
           - delta_ops_all_skipped
           - delta_not_applied
           - structured_output_failed
+          - retrieval_failed
+          - no_answer
+          - unexpected_error
           nullable: true
           type: string
       required:

--- a/hindsight-clients/python/hindsight_client_api/models/refresh_mental_model_operation_details.py
+++ b/hindsight-clients/python/hindsight_client_api/models/refresh_mental_model_operation_details.py
@@ -44,8 +44,8 @@ class RefreshMentalModelOperationDetails(BaseModel):
     @field_validator('outcome')
     def outcome_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['content_written', 'content_unchanged', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_delta_not_applied', 'refresh_failed_structured_output']):
-            raise ValueError("must be one of enum values ('content_written', 'content_unchanged', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_delta_not_applied', 'refresh_failed_structured_output')")
+        if value not in set(['content_written', 'content_unchanged', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_delta_not_applied', 'refresh_failed_structured_output', 'refresh_failed_error']):
+            raise ValueError("must be one of enum values ('content_written', 'content_unchanged', 'content_preserved_no_new_facts', 'refresh_failed_empty_candidate', 'refresh_failed_delta_not_applied', 'refresh_failed_structured_output', 'refresh_failed_error')")
         return value
 
     @field_validator('failure_reason')
@@ -54,8 +54,8 @@ class RefreshMentalModelOperationDetails(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['empty_candidate', 'structured_doc_unreadable', 'delta_ops_failed', 'delta_ops_all_skipped', 'delta_not_applied', 'structured_output_failed']):
-            raise ValueError("must be one of enum values ('empty_candidate', 'structured_doc_unreadable', 'delta_ops_failed', 'delta_ops_all_skipped', 'delta_not_applied', 'structured_output_failed')")
+        if value not in set(['empty_candidate', 'structured_doc_unreadable', 'delta_ops_failed', 'delta_ops_all_skipped', 'delta_not_applied', 'structured_output_failed', 'retrieval_failed', 'no_answer', 'unexpected_error']):
+            raise ValueError("must be one of enum values ('empty_candidate', 'structured_doc_unreadable', 'delta_ops_failed', 'delta_ops_all_skipped', 'delta_not_applied', 'structured_output_failed', 'retrieval_failed', 'no_answer', 'unexpected_error')")
         return value
 
     model_config = ConfigDict(

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -4750,7 +4750,8 @@ export type RefreshMentalModelOperationDetails = {
     | "content_preserved_no_new_facts"
     | "refresh_failed_empty_candidate"
     | "refresh_failed_delta_not_applied"
-    | "refresh_failed_structured_output";
+    | "refresh_failed_structured_output"
+    | "refresh_failed_error";
   /**
    * Failure Reason
    *
@@ -4763,6 +4764,9 @@ export type RefreshMentalModelOperationDetails = {
     | "delta_ops_all_skipped"
     | "delta_not_applied"
     | "structured_output_failed"
+    | "retrieval_failed"
+    | "no_answer"
+    | "unexpected_error"
     | null;
 };
 

--- a/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
+++ b/hindsight-control-plane/src/components/mental-model-detail-modal.tsx
@@ -27,6 +27,7 @@ import {
   Pencil,
   RefreshCw,
   Trash2,
+  AlertTriangle,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import { toast } from "sonner";
@@ -39,7 +40,7 @@ import {
   MentalModelDryRunDialog,
   TraceSummary,
 } from "./mental-model-diagnostics-view";
-import type { MentalModelRefreshTrace } from "@/lib/api";
+import type { MentalModelRefreshTrace, RefreshFailureReason } from "@/lib/api";
 import { MemoryDetailModal } from "./memory-detail-modal";
 import { DirectiveDetailModal } from "./directive-detail-modal";
 import { formatAbsoluteDateTime as formatDateTime, formatRelativeTime } from "@/lib/relative-time";
@@ -82,11 +83,122 @@ type ReflectResponseSnapshot = {
   trace?: MentalModelRefreshTrace;
 } | null;
 
-type HistoryEntry = {
+export type HistoryEntry = {
   previous_content: string | null;
   previous_reflect_response?: ReflectResponseSnapshot;
   changed_at: string;
+  /** Failure records carry these; version snapshots do not. A refresh that
+   *  refused to write produced no version, so it is an event on the timeline
+   *  rather than a diff — and without it the model looked as though it had
+   *  simply never been refreshed (#2894). */
+  kind?: "refresh_failed";
+  failure_reason?: RefreshFailureReason;
+  error_message?: string;
 };
+
+const isFailureEntry = (e: HistoryEntry) => e.kind === "refresh_failed";
+
+/** Consecutive attempts that failed the same way, as one entry on the timeline. */
+export type FailureGroup = { entry: HistoryEntry; attempts: number; oldest: string };
+
+/** The failures in a model's history, as episodes.
+ *
+ * A failed refresh is retried by the worker and each attempt records its own
+ * row, so one broken retriever produces a run of identical entries. They are
+ * collapsed into a single event with an attempt count.
+ *
+ * Takes the WHOLE history, not just the failures: a successful refresh between
+ * two identical failures means the thing broke, recovered, and broke again —
+ * two episodes, not one. Filtering the versions out first would silently merge
+ * them and under-report how often the model has been failing. */
+export function groupFailures(history: HistoryEntry[]): FailureGroup[] {
+  const groups: FailureGroup[] = [];
+  let previousWasFailure = false;
+  for (const entry of history) {
+    if (!isFailureEntry(entry)) {
+      previousWasFailure = false;
+      continue;
+    }
+    const last = groups[groups.length - 1];
+    if (
+      previousWasFailure &&
+      last &&
+      last.entry.failure_reason === entry.failure_reason &&
+      last.entry.error_message === entry.error_message
+    ) {
+      last.attempts += 1;
+      last.oldest = entry.changed_at;
+    } else {
+      groups.push({ entry, attempts: 1, oldest: entry.changed_at });
+    }
+    previousWasFailure = true;
+  }
+  return groups;
+}
+
+/** The model's failed refreshes, newest first, as a timeline of events.
+
+ * Kept out of the History tab on purpose: that tab is a version browser, and a
+ * refusal to write produces no version — interleaving the two made the failures
+ * read as versions and buried the diffs under repetitions of one outage. */
+function RefreshErrorTimeline({ groups }: { groups: FailureGroup[] }) {
+  const t = useTranslations("mentalModelDetailModal");
+  const reasonLabels: Record<RefreshFailureReason, string> = {
+    retrieval_failed: t("failureReasonRetrievalFailed"),
+    no_answer: t("failureReasonNoAnswer"),
+    empty_candidate: t("failureReasonEmptyCandidate"),
+    structured_doc_unreadable: t("failureReasonDocUnreadable"),
+    delta_ops_failed: t("failureReasonDeltaOpsFailed"),
+    delta_ops_all_skipped: t("failureReasonDeltaOpsAllSkipped"),
+    delta_not_applied: t("failureReasonDeltaNotApplied"),
+    structured_output_failed: t("failureReasonStructuredOutput"),
+    unexpected_error: t("failureReasonUnexpected"),
+  };
+
+  if (groups.length === 0) {
+    return <p className="text-sm text-muted-foreground italic">{t("noErrors")}</p>;
+  }
+
+  return (
+    <div className="space-y-1">
+      <p className="text-sm text-muted-foreground pb-2">{t("errorsIntro")}</p>
+      <ol className="relative border-l border-border ml-2">
+        {groups.map((g, i) => (
+          <li key={`${g.entry.changed_at}-${i}`} className="relative pl-6 pb-5 last:pb-0">
+            <span className="absolute -left-[5px] top-1.5 h-2.5 w-2.5 rounded-full bg-red-500 ring-4 ring-background" />
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <span className="text-sm font-semibold text-red-700 dark:text-red-400">
+                {g.entry.failure_reason
+                  ? reasonLabels[g.entry.failure_reason]
+                  : t("failureReasonUnknown")}
+              </span>
+              {g.attempts > 1 && (
+                <span className="text-xs text-muted-foreground">
+                  {t("failureAttempts", { count: g.attempts })}
+                </span>
+              )}
+              <span
+                className="text-xs text-muted-foreground"
+                title={
+                  g.attempts > 1
+                    ? `${formatDateTime(g.oldest)} — ${formatDateTime(g.entry.changed_at)}`
+                    : formatDateTime(g.entry.changed_at)
+                }
+              >
+                &middot; {formatRelativeTime(g.entry.changed_at)}
+              </span>
+            </div>
+            {g.entry.error_message && (
+              <pre className="mt-1.5 rounded-md border border-border bg-muted/40 p-2 text-xs font-mono whitespace-pre-wrap break-words text-muted-foreground">
+                {g.entry.error_message}
+              </pre>
+            )}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
 
 function getFactTypeDisplay(factType: string, t?: (key: string) => string) {
   if (factType === "directives") {
@@ -561,6 +673,8 @@ function MentalModelHistoryView({
 }) {
   const t = useTranslations("mentalModelDetailModal");
   const [idx, setIdx] = useState(0);
+  // Failures are not versions — they have no before/after to diff — so they live
+  // on their own Errors tab rather than in this pager.
   const entry = history[idx];
   const afterContent = idx === 0 ? currentContent : (history[idx - 1].previous_content ?? "");
   const beforeBasedOn = entry.previous_reflect_response?.based_on;
@@ -683,6 +797,14 @@ export function MentalModelDetailModal({
   const [viewDirectiveId, setViewDirectiveId] = useState<string | null>(null);
 
   const [history, setHistory] = useState<HistoryEntry[] | null>(null);
+  // Failures are events, not versions: they drive the Errors tab and its dot,
+  // and never appear in the version pager.
+  const failureEntries = useMemo(() => (history ?? []).filter(isFailureEntry), [history]);
+  const versionEntries = useMemo(
+    () => (history ?? []).filter((e) => !isFailureEntry(e)),
+    [history]
+  );
+  const failureGroups = useMemo(() => groupFailures(history ?? []), [history]);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [dryRunning, setDryRunning] = useState(false);
   const [dryRunResult, setDryRunResult] = useState<MentalModelDryRunRefreshResult | null>(null);
@@ -711,8 +833,12 @@ export function MentalModelDetailModal({
     load();
   }, [mentalModelId, currentBank, initialTab]);
 
+  // Loaded as soon as the model is, not only when the Errors or History tab is
+  // opened: the history is where a failed refresh is recorded, and the red dot on
+  // the Errors tab has to be right from the moment the modal opens (#2894). An
+  // earlier revision showed a banner on every tab instead; the dot replaced it.
   useEffect(() => {
-    if (activeTab !== "history" || !mentalModel || !currentBank || history !== null) return;
+    if (!mentalModel || !currentBank || history !== null) return;
 
     const loadHistory = async () => {
       setLoadingHistory(true);
@@ -728,7 +854,7 @@ export function MentalModelDetailModal({
     };
 
     loadHistory();
-  }, [activeTab, mentalModel, currentBank, history]);
+  }, [mentalModel, currentBank, history]);
 
   // A dry run changes nothing, so it is an action with a transient result rather
   // than a tab: run it, show the preview, throw it away.
@@ -854,7 +980,7 @@ export function MentalModelDetailModal({
               className="flex-1 flex flex-col overflow-hidden"
             >
               <div className="flex items-center justify-between gap-2">
-                <TabsList className="grid grid-cols-3 w-full max-w-md">
+                <TabsList className="grid grid-cols-4 w-full max-w-2xl">
                   <TabsTrigger value="content" className="flex items-center gap-1.5">
                     <FileText className="w-3.5 h-3.5" />
                     {t("tabContent")}
@@ -866,6 +992,19 @@ export function MentalModelDetailModal({
                   <TabsTrigger value="history" className="flex items-center gap-1.5">
                     <HistoryIcon className="w-3.5 h-3.5" />
                     {t("tabHistory")}
+                  </TabsTrigger>
+                  <TabsTrigger value="errors" className="flex items-center gap-1.5">
+                    <AlertTriangle className="w-3.5 h-3.5" />
+                    {t("tabErrors")}
+                    {/* The whole signal that something is wrong: a full alert on
+                        every tab shouted at people reading a document that was
+                        never damaged. */}
+                    {failureEntries.length > 0 && (
+                      <span
+                        className="h-2 w-2 rounded-full bg-red-500"
+                        aria-label={t("errorsPresent")}
+                      />
+                    )}
                   </TabsTrigger>
                 </TabsList>
                 <DropdownMenu>
@@ -980,14 +1119,26 @@ export function MentalModelDetailModal({
                   <ConfigurationTab mentalModel={mentalModel} />
                 </TabsContent>
 
+                <TabsContent value="errors" className="mt-0">
+                  {/* Until the history is in, "no failed refreshes" would be a claim
+                      the UI cannot yet make. */}
+                  {loadingHistory ? (
+                    <div className="flex items-center justify-center py-12">
+                      <Spinner size="md" variant="jump" />
+                    </div>
+                  ) : (
+                    <RefreshErrorTimeline groups={failureGroups} />
+                  )}
+                </TabsContent>
+
                 <TabsContent value="history" className="mt-0">
                   {loadingHistory ? (
                     <div className="flex items-center justify-center py-12">
                       <Spinner size="md" variant="jump" />
                     </div>
-                  ) : history && history.length > 0 ? (
+                  ) : versionEntries.length > 0 ? (
                     <MentalModelHistoryView
-                      history={history}
+                      history={versionEntries}
                       currentContent={mentalModel.content}
                       currentBasedOn={basedOn}
                       currentTrace={

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -240,6 +240,18 @@ export type RefreshOutcome =
   | "refresh_failed_empty_candidate"
   | "refresh_failed_delta_not_applied";
 
+/** Why a refresh refused to write, as recorded on the model's own history. */
+export type RefreshFailureReason =
+  | "empty_candidate"
+  | "structured_doc_unreadable"
+  | "delta_ops_failed"
+  | "delta_ops_all_skipped"
+  | "delta_not_applied"
+  | "structured_output_failed"
+  | "retrieval_failed"
+  | "no_answer"
+  | "unexpected_error";
+
 export interface MentalModelRefreshScope {
   tags?: string[] | null;
   tags_match: TagsMatch;
@@ -1727,6 +1739,12 @@ export class ControlPlaneClient {
           mental_models?: unknown[];
         } | null;
         changed_at: string;
+        /** Present only on failure records: a refresh that refused to write.
+         *  Absent (undefined) on the version snapshots a successful refresh
+         *  writes, which is every row written before failures were recorded. */
+        kind?: "refresh_failed";
+        failure_reason?: RefreshFailureReason;
+        error_message?: string;
       }[]
     >(bankApi(bankId, `/mental-models/${encodeURIComponent(mentalModelId)}/history`));
   }

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -1512,7 +1512,22 @@
     "refreshTrace": "Aktualisierungs-Trace",
     "traceNotCaptured": "Für diese Aktualisierung wurde kein Trace aufgezeichnet. Aktivieren Sie „Aktualisierungs-Traces behalten“ in den Modelleinstellungen.",
     "actionDryRun": "Testlauf ausführen",
-    "actionDryRunRunning": "Probelauf läuft…"
+    "actionDryRunRunning": "Probelauf läuft…",
+    "failureReasonUnknown": "Aktualisierung fehlgeschlagen",
+    "failureReasonRetrievalFailed": "Abruf fehlgeschlagen",
+    "failureReasonNoAnswer": "Keine Antwort erzeugt",
+    "failureReasonEmptyCandidate": "Leerer Inhalt erzeugt",
+    "failureReasonDocUnreadable": "Gespeichertes Dokument nicht lesbar",
+    "failureReasonDeltaOpsFailed": "Delta-Operationen fehlgeschlagen",
+    "failureReasonDeltaOpsAllSkipped": "Alle Delta-Operationen abgelehnt",
+    "failureReasonDeltaNotApplied": "Delta nicht angewendet",
+    "failureReasonStructuredOutput": "Extraktion der strukturierten Ausgabe fehlgeschlagen",
+    "failureAttempts": "· {count} Versuche",
+    "tabErrors": "Fehler",
+    "noErrors": "Keine fehlgeschlagenen Aktualisierungen.",
+    "errorsIntro": "Aktualisierungen, die nicht geschrieben haben – neueste zuerst. Der gespeicherte Inhalt blieb dabei jeweils unberührt. Eine fehlgeschlagene Aktualisierung wird einige Male automatisch wiederholt; danach behält das Modell seine letzte gültige Version, bis es erneut ausgelöst wird.",
+    "errorsPresent": "Dieses Mental Model hat fehlgeschlagene Aktualisierungen",
+    "failureReasonUnexpected": "Unerwarteter Fehler"
   },
   "constellation": {
     "instructions": "Scrollen zum Zoomen · Ziehen zum Verschieben · Hover zum Erkunden · Klicken zum Auswählen",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -1512,7 +1512,22 @@
     "refreshTrace": "Refresh trace",
     "traceNotCaptured": "No trace recorded for this refresh. Turn on “Keep refresh traces” in the model's settings to record how each refresh reaches its result.",
     "actionDryRun": "Run dry run",
-    "actionDryRunRunning": "Running dry run…"
+    "actionDryRunRunning": "Running dry run…",
+    "failureReasonUnknown": "Refresh failed",
+    "failureReasonRetrievalFailed": "Retrieval failed",
+    "failureReasonNoAnswer": "No answer produced",
+    "failureReasonEmptyCandidate": "Empty content produced",
+    "failureReasonDocUnreadable": "Stored document unreadable",
+    "failureReasonDeltaOpsFailed": "Delta operations failed",
+    "failureReasonDeltaOpsAllSkipped": "All delta operations rejected",
+    "failureReasonDeltaNotApplied": "Delta not applied",
+    "failureReasonStructuredOutput": "Structured output extraction failed",
+    "failureAttempts": "· {count} attempts",
+    "tabErrors": "Errors",
+    "noErrors": "No failed refreshes.",
+    "errorsIntro": "Refreshes that refused to write, newest first. The stored content was left untouched by each of these. A failed refresh is retried a few times automatically; after that the model keeps its last good version until something triggers it again.",
+    "errorsPresent": "This mental model has failed refreshes",
+    "failureReasonUnexpected": "Unexpected error"
   },
   "constellation": {
     "instructions": "Scroll to zoom · Drag to pan · Hover to explore · Click to select",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -1512,7 +1512,22 @@
     "refreshTrace": "Traza de la actualización",
     "traceNotCaptured": "No se registró ninguna traza para esta actualización. Activa «Conservar trazas de actualización» en los ajustes del modelo.",
     "actionDryRun": "Ejecutar simulación",
-    "actionDryRunRunning": "Ejecutando simulación…"
+    "actionDryRunRunning": "Ejecutando simulación…",
+    "failureReasonUnknown": "Actualización fallida",
+    "failureReasonRetrievalFailed": "Fallo en la recuperación",
+    "failureReasonNoAnswer": "No se produjo respuesta",
+    "failureReasonEmptyCandidate": "Se generó contenido vacío",
+    "failureReasonDocUnreadable": "Documento almacenado ilegible",
+    "failureReasonDeltaOpsFailed": "Fallaron las operaciones delta",
+    "failureReasonDeltaOpsAllSkipped": "Se rechazaron todas las operaciones delta",
+    "failureReasonDeltaNotApplied": "Delta no aplicado",
+    "failureReasonStructuredOutput": "Falló la extracción de salida estructurada",
+    "failureAttempts": "· {count} intentos",
+    "tabErrors": "Errores",
+    "noErrors": "No hay actualizaciones fallidas.",
+    "errorsIntro": "Actualizaciones que se negaron a escribir, de la más reciente a la más antigua. Ninguna modificó el contenido almacenado. Una actualización fallida se reintenta automáticamente unas cuantas veces; después el modelo conserva su última versión válida hasta que algo vuelva a activarlo.",
+    "errorsPresent": "Este modelo mental tiene actualizaciones fallidas",
+    "failureReasonUnexpected": "Error inesperado"
   },
   "constellation": {
     "instructions": "Desplaza para hacer zoom · Arrastra para mover · Pasa el cursor para explorar · Haz clic para seleccionar",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -1512,7 +1512,22 @@
     "refreshTrace": "Trace de l'actualisation",
     "traceNotCaptured": "Aucune trace enregistrée pour cette actualisation. Activez « Conserver les traces d'actualisation » dans les réglages du modèle.",
     "actionDryRun": "Exécuter à blanc",
-    "actionDryRunRunning": "Simulation en cours…"
+    "actionDryRunRunning": "Simulation en cours…",
+    "failureReasonUnknown": "Échec de l'actualisation",
+    "failureReasonRetrievalFailed": "Échec de la récupération",
+    "failureReasonNoAnswer": "Aucune réponse produite",
+    "failureReasonEmptyCandidate": "Contenu vide produit",
+    "failureReasonDocUnreadable": "Document stocké illisible",
+    "failureReasonDeltaOpsFailed": "Échec des opérations delta",
+    "failureReasonDeltaOpsAllSkipped": "Toutes les opérations delta rejetées",
+    "failureReasonDeltaNotApplied": "Delta non appliqué",
+    "failureReasonStructuredOutput": "Échec de l'extraction de la sortie structurée",
+    "failureAttempts": "· {count} tentatives",
+    "tabErrors": "Erreurs",
+    "noErrors": "Aucune actualisation échouée.",
+    "errorsIntro": "Actualisations qui ont refusé d'écrire, les plus récentes d'abord. Aucune n'a modifié le contenu stocké. Une actualisation échouée est réessayée automatiquement quelques fois ; ensuite le modèle conserve sa dernière version valide jusqu'au prochain déclenchement.",
+    "errorsPresent": "Ce modèle mental a des actualisations échouées",
+    "failureReasonUnexpected": "Erreur inattendue"
   },
   "constellation": {
     "instructions": "Défiler pour zoomer · Glisser pour déplacer · Survoler pour explorer · Cliquer pour sélectionner",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -1512,7 +1512,22 @@
     "refreshTrace": "更新トレース",
     "traceNotCaptured": "この更新のトレースは記録されていません。モデル設定で「更新トレースを保持」を有効にしてください。",
     "actionDryRun": "ドライラン実行",
-    "actionDryRunRunning": "ドライラン実行中…"
+    "actionDryRunRunning": "ドライラン実行中…",
+    "failureReasonUnknown": "更新に失敗しました",
+    "failureReasonRetrievalFailed": "検索に失敗しました",
+    "failureReasonNoAnswer": "回答が生成されませんでした",
+    "failureReasonEmptyCandidate": "空のコンテンツが生成されました",
+    "failureReasonDocUnreadable": "保存されたドキュメントを読み取れません",
+    "failureReasonDeltaOpsFailed": "デルタ操作に失敗しました",
+    "failureReasonDeltaOpsAllSkipped": "すべてのデルタ操作が拒否されました",
+    "failureReasonDeltaNotApplied": "デルタが適用されませんでした",
+    "failureReasonStructuredOutput": "構造化出力の抽出に失敗しました",
+    "failureAttempts": "· {count} 回試行",
+    "tabErrors": "エラー",
+    "noErrors": "失敗した更新はありません。",
+    "errorsIntro": "書き込みを拒否した更新を新しい順に表示します。いずれも保存済みコンテンツには手を加えていません。失敗した更新は数回自動で再試行され、その後は次のトリガーまで最後に成功したバージョンが保持されます。",
+    "errorsPresent": "このメンタルモデルには失敗した更新があります",
+    "failureReasonUnexpected": "予期しないエラー"
   },
   "constellation": {
     "instructions": "スクロールでズーム · ドラッグで移動 · ホバーで探索 · クリックで選択",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -1512,7 +1512,22 @@
     "refreshTrace": "새로 고침 트레이스",
     "traceNotCaptured": "이 새로 고침에 대한 트레이스가 기록되지 않았습니다. 모델 설정에서 ‘새로 고침 트레이스 보관’을 켜세요.",
     "actionDryRun": "드라이 런 실행",
-    "actionDryRunRunning": "드라이런 실행 중…"
+    "actionDryRunRunning": "드라이런 실행 중…",
+    "failureReasonUnknown": "새로 고침 실패",
+    "failureReasonRetrievalFailed": "검색 실패",
+    "failureReasonNoAnswer": "답변이 생성되지 않음",
+    "failureReasonEmptyCandidate": "빈 콘텐츠가 생성됨",
+    "failureReasonDocUnreadable": "저장된 문서를 읽을 수 없음",
+    "failureReasonDeltaOpsFailed": "델타 작업 실패",
+    "failureReasonDeltaOpsAllSkipped": "모든 델타 작업이 거부됨",
+    "failureReasonDeltaNotApplied": "델타가 적용되지 않음",
+    "failureReasonStructuredOutput": "구조화된 출력 추출 실패",
+    "failureAttempts": "· {count}회 시도",
+    "tabErrors": "오류",
+    "noErrors": "실패한 새로 고침이 없습니다.",
+    "errorsIntro": "쓰기를 거부한 새로 고침을 최신순으로 표시합니다. 모두 저장된 콘텐츠를 그대로 두었습니다. 실패한 새로 고침은 자동으로 몇 번 재시도되며, 그 후에는 다시 트리거될 때까지 마지막으로 성공한 버전이 유지됩니다.",
+    "errorsPresent": "이 멘탈 모델에 실패한 새로 고침이 있습니다",
+    "failureReasonUnexpected": "예기치 않은 오류"
   },
   "constellation": {
     "instructions": "스크롤하여 확대/축소 · 드래그하여 이동 · 호버하여 탐색 · 클릭하여 선택",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -1512,7 +1512,22 @@
     "refreshTrace": "Rastro da atualização",
     "traceNotCaptured": "Nenhum rastro registrado para esta atualização. Ative “Manter rastros de atualização” nas configurações do modelo.",
     "actionDryRun": "Executar simulação",
-    "actionDryRunRunning": "Executando simulação…"
+    "actionDryRunRunning": "Executando simulação…",
+    "failureReasonUnknown": "Falha na atualização",
+    "failureReasonRetrievalFailed": "Falha na recuperação",
+    "failureReasonNoAnswer": "Nenhuma resposta produzida",
+    "failureReasonEmptyCandidate": "Conteúdo vazio produzido",
+    "failureReasonDocUnreadable": "Documento armazenado ilegível",
+    "failureReasonDeltaOpsFailed": "Falha nas operações delta",
+    "failureReasonDeltaOpsAllSkipped": "Todas as operações delta rejeitadas",
+    "failureReasonDeltaNotApplied": "Delta não aplicado",
+    "failureReasonStructuredOutput": "Falha na extração de saída estruturada",
+    "failureAttempts": "· {count} tentativas",
+    "tabErrors": "Erros",
+    "noErrors": "Nenhuma atualização com falha.",
+    "errorsIntro": "Atualizações que se recusaram a escrever, da mais recente para a mais antiga. Nenhuma alterou o conteúdo armazenado. Uma atualização com falha é repetida automaticamente algumas vezes; depois disso o modelo mantém a última versão válida até ser acionado novamente.",
+    "errorsPresent": "Este modelo mental tem atualizações com falha",
+    "failureReasonUnexpected": "Erro inesperado"
   },
   "constellation": {
     "instructions": "Scroll para zoom · Arraste para mover · Passe o mouse para explorar · Clique para selecionar",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -1512,7 +1512,22 @@
     "refreshTrace": "重新整理追蹤",
     "traceNotCaptured": "今次重新整理冇記錄追蹤。喺模型設定開啟「保留重新整理追蹤」啦。",
     "actionDryRun": "執行試運行演練",
-    "actionDryRunRunning": "試行緊…"
+    "actionDryRunRunning": "試行緊…",
+    "failureReasonUnknown": "重新整理失敗",
+    "failureReasonRetrievalFailed": "檢索失敗",
+    "failureReasonNoAnswer": "冇產生答案",
+    "failureReasonEmptyCandidate": "產生咗空內容",
+    "failureReasonDocUnreadable": "讀唔到已儲存嘅文件",
+    "failureReasonDeltaOpsFailed": "增量操作失敗",
+    "failureReasonDeltaOpsAllSkipped": "所有增量操作都俾拒絕咗",
+    "failureReasonDeltaNotApplied": "冇套用增量",
+    "failureReasonStructuredOutput": "結構化輸出擷取失敗",
+    "failureAttempts": "· 試咗 {count} 次",
+    "tabErrors": "錯誤",
+    "noErrors": "冇失敗嘅重新整理。",
+    "errorsIntro": "拒絕寫入嘅重新整理，由新到舊排。佢哋都冇改動過已儲存嘅內容。失敗嘅重新整理會自動再試幾次；之後模型會保住最後一個成功嘅版本，直到再次觸發為止。",
+    "errorsPresent": "呢個心智模型有失敗嘅重新整理",
+    "failureReasonUnexpected": "非預期錯誤"
   },
   "constellation": {
     "instructions": "滾動縮放 · 拖曳平移 · 懸停探索 · 選取項目",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -1512,7 +1512,22 @@
     "refreshTrace": "刷新追踪",
     "traceNotCaptured": "本次刷新没有记录追踪。请在模型设置中开启“保留刷新追踪”。",
     "actionDryRun": "执行试运行演练",
-    "actionDryRunRunning": "试运行中…"
+    "actionDryRunRunning": "试运行中…",
+    "failureReasonUnknown": "刷新失败",
+    "failureReasonRetrievalFailed": "检索失败",
+    "failureReasonNoAnswer": "未生成回答",
+    "failureReasonEmptyCandidate": "生成了空内容",
+    "failureReasonDocUnreadable": "无法读取已存储的文档",
+    "failureReasonDeltaOpsFailed": "增量操作失败",
+    "failureReasonDeltaOpsAllSkipped": "所有增量操作均被拒绝",
+    "failureReasonDeltaNotApplied": "未应用增量",
+    "failureReasonStructuredOutput": "结构化输出提取失败",
+    "failureAttempts": "· {count} 次尝试",
+    "tabErrors": "错误",
+    "noErrors": "没有失败的刷新。",
+    "errorsIntro": "拒绝写入的刷新，按时间倒序排列。它们都没有改动已存储的内容。失败的刷新会自动重试几次；之后模型将保留最后一个有效版本，直到再次被触发。",
+    "errorsPresent": "此心智模型有失败的刷新",
+    "failureReasonUnexpected": "意外错误"
   },
   "constellation": {
     "instructions": "滚动缩放 · 拖拽平移 · 悬停探索 · 点击选择",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -1512,7 +1512,22 @@
     "refreshTrace": "重新整理追蹤",
     "traceNotCaptured": "本次重新整理沒有記錄追蹤。請在模型設定中開啟「保留重新整理追蹤」。",
     "actionDryRun": "執行試運行演練",
-    "actionDryRunRunning": "試執行中…"
+    "actionDryRunRunning": "試執行中…",
+    "failureReasonUnknown": "重新整理失敗",
+    "failureReasonRetrievalFailed": "檢索失敗",
+    "failureReasonNoAnswer": "未產生回答",
+    "failureReasonEmptyCandidate": "產生了空內容",
+    "failureReasonDocUnreadable": "無法讀取已儲存的文件",
+    "failureReasonDeltaOpsFailed": "增量操作失敗",
+    "failureReasonDeltaOpsAllSkipped": "所有增量操作皆遭拒絕",
+    "failureReasonDeltaNotApplied": "未套用增量",
+    "failureReasonStructuredOutput": "結構化輸出擷取失敗",
+    "failureAttempts": "· {count} 次嘗試",
+    "tabErrors": "錯誤",
+    "noErrors": "沒有失敗的重新整理。",
+    "errorsIntro": "拒絕寫入的重新整理，依時間由新到舊排列。它們都沒有更動已儲存的內容。失敗的重新整理會自動重試幾次；之後模型會保留最後一個有效版本，直到再次被觸發。",
+    "errorsPresent": "此心智模型有失敗的重新整理",
+    "failureReasonUnexpected": "非預期錯誤"
   },
   "constellation": {
     "instructions": "滾動縮放 · 拖曳平移 · 懸停探索 · 按一下選取",

--- a/hindsight-control-plane/tests/components/group-failures.test.ts
+++ b/hindsight-control-plane/tests/components/group-failures.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { groupFailures, type HistoryEntry } from "@/components/mental-model-detail-modal";
+
+/**
+ * A failed mental-model refresh is retried by the worker, and every attempt
+ * records its own history row. Grouping is what stops one outage rendering as N
+ * identical events — and what keeps two outages from rendering as one.
+ */
+
+const failure = (
+  changed_at: string,
+  error_message = "recall failed",
+  failure_reason: HistoryEntry["failure_reason"] = "retrieval_failed"
+): HistoryEntry => ({
+  previous_content: null,
+  changed_at,
+  kind: "refresh_failed",
+  failure_reason,
+  error_message,
+});
+
+const version = (changed_at: string): HistoryEntry => ({
+  previous_content: "# Team\n\nold\n",
+  changed_at,
+});
+
+describe("groupFailures", () => {
+  it("returns nothing for a history with no failures", () => {
+    expect(groupFailures([version("3"), version("2")])).toEqual([]);
+  });
+
+  it("collapses consecutive identical failures into one event", () => {
+    const groups = groupFailures([failure("4"), failure("3"), failure("2")]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].attempts).toBe(3);
+    // Newest first, so the group is stamped with the newest attempt and remembers
+    // the oldest — the two ends of the episode.
+    expect(groups[0].entry.changed_at).toBe("4");
+    expect(groups[0].oldest).toBe("2");
+  });
+
+  it("splits identical failures that a successful refresh separates", () => {
+    // It broke, recovered, and broke again: two episodes. Merging them would
+    // under-report how often the model has been failing.
+    const groups = groupFailures([failure("5"), failure("4"), version("3"), failure("2")]);
+    expect(groups.map((g) => g.attempts)).toEqual([2, 1]);
+    expect(groups[1].entry.changed_at).toBe("2");
+  });
+
+  it("splits on a different reason", () => {
+    const groups = groupFailures([failure("3"), failure("2", "no answer", "no_answer")]);
+    expect(groups.map((g) => g.entry.failure_reason)).toEqual(["retrieval_failed", "no_answer"]);
+  });
+
+  it("splits on a different message under the same reason", () => {
+    // Same class of failure, different cause — worth seeing separately.
+    const groups = groupFailures([
+      failure("3", "the embedder is down"),
+      failure("2", "the store is down"),
+    ]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("ignores versions between failures of different kinds", () => {
+    const groups = groupFailures([
+      failure("5"),
+      version("4"),
+      failure("3", "no answer", "no_answer"),
+      failure("2", "no answer", "no_answer"),
+    ]);
+    expect(groups.map((g) => g.attempts)).toEqual([1, 2]);
+  });
+});

--- a/hindsight-docs/docs/developer/api/mental-models.mdx
+++ b/hindsight-docs/docs/developer/api/mental-models.mdx
@@ -220,6 +220,7 @@ Listing does not cost one query per model — the whole page is answered togethe
 - **Cumulative grounding.** Even in delta mode, `reflect_response.based_on` accumulates: the facts from this refresh are merged with everything previous refreshes relied on, deduplicated by id. The document rests on all of them, not just the latest slice.
 - **Nothing, if nothing is relevant.** A refresh that finds no topic-relevant memories leaves the content alone and only advances the watermark, so the same empty window stops re-triggering.
 - **No LLM call at all, if there is nothing to read.** Before the agentic loop starts, a refresh checks whether anything is in reach under this model's own settings: an in-scope memory (`tags`/`tags_match`, `tag_groups` and `fact_types` all narrow it) inside the window it would read — the whole bank in `full` mode, everything since `last_memory_seen_at` in `delta` mode — or a sibling mental model, unless `exclude_mental_models` closed that door. When there is nothing, the refresh completes immediately, leaves the document untouched, and spends nothing. This is the common case on a bank that was just created: its pages are refreshed the moment they exist, before anything has been retained.
+- **A failed retrieval is not an empty one.** If a retrieval step raises — the database, the embedder or the reranker is unavailable — the refresh **fails** instead of writing what the model came up with without it. Content, `structured_output` and the watermark are all left untouched, so the retry reads the same window again. This is the distinction that matters: "we looked and there is nothing on this topic" is an answer and gets written; "we could not look" is a failure and gets preserved. Without it, a broken retriever silently replaced a document built over months with a generic "I don't have information about that".
 
 ### Refresh Mode
 
@@ -482,7 +483,7 @@ somewhere else.
 |-------|----------|
 | `effective_mode` | Whether the run ended up `full` or `delta` |
 | `mode_fallback_reason` | Why delta was requested but not applied — `no_baseline_content`, `source_query_changed`, `structured_doc_unreadable`, `delta_ops_failed`, `delta_ops_all_skipped` |
-| `outcome` | `content_written`, `content_preserved_no_new_facts`, `refresh_failed_empty_candidate`, or `refresh_failed_delta_not_applied` (the edits didn't apply, so the document was kept and the refresh failed) |
+| `outcome` | `content_written`, `content_preserved_no_new_facts`, `refresh_failed_empty_candidate`, or `refresh_failed_delta_not_applied` (the edits didn't apply, so the document was kept and the refresh failed). The operation record adds two the executor cannot produce, because they happen outside a run: `refresh_failed_structured_output` and `refresh_failed_error` (a retrieval tool raised, the agent produced no answer, or something unforeseen escaped the refresh) |
 | `tool_calls[]` | Per call: `tool`, the agent's `reason`, the full `input`, `result_count`, `duration_ms`, and the `iteration` it belongs to |
 | `llm_calls[]` | Per call: `scope` (`agent_1`, `agent_2`, …, `final`) and `duration_ms` |
 | `delta_operations` | The operations emitted in delta mode, `applied` and `skipped` |
@@ -666,10 +667,18 @@ The endpoint returns a list of history entries, most recent first:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `previous_content` | string \| null | The content before this change (`null` if not available) |
+| `previous_content` | string \| null | The content before this change (`null` if not available, and always `null` on a failure record) |
 | `changed_at` | string | ISO 8601 timestamp of when the change occurred |
+| `kind` | `"refresh_failed"` \| absent | Present only on a **failure record** — a refresh that refused to write. Absent on version snapshots |
+| `outcome` | string \| absent | On a failure record: the operation outcome, e.g. `refresh_failed_error` |
+| `failure_reason` | string \| absent | On a failure record: why it refused — `retrieval_failed`, `no_answer`, `unexpected_error`, `empty_candidate`, `structured_doc_unreadable`, `delta_ops_failed`, `delta_ops_all_skipped`, `delta_not_applied`, `structured_output_failed` |
+| `error_message` | string \| absent | On a failure record: the exception, as the operation reports it |
 
-Each entry captures the **content before the change** and when it happened. The current content is returned by the standard [Get a Mental Model](#get-a-mental-model) endpoint.
+Each version entry captures the **content before the change** and when it happened. The current content is returned by the standard [Get a Mental Model](#get-a-mental-model) endpoint.
+
+**Failures are recorded too.** A refresh that refuses to write produces no version, so before this it left no trace on the model at all — a document whose refreshes had been failing for a week was indistinguishable from one nobody had refreshed, and its stored `reflect_response` still described the last run that *succeeded*. Those runs now append a failure record carrying the reason and the exception. Read them by their `kind`: a client that only wants versions filters `kind` out, and one that wants to know whether the model is current checks whether the newest entry is a failure.
+
+Retention is applied per kind, so a run of failures cannot evict the version history — each is capped at `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` independently. A retried refresh records one entry per attempt.
 
 :::note
 History tracking is enabled by default. Set `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY=false` to disable it, and `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` to change how many versions are kept per model (default `50`).

--- a/hindsight-docs/docs/developer/api/reflect.mdx
+++ b/hindsight-docs/docs/developer/api/reflect.mdx
@@ -251,3 +251,16 @@ The full execution log of the agentic loop. Only present when `include.tool_call
 
 - `tool_calls` — each tool invocation with `tool` name (`lookup`, `recall`, `learn`, `expand`), `input`, `output` (if `output: true`), `duration_ms`, and `iteration` number.
 - `llm_calls` — each LLM call with `scope` (e.g., `"agent_1"`, `"final"`) and `duration_ms`.
+
+## When Reflect Fails
+
+Reflect answers from evidence it gathered, so a run that could not gather it does not answer at all — it fails with a **500**, rather than returning a confident reply built on nothing:
+
+- **A retrieval tool raised.** The database, the embedder or the reranker was unavailable. One failure in a batch fails the run: an answer written around a tool that never returned is indistinguishable from one over a bank that genuinely holds nothing on the topic, and callers store it as a real answer.
+- **The model produced no answer.** The `done` call arrived empty, or the final synthesis returned nothing.
+- **The model or transport cannot drive tool calls.** Reflect is driven entirely by structured tool calls; a transport that silently drops the tool definitions fails loudly so you can switch to a tool-calling-capable model.
+- **The provider kept failing.** A non-context-overflow LLM error is retried once inside the loop and then given up on.
+
+A **successful retrieval that returns nothing is not a failure**: the bank genuinely has nothing on the topic, and reflect says so in its answer.
+
+Two cases are deliberately not failures. A run whose *context window* overflows synthesizes from the evidence it has — the prompt was too big for the model, which is a budgeting problem, not a broken dependency. And a tool call the model got *wrong* — a missing argument, a tool that does not exist — is returned to it as an error to fix, not raised.

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -14806,7 +14806,8 @@
               "content_preserved_no_new_facts",
               "refresh_failed_empty_candidate",
               "refresh_failed_delta_not_applied",
-              "refresh_failed_structured_output"
+              "refresh_failed_structured_output",
+              "refresh_failed_error"
             ],
             "title": "Outcome",
             "description": "What the refresh did with the document: rewrote it (`content_written`), produced a document identical to the stored one (`content_unchanged`), had no new facts to read at all (`content_preserved_no_new_facts`), or refused to write (the `refresh_failed_*` values)."
@@ -14821,7 +14822,10 @@
                   "delta_ops_failed",
                   "delta_ops_all_skipped",
                   "delta_not_applied",
-                  "structured_output_failed"
+                  "structured_output_failed",
+                  "retrieval_failed",
+                  "no_answer",
+                  "unexpected_error"
                 ]
               },
               {

--- a/skills/hindsight-docs/references/developer/api/mental-models.md
+++ b/skills/hindsight-docs/references/developer/api/mental-models.md
@@ -267,6 +267,7 @@ Listing does not cost one query per model — the whole page is answered togethe
 - **Cumulative grounding.** Even in delta mode, `reflect_response.based_on` accumulates: the facts from this refresh are merged with everything previous refreshes relied on, deduplicated by id. The document rests on all of them, not just the latest slice.
 - **Nothing, if nothing is relevant.** A refresh that finds no topic-relevant memories leaves the content alone and only advances the watermark, so the same empty window stops re-triggering.
 - **No LLM call at all, if there is nothing to read.** Before the agentic loop starts, a refresh checks whether anything is in reach under this model's own settings: an in-scope memory (`tags`/`tags_match`, `tag_groups` and `fact_types` all narrow it) inside the window it would read — the whole bank in `full` mode, everything since `last_memory_seen_at` in `delta` mode — or a sibling mental model, unless `exclude_mental_models` closed that door. When there is nothing, the refresh completes immediately, leaves the document untouched, and spends nothing. This is the common case on a bank that was just created: its pages are refreshed the moment they exist, before anything has been retained.
+- **A failed retrieval is not an empty one.** If a retrieval step raises — the database, the embedder or the reranker is unavailable — the refresh **fails** instead of writing what the model came up with without it. Content, `structured_output` and the watermark are all left untouched, so the retry reads the same window again. This is the distinction that matters: "we looked and there is nothing on this topic" is an answer and gets written; "we could not look" is a failure and gets preserved. Without it, a broken retriever silently replaced a document built over months with a generic "I don't have information about that".
 
 ### Refresh Mode
 
@@ -601,7 +602,7 @@ somewhere else.
 |-------|----------|
 | `effective_mode` | Whether the run ended up `full` or `delta` |
 | `mode_fallback_reason` | Why delta was requested but not applied — `no_baseline_content`, `source_query_changed`, `structured_doc_unreadable`, `delta_ops_failed`, `delta_ops_all_skipped` |
-| `outcome` | `content_written`, `content_preserved_no_new_facts`, `refresh_failed_empty_candidate`, or `refresh_failed_delta_not_applied` (the edits didn't apply, so the document was kept and the refresh failed) |
+| `outcome` | `content_written`, `content_preserved_no_new_facts`, `refresh_failed_empty_candidate`, or `refresh_failed_delta_not_applied` (the edits didn't apply, so the document was kept and the refresh failed). The operation record adds two the executor cannot produce, because they happen outside a run: `refresh_failed_structured_output` and `refresh_failed_error` (a retrieval tool raised, the agent produced no answer, or something unforeseen escaped the refresh) |
 | `tool_calls[]` | Per call: `tool`, the agent's `reason`, the full `input`, `result_count`, `duration_ms`, and the `iteration` it belongs to |
 | `llm_calls[]` | Per call: `scope` (`agent_1`, `agent_2`, …, `final`) and `duration_ms` |
 | `delta_operations` | The operations emitted in delta mode, `applied` and `skipped` |
@@ -881,10 +882,18 @@ The endpoint returns a list of history entries, most recent first:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `previous_content` | string \| null | The content before this change (`null` if not available) |
+| `previous_content` | string \| null | The content before this change (`null` if not available, and always `null` on a failure record) |
 | `changed_at` | string | ISO 8601 timestamp of when the change occurred |
+| `kind` | `"refresh_failed"` \| absent | Present only on a **failure record** — a refresh that refused to write. Absent on version snapshots |
+| `outcome` | string \| absent | On a failure record: the operation outcome, e.g. `refresh_failed_error` |
+| `failure_reason` | string \| absent | On a failure record: why it refused — `retrieval_failed`, `no_answer`, `unexpected_error`, `empty_candidate`, `structured_doc_unreadable`, `delta_ops_failed`, `delta_ops_all_skipped`, `delta_not_applied`, `structured_output_failed` |
+| `error_message` | string \| absent | On a failure record: the exception, as the operation reports it |
 
-Each entry captures the **content before the change** and when it happened. The current content is returned by the standard [Get a Mental Model](#get-a-mental-model) endpoint.
+Each version entry captures the **content before the change** and when it happened. The current content is returned by the standard [Get a Mental Model](#get-a-mental-model) endpoint.
+
+**Failures are recorded too.** A refresh that refuses to write produces no version, so before this it left no trace on the model at all — a document whose refreshes had been failing for a week was indistinguishable from one nobody had refreshed, and its stored `reflect_response` still described the last run that *succeeded*. Those runs now append a failure record carrying the reason and the exception. Read them by their `kind`: a client that only wants versions filters `kind` out, and one that wants to know whether the model is current checks whether the newest entry is a failure.
+
+Retention is applied per kind, so a run of failures cannot evict the version history — each is capped at `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` independently. A retried refresh records one entry per attempt.
 
 > **📝 Note**
 >

--- a/skills/hindsight-docs/references/developer/api/reflect.md
+++ b/skills/hindsight-docs/references/developer/api/reflect.md
@@ -375,3 +375,16 @@ The full execution log of the agentic loop. Only present when `include.tool_call
 
 - `tool_calls` — each tool invocation with `tool` name (`lookup`, `recall`, `learn`, `expand`), `input`, `output` (if `output: true`), `duration_ms`, and `iteration` number.
 - `llm_calls` — each LLM call with `scope` (e.g., `"agent_1"`, `"final"`) and `duration_ms`.
+
+## When Reflect Fails
+
+Reflect answers from evidence it gathered, so a run that could not gather it does not answer at all — it fails with a **500**, rather than returning a confident reply built on nothing:
+
+- **A retrieval tool raised.** The database, the embedder or the reranker was unavailable. One failure in a batch fails the run: an answer written around a tool that never returned is indistinguishable from one over a bank that genuinely holds nothing on the topic, and callers store it as a real answer.
+- **The model produced no answer.** The `done` call arrived empty, or the final synthesis returned nothing.
+- **The model or transport cannot drive tool calls.** Reflect is driven entirely by structured tool calls; a transport that silently drops the tool definitions fails loudly so you can switch to a tool-calling-capable model.
+- **The provider kept failing.** A non-context-overflow LLM error is retried once inside the loop and then given up on.
+
+A **successful retrieval that returns nothing is not a failure**: the bank genuinely has nothing on the topic, and reflect says so in its answer.
+
+Two cases are deliberately not failures. A run whose *context window* overflows synthesizes from the evidence it has — the prompt was too big for the model, which is a budgeting problem, not a broken dependency. And a tool call the model got *wrong* — a missing argument, a tool that does not exist — is returned to it as an error to fix, not raised.

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -14806,7 +14806,8 @@
               "content_preserved_no_new_facts",
               "refresh_failed_empty_candidate",
               "refresh_failed_delta_not_applied",
-              "refresh_failed_structured_output"
+              "refresh_failed_structured_output",
+              "refresh_failed_error"
             ],
             "title": "Outcome",
             "description": "What the refresh did with the document: rewrote it (`content_written`), produced a document identical to the stored one (`content_unchanged`), had no new facts to read at all (`content_preserved_no_new_facts`), or refused to write (the `refresh_failed_*` values)."
@@ -14821,7 +14822,10 @@
                   "delta_ops_failed",
                   "delta_ops_all_skipped",
                   "delta_not_applied",
-                  "structured_output_failed"
+                  "structured_output_failed",
+                  "retrieval_failed",
+                  "no_answer",
+                  "unexpected_error"
                 ]
               },
               {


### PR DESCRIPTION
Fixes #2894.

## The bug

A mental-model refresh could replace a document built over months with "I don't have information about that". When a reflect tool raised, reflect handed the exception back to the model as a tool result and let the loop continue; the model answered from whatever it had — usually nothing — and that answer was **indistinguishable from a run over a bank that genuinely holds nothing on the topic**. It is non-empty prose, so every emptiness guard on the write path let it through, and the operation was recorded as `completed`.

The contributor reproduction on the issue could not confirm the reported trigger (a missing HNSW index still returns results; a locked relation blocks rather than returning empty), and that holds up — but the overwrite gap is real and is what this fixes.

## What changes

**Reflect fails instead of answering around a broken dependency.**

- A tool that **raises** is an infrastructure failure — the database, the embedder, the reranker — not something the model can retry its way out of, so it raises `ReflectToolExecutionError`. One failure in a parallel batch fails the run.
- A tool that **returns** `{"error": ...}` for a malformed or unavailable call is the model's own mistake, is fixable by calling again, and is still fed back to it unchanged.
- A non-context-overflow LLM error that survives one retry re-raises rather than falling through to a forced final synthesis built on evidence the failed turn never finished gathering. Context overflow keeps its deliberate degradation: a prompt-budgeting problem with the gathered evidence intact.
- `OperationCancelledError` passes through untouched on both paths, so a client disconnect stays a 499 (#2122) rather than becoming a 500.

The line this draws is between *"we could not look"* and *"we looked and there is nothing there"*. **A retrieval that succeeds and returns nothing is an answer, and still rewrites the document** — asserted directly in `test_refresh_still_writes_when_retrieval_genuinely_found_nothing`.

**A refused refresh now leaves a record.** Both new reflect failures re-raise as a typed `MentalModelRefreshError` (`refresh_failed_error`, reasons `retrieval_failed` / `no_answer`), so they reach the operation's typed `details` through the same hook every other refusal uses. Anything else that escapes a refresh is recorded as `unexpected_error` — but the **original** exception is re-raised, not a wrapper, so the worker's retryability classification still sees the real class (a `ProviderContentPolicyError` must stay permanent, #3690).

Every refusal — the new ones and the existing `_preserve_and_fail` paths — also appends a **failure record to `mental_model_history`** carrying the reason and the exception. Before this a failed refresh left no trace on the model at all: the History tab kept rendering the last *successful* trace as though it were current. Retention is per kind, so a run of failures cannot evict the version history.

**Control plane:** a new **Errors** tab on the mental-model modal renders those records as a timeline of events — reason, attempt count, time, exception — with a red dot on the tab when there are any. History goes back to being a version browser. Consecutive identical failures collapse into one event (the worker retries each refresh), but a *successful* refresh between two of them breaks the chain, so separate outages stay separate.

Also fixes a metadata bug found while verifying this against a live UI: a refresh is retried on the same operation row, and the success path wrote no `failure_reason` to overwrite the failed attempt's — producing `outcome=content_written` alongside `failure_reason=no_answer`. The success now writes it as null explicitly.

## Verification

Run against a live API + control plane with a retrieval failure injected: the banner/dot appears, the document is untouched, the operation's `details` carries the typed outcome, and a subsequent healthy refresh writes normally with the error history preserved.

- 751 passed across the mental-model / reflect / operations / refresh-metadata / MCP / backup-restore suites; control plane 165 passed.
- New: 6 agent tests (tool failure, parallel batch, argument errors still fed back, cancellation on both paths, persistent vs transient LLM error), 5 engine tests (content preserved, watermark not advanced, empty-but-successful still writes, failure recorded in history, per-kind retention), 2 outcome-matrix cases + 1 for the catch-all, 1 metadata-retry test, and a `groupFailures` unit test in the control plane.
- Note for reviewers: `test_refresh_outcome_metadata.py` imports the reflect exception classes at module scope on purpose — `test_reflect_tokenizer_lazy_load` purges `hindsight_api.engine.reflect*` from `sys.modules`, so a late import can hand back a class whose identity no longer matches the one `memory_engine` bound, and the `except` misses.

https://claude.ai/code/session_01F3i5UVdZRK16AZ9oFQqsg4