### PR TITLE
docs: make every integration changelog reachable, and compact the Integrations Hub

### DIFF
--- a/hindsight-docs/docs-integrations/agentcore.md
+++ b/hindsight-docs/docs-integrations/agentcore.md
@@ -10,6 +10,8 @@ Persistent memory for [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon
 
 AgentCore Runtime sessions are explicitly ephemeral — they terminate on inactivity and reprovision fresh environments. `hindsight-agentcore` adds durable cross-session memory so agents remember users, decisions, and learned patterns across any number of Runtime sessions.
 
+[View Changelog →](/changelog/integrations/agentcore)
+
 ## How It Works
 
 ```

--- a/hindsight-docs/docs-integrations/aider.md
+++ b/hindsight-docs/docs-integrations/aider.md
@@ -8,6 +8,8 @@ description: "Give Aider persistent long-term memory with Hindsight. hindsight-a
 
 Persistent long-term memory for [Aider](https://aider.chat), powered by [Hindsight](https://vectorize.io/hindsight). `hindsight-aider` is a drop-in wrapper for the `aider` command: it **recalls relevant project memory before each session** (injected into Aider's context via a read-only file) and **retains the session transcript after** — so each Aider session starts with what you've learned and saves what it learns. Memory is scoped **per git repo**.
 
+[View Changelog →](/changelog/integrations/aider)
+
 ## How It Works
 
 Aider has no MCP client or per-prompt hook, but it loads **read-only context files** and writes a **chat-history file**. The wrapper uses both:

--- a/hindsight-docs/docs-integrations/autogen.md
+++ b/hindsight-docs/docs-integrations/autogen.md
@@ -8,6 +8,8 @@ description: "Add long-term memory to AutoGen agents with Hindsight. Provides Fu
 
 Persistent long-term memory for [AutoGen](https://microsoft.github.io/autogen/) agents via Hindsight. Provides `FunctionTool` instances that plug directly into AutoGen's `AssistantAgent`.
 
+[View Changelog →](/changelog/integrations/autogen)
+
 ## Features
 
 - **Memory Tools** — retain, recall, and reflect as AutoGen `FunctionTool` instances compatible with `AssistantAgent(tools=[...])`

--- a/hindsight-docs/docs-integrations/claude-agent-sdk.md
+++ b/hindsight-docs/docs-integrations/claude-agent-sdk.md
@@ -7,6 +7,8 @@ description: "Add persistent long-term memory to Anthropic's Claude Agent SDK wi
 
 Persistent long-term memory for Anthropic's [Claude Agent SDK](https://pypi.org/project/claude-agent-sdk/) via [Hindsight](https://vectorize.io/hindsight). Expose retain/recall/reflect as MCP tools so the agent decides when to use memory, or wire up hooks to inject relevant memories automatically before every turn.
 
+[View Changelog →](/changelog/integrations/claude-agent-sdk)
+
 ## Quick Start
 
 :::tip Recommended: Hindsight Cloud

--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -19,6 +19,8 @@ tie-break policy. Those decisions live in git history and past conversations. Th
 in front of the agent at the moment it starts working, and keeps a curated set of **knowledge pages**
 (architecture, conventions, in-flight initiatives) that future sessions start from.
 
+[View Changelog →](/changelog/integrations/coding-agents)
+
 ## Install
 
 ```bash

--- a/hindsight-docs/docs-integrations/composio.md
+++ b/hindsight-docs/docs-integrations/composio.md
@@ -13,6 +13,8 @@ can call directly.
 The Hindsight memory bank for each call is the Composio session's `user_id`, so a single
 registered tool set isolates memory per user automatically.
 
+[View Changelog →](/changelog/integrations/composio)
+
 ## Features
 
 - **Composio Custom Tools** — registered via `composio.experimental.tool()` and bound to a session

--- a/hindsight-docs/docs-integrations/continue.md
+++ b/hindsight-docs/docs-integrations/continue.md
@@ -8,6 +8,8 @@ description: "Add long-term memory to the Continue.dev coding assistant with Hin
 
 Long-term memory for the [Continue.dev](https://continue.dev) coding assistant, powered by [Hindsight](https://vectorize.io/hindsight). Recall relevant project memory directly into chat, and optionally let the agent recall and retain automatically in agent mode.
 
+[View Changelog →](/changelog/integrations/continue)
+
 ## How It Works
 
 Continue has no hook that runs before a message is sent, but it supports two native extension points that `hindsight-continue` uses:

--- a/hindsight-docs/docs-integrations/copilot-cli.md
+++ b/hindsight-docs/docs-integrations/copilot-cli.md
@@ -25,6 +25,8 @@ Memory does not move automatically — the banks are scoped differently and this
 
 Persistent memory for [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks) using [Hindsight](https://vectorize.io/hindsight). Python hook scripts automatically recall relevant context at session start (and for every subagent Copilot CLI spawns) and retain conversations as they happen — no changes to your Copilot CLI workflow required.
 
+[View Changelog →](/changelog/integrations/copilot-cli)
+
 ## Quick Start
 
 :::tip Recommended: Hindsight Cloud

--- a/hindsight-docs/docs-integrations/devin-desktop.md
+++ b/hindsight-docs/docs-integrations/devin-desktop.md
@@ -12,6 +12,8 @@ Long-term memory for [Devin Desktop](https://devin.ai) — the editor formerly k
 Cognition rebranded Windsurf to Devin Desktop in June 2026. The MCP config still lives under `~/.codeium/windsurf/` — that's Devin Desktop's on-disk data directory and is unchanged by the rebrand. The workspace rule now lives under `.devin/rules/` (with `.windsurf/rules/` kept as a legacy fallback).
 :::
 
+[View Changelog →](/changelog/integrations/devin-desktop)
+
 ## How It Works
 
 Devin Desktop supports two things this integration uses:

--- a/hindsight-docs/docs-integrations/dify.md
+++ b/hindsight-docs/docs-integrations/dify.md
@@ -8,6 +8,8 @@ description: "Add persistent long-term memory to any Dify workflow with Hindsigh
 
 Persistent memory for [Dify](https://dify.ai) workflows via [Hindsight](https://hindsight.vectorize.io). The Hindsight Dify plugin adds three tools — **Retain**, **Recall**, **Reflect** — that work alongside any other Dify node in workflows, chatflows, and agent apps.
 
+[View Changelog →](/changelog/integrations/dify)
+
 ## Why this matters
 
 Dify is one of the most popular open-source LLM app platforms — visual workflow builder, prompt management, and a growing tool/plugin ecosystem. Until now, Dify workflows have been **stateless across runs**. With Hindsight tools you can:

--- a/hindsight-docs/docs-integrations/eliza.md
+++ b/hindsight-docs/docs-integrations/eliza.md
@@ -14,6 +14,8 @@ It registers two components on your agent:
 
 Both are enabled by default, layer on top of elizaOS's existing memory, and fail safe — a memory-service hiccup never blocks your agent from responding.
 
+[View Changelog →](/changelog/integrations/eliza)
+
 ## Installation
 
 ```bash

--- a/hindsight-docs/docs-integrations/eve.md
+++ b/hindsight-docs/docs-integrations/eve.md
@@ -8,6 +8,8 @@ description: "Add automatic long-term memory to Vercel Eve agents with Hindsight
 
 Automatic long-term memory for [Vercel Eve](https://github.com/vercel/eve) agents using [Hindsight](https://vectorize.io/hindsight). Eve is filesystem-first — an agent gains a capability by dropping a file under `agent/`. The `@vectorize-io/hindsight-eve` package wires two files that call Hindsight's REST API directly, so your agent gets memory that **just works** — relevant memory is injected before every turn and each exchange is retained after — **without the model ever choosing to call a tool.**
 
+[View Changelog →](/changelog/integrations/eve)
+
 ## Install
 
 ```bash

--- a/hindsight-docs/docs-integrations/flowise.md
+++ b/hindsight-docs/docs-integrations/flowise.md
@@ -8,6 +8,8 @@ description: "Add persistent long-term memory to any Flowise chatflow or agent w
 
 Persistent memory for [Flowise](https://flowiseai.com) chatflows and agents via [Hindsight](https://hindsight.vectorize.io). Three Tool nodes — **Hindsight Retain**, **Hindsight Recall**, **Hindsight Reflect** — drop into any flow alongside your other LangChain tools.
 
+[View Changelog →](/changelog/integrations/flowise)
+
 ## Why this matters
 
 Flowise is the LangChain-derived visual builder for non-developers and developers alike. Until now, Flowise chatflows have been **stateless across sessions**. With Hindsight tool nodes you can:

--- a/hindsight-docs/docs-integrations/github-copilot.md
+++ b/hindsight-docs/docs-integrations/github-copilot.md
@@ -8,6 +8,8 @@ description: "Add long-term memory to GitHub Copilot in VS Code with Hindsight v
 
 Long-term memory for [GitHub Copilot](https://github.com/features/copilot) in VS Code, powered by [Hindsight](https://vectorize.io/hindsight). One command connects Copilot's agent mode to the Hindsight MCP server and adds a recall/retain rule — so Copilot recalls relevant memory at the start of a task and retains durable facts as it works.
 
+[View Changelog →](/changelog/integrations/github-copilot)
+
 ## How It Works
 
 VS Code Copilot supports two things this integration uses:

--- a/hindsight-docs/docs-integrations/google-adk.md
+++ b/hindsight-docs/docs-integrations/google-adk.md
@@ -15,6 +15,8 @@ Persistent long-term memory for [Google ADK](https://adk.dev/) agents via Hindsi
 [Sign up free](https://ui.hindsight.vectorize.io/signup) for a Hindsight Cloud API key. The integration points at production by default — no local server to manage.
 :::
 
+[View Changelog →](/changelog/integrations/google-adk)
+
 ## Installation
 
 ```bash

--- a/hindsight-docs/docs-integrations/haystack.md
+++ b/hindsight-docs/docs-integrations/haystack.md
@@ -11,6 +11,8 @@ Persistent long-term memory for [Haystack](https://haystack.deepset.ai/) agents 
 - **`create_hindsight_tools(...)`** — Returns a list of Haystack `Tool`s (`retain_memory`, `recall_memory`, `reflect_on_memory`) the model can call directly inside a turn.
 - **`HindsightMemoryWrapper`** — A Haystack `Toolset` that bundles the same tools and adds optional **auto-recall** (inject relevant memories into the system prompt before each turn) and **auto-retain** (store user + assistant messages after each turn).
 
+[View Changelog →](/changelog/integrations/haystack)
+
 ## Installation
 
 ```bash

--- a/hindsight-docs/docs-integrations/llamaindex.md
+++ b/hindsight-docs/docs-integrations/llamaindex.md
@@ -11,6 +11,8 @@ Persistent long-term memory for [LlamaIndex](https://docs.llamaindex.ai/) agents
 - **`HindsightToolSpec`** — Agent-driven memory tools (retain/recall/reflect)
 - **`HindsightMemory`** — Automatic memory via LlamaIndex's `BaseMemory` interface
 
+[View Changelog →](/changelog/integrations/llamaindex)
+
 ## Installation
 
 ```bash

--- a/hindsight-docs/docs-integrations/n8n.md
+++ b/hindsight-docs/docs-integrations/n8n.md
@@ -8,6 +8,8 @@ description: "Add persistent long-term memory to any n8n workflow with Hindsight
 
 Persistent memory for [n8n](https://n8n.io) workflows via [Hindsight](https://hindsight.vectorize.io). The `@vectorize-io/n8n-nodes-hindsight` community node package adds three operations — **Retain**, **Recall**, **Reflect** — that work alongside any other n8n node.
 
+[View Changelog →](/changelog/integrations/n8n)
+
 ## Why this matters
 
 n8n is the connective tissue of automation: triggers from Gmail, Slack, Sheets, Stripe, Notion; actions across 400+ apps. Until now it has been **stateless** — every workflow run starts fresh. With Hindsight nodes you can:

--- a/hindsight-docs/docs-integrations/obsidian.md
+++ b/hindsight-docs/docs-integrations/obsidian.md
@@ -8,6 +8,8 @@ description: "Sync your Obsidian vault into Hindsight and chat with an agent gro
 
 Give your [Obsidian](https://obsidian.md) vault an agent that actually knows your notes, powered by [Hindsight](https://hindsight.vectorize.io). The plugin syncs your vault into a Hindsight bank and adds a chat panel whose answers are grounded on your notes — and cite them.
 
+[View Changelog →](/changelog/integrations/obsidian)
+
 ## Why this matters
 
 Obsidian is where your knowledge lives. Vector-search plugins can find related notes, but they can't reason across them, remember what you asked, or keep a running synthesis as your vault grows. Hindsight adds that layer:

--- a/hindsight-docs/docs-integrations/openai-agents.md
+++ b/hindsight-docs/docs-integrations/openai-agents.md
@@ -8,6 +8,8 @@ description: "Add long-term memory to OpenAI Agents SDK agents with Hindsight. P
 
 Persistent long-term memory for [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) agents via Hindsight. Provides `FunctionTool` instances that plug directly into the OpenAI Agents SDK `Agent`.
 
+[View Changelog →](/changelog/integrations/openai-agents)
+
 ## Features
 
 - **Memory Tools** — retain, recall, and reflect as OpenAI Agents SDK `FunctionTool` instances compatible with `Agent(tools=[...])`

--- a/hindsight-docs/docs-integrations/opencode.md
+++ b/hindsight-docs/docs-integrations/opencode.md
@@ -25,6 +25,8 @@ Memory does not move automatically — the banks are scoped differently and this
 
 Persistent long-term memory plugin for [OpenCode](https://opencode.ai) using [Hindsight](https://vectorize.io/hindsight). Automatically captures conversations, recalls relevant context on session start, and provides retain/recall/reflect tools the agent can call directly.
 
+[View Changelog →](/changelog/integrations/opencode)
+
 ## Quick Start
 
 Add to your `opencode.json` (project) or `~/.config/opencode/opencode.json` (global):

--- a/hindsight-docs/docs-integrations/openhands.md
+++ b/hindsight-docs/docs-integrations/openhands.md
@@ -8,6 +8,8 @@ description: "Add long-term memory to OpenHands (formerly OpenDevin) with Hindsi
 
 Long-term memory for [OpenHands](https://github.com/OpenHands/OpenHands) (formerly OpenDevin), powered by [Hindsight](https://vectorize.io/hindsight). One command connects OpenHands to the Hindsight MCP server and adds a recall/retain rule — so the agent recalls relevant memory at the start of a task and retains durable facts as it works.
 
+[View Changelog →](/changelog/integrations/openhands)
+
 ## How It Works
 
 OpenHands has **native Streamable-HTTP MCP support**, so the Hindsight MCP endpoint connects directly (no bridge):

--- a/hindsight-docs/docs-integrations/paperclip.md
+++ b/hindsight-docs/docs-integrations/paperclip.md
@@ -10,6 +10,8 @@ Persistent memory for [Paperclip AI](https://github.com/paperclipai/paperclip) a
 
 Install the `@vectorize-io/hindsight-paperclip` plugin once. Every agent in your Paperclip instance automatically gets long-term memory that persists across runs, companies, and restarts — no code changes required.
 
+[View Changelog →](/changelog/integrations/paperclip)
+
 ## Installation
 
 ```bash

--- a/hindsight-docs/docs-integrations/pipecat.md
+++ b/hindsight-docs/docs-integrations/pipecat.md
@@ -8,6 +8,8 @@ description: "Add persistent long-term memory to Pipecat voice AI pipelines via 
 
 Persistent long-term memory for [Pipecat](https://github.com/pipecat-ai/pipecat) voice AI pipelines via [Hindsight](https://vectorize.io/hindsight). A single `FrameProcessor` slots between your user context aggregator and LLM service — recalling relevant memories before each turn and retaining conversation content after.
 
+[View Changelog →](/changelog/integrations/pipecat)
+
 ## Quick Start
 
 :::tip Recommended: Hindsight Cloud

--- a/hindsight-docs/docs-integrations/roo-code.md
+++ b/hindsight-docs/docs-integrations/roo-code.md
@@ -8,6 +8,8 @@ description: "Add persistent long-term memory to Roo Code via Hindsight MCP. Aut
 
 Persistent long-term memory for [Roo Code](https://github.com/RooVetGit/Roo-Code) via [Hindsight](https://vectorize.io/hindsight). A one-command installer registers Hindsight's MCP server and injects custom rules that teach Roo to recall context before tasks and retain learnings after.
 
+[View Changelog →](/changelog/integrations/roo-code)
+
 ## Quick Start
 
 :::tip Hindsight Cloud (recommended)

--- a/hindsight-docs/docs-integrations/smolagents.md
+++ b/hindsight-docs/docs-integrations/smolagents.md
@@ -8,6 +8,8 @@ description: "Add long-term memory to HuggingFace SmolAgents with Hindsight reta
 
 Persistent memory tools for [SmolAgents](https://github.com/huggingface/smolagents) agents via Hindsight. Give your agents long-term memory with retain, recall, and reflect — using SmolAgents' native Tool pattern.
 
+[View Changelog →](/changelog/integrations/smolagents)
+
 ## Features
 
 - **Native Tool Subclasses** - Each tool extends SmolAgents' `Tool` base class

--- a/hindsight-docs/docs-integrations/strands.md
+++ b/hindsight-docs/docs-integrations/strands.md
@@ -8,6 +8,8 @@ description: "Add long-term memory to Strands Agents SDK agents with Hindsight. 
 
 Persistent memory tools for [Strands Agents SDK](https://github.com/strands-agents/sdk-python) agents via Hindsight. Give your agents long-term memory with retain, recall, and reflect — using Strands' native `@tool` pattern.
 
+[View Changelog →](/changelog/integrations/strands)
+
 ## Features
 
 - **Native `@tool` Functions** - Tools are plain Python functions, compatible with `Agent(tools=[...])`

--- a/hindsight-docs/docs-integrations/superagent.md
+++ b/hindsight-docs/docs-integrations/superagent.md
@@ -7,6 +7,8 @@ description: "Guard Hindsight memory operations with Superagent. Blocks prompt i
 
 Safety middleware for [Hindsight](https://vectorize.io/hindsight) memory operations, powered by [Superagent](https://www.superagent.sh). Wrap your memory client with `SafeHindsight` to guard against prompt injection and strip PII before anything is written to memory — and to screen queries before they reach recall or reflect.
 
+[View Changelog →](/changelog/integrations/superagent)
+
 ## Quick Start
 
 :::tip Recommended: Hindsight Cloud

--- a/hindsight-docs/docs-integrations/vapi.md
+++ b/hindsight-docs/docs-integrations/vapi.md
@@ -8,6 +8,8 @@ description: "Add persistent long-term memory to Vapi voice AI calls via Hindsig
 
 Persistent long-term memory for [Vapi](https://vapi.ai) voice AI calls via [Hindsight](https://vectorize.io/hindsight). A single webhook handler recalls relevant memories at call start (injected as `assistantOverrides`) and retains the full transcript when the call ends.
 
+[View Changelog →](/changelog/integrations/vapi)
+
 ## Quick Start
 
 :::tip Hindsight Cloud (recommended)

--- a/hindsight-docs/docs-integrations/zcode.md
+++ b/hindsight-docs/docs-integrations/zcode.md
@@ -8,6 +8,8 @@ description: "Add persistent long-term memory to ZCode (Z.ai's GLM desktop codin
 
 Persistent memory for [ZCode](https://zcode.z.ai) — Z.ai's GLM desktop coding agent — using [Hindsight](https://vectorize.io/hindsight). ZCode embeds the Claude Code agent runtime, so Python hook scripts automatically recall relevant context before each prompt and retain conversations after each turn. No MCP server, no changes to your ZCode workflow.
 
+[View Changelog →](/changelog/integrations/zcode)
+
 ## Quick Start
 
 :::tip Recommended: Hindsight Cloud

--- a/hindsight-docs/docs-integrations/zed.md
+++ b/hindsight-docs/docs-integrations/zed.md
@@ -8,6 +8,8 @@ description: "Add long-term memory to the Zed editor's AI assistant with Hindsig
 
 Long-term memory for the [Zed](https://zed.dev) editor's AI assistant, powered by [Hindsight](https://vectorize.io/hindsight). One command connects Zed's Agent Panel to the Hindsight MCP server and adds a rule telling the agent to use it — so it recalls relevant memory at the start of a task and retains durable facts as it goes. Recall happens at query time against your actual message, and from your seat it's automatic.
 
+[View Changelog →](/changelog/integrations/zed)
+
 ## How It Works
 
 Zed has no pre-prompt hook, but it supports two things this integration uses:

--- a/hindsight-docs/docusaurus.config.ts
+++ b/hindsight-docs/docusaurus.config.ts
@@ -193,6 +193,9 @@ const config: Config = {
   ],
 
   plugins: [
+    // Indexes src/pages/changelog/integrations/*.md at build time so the
+    // Integrations Hub knows which integrations have a changelog page.
+    './plugins/integration-changelogs',
     [
       '@docusaurus/plugin-content-docs',
       {

--- a/hindsight-docs/plugins/integration-changelogs/index.js
+++ b/hindsight-docs/plugins/integration-changelogs/index.js
@@ -1,0 +1,80 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Build-time index of the per-integration changelog pages.
+ *
+ * `src/pages/changelog/integrations/<slug>.md` is written by the release script
+ * (hindsight-dev/hindsight_dev/generate_changelog.py) — nothing in the docs site
+ * linked those pages, so for a long time they were reachable only by guessing
+ * the URL. This plugin reads that directory at build time and exposes one entry
+ * per page as global data, so the Integrations Hub can put a Changelog button on
+ * exactly the integrations that have one — a new integration grows the button on
+ * its first release, with nothing to update by hand.
+ *
+ * Display metadata (name, icon, category) is joined from integrations.json on
+ * the *link slug*, not the entry id — `vercel-ai-sdk` links to
+ * `/sdks/integrations/ai-sdk` and its changelog is `ai-sdk.md`. A changelog with
+ * no gallery entry is skipped: that means it isn't user-facing
+ * (cloudflare-oauth-proxy, an internal OAuth Worker), and check-integrations.mjs
+ * already guarantees every *released* integration has an entry.
+ */
+module.exports = function integrationChangelogsPlugin(context) {
+  const siteDir = context.siteDir;
+  const changelogDir = path.join(siteDir, 'src', 'pages', 'changelog', 'integrations');
+  const integrationsJson = path.join(siteDir, 'src', 'data', 'integrations.json');
+
+  return {
+    name: 'integration-changelogs',
+
+    getPathsToWatch() {
+      return [path.join(changelogDir, '*.md'), integrationsJson];
+    },
+
+    async loadContent() {
+      const {integrations} = JSON.parse(fs.readFileSync(integrationsJson, 'utf8'));
+
+      const bySlug = new Map();
+      for (const entry of integrations) {
+        if (entry.link.startsWith('/sdks/integrations/')) {
+          bySlug.set(entry.link.replace('/sdks/integrations/', ''), entry);
+        }
+      }
+
+      const files = fs
+        .readdirSync(changelogDir)
+        .filter((f) => f.endsWith('.md') && f !== 'index.md');
+
+      const entries = [];
+      for (const file of files) {
+        const slug = file.slice(0, -'.md'.length);
+        const meta = bySlug.get(slug);
+        if (!meta) continue;
+
+        const body = fs.readFileSync(path.join(changelogDir, file), 'utf8');
+        // The release script prepends `## [x.y.z](tag url)`, newest first.
+        const latest = body.match(/^## \[([^\]]+)\]/m);
+        const releaseCount = (body.match(/^## \[/gm) || []).length;
+
+        entries.push({
+          slug,
+          id: meta.id,
+          name: meta.name,
+          description: meta.description,
+          icon: meta.icon,
+          category: meta.category,
+          docLink: meta.link,
+          latestVersion: latest ? latest[1] : null,
+          releaseCount,
+        });
+      }
+
+      entries.sort((a, b) => a.name.localeCompare(b.name));
+      return entries;
+    },
+
+    async contentLoaded({content, actions}) {
+      actions.setGlobalData({entries: content});
+    },
+  };
+};

--- a/hindsight-docs/scripts/check-integrations.mjs
+++ b/hindsight-docs/scripts/check-integrations.mjs
@@ -12,6 +12,10 @@
  *      injected at render time, so it isn't covered by Docusaurus' build-time
  *      broken-link check — this is what catches a missing page.)
  *
+ *   3. Discoverable — every integration with a changelog page links to it from
+ *      its doc page. The changelog pages are written by the release script and
+ *      were otherwise reachable only by guessing the URL.
+ *
  *   2. Reverse — every *released* integration (a published git tag
  *      `integrations/<name>/vX.Y.Z`) appears in integrations.json, so a release
  *      can't silently skip the gallery/sidebar. Degrades to a skip when tags
@@ -20,7 +24,7 @@
  * Run: node scripts/check-integrations.mjs
  */
 
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
@@ -29,6 +33,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const docsDir = join(__dirname, '..');
 const integrationsJson = join(docsDir, 'src', 'data', 'integrations.json');
 const integrationsDocsDir = join(docsDir, 'docs-integrations');
+const changelogDir = join(docsDir, 'src', 'pages', 'changelog', 'integrations');
 
 // Released integrations that intentionally have no gallery/doc page.
 // cloudflare-oauth-proxy is internal infrastructure (an OAuth proxy Worker,
@@ -105,6 +110,38 @@ if (released === null || released.size === 0) {
   } else {
     console.log(`[integrations] ✅ All ${released.size - EXCLUDED.size} released integrations are present in integrations.json.`);
   }
+}
+
+// ─── 3. Discoverable: a changelog page is linked from its doc page ────────────
+const changelogSlugs = readdirSync(changelogDir)
+  .filter((f) => f.endsWith('.md') && f !== 'index.md')
+  .map((f) => f.slice(0, -'.md'.length));
+
+const unlinked = [];
+let checkedChangelogs = 0;
+for (const slug of changelogSlugs) {
+  if (!documented.has(slug)) continue; // no gallery entry ⇒ not user-facing (see EXCLUDED)
+  checkedChangelogs++;
+  const docPath = ['md', 'mdx']
+    .map((ext) => join(integrationsDocsDir, `${slug}.${ext}`))
+    .find((p) => existsSync(p));
+  if (!docPath) continue; // already reported by check 1
+  if (!readFileSync(docPath, 'utf8').includes(`/changelog/integrations/${slug}`)) {
+    unlinked.push(slug);
+  }
+}
+if (unlinked.length > 0) {
+  failed = true;
+  console.error('[integrations] ❌ Changelog pages not linked from their doc page:\n');
+  for (const slug of unlinked) {
+    console.error(`  ${slug} — add [View Changelog →](/changelog/integrations/${slug})`);
+  }
+  console.error(
+    '\nThe /changelog listing finds these pages automatically, but the doc page is where ' +
+      'someone using the integration looks first.\n',
+  );
+} else {
+  console.log(`[integrations] ✅ All ${checkedChangelogs} changelog pages are linked from their doc page.`);
 }
 
 process.exit(failed ? 1 : 0);

--- a/hindsight-docs/src/lib/integrations.ts
+++ b/hindsight-docs/src/lib/integrations.ts
@@ -25,3 +25,38 @@ export const integrationsSorted: IntegrationEntry[] = [
 export const internalIntegrationsSorted: IntegrationEntry[] = integrationsSorted.filter((entry) =>
   entry.link.startsWith('/sdks/integrations/'),
 );
+
+// Display labels and running order for `category`, shared by the Integrations Hub
+// gallery and the changelog listing so the two read as the same taxonomy. A
+// category missing here falls to the end under its raw value rather than
+// disappearing from the page.
+export const CATEGORY_LABELS: Record<string, string> = {
+  'coding-agent': 'Coding agents',
+  framework: 'Frameworks & SDKs',
+  mcp: 'MCP',
+  tool: 'Tools & apps',
+  legacy: 'Superseded',
+};
+
+const CATEGORY_ORDER = ['coding-agent', 'framework', 'mcp', 'tool', 'legacy'];
+
+function categoryRank(category: string): number {
+  const i = CATEGORY_ORDER.indexOf(category);
+  return i === -1 ? CATEGORY_ORDER.length : i;
+}
+
+/** Group entries by category, in display order, dropping empty groups. */
+export function groupByCategory<T extends {category: string}>(entries: T[]): [string, T[]][] {
+  const groups = new Map<string, T[]>();
+  for (const entry of entries) {
+    const bucket = groups.get(entry.category);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      groups.set(entry.category, [entry]);
+    }
+  }
+  return [...groups.entries()].sort(
+    ([a], [b]) => categoryRank(a) - categoryRank(b) || a.localeCompare(b),
+  );
+}

--- a/hindsight-docs/src/pages/changelog/index.md
+++ b/hindsight-docs/src/pages/changelog/index.md
@@ -6,6 +6,9 @@ import PageHero from '@site/src/components/PageHero';
 
 <PageHero title="Changelog" subtitle="User-facing changes only. Internal maintenance and infrastructure updates are omitted." />
 
+This page covers the Hindsight core (API, CLI, control plane). Each integration is released on its own
+cadence and has its own changelog — find it on the [integration's page](/integrations).
+
 ## [0.9.2](https://github.com/vectorize-io/hindsight/releases/tag/v0.9.2)
 
 **Features**
@@ -1600,14 +1603,3 @@ _This release contains internal maintenance and infrastructure changes only._
 **Bug Fixes**
 
 - Fixed the standalone Docker image so it builds/runs correctly. ([`1056a20`](https://github.com/vectorize-io/hindsight/commit/1056a20))
-
-## Integration Changelogs
-
-| Integration                                        | Package                            | Description                                       |
-| -------------------------------------------------- | ---------------------------------- | ------------------------------------------------- |
-| [LiteLLM](/changelog/integrations/litellm)         | `hindsight-litellm`                | Universal LLM memory via LiteLLM (100+ providers) |
-| [Pydantic AI](/changelog/integrations/pydantic-ai) | `hindsight-pydantic-ai`            | Persistent memory tools for Pydantic AI agents    |
-| [CrewAI](/changelog/integrations/crewai)           | `hindsight-crewai`                 | Persistent memory for CrewAI agents               |
-| [AI SDK](/changelog/integrations/ai-sdk)           | `@vectorize-io/hindsight-ai-sdk`   | Memory integration for Vercel AI SDK              |
-| [Chat SDK](/changelog/integrations/chat)           | `@vectorize-io/hindsight-chat`     | Memory integration for Vercel Chat SDK            |
-| [OpenClaw](/changelog/integrations/openclaw)       | `@vectorize-io/hindsight-openclaw` | Hindsight memory plugin for OpenClaw              |

--- a/hindsight-docs/src/pages/integrations/index.module.css
+++ b/hindsight-docs/src/pages/integrations/index.module.css
@@ -184,155 +184,11 @@
 }
 
 /* ── Grid ────────────────────────────────────────────────────────────────── */
-.grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
-  margin-bottom: 4rem;
-}
-
-@media (max-width: 996px) {
-  .grid { grid-template-columns: repeat(2, 1fr); }
-}
-
 @media (max-width: 640px) {
-  .grid { grid-template-columns: 1fr; }
   .heroTitle { font-size: 2.2rem; }
 }
 
 /* ── Card ────────────────────────────────────────────────────────────────── */
-.card {
-  display: flex;
-  flex-direction: column;
-  border-radius: 12px;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  background: var(--ifm-background-surface-color);
-  text-decoration: none !important;
-  color: inherit;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
-  overflow: hidden;
-}
-
-[data-theme='dark'] .card {
-  background: #1c1c1e;
-  border-color: rgba(255, 255, 255, 0.07);
-}
-
-.card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 24px rgba(0, 116, 217, 0.12);
-  text-decoration: none !important;
-  color: inherit;
-}
-
-.cardHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 1.1rem 0;
-}
-
-.cardIcon {
-  width: 36px;
-  height: 36px;
-  object-fit: contain;
-  flex-shrink: 0;
-}
-
-.typeBadge {
-  font-size: 0.63rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0.15rem 0.5rem;
-  border-radius: 999px;
-}
-
-.typeBadgeOfficial {
-  background: rgba(0, 116, 217, 0.12);
-  color: #0074d9;
-}
-
-[data-theme='dark'] .typeBadgeOfficial {
-  background: rgba(0, 116, 217, 0.2);
-  color: #4da6ff;
-}
-
-.typeBadgeCommunity {
-  background: rgba(0, 146, 150, 0.12);
-  color: #009296;
-}
-
-[data-theme='dark'] .typeBadgeCommunity {
-  background: rgba(0, 146, 150, 0.2);
-  color: #00bcc0;
-}
-
-.cardBody {
-  flex: 1;
-  padding: 0.85rem 1.1rem 0.75rem;
-}
-
-.cardTitle {
-  font-size: 1rem;
-  font-weight: 700;
-  margin: 0 0 0.4rem;
-  color: var(--ifm-heading-color);
-  letter-spacing: -0.01em;
-  border-bottom: none !important;
-  border-image: none !important;
-}
-
-.cardDescription {
-  font-size: 0.82rem;
-  color: var(--ifm-color-emphasis-600);
-  line-height: 1.6;
-  margin: 0;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.cardFooter {
-  display: flex;
-  align-items: center;
-  padding: 0.65rem 1.1rem 0.9rem;
-  margin-top: 0.25rem;
-  border-top: 1px solid var(--ifm-color-emphasis-100);
-}
-
-[data-theme='dark'] .cardFooter {
-  border-top-color: rgba(255, 255, 255, 0.06);
-}
-
-.byLine {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.78rem;
-  font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', Monaco, Consolas, monospace;
-  color: var(--ifm-color-emphasis-600);
-}
-
-.authorIcon {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  object-fit: cover;
-  flex-shrink: 0;
-  border: 1px solid var(--ifm-color-emphasis-200);
-}
-
-[data-theme='dark'] .authorIcon {
-  border-color: rgba(255, 255, 255, 0.1);
-}
-
-.authorName {
-  font-weight: 500;
-}
-
-/* ── Empty state ─────────────────────────────────────────────────────────── */
 .empty {
   text-align: center;
   padding: 4rem 2rem;
@@ -441,17 +297,17 @@
 
 .harnessStrip {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
-  gap: 0.4rem;
-  margin-top: 0.85rem;
+  gap: 0.3rem;
+  margin-top: 0.5rem;
 }
 
 .harnessLogo {
-  width: 20px;
-  height: 20px;
+  width: 17px;
+  height: 17px;
   object-fit: contain;
-  border-radius: 4px;
+  border-radius: 3px;
   /* Several of these are near-black marks that vanish on a dark background; a faint plate keeps
      every logo legible in both themes without per-logo special-casing. */
   background: var(--ifm-color-emphasis-100);
@@ -476,4 +332,206 @@
   letter-spacing: 0.01em;
   margin: 0 0 1rem;
   color: var(--ifm-heading-color);
+}
+
+/* ── Compact list (the full catalogue) ───────────────────────────────────── */
+.groups {
+  margin-bottom: 4rem;
+}
+
+.group {
+  margin-bottom: 2.25rem;
+}
+
+.groupTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.85rem;
+}
+
+.groupCount {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  padding: 0.05rem 0.4rem;
+  border-radius: 4px;
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-700);
+}
+
+.compactGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.6rem;
+}
+
+@media (max-width: 996px) {
+  .compactGrid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 640px) {
+  .compactGrid { grid-template-columns: 1fr; }
+}
+
+.compactCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  /* Grid items default to min-width:auto, so the clamped text below would push
+     each track to the width of its longest description and blow the page out. */
+  min-width: 0;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 6px;
+  background: var(--ifm-background-surface-color);
+  text-decoration: none !important;
+  color: inherit;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+[data-theme='dark'] .compactCard {
+  background: #1c1c1e;
+  border-color: rgba(255, 255, 255, 0.07);
+}
+
+.compactCard:hover {
+  border-color: rgba(0, 116, 217, 0.45);
+  box-shadow: 0 4px 16px rgba(0, 116, 217, 0.08);
+}
+
+.compactCard:hover .compactName {
+  color: var(--ifm-color-primary) !important;
+}
+
+.compactIcon {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.compactHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.compactName {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ifm-heading-color) !important;
+  text-decoration: none !important;
+  letter-spacing: -0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compactDescription {
+  margin: 0;
+  font-size: 0.76rem;
+  line-height: 1.4;
+  color: var(--ifm-color-emphasis-600);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.compactAuthor {
+  margin-left: auto;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+[data-theme='dark'] .compactAuthor {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+/* ── Featured rows ───────────────────────────────────────────────────────── */
+.compactCardFeatured {
+  border-color: rgba(0, 116, 217, 0.35);
+  background: linear-gradient(
+    180deg,
+    rgba(0, 116, 217, 0.06) 0%,
+    var(--ifm-background-surface-color) 60%
+  );
+}
+
+[data-theme='dark'] .compactCardFeatured {
+  border-color: rgba(0, 116, 217, 0.4);
+  background: linear-gradient(180deg, rgba(0, 116, 217, 0.14) 0%, #1c1c1e 60%);
+}
+
+/* ── Card actions ────────────────────────────────────────────────────────── */
+.compactActions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: auto;
+  padding-top: 0.5rem;
+}
+
+.actionPill {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  padding: 0.36rem 0.6rem;
+  border-radius: 5px;
+  border: 0;
+  color: var(--ifm-color-emphasis-700) !important;
+  background: var(--ifm-color-emphasis-100);
+  text-decoration: none !important;
+  white-space: nowrap;
+  transition: color 0.12s ease, background 0.12s ease;
+}
+
+.actionPill:hover {
+  color: var(--ifm-color-primary) !important;
+  background: rgba(0, 116, 217, 0.1);
+  text-decoration: none !important;
+}
+
+/* The first pill is the page someone actually wants nine times out of ten; the tint marks it as
+   the default action without making the row look like two competing buttons. */
+.actionPill:first-child {
+  color: var(--ifm-color-primary) !important;
+  background: rgba(0, 116, 217, 0.09);
+}
+
+.actionPill:first-child:hover {
+  background: rgba(0, 116, 217, 0.17);
+}
+
+[data-theme='dark'] .actionPill {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.72) !important;
+}
+
+[data-theme='dark'] .actionPill:hover {
+  background: rgba(0, 116, 217, 0.28);
+  color: #7cc0ff !important;
+}
+
+[data-theme='dark'] .actionPill:first-child {
+  background: rgba(0, 116, 217, 0.22);
+  color: #7cc0ff !important;
+}
+
+[data-theme='dark'] .actionPill:first-child:hover {
+  background: rgba(0, 116, 217, 0.32);
 }

--- a/hindsight-docs/src/pages/integrations/index.tsx
+++ b/hindsight-docs/src/pages/integrations/index.tsx
@@ -2,8 +2,9 @@ import React, {useMemo, useState} from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
+import {usePluginData} from '@docusaurus/useGlobalData';
 import IntegrationsBanner from '@site/src/components/IntegrationsBanner';
-import {integrationsSorted} from '@site/src/lib/integrations';
+import {integrationsSorted, CATEGORY_LABELS, groupByCategory} from '@site/src/lib/integrations';
 import styles from './index.module.css';
 
 /**
@@ -51,58 +52,99 @@ interface Integration {
   icon?: string;
 }
 
-function IntegrationCard({integration}: {integration: Integration}) {
+/**
+ * The gallery is a browse surface, not a reading surface: 60 three-line cards with a repeated
+ * "Hindsight Team" byline made the page long enough that scanning it meant scrolling past what you
+ * were looking for. This is the same row the changelog listing uses — icon, name, two lines of
+ * description — grouped by category so the shape of the catalogue is visible at a glance.
+ *
+ * Featured uses the same row, tinted and spanning wider tracks, so the page reads as one list with
+ * three entries lifted out of it rather than two competing card designs. The coding-agents card
+ * keeps its harness strip: "one install, every agent" is a claim a single icon cannot make.
+ */
+function IntegrationCard({
+  integration,
+  changelogSlug,
+  featured = false,
+}: {
+  integration: Integration;
+  changelogSlug?: string;
+  featured?: boolean;
+}) {
   const harnessBase = useBaseUrl('/img/harness/');
   const iconSrc = useBaseUrl(integration.icon ?? '');
-  const faviconSrc = useBaseUrl('/img/favicon.png');
   const isExternal = integration.link.startsWith('http');
 
   return (
-    <Link to={integration.link} className={styles.card} {...(isExternal ? {target: '_blank', rel: 'noopener noreferrer'} : {})}>
-      <div className={styles.cardHeader}>
-        {integration.icon && <img src={iconSrc} alt="" className={styles.cardIcon} aria-hidden />}
-        <span className={`${styles.typeBadge} ${integration.type === 'official' ? styles.typeBadgeOfficial : styles.typeBadgeCommunity}`}>
-          {integration.type === 'official' ? 'Official' : 'Community'}
-        </span>
-      </div>
-      <div className={styles.cardBody}>
-        <h3 className={styles.cardTitle}>{integration.name}</h3>
-        <p className={styles.cardDescription}>{integration.description}</p>
-        {integration.id === 'coding-agents' && (
-          <div className={styles.harnessStrip} aria-label="Supported coding agents">
-            {CODING_AGENT_LOGOS.map((h) => (
-              <img
-                key={h.id}
-                src={`${harnessBase}${h.file}`}
-                alt={h.name}
-                title={h.name}
-                className={styles.harnessLogo}
-                loading="lazy"
-              />
-            ))}
-          </div>
+    <div className={`${styles.compactCard} ${featured ? styles.compactCardFeatured : ''}`}>
+      <div className={styles.compactHeader}>
+        {integration.icon && <img src={iconSrc} alt="" className={styles.compactIcon} aria-hidden />}
+        <Link
+          to={integration.link}
+          className={styles.compactName}
+          {...(isExternal ? {target: '_blank', rel: 'noopener noreferrer'} : {})}>
+          {integration.name}
+        </Link>
+        {integration.type === 'community' && (
+          <img
+            src={`https://github.com/${integration.by}.png?size=40`}
+            alt={`Community integration by @${integration.by}`}
+            title={`Community integration by @${integration.by}`}
+            className={styles.compactAuthor}
+            loading="lazy"
+          />
         )}
       </div>
-      <div className={styles.cardFooter}>
-        {integration.type === 'official' ? (
-          <span className={styles.byLine}>
-            <img src={faviconSrc} alt="" className={styles.authorIcon} aria-hidden />
-            <span className={styles.authorName}>Hindsight Team</span>
-          </span>
-        ) : (
-          <span className={styles.byLine}>
-            <img src={`https://github.com/${integration.by}.png?size=40`} alt="" className={styles.authorIcon} aria-hidden />
-            <span className={styles.authorName}>@{integration.by}</span>
-          </span>
+
+      <p className={styles.compactDescription}>{integration.description}</p>
+
+      {featured && integration.id === 'coding-agents' && (
+        <div className={styles.harnessStrip} aria-label="Supported coding agents">
+          {CODING_AGENT_LOGOS.map((h) => (
+            <img
+              key={h.id}
+              src={`${harnessBase}${h.file}`}
+              alt={h.name}
+              title={h.name}
+              className={styles.harnessLogo}
+              loading="lazy"
+            />
+          ))}
+        </div>
+      )}
+
+      <div className={styles.compactActions}>
+        <Link
+          to={integration.link}
+          className={styles.actionPill}
+          {...(isExternal ? {target: '_blank', rel: 'noopener noreferrer'} : {})}>
+          {isExternal ? 'Site ↗' : 'Docs'}
+        </Link>
+        {/* Only integrations that publish a package have a changelog; the rest would link to a 404. */}
+        {changelogSlug && (
+          <Link to={`/changelog/integrations/${changelogSlug}`} className={styles.actionPill}>
+            Changelog
+          </Link>
         )}
       </div>
-    </Link>
+    </div>
   );
 }
 
 export default function IntegrationsHub(): React.ReactElement {
   const [search, setSearch] = useState('');
   const [selectedType, setSelectedType] = useState<IntegrationType | 'all'>('all');
+
+  // Which integrations have a changelog page, from the same build-time index the /changelog
+  // listing uses — so a card grows a Changelog button the release after its first release,
+  // with nothing here to update.
+  const {entries: changelogEntries} = usePluginData('integration-changelogs') as {
+    entries: {id: string; slug: string}[];
+  };
+  const changelogSlugs = useMemo(
+    () => new Map(changelogEntries.map((e) => [e.id, e.slug])),
+    [changelogEntries],
+  );
 
   // Superseded pages stay published and linked from the docs sidebar, but the gallery is where
   // people come to CHOOSE an integration — offering something we are actively migrating them off
@@ -196,7 +238,12 @@ export default function IntegrationsHub(): React.ReactElement {
             <h2 className={styles.featuredTitle}>Featured</h2>
             <div className={styles.featuredGrid}>
               {featured.map((integration) => (
-                <IntegrationCard key={integration.id} integration={integration} />
+                <IntegrationCard
+                  key={integration.id}
+                  integration={integration}
+                  changelogSlug={changelogSlugs.get(integration.id)}
+                  featured
+                />
               ))}
             </div>
           </section>
@@ -217,9 +264,23 @@ export default function IntegrationsHub(): React.ReactElement {
             </button>
           </div>
         ) : (
-          <div className={styles.grid}>
-            {rest.map((integration) => (
-              <IntegrationCard key={integration.id} integration={integration} />
+          <div className={styles.groups}>
+            {groupByCategory(rest).map(([category, items]) => (
+              <section key={category} className={styles.group}>
+                <h3 className={styles.groupTitle}>
+                  {CATEGORY_LABELS[category] ?? category}
+                  <span className={styles.groupCount}>{items.length}</span>
+                </h3>
+                <div className={styles.compactGrid}>
+                  {items.map((integration) => (
+                    <IntegrationCard
+                      key={integration.id}
+                      integration={integration}
+                      changelogSlug={changelogSlugs.get(integration.id)}
+                    />
+                  ))}
+                </div>
+              </section>
             ))}
           </div>
         )}

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -12,6 +12,8 @@ tie-break policy. Those decisions live in git history and past conversations. Th
 in front of the agent at the moment it starts working, and keeps a curated set of **knowledge pages**
 (architecture, conventions, in-flight initiatives) that future sessions start from.
 
+[View Changelog →](https://hindsight.vectorize.io/changelog/integrations/coding-agents)
+
 ## Install
 
 <!-- skill:begin title="Install / update" -->

--- a/skills/hindsight-docs/references/changelog/index.md
+++ b/skills/hindsight-docs/references/changelog/index.md
@@ -6,6 +6,9 @@ import PageHero from '@site/src/components/PageHero';
 
 <PageHero title="Changelog" subtitle="User-facing changes only. Internal maintenance and infrastructure updates are omitted." />
 
+This page covers the Hindsight core (API, CLI, control plane). Each integration is released on its own
+cadence and has its own changelog — find it on the integration's page.
+
 ## [0.9.2](https://github.com/vectorize-io/hindsight/releases/tag/v0.9.2)
 
 **Features**
@@ -1600,14 +1603,3 @@ _This release contains internal maintenance and infrastructure changes only._
 **Bug Fixes**
 
 - Fixed the standalone Docker image so it builds/runs correctly. ([`1056a20`](https://github.com/vectorize-io/hindsight/commit/1056a20))
-
-## Integration Changelogs
-
-| Integration                                        | Package                            | Description                                       |
-| -------------------------------------------------- | ---------------------------------- | ------------------------------------------------- |
-| [LiteLLM](integrations/litellm.md)         | `hindsight-litellm`                | Universal LLM memory via LiteLLM (100+ providers) |
-| [Pydantic AI](integrations/pydantic-ai.md) | `hindsight-pydantic-ai`            | Persistent memory tools for Pydantic AI agents    |
-| [CrewAI](integrations/crewai.md)           | `hindsight-crewai`                 | Persistent memory for CrewAI agents               |
-| [AI SDK](integrations/ai-sdk.md)           | `@vectorize-io/hindsight-ai-sdk`   | Memory integration for Vercel AI SDK              |
-| [Chat SDK](integrations/chat.md)           | `@vectorize-io/hindsight-chat`     | Memory integration for Vercel Chat SDK            |
-| [OpenClaw](integrations/openclaw.md)       | `@vectorize-io/hindsight-openclaw` | Hindsight memory plugin for OpenClaw              |

--- a/skills/hindsight-docs/references/sdks/integrations/agentcore.md
+++ b/skills/hindsight-docs/references/sdks/integrations/agentcore.md
@@ -5,6 +5,8 @@ Persistent memory for [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon
 
 AgentCore Runtime sessions are explicitly ephemeral — they terminate on inactivity and reprovision fresh environments. `hindsight-agentcore` adds durable cross-session memory so agents remember users, decisions, and learned patterns across any number of Runtime sessions.
 
+[View Changelog →](../../changelog/integrations/agentcore.md)
+
 ## How It Works
 
 ```

--- a/skills/hindsight-docs/references/sdks/integrations/aider.md
+++ b/skills/hindsight-docs/references/sdks/integrations/aider.md
@@ -3,6 +3,8 @@
 
 Persistent long-term memory for [Aider](https://aider.chat), powered by [Hindsight](https://vectorize.io/hindsight). `hindsight-aider` is a drop-in wrapper for the `aider` command: it **recalls relevant project memory before each session** (injected into Aider's context via a read-only file) and **retains the session transcript after** — so each Aider session starts with what you've learned and saves what it learns. Memory is scoped **per git repo**.
 
+[View Changelog →](../../changelog/integrations/aider.md)
+
 ## How It Works
 
 Aider has no MCP client or per-prompt hook, but it loads **read-only context files** and writes a **chat-history file**. The wrapper uses both:

--- a/skills/hindsight-docs/references/sdks/integrations/autogen.md
+++ b/skills/hindsight-docs/references/sdks/integrations/autogen.md
@@ -3,6 +3,8 @@
 
 Persistent long-term memory for [AutoGen](https://microsoft.github.io/autogen/) agents via Hindsight. Provides `FunctionTool` instances that plug directly into AutoGen's `AssistantAgent`.
 
+[View Changelog →](../../changelog/integrations/autogen.md)
+
 ## Features
 
 - **Memory Tools** — retain, recall, and reflect as AutoGen `FunctionTool` instances compatible with `AssistantAgent(tools=[...])`

--- a/skills/hindsight-docs/references/sdks/integrations/claude-agent-sdk.md
+++ b/skills/hindsight-docs/references/sdks/integrations/claude-agent-sdk.md
@@ -3,6 +3,8 @@
 
 Persistent long-term memory for Anthropic's [Claude Agent SDK](https://pypi.org/project/claude-agent-sdk/) via [Hindsight](https://vectorize.io/hindsight). Expose retain/recall/reflect as MCP tools so the agent decides when to use memory, or wire up hooks to inject relevant memories automatically before every turn.
 
+[View Changelog →](../../changelog/integrations/claude-agent-sdk.md)
+
 ## Quick Start
 
 > **💡 Recommended: Hindsight Cloud**

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -14,6 +14,8 @@ tie-break policy. Those decisions live in git history and past conversations. Th
 in front of the agent at the moment it starts working, and keeps a curated set of **knowledge pages**
 (architecture, conventions, in-flight initiatives) that future sessions start from.
 
+[View Changelog →](../../changelog/integrations/coding-agents.md)
+
 ## Install
 
 ```bash

--- a/skills/hindsight-docs/references/sdks/integrations/composio.md
+++ b/skills/hindsight-docs/references/sdks/integrations/composio.md
@@ -8,6 +8,8 @@ can call directly.
 The Hindsight memory bank for each call is the Composio session's `user_id`, so a single
 registered tool set isolates memory per user automatically.
 
+[View Changelog →](../../changelog/integrations/composio.md)
+
 ## Features
 
 - **Composio Custom Tools** — registered via `composio.experimental.tool()` and bound to a session

--- a/skills/hindsight-docs/references/sdks/integrations/continue.md
+++ b/skills/hindsight-docs/references/sdks/integrations/continue.md
@@ -3,6 +3,8 @@
 
 Long-term memory for the [Continue.dev](https://continue.dev) coding assistant, powered by [Hindsight](https://vectorize.io/hindsight). Recall relevant project memory directly into chat, and optionally let the agent recall and retain automatically in agent mode.
 
+[View Changelog →](../../changelog/integrations/continue.md)
+
 ## How It Works
 
 Continue has no hook that runs before a message is sent, but it supports two native extension points that `hindsight-continue` uses:

--- a/skills/hindsight-docs/references/sdks/integrations/copilot-cli.md
+++ b/skills/hindsight-docs/references/sdks/integrations/copilot-cli.md
@@ -18,6 +18,8 @@ Memory does not move automatically — the banks are scoped differently and this
 [Migrating from the per-agent plugins](coding-agents.md#migrating-from-the-per-agent-plugins).
 Persistent memory for [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks) using [Hindsight](https://vectorize.io/hindsight). Python hook scripts automatically recall relevant context at session start (and for every subagent Copilot CLI spawns) and retain conversations as they happen — no changes to your Copilot CLI workflow required.
 
+[View Changelog →](../../changelog/integrations/copilot-cli.md)
+
 ## Quick Start
 
 > **💡 Recommended: Hindsight Cloud**

--- a/skills/hindsight-docs/references/sdks/integrations/devin-desktop.md
+++ b/skills/hindsight-docs/references/sdks/integrations/devin-desktop.md
@@ -6,6 +6,8 @@ Long-term memory for [Devin Desktop](https://devin.ai) — the editor formerly k
 > **📝 Note**
 >
 Cognition rebranded Windsurf to Devin Desktop in June 2026. The MCP config still lives under `~/.codeium/windsurf/` — that's Devin Desktop's on-disk data directory and is unchanged by the rebrand. The workspace rule now lives under `.devin/rules/` (with `.windsurf/rules/` kept as a legacy fallback).
+[View Changelog →](../../changelog/integrations/devin-desktop.md)
+
 ## How It Works
 
 Devin Desktop supports two things this integration uses:

--- a/skills/hindsight-docs/references/sdks/integrations/dify.md
+++ b/skills/hindsight-docs/references/sdks/integrations/dify.md
@@ -3,6 +3,8 @@
 
 Persistent memory for [Dify](https://dify.ai) workflows via [Hindsight](https://hindsight.vectorize.io). The Hindsight Dify plugin adds three tools — **Retain**, **Recall**, **Reflect** — that work alongside any other Dify node in workflows, chatflows, and agent apps.
 
+[View Changelog →](../../changelog/integrations/dify.md)
+
 ## Why this matters
 
 Dify is one of the most popular open-source LLM app platforms — visual workflow builder, prompt management, and a growing tool/plugin ecosystem. Until now, Dify workflows have been **stateless across runs**. With Hindsight tools you can:

--- a/skills/hindsight-docs/references/sdks/integrations/eliza.md
+++ b/skills/hindsight-docs/references/sdks/integrations/eliza.md
@@ -10,6 +10,8 @@ It registers two components on your agent:
 
 Both are enabled by default, layer on top of elizaOS's existing memory, and fail safe — a memory-service hiccup never blocks your agent from responding.
 
+[View Changelog →](../../changelog/integrations/eliza.md)
+
 ## Installation
 
 ```bash

--- a/skills/hindsight-docs/references/sdks/integrations/eve.md
+++ b/skills/hindsight-docs/references/sdks/integrations/eve.md
@@ -3,6 +3,8 @@
 
 Automatic long-term memory for [Vercel Eve](https://github.com/vercel/eve) agents using [Hindsight](https://vectorize.io/hindsight). Eve is filesystem-first — an agent gains a capability by dropping a file under `agent/`. The `@vectorize-io/hindsight-eve` package wires two files that call Hindsight's REST API directly, so your agent gets memory that **just works** — relevant memory is injected before every turn and each exchange is retained after — **without the model ever choosing to call a tool.**
 
+[View Changelog →](../../changelog/integrations/eve.md)
+
 ## Install
 
 ```bash

--- a/skills/hindsight-docs/references/sdks/integrations/flowise.md
+++ b/skills/hindsight-docs/references/sdks/integrations/flowise.md
@@ -3,6 +3,8 @@
 
 Persistent memory for [Flowise](https://flowiseai.com) chatflows and agents via [Hindsight](https://hindsight.vectorize.io). Three Tool nodes — **Hindsight Retain**, **Hindsight Recall**, **Hindsight Reflect** — drop into any flow alongside your other LangChain tools.
 
+[View Changelog →](../../changelog/integrations/flowise.md)
+
 ## Why this matters
 
 Flowise is the LangChain-derived visual builder for non-developers and developers alike. Until now, Flowise chatflows have been **stateless across sessions**. With Hindsight tool nodes you can:

--- a/skills/hindsight-docs/references/sdks/integrations/github-copilot.md
+++ b/skills/hindsight-docs/references/sdks/integrations/github-copilot.md
@@ -3,6 +3,8 @@
 
 Long-term memory for [GitHub Copilot](https://github.com/features/copilot) in VS Code, powered by [Hindsight](https://vectorize.io/hindsight). One command connects Copilot's agent mode to the Hindsight MCP server and adds a recall/retain rule — so Copilot recalls relevant memory at the start of a task and retains durable facts as it works.
 
+[View Changelog →](../../changelog/integrations/github-copilot.md)
+
 ## How It Works
 
 VS Code Copilot supports two things this integration uses:

--- a/skills/hindsight-docs/references/sdks/integrations/google-adk.md
+++ b/skills/hindsight-docs/references/sdks/integrations/google-adk.md
@@ -9,6 +9,8 @@ Persistent long-term memory for [Google ADK](https://adk.dev/) agents via Hindsi
 > **💡 Recommended: Hindsight Cloud**
 >
 [Sign up free](https://ui.hindsight.vectorize.io/signup) for a Hindsight Cloud API key. The integration points at production by default — no local server to manage.
+[View Changelog →](../../changelog/integrations/google-adk.md)
+
 ## Installation
 
 ```bash

--- a/skills/hindsight-docs/references/sdks/integrations/haystack.md
+++ b/skills/hindsight-docs/references/sdks/integrations/haystack.md
@@ -6,6 +6,8 @@ Persistent long-term memory for [Haystack](https://haystack.deepset.ai/) agents 
 - **`create_hindsight_tools(...)`** — Returns a list of Haystack `Tool`s (`retain_memory`, `recall_memory`, `reflect_on_memory`) the model can call directly inside a turn.
 - **`HindsightMemoryWrapper`** — A Haystack `Toolset` that bundles the same tools and adds optional **auto-recall** (inject relevant memories into the system prompt before each turn) and **auto-retain** (store user + assistant messages after each turn).
 
+[View Changelog →](../../changelog/integrations/haystack.md)
+
 ## Installation
 
 ```bash

--- a/skills/hindsight-docs/references/sdks/integrations/llamaindex.md
+++ b/skills/hindsight-docs/references/sdks/integrations/llamaindex.md
@@ -6,6 +6,8 @@ Persistent long-term memory for [LlamaIndex](https://docs.llamaindex.ai/) agents
 - **`HindsightToolSpec`** — Agent-driven memory tools (retain/recall/reflect)
 - **`HindsightMemory`** — Automatic memory via LlamaIndex's `BaseMemory` interface
 
+[View Changelog →](../../changelog/integrations/llamaindex.md)
+
 ## Installation
 
 ```bash

--- a/skills/hindsight-docs/references/sdks/integrations/n8n.md
+++ b/skills/hindsight-docs/references/sdks/integrations/n8n.md
@@ -3,6 +3,8 @@
 
 Persistent memory for [n8n](https://n8n.io) workflows via [Hindsight](https://hindsight.vectorize.io). The `@vectorize-io/n8n-nodes-hindsight` community node package adds three operations — **Retain**, **Recall**, **Reflect** — that work alongside any other n8n node.
 
+[View Changelog →](../../changelog/integrations/n8n.md)
+
 ## Why this matters
 
 n8n is the connective tissue of automation: triggers from Gmail, Slack, Sheets, Stripe, Notion; actions across 400+ apps. Until now it has been **stateless** — every workflow run starts fresh. With Hindsight nodes you can:

--- a/skills/hindsight-docs/references/sdks/integrations/obsidian.md
+++ b/skills/hindsight-docs/references/sdks/integrations/obsidian.md
@@ -3,6 +3,8 @@
 
 Give your [Obsidian](https://obsidian.md) vault an agent that actually knows your notes, powered by [Hindsight](https://hindsight.vectorize.io). The plugin syncs your vault into a Hindsight bank and adds a chat panel whose answers are grounded on your notes — and cite them.
 
+[View Changelog →](../../changelog/integrations/obsidian.md)
+
 ## Why this matters
 
 Obsidian is where your knowledge lives. Vector-search plugins can find related notes, but they can't reason across them, remember what you asked, or keep a running synthesis as your vault grows. Hindsight adds that layer:

--- a/skills/hindsight-docs/references/sdks/integrations/openai-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/openai-agents.md
@@ -3,6 +3,8 @@
 
 Persistent long-term memory for [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) agents via Hindsight. Provides `FunctionTool` instances that plug directly into the OpenAI Agents SDK `Agent`.
 
+[View Changelog →](../../changelog/integrations/openai-agents.md)
+
 ## Features
 
 - **Memory Tools** — retain, recall, and reflect as OpenAI Agents SDK `FunctionTool` instances compatible with `Agent(tools=[...])`

--- a/skills/hindsight-docs/references/sdks/integrations/opencode.md
+++ b/skills/hindsight-docs/references/sdks/integrations/opencode.md
@@ -18,6 +18,8 @@ Memory does not move automatically — the banks are scoped differently and this
 [Migrating from the per-agent plugins](coding-agents.md#migrating-from-the-per-agent-plugins).
 Persistent long-term memory plugin for [OpenCode](https://opencode.ai) using [Hindsight](https://vectorize.io/hindsight). Automatically captures conversations, recalls relevant context on session start, and provides retain/recall/reflect tools the agent can call directly.
 
+[View Changelog →](../../changelog/integrations/opencode.md)
+
 ## Quick Start
 
 Add to your `opencode.json` (project) or `~/.config/opencode/opencode.json` (global):

--- a/skills/hindsight-docs/references/sdks/integrations/openhands.md
+++ b/skills/hindsight-docs/references/sdks/integrations/openhands.md
@@ -3,6 +3,8 @@
 
 Long-term memory for [OpenHands](https://github.com/OpenHands/OpenHands) (formerly OpenDevin), powered by [Hindsight](https://vectorize.io/hindsight). One command connects OpenHands to the Hindsight MCP server and adds a recall/retain rule — so the agent recalls relevant memory at the start of a task and retains durable facts as it works.
 
+[View Changelog →](../../changelog/integrations/openhands.md)
+
 ## How It Works
 
 OpenHands has **native Streamable-HTTP MCP support**, so the Hindsight MCP endpoint connects directly (no bridge):

--- a/skills/hindsight-docs/references/sdks/integrations/paperclip.md
+++ b/skills/hindsight-docs/references/sdks/integrations/paperclip.md
@@ -5,6 +5,8 @@ Persistent memory for [Paperclip AI](https://github.com/paperclipai/paperclip) a
 
 Install the `@vectorize-io/hindsight-paperclip` plugin once. Every agent in your Paperclip instance automatically gets long-term memory that persists across runs, companies, and restarts — no code changes required.
 
+[View Changelog →](../../changelog/integrations/paperclip.md)
+
 ## Installation
 
 ```bash

--- a/skills/hindsight-docs/references/sdks/integrations/pipecat.md
+++ b/skills/hindsight-docs/references/sdks/integrations/pipecat.md
@@ -3,6 +3,8 @@
 
 Persistent long-term memory for [Pipecat](https://github.com/pipecat-ai/pipecat) voice AI pipelines via [Hindsight](https://vectorize.io/hindsight). A single `FrameProcessor` slots between your user context aggregator and LLM service — recalling relevant memories before each turn and retaining conversation content after.
 
+[View Changelog →](../../changelog/integrations/pipecat.md)
+
 ## Quick Start
 
 > **💡 Recommended: Hindsight Cloud**

--- a/skills/hindsight-docs/references/sdks/integrations/roo-code.md
+++ b/skills/hindsight-docs/references/sdks/integrations/roo-code.md
@@ -3,6 +3,8 @@
 
 Persistent long-term memory for [Roo Code](https://github.com/RooVetGit/Roo-Code) via [Hindsight](https://vectorize.io/hindsight). A one-command installer registers Hindsight's MCP server and injects custom rules that teach Roo to recall context before tasks and retain learnings after.
 
+[View Changelog →](../../changelog/integrations/roo-code.md)
+
 ## Quick Start
 
 > **💡 Hindsight Cloud (recommended)**

--- a/skills/hindsight-docs/references/sdks/integrations/smolagents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/smolagents.md
@@ -3,6 +3,8 @@
 
 Persistent memory tools for [SmolAgents](https://github.com/huggingface/smolagents) agents via Hindsight. Give your agents long-term memory with retain, recall, and reflect — using SmolAgents' native Tool pattern.
 
+[View Changelog →](../../changelog/integrations/smolagents.md)
+
 ## Features
 
 - **Native Tool Subclasses** - Each tool extends SmolAgents' `Tool` base class

--- a/skills/hindsight-docs/references/sdks/integrations/strands.md
+++ b/skills/hindsight-docs/references/sdks/integrations/strands.md
@@ -3,6 +3,8 @@
 
 Persistent memory tools for [Strands Agents SDK](https://github.com/strands-agents/sdk-python) agents via Hindsight. Give your agents long-term memory with retain, recall, and reflect — using Strands' native `@tool` pattern.
 
+[View Changelog →](../../changelog/integrations/strands.md)
+
 ## Features
 
 - **Native `@tool` Functions** - Tools are plain Python functions, compatible with `Agent(tools=[...])`

--- a/skills/hindsight-docs/references/sdks/integrations/superagent.md
+++ b/skills/hindsight-docs/references/sdks/integrations/superagent.md
@@ -3,6 +3,8 @@
 
 Safety middleware for [Hindsight](https://vectorize.io/hindsight) memory operations, powered by [Superagent](https://www.superagent.sh). Wrap your memory client with `SafeHindsight` to guard against prompt injection and strip PII before anything is written to memory — and to screen queries before they reach recall or reflect.
 
+[View Changelog →](../../changelog/integrations/superagent.md)
+
 ## Quick Start
 
 > **💡 Recommended: Hindsight Cloud**

--- a/skills/hindsight-docs/references/sdks/integrations/vapi.md
+++ b/skills/hindsight-docs/references/sdks/integrations/vapi.md
@@ -3,6 +3,8 @@
 
 Persistent long-term memory for [Vapi](https://vapi.ai) voice AI calls via [Hindsight](https://vectorize.io/hindsight). A single webhook handler recalls relevant memories at call start (injected as `assistantOverrides`) and retains the full transcript when the call ends.
 
+[View Changelog →](../../changelog/integrations/vapi.md)
+
 ## Quick Start
 
 > **💡 Hindsight Cloud (recommended)**

--- a/skills/hindsight-docs/references/sdks/integrations/zcode.md
+++ b/skills/hindsight-docs/references/sdks/integrations/zcode.md
@@ -3,6 +3,8 @@
 
 Persistent memory for [ZCode](https://zcode.z.ai) — Z.ai's GLM desktop coding agent — using [Hindsight](https://vectorize.io/hindsight). ZCode embeds the Claude Code agent runtime, so Python hook scripts automatically recall relevant context before each prompt and retain conversations after each turn. No MCP server, no changes to your ZCode workflow.
 
+[View Changelog →](../../changelog/integrations/zcode.md)
+
 ## Quick Start
 
 > **💡 Recommended: Hindsight Cloud**

--- a/skills/hindsight-docs/references/sdks/integrations/zed.md
+++ b/skills/hindsight-docs/references/sdks/integrations/zed.md
@@ -3,6 +3,8 @@
 
 Long-term memory for the [Zed](https://zed.dev) editor's AI assistant, powered by [Hindsight](https://vectorize.io/hindsight). One command connects Zed's Agent Panel to the Hindsight MCP server and adds a rule telling the agent to use it — so it recalls relevant memory at the start of a task and retains durable facts as it goes. Recall happens at query time against your actual message, and from your seat it's automatic.
 
+[View Changelog →](../../changelog/integrations/zed.md)
+
 ## How It Works
 
 Zed has no pre-prompt hook, but it supports two things this integration uses:


### PR DESCRIPTION
## Why

The release script has written a changelog page per integration since 0.4.20 (`hindsight-docs/src/pages/changelog/integrations/<slug>.md`), but nothing reliably linked them:

- **16 of 61** integration doc pages carried a `View Changelog →` link.
- The only index was a hand-written table at the bottom of `/changelog` listing **6 of 48** pages — stale since the release that introduced per-integration changelogs.

So `coding-agents` (and 30 others) had a published changelog reachable only by guessing the URL.

## What

**1. Every changelog is linked from its doc page** — the 30 missing links added, plus a third invariant in `check-integrations.mjs` so the next one can't ship unlinked. Verified it fails by removing one link.

`coding-agents.md` is generated from the README, so its link lives in the README as an absolute `hindsight.vectorize.io` URL; the sync script rewrites our own absolute URLs to site-relative, so it resolves on npm, GitHub and the docs site. It sits outside the `skill:begin` regions, so `SKILL.md` is byte-identical.

**2. The Integrations Hub is where you find them.** Each card now carries `Docs` and `Changelog` buttons. Which integrations have a changelog comes from a new build-time plugin that indexes the changelog directory and joins `integrations.json` on the **link slug** (`vercel-ai-sdk` → `/sdks/integrations/ai-sdk` → `ai-sdk.md`) — so an integration grows the button on its first release with nothing to update by hand.

The gallery itself was 60 three-line cards with a repeated "Hindsight Team" byline and an `OFFICIAL` badge on 52 of them, running 6092px. Cards are now a compact row grouped by category, featured included (same row, tinted, keeping the harness strip): **6092px → 4352px**. `/changelog`'s first line points at `/integrations` instead of carrying its own listing.

## Notes for review

- The card is a `<div>` now — nested anchors are invalid HTML — so the name and the pills are the links, not the whole card background.
- Drops the 14 CSS classes the old card owned; `CATEGORY_LABELS` / `groupByCategory` move to `src/lib/integrations.ts` so the gallery and any future consumer share one taxonomy.
- `/changelog/integrations` (the bare directory URL) 404s, as it did before this PR.

## Verification

- `./scripts/hooks/lint.sh` clean
- `npm run build` in `hindsight-docs` passes (the one broken-anchor warning is a pre-existing blog post)
- `check-integrations.mjs` green on all three invariants; `sync-coding-agents-doc.mjs --check` green; docs skill regenerated
- knip clean on the changed files
- Light and dark mode both checked in a browser

https://claude.ai/code/session_01DNWFQn8AUN6SApcswHG3aN