### PR TITLE
fix(tracing): name API traces after the operation and link queued retain to its worker

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -14,7 +14,7 @@ import uuid
 from collections.abc import Awaitable
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.gzip import GZipMiddleware
@@ -51,6 +51,9 @@ def _parse_metadata(metadata: Any) -> dict[str, Any]:
 from collections.abc import Iterable
 from types import UnionType
 from typing import Callable, Union, get_args, get_origin
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Span
 
 from fastapi.routing import APIRoute
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -4192,6 +4195,50 @@ def create_app(
     return app
 
 
+# Endpoints whose HTTP span should be renamed after the Hindsight operation it
+# performs, as (method, path pattern with the bank id captured, operation name).
+# Matched against the concrete request path, so an extension that mounts these
+# routes under a different prefix is still recognised.
+_TRACED_OPERATION_ROUTES: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    ("POST", re.compile(r"/banks/(?P<bank_id>[^/]+)/memories/recall/?$"), "recall"),
+    ("POST", re.compile(r"/banks/(?P<bank_id>[^/]+)/memories/dry-run-extract/?$"), "dry_run_extract"),
+    ("POST", re.compile(r"/banks/(?P<bank_id>[^/]+)/memories/?$"), "retain"),
+    ("POST", re.compile(r"/banks/(?P<bank_id>[^/]+)/reflect/?$"), "reflect"),
+    ("POST", re.compile(r"/banks/(?P<bank_id>[^/]+)/files/retain/?$"), "file_convert_retain"),
+)
+
+
+def _name_server_span_after_operation(span: "Span", scope: dict[str, Any]) -> None:
+    """
+    Rename the HTTP server span after the Hindsight operation the request runs.
+
+    Trace viewers name a trace after its root span, and the ASGI instrumentation's
+    root is an HTTP span named ``{method} {http.route}`` per OTel semantic
+    conventions. That makes every trace read as a URL template
+    ("POST /v1/default/banks/{bank_id}/memories") rather than as the operation it
+    performed, and buries the ``hindsight.*`` span that carries the real meaning
+    one level down where it can no longer title the trace.
+
+    Renaming only the operation endpoints keeps ordinary CRUD routes on their
+    semconv names, and ``http.route``/``http.request.method`` stay on the span
+    either way, so grouping by route is unaffected.
+    """
+    if not span.is_recording():
+        return
+    method = scope.get("method", "")
+    path = scope.get("path", "")
+    for route_method, pattern, operation in _TRACED_OPERATION_ROUTES:
+        if route_method != method:
+            continue
+        match = pattern.search(path)
+        if match is None:
+            continue
+        span.update_name(f"hindsight.{operation}")
+        span.set_attribute("hindsight.operation", operation)
+        span.set_attribute("hindsight.bank_id", match.group("bank_id"))
+        return
+
+
 def _instrument_app_for_tracing(app: FastAPI, config: HindsightConfig | StaticConfigProxy) -> None:
     """
     Make incoming requests continue the caller's trace instead of starting a new one.
@@ -4220,6 +4267,10 @@ def _instrument_app_for_tracing(app: FastAPI, config: HindsightConfig | StaticCo
         FastAPIInstrumentor.instrument_app(
             app,
             excluded_urls=excluded_urls,
+            # Fires right after the server span is created, and the ASGI
+            # instrumentation never renames it afterwards (the route is already
+            # resolved at creation), so an update_name() here is the final name.
+            server_request_hook=_name_server_span_after_operation,
             # Two reasons, both load-bearing. Per-ASGI-message spans triple the
             # span count per request while saying nothing the request span
             # doesn't. And excluding "receive" makes the instrumentation pass the

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3272,7 +3272,7 @@ class MemoryEngine(MemoryEngineInterface):
         logger.info(f"[REFRESH_MENTAL_MODEL_TASK] Completed for bank_id={bank_id}, mental_model_id={mental_model_id}")
 
     @_bind_bank_id("task_dict", key="bank_id")
-    async def execute_task(self, task_dict: dict[str, Any]):
+    async def execute_task(self, task_dict: dict[str, Any]) -> None:
         """
         Execute a task by routing it to the appropriate handler.
 
@@ -3290,17 +3290,18 @@ class MemoryEngine(MemoryEngineInterface):
         # starting a second, unrelated trace for the same logical operation.
         parent_context = extract_task_trace_context(task_dict)
         if parent_context is None:
-            return await self._execute_task(task_dict)
+            await self._execute_task(task_dict)
+            return
 
         from opentelemetry import context as otel_context
 
         token = otel_context.attach(parent_context)
         try:
-            return await self._execute_task(task_dict)
+            await self._execute_task(task_dict)
         finally:
             otel_context.detach(token)
 
-    async def _execute_task(self, task_dict: dict[str, Any]):
+    async def _execute_task(self, task_dict: dict[str, Any]) -> None:
         """Route a task to its handler. See :meth:`execute_task`."""
         task_type = task_dict.get("type")
         operation_id = task_dict.get("operation_id")

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -52,7 +52,7 @@ from ..config import (
     LLMStrategyConfig,
     get_config,
 )
-from ..tracing import create_operation_span
+from ..tracing import create_operation_span, extract_task_trace_context, inject_task_trace_context
 from ..utils import mask_network_location
 from ..worker.exceptions import DeferOperation, RetryTaskAt, format_task_error
 from ..worker.stage import set_stage
@@ -3283,6 +3283,25 @@ class MemoryEngine(MemoryEngineInterface):
             task_dict: Task dictionary with 'type' key and other payload data
                       Example: {'type': 'batch_retain', 'bank_id': '...', 'contents': [...]}
         """
+        # Continue the trace of whatever enqueued this task, when the payload
+        # carries one (see inject_task_trace_context). Attached around the whole
+        # dispatch so every span the handler opens — hindsight.retain and its
+        # GenAI children — nests under the originating request rather than
+        # starting a second, unrelated trace for the same logical operation.
+        parent_context = extract_task_trace_context(task_dict)
+        if parent_context is None:
+            return await self._execute_task(task_dict)
+
+        from opentelemetry import context as otel_context
+
+        token = otel_context.attach(parent_context)
+        try:
+            return await self._execute_task(task_dict)
+        finally:
+            otel_context.detach(token)
+
+    async def _execute_task(self, task_dict: dict[str, Any]):
+        """Route a task to its handler. See :meth:`execute_task`."""
         task_type = task_dict.get("type")
         operation_id = task_dict.get("operation_id")
 
@@ -19595,6 +19614,10 @@ class MemoryEngine(MemoryEngineInterface):
                             task_payload["_tenant_id"] = request_context.tenant_id
                         if request_context.api_key_id:
                             task_payload["_api_key_id"] = request_context.api_key_id
+                        # Carry the enqueueing request's trace context so the
+                        # worker's hindsight.retain span continues this trace
+                        # rather than starting an unrelated one.
+                        inject_task_trace_context(task_payload)
 
                         # Per-child single-document surfacing (see parent note):
                         # in a multi-document batch, each single-document child

--- a/hindsight-api-slim/hindsight_api/tracing.py
+++ b/hindsight-api-slim/hindsight_api/tracing.py
@@ -24,6 +24,8 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import Status, StatusCode
 
 if TYPE_CHECKING:
+    from opentelemetry.context import Context
+
     from .config import HindsightConfig, StaticConfigProxy
 
 logger = logging.getLogger(__name__)
@@ -335,6 +337,58 @@ def create_operation_span(operation: str, bank_id: str | None = None):
 def is_tracing_enabled() -> bool:
     """Check if tracing is enabled."""
     return _tracing_enabled
+
+
+# Key under which the W3C trace context travels inside a task payload. Named
+# like the other worker-only payload passengers (_tenant_id, _api_key_id).
+TASK_TRACE_CONTEXT_KEY = "_traceparent"
+
+
+def inject_task_trace_context(payload: dict[str, Any]) -> None:
+    """
+    Stamp the current trace context onto a task payload, in place.
+
+    Queued work runs in the worker process, which has no way to know which
+    request enqueued it: without this, the API's span for (say) an async retain
+    and the worker's ``hindsight.retain`` span are two unrelated traces, and the
+    API half contains nothing but the enqueue. Carrying the W3C traceparent in
+    the payload lets the worker continue the caller's trace instead.
+
+    No-op when tracing is disabled, so a payload never grows a null key.
+    """
+    if not _tracing_enabled:
+        return
+    try:
+        from opentelemetry.propagate import inject
+
+        carrier: dict[str, str] = {}
+        inject(carrier)
+        if carrier:
+            payload[TASK_TRACE_CONTEXT_KEY] = carrier
+    except Exception as e:  # tracing must never break enqueueing
+        logger.debug(f"Failed to inject trace context into task payload: {e}", exc_info=True)
+
+
+def extract_task_trace_context(payload: dict[str, Any]) -> "Context | None":
+    """
+    Rebuild the enqueueing request's trace context from a task payload.
+
+    Returns an OpenTelemetry ``Context`` to attach around task execution, or
+    None when the payload carries no trace context (an internally scheduled
+    task, or a payload queued while tracing was off).
+    """
+    if not _tracing_enabled:
+        return None
+    carrier = payload.get(TASK_TRACE_CONTEXT_KEY)
+    if not isinstance(carrier, dict):
+        return None
+    try:
+        from opentelemetry.propagate import extract
+
+        return extract(carrier)
+    except Exception as e:
+        logger.debug(f"Failed to extract trace context from task payload: {e}", exc_info=True)
+        return None
 
 
 # Maximum content length before truncation (to stay within span size limits)

--- a/hindsight-api-slim/tests/test_tracing_context_propagation.py
+++ b/hindsight-api-slim/tests/test_tracing_context_propagation.py
@@ -165,6 +165,14 @@ def _recording_app(config) -> tuple[FastAPI, "InMemorySpanExporter"]:
     def reflect(bank_id: str):
         return {}
 
+    @app.post("/v1/default/banks/{bank_id}/memories/dry-run-extract")
+    def dry_run_extract(bank_id: str):
+        return {}
+
+    @app.post("/v1/default/banks/{bank_id}/files/retain")
+    def files_retain(bank_id: str):
+        return {}
+
     @app.get("/v1/default/banks/{bank_id}")
     def get_bank(bank_id: str):
         return {}
@@ -209,6 +217,19 @@ def test_operation_endpoints_are_named_after_the_hindsight_operation(monkeypatch
     assert _span_name_for(exporter, "/v1/default/banks/bank-a/memories/recall") == "hindsight.recall"
     assert _span_name_for(exporter, "/v1/default/banks/bank-a/memories") == "hindsight.retain"
     assert _span_name_for(exporter, "/v1/default/banks/bank-a/reflect") == "hindsight.reflect"
+
+
+def test_every_mapped_route_is_matched_by_its_pattern(monkeypatch):
+    """Guards the regex table: a typo in any entry silently falls back to the URL name."""
+    monkeypatch.delenv("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", raising=False)
+    app, exporter = _recording_app(_config())
+
+    with TestClient(app) as client:
+        client.post("/v1/default/banks/bank-a/memories/dry-run-extract")
+        client.post("/v1/default/banks/bank-a/files/retain")
+
+    assert _span_name_for(exporter, "/v1/default/banks/bank-a/memories/dry-run-extract") == "hindsight.dry_run_extract"
+    assert _span_name_for(exporter, "/v1/default/banks/bank-a/files/retain") == "hindsight.file_convert_retain"
 
 
 def test_renamed_span_keeps_its_http_route_and_gains_the_bank_id(monkeypatch):

--- a/hindsight-api-slim/tests/test_tracing_context_propagation.py
+++ b/hindsight-api-slim/tests/test_tracing_context_propagation.py
@@ -131,3 +131,108 @@ def test_instrumentation_failure_does_not_break_app_creation(monkeypatch):
 
     with TestClient(app) as client:
         assert client.get("/v1/probe").status_code == 200
+
+
+# --- Server-span naming (Langfuse trace titles) ------------------------------
+#
+# A trace is named after its root span, and the ASGI instrumentation's root is
+# an HTTP span named "{method} {http.route}". That titled every Hindsight trace
+# with a URL template instead of the operation it ran, so operation endpoints
+# rename their server span to "hindsight.<operation>".
+
+
+def _recording_app(config) -> tuple[FastAPI, "InMemorySpanExporter"]:
+    """An instrumented app whose finished server spans are readable in-process."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    app = FastAPI()
+
+    @app.post("/v1/default/banks/{bank_id}/memories/recall")
+    def recall(bank_id: str):
+        return {}
+
+    @app.post("/v1/default/banks/{bank_id}/memories")
+    def retain(bank_id: str):
+        return {}
+
+    @app.post("/v1/default/banks/{bank_id}/reflect")
+    def reflect(bank_id: str):
+        return {}
+
+    @app.get("/v1/default/banks/{bank_id}")
+    def get_bank(bank_id: str):
+        return {}
+
+    # instrument_app resolves its tracer lazily, so passing the provider here is
+    # what makes the spans land in our exporter without touching the global one.
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+    original = FastAPIInstrumentor.instrument_app
+
+    def _with_provider(app_, **kwargs):
+        return original(app_, tracer_provider=provider, **kwargs)
+
+    import opentelemetry.instrumentation.fastapi as fastapi_instrumentation
+
+    saved = fastapi_instrumentation.FastAPIInstrumentor.instrument_app
+    fastapi_instrumentation.FastAPIInstrumentor.instrument_app = staticmethod(_with_provider)
+    try:
+        _instrument_app_for_tracing(app, config)
+    finally:
+        fastapi_instrumentation.FastAPIInstrumentor.instrument_app = saved
+    return app, exporter
+
+
+def _span_name_for(exporter, path: str) -> str:
+    """Name of the single server span recorded for ``path``."""
+    spans = [s for s in exporter.get_finished_spans() if s.attributes.get("http.target", "") == path]
+    assert len(spans) == 1, [(s.name, dict(s.attributes)) for s in exporter.get_finished_spans()]
+    return spans[0].name
+
+
+def test_operation_endpoints_are_named_after_the_hindsight_operation(monkeypatch):
+    """Recall/retain/reflect traces are titled by operation, not by URL template."""
+    monkeypatch.delenv("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", raising=False)
+    app, exporter = _recording_app(_config())
+
+    with TestClient(app) as client:
+        client.post("/v1/default/banks/bank-a/memories/recall")
+        client.post("/v1/default/banks/bank-a/memories")
+        client.post("/v1/default/banks/bank-a/reflect")
+
+    assert _span_name_for(exporter, "/v1/default/banks/bank-a/memories/recall") == "hindsight.recall"
+    assert _span_name_for(exporter, "/v1/default/banks/bank-a/memories") == "hindsight.retain"
+    assert _span_name_for(exporter, "/v1/default/banks/bank-a/reflect") == "hindsight.reflect"
+
+
+def test_renamed_span_keeps_its_http_route_and_gains_the_bank_id(monkeypatch):
+    """Renaming must not cost the semconv attributes anything groups by."""
+    monkeypatch.delenv("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", raising=False)
+    app, exporter = _recording_app(_config())
+
+    with TestClient(app) as client:
+        client.post("/v1/default/banks/bank-a/memories/recall")
+
+    (span,) = exporter.get_finished_spans()
+    assert span.attributes["http.route"] == "/v1/default/banks/{bank_id}/memories/recall"
+    assert span.attributes["http.method"] == "POST"
+    assert span.attributes["hindsight.operation"] == "recall"
+    # The route template carries the placeholder; the real id is on the span.
+    assert span.attributes["hindsight.bank_id"] == "bank-a"
+
+
+def test_non_operation_endpoints_keep_their_semconv_name(monkeypatch):
+    """Ordinary CRUD routes are HTTP calls, not Hindsight operations."""
+    monkeypatch.delenv("OTEL_PYTHON_FASTAPI_EXCLUDED_URLS", raising=False)
+    app, exporter = _recording_app(_config())
+
+    with TestClient(app) as client:
+        client.get("/v1/default/banks/bank-a")
+
+    assert _span_name_for(exporter, "/v1/default/banks/bank-a") == "GET /v1/default/banks/{bank_id}"

--- a/hindsight-api-slim/tests/test_tracing_task_handoff.py
+++ b/hindsight-api-slim/tests/test_tracing_task_handoff.py
@@ -1,0 +1,95 @@
+"""Trace-context hand-off from the API to the worker.
+
+Async retain returns as soon as the operation row is queued; the extraction
+itself runs in the worker process. Without a trace context in the payload the
+API's span for the enqueue and the worker's ``hindsight.retain`` span are two
+unrelated traces, and the API half contains nothing but the INSERT. These tests
+assert the payload carries a W3C traceparent and that ``execute_task`` runs the
+handler inside the trace it names.
+"""
+
+import types
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+import hindsight_api.tracing as tracing
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.tracing import (
+    TASK_TRACE_CONTEXT_KEY,
+    extract_task_trace_context,
+    inject_task_trace_context,
+)
+
+
+@pytest.fixture
+def tracing_on(monkeypatch):
+    """Enable tracing with a real SDK provider, without an exporter."""
+    provider = TracerProvider()
+    monkeypatch.setattr(tracing, "_tracing_enabled", True)
+    monkeypatch.setattr(tracing, "_tracer", provider.get_tracer(__name__))
+    return provider.get_tracer(__name__)
+
+
+def test_payload_gets_no_trace_key_when_tracing_is_disabled(monkeypatch):
+    """A disabled pipeline must not grow a null passenger on every task."""
+    monkeypatch.setattr(tracing, "_tracing_enabled", False)
+    payload: dict = {}
+
+    inject_task_trace_context(payload)
+
+    assert payload == {}
+    assert extract_task_trace_context({TASK_TRACE_CONTEXT_KEY: {"traceparent": "x"}}) is None
+
+
+def test_traceparent_round_trips_through_the_payload(tracing_on):
+    """The worker rebuilds the enqueueing request's trace from the payload."""
+    payload: dict = {}
+    with tracing_on.start_as_current_span("hindsight.retain") as span:
+        enqueue_trace_id = span.get_span_context().trace_id
+        inject_task_trace_context(payload)
+
+    assert "traceparent" in payload[TASK_TRACE_CONTEXT_KEY]
+
+    restored = extract_task_trace_context(payload)
+    assert trace.get_current_span(restored).get_span_context().trace_id == enqueue_trace_id
+
+
+def test_payload_without_a_traceparent_extracts_to_nothing(tracing_on):
+    """Internally scheduled work (consolidation, refresh) has no caller trace."""
+    assert extract_task_trace_context({"type": "consolidation"}) is None
+    assert extract_task_trace_context({TASK_TRACE_CONTEXT_KEY: "not-a-carrier"}) is None
+
+
+async def test_execute_task_runs_the_handler_in_the_enqueueing_trace(tracing_on):
+    """The worker's spans nest under the request that queued the task."""
+    payload: dict = {"type": "batch_retain", "bank_id": "bank-a"}
+    with tracing_on.start_as_current_span("POST /memories") as span:
+        enqueue_trace_id = span.get_span_context().trace_id
+        inject_task_trace_context(payload)
+
+    observed: list[int] = []
+
+    async def _fake_execute(task_dict):
+        with tracing_on.start_as_current_span("hindsight.retain") as worker_span:
+            observed.append(worker_span.get_span_context().trace_id)
+
+    stub = types.SimpleNamespace(_execute_task=_fake_execute)
+    await MemoryEngine.execute_task(stub, payload)
+
+    assert observed == [enqueue_trace_id]
+
+
+async def test_execute_task_without_a_traceparent_starts_its_own_trace(tracing_on):
+    """Internally scheduled tasks still trace, just as their own root."""
+    observed: list[int] = []
+
+    async def _fake_execute(task_dict):
+        with tracing_on.start_as_current_span("hindsight.consolidation") as worker_span:
+            observed.append(worker_span.get_span_context().trace_id)
+
+    stub = types.SimpleNamespace(_execute_task=_fake_execute)
+    await MemoryEngine.execute_task(stub, {"type": "consolidation", "bank_id": "bank-a"})
+
+    assert observed and observed[0] != 0


### PR DESCRIPTION
Running the API and the worker with OTel tracing on produces traces that are hard to read on the API side. Two separate causes.

## Traces are titled with a URL template

A trace is named after its root span. In the API process the root is the HTTP span opened by the ASGI instrumentation, named `{method} {http.route}` per OTel semantic conventions. So every trace was titled:

```
POST /v1/default/banks/{bank_id}/memories/recall
POST /v1/default/banks/{bank_id}/memories
```

…while the `hindsight.*` span carrying the actual meaning sat one level down, where it could no longer title anything.

The five operation endpoints (`recall`, `dry-run-extract`, `retain`, `reflect`, `files/retain`) now rename their server span to `hindsight.<operation>` via a `server_request_hook`. The hook fires right after span creation and the ASGI middleware never renames afterwards — the route is already resolved at creation — so `update_name()` there is final.

- `http.route` and `http.request.method` stay on the span, so anything grouping by route is unaffected.
- Only operation endpoints are renamed; ordinary CRUD routes keep their semconv names, because they *are* HTTP calls rather than Hindsight operations.
- The hook also records the real `hindsight.bank_id`, which the route template only carries as a placeholder.

## Queued retain produced an empty trace, unlinked from the work

An async retain returns as soon as the operation row is written; the extraction runs in the worker. Nothing carried the trace context across, so the API's span for the enqueue and the worker's `hindsight.retain` span were two unrelated traces — and the API half contained nothing but the INSERT, which is why `POST …/memories` looked like an empty shell.

`submit_async_retain` now stamps the W3C traceparent into the task payload alongside `_tenant_id`/`_api_key_id`, and `execute_task` attaches it around the dispatch so the worker's spans continue the originating trace. Attaching at `execute_task` rather than inside the retain handler keeps it generic: any task type that later carries a traceparent is linked for free.

Both halves are no-ops when tracing is disabled, so a payload never grows a null passenger and existing payload assertions are untouched.

## Not changed

`recall` already opens its own `hindsight.recall` span — directly via `tracer.start_as_current_span` at `memory_engine.py:6466` rather than through `create_operation_span`, which is why it does not show up when grepping for the latter. No change was needed there.

## Tests

- `test_tracing_context_propagation.py` — four new tests over an in-memory span exporter: operation endpoints get `hindsight.*` names; the rename preserves `http.route`/`http.method` and adds the real bank id; non-operation routes keep the semconv name.
- `test_tracing_task_handoff.py` (new) — traceparent round-trips through the payload; a disabled pipeline adds no key; `execute_task` runs the handler inside the enqueueing trace; internally scheduled tasks (consolidation, refresh) still start their own root.

`lint.sh` and `ty check` clean. `generate-openapi.sh` produces no diff — no API contract change.

## Notes for review

- Renaming the server span is a deliberate departure from HTTP semconv naming. The attributes are preserved so nothing is lost analytically, and the scope is limited to operation endpoints. The vendor-specific alternative (a `langfuse.trace.name` attribute) was rejected as backend-lock-in — this module targets any OTLP backend.
- A batch retain split into many children now yields one trace containing all of them, with a gap between the HTTP span ending and the workers starting. That is the correct producer/consumer picture, but it does make traces wide for large batches.

Builds on the tracing bootstrap from #3614 and the incoming-traceparent extraction from #3604.

https://claude.ai/code/session_01WbaYxouCERUv9djo3GnnA2