### PR TITLE
feat(recall): query_tag_gate — restrict recall to the identities a query names

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -188,6 +188,7 @@ from hindsight_api.engine.response_models import (
     DryRunExtractionResult,
     MemoryFact,
     MinScores,
+    QueryTagGate,
     RecallScores,
     TemporalWindow,
     TokenUsage,
@@ -352,6 +353,16 @@ class RecallRequest(BaseModel):
         default=None,
         description="Compound tag filter using boolean groups. Groups in the list are AND-ed. "
         "Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}.",
+    )
+    query_tag_gate: QueryTagGate | None = Field(
+        default=None,
+        description="Restrict this recall to the tagged identities the query actually names, "
+        "and optionally return nothing when it names none of them. For banks whose memories "
+        "are tagged with what they are about (`customer:acme`, `service:auth`): ranking cannot "
+        "say which of those a query means, and never says 'none', so a query about something "
+        "the bank has no memory of still returns its best unrelated match. The matched tags "
+        "are AND-ed into the tag filter and applied in SQL, so excluded memories never enter "
+        "retrieval or ranking.",
     )
     min_scores: MinScores | None = Field(
         default=None,
@@ -4929,6 +4940,7 @@ def _register_routes(app: FastAPI):
                         tags=request.tags,
                         tags_match=request.tags_match,
                         tag_groups=request.tag_groups,
+                        query_tag_gate=request.query_tag_gate,
                         min_scores=request.min_scores,
                         temporal_window=request.temporal_window,
                     ),

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -554,6 +554,7 @@ from .response_models import (
     LLMCallTrace,
     MemoryFact,
     MinScores,
+    QueryTagGate,
     RecallScores,
     ReflectResult,
     TemporalWindow,
@@ -564,8 +565,15 @@ from .response_models import RecallResult as RecallResultModel
 from .retain import bank_utils, embedding_utils
 from .retain.fold import FoldMemberRef
 from .retain.types import RetainContentDict
+from .search import query_tag_gate as query_tag_gate_matching
 from .search.reranking import CrossEncoderReranker, apply_combined_scoring
-from .search.tags import TagGroup, TagsMatch, build_tag_groups_where_clause, build_tags_where_clause
+from .search.tags import (
+    TagGroup,
+    TagGroupLeaf,
+    TagsMatch,
+    build_tag_groups_where_clause,
+    build_tags_where_clause,
+)
 from .search.types import ScoredResult
 from .source_facts import select_source_facts_within_budget
 from .task_backend import TaskBackend
@@ -6372,6 +6380,7 @@ class MemoryEngine(MemoryEngineInterface):
         tags: list[str] | None = None,
         tags_match: TagsMatch = "any",
         tag_groups: list[TagGroup] | None = None,
+        query_tag_gate: QueryTagGate | None = None,
         created_after: datetime | None = None,
         created_before: datetime | None = None,
         min_scores: MinScores | None = None,
@@ -6576,6 +6585,7 @@ class MemoryEngine(MemoryEngineInterface):
                             tags=tags,
                             tags_match=tags_match,
                             tag_groups=tag_groups,
+                            query_tag_gate=query_tag_gate,
                             created_after=created_after,
                             created_before=created_before,
                             min_scores=min_scores,
@@ -6719,6 +6729,7 @@ class MemoryEngine(MemoryEngineInterface):
         tags: list[str] | None = None,
         tags_match: TagsMatch = "any",
         tag_groups: list[TagGroup] | None = None,
+        query_tag_gate: QueryTagGate | None = None,
         created_after: datetime | None = None,
         created_before: datetime | None = None,
         min_scores: MinScores | None = None,
@@ -6797,6 +6808,39 @@ class MemoryEngine(MemoryEngineInterface):
         tracer_otel = get_tracer()
 
         try:
+            # Step 0.5: query tag gate. When the caller says its memories are tagged with the
+            # names of the things they describe, restrict this recall to the names the query
+            # actually mentions — and, when it mentions none of them, return nothing rather
+            # than the best-scoring unrelated memory. Ranking cannot express either: it has no
+            # notion of what a query is *about*, and its top result is always its top result.
+            # Resolved to plain tags here so the restriction rides the normal tag filter into
+            # SQL, and unwanted memories never reach retrieval or reranking.
+            if query_tag_gate is not None:
+                gate_start = time.time()
+                vocabulary = await self._load_tag_vocabulary(bank_id, query_tag_gate, request_context=request_context)
+                matched_tags = query_tag_gate_matching.match_tags(
+                    query,
+                    vocabulary,
+                    prefix=query_tag_gate.prefix,
+                    match=query_tag_gate.match,
+                    min_token_length=query_tag_gate.min_token_length,
+                )
+                log_buffer.append(
+                    f"  [0.5] query_tag_gate(prefix={query_tag_gate.prefix!r}, "
+                    f"match={query_tag_gate.match}): {len(vocabulary)} known -> "
+                    f"{len(matched_tags)} matched {matched_tags[:5]}"
+                )
+                if matched_tags:
+                    gate_group: TagGroup = TagGroupLeaf(tags=matched_tags, match="any_strict")
+                    tag_groups = [*(tag_groups or []), gate_group]
+                elif query_tag_gate.on_no_match == "abstain":
+                    log_buffer.append(
+                        f"  [0.5] query names nothing in the vocabulary -> abstaining ({time.time() - gate_start:.3f}s)"
+                    )
+                    if not quiet:
+                        logger.info("\n".join(log_buffer))
+                    return RecallResultModel(results=[], entities={}, chunks={}, source_facts={})
+
             # Step 1: Generate query embedding (for semantic search)
             step_start = time.time()
 
@@ -13594,6 +13638,26 @@ class MemoryEngine(MemoryEngineInterface):
             "total_edges": len(edges),
             "limit": limit,
         }
+
+    async def _load_tag_vocabulary(
+        self,
+        bank_id: str,
+        gate: QueryTagGate,
+        *,
+        request_context: "RequestContext",
+    ) -> list[str]:
+        """The bank's identity tags under the gate's prefix, for query matching.
+
+        Read through list_tags so the gate sees exactly the tags recall would filter on.
+        Truncated at `max_vocabulary` rather than scanning an unbounded set — a gate over a
+        vocabulary that large is not the tool the caller wants."""
+        listing = await self.list_tags(
+            bank_id,
+            pattern=f"{gate.prefix}*",
+            limit=gate.max_vocabulary,
+            request_context=request_context,
+        )
+        return [item["tag"] for item in listing.get("items", []) if item.get("tag")]
 
     async def list_tags(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -7,7 +7,7 @@ API stability even if internal models change.
 """
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -245,6 +245,53 @@ class MinScores(BaseModel):
     final: float | None = Field(
         default=None,
         description="Post-query: minimum final ranking score. Applied to every returned result.",
+    )
+
+
+class QueryTagGate(BaseModel):
+    """Restrict recall to the tagged identities the query actually names.
+
+    Ranking cannot say *which* memory a query is about, and can never say "none of
+    them" — the top-scored memory is still the top-scored memory on a query the bank
+    has no answer for. A bank that tags memories with the names of what they describe
+    (``customer:acme``, ``service:auth``) already holds what settles both questions:
+    which of those names the query mentions.
+
+    The matched tags are AND-ed into the tag filter, so the restriction runs in SQL
+    with every other tag condition and unwanted memories never enter ranking.
+    """
+
+    prefix: str = Field(
+        description="Tag namespace holding the identities, e.g. 'name:'. Only tags starting "
+        "with this are considered, and the prefix is stripped before matching, so "
+        "`name:session-backend` is matched as 'session backend'.",
+    )
+    match: Literal["exact", "typos"] = Field(
+        default="typos",
+        description="'exact' requires the query to name the tag verbatim (token-wise). 'typos' "
+        "also accepts one insertion, deletion or transposition per token — but never a "
+        "substitution, which at one edit reliably means a *different* word ('mango' is not "
+        "'mongo', 'k9s' is not 'k8s') where the other three mean a mistyped one ('eror' for "
+        "'error', 'typsecript' for 'typescript'). No distance threshold separates those cases; "
+        "both sit at edit distance 1.",
+    )
+    min_token_length: int = Field(
+        default=4,
+        ge=1,
+        description="Tokens shorter than this must match exactly. At three characters almost "
+        "every identifier is one edit from another, so fuzzy matching there is noise.",
+    )
+    on_no_match: Literal["abstain", "ignore"] = Field(
+        default="abstain",
+        description="What to do when the query names nothing in the vocabulary. 'abstain' "
+        "returns no results — the honest answer when the caller is asking which known thing "
+        "the query is about. 'ignore' drops the gate and recalls normally.",
+    )
+    max_vocabulary: int = Field(
+        default=1000,
+        ge=1,
+        description="Cap on identity tags loaded for matching. A vocabulary larger than this is "
+        "truncated rather than silently scanned in full.",
     )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/entity_labels.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/entity_labels.py
@@ -21,7 +21,7 @@ class LabelValue(BaseModel):
 class MapField(BaseModel):
     """A field within a map-type entity label group. Supports recursion via type='map'."""
 
-    type: Literal["text", "value", "multi-values", "map"] = "text"
+    type: Literal["text", "multi-text", "value", "multi-values", "map"] = "text"
     description: str = ""
     values: list[LabelValue] = []
     fields: dict[str, "MapField"] = {}
@@ -35,7 +35,7 @@ class LabelGroup(BaseModel):
 
     key: str
     description: str = ""
-    type: Literal["value", "multi-values", "text", "map"] = "value"
+    type: Literal["value", "multi-values", "text", "multi-text", "map"] = "value"
     optional: bool = True
     tag: bool = False
     values: list[LabelValue] = []
@@ -175,6 +175,7 @@ def build_labels_model(labels_cfg: EntityLabelsConfig) -> type[BaseModel] | None
 
     Each LabelGroup becomes a typed field based on its type:
     - type="text"                        → str | None  (always optional)
+    - type="multi-text"                  → list[str]   (open vocabulary, many values)
     - type="value",   optional=True      → Literal["v1","v2"] | None
     - type="value",   optional=False     → Literal["v1","v2"]  (required)
     - type="multi-values"                → list[Literal["v1","v2"]]
@@ -202,6 +203,11 @@ def build_labels_model(labels_cfg: EntityLabelsConfig) -> type[BaseModel] | None
         elif group.type == "text":
             # Free-form: any string value accepted, always optional
             fields[group.key] = (str | None, Field(default=None, description=description))
+        elif group.type == "multi-text":
+            # Open vocabulary, many values per fact — the values cannot be enumerated in
+            # advance (names something goes by, ticket references, product codes), so unlike
+            # "multi-values" there is no Literal to constrain them to.
+            fields[group.key] = (list[str], Field(default_factory=list, description=description))
         else:
             # Enum-constrained: must have defined values
             if not group.values:
@@ -256,7 +262,7 @@ def is_label_entity(text: str, labels_cfg: EntityLabelsConfig, labels_lookup: se
     if text.lower() in labels_lookup:
         return True
     for group in labels_cfg.attributes:
-        if group.type == "text" and group.key and text.lower().startswith(f"{group.key.lower()}:"):
+        if group.type in ("text", "multi-text") and group.key and text.lower().startswith(f"{group.key.lower()}:"):
             return True
         if group.type == "map" and group.key and group.fields:
             prefix = f"{group.key.lower()}:"
@@ -289,8 +295,8 @@ def build_labels_lookup(labels_cfg: EntityLabelsConfig | list | None) -> set[str
 
     valid = set()
     for group in labels_cfg.attributes:
-        if group.type in ("text", "map"):
-            continue  # text: no fixed vocabulary; map: uses three-level key:field:value strings
+        if group.type in ("text", "multi-text", "map"):
+            continue  # text/multi-text: no fixed vocabulary; map: three-level key:field:value strings
         for v in group.values:
             if group.key and v.value:
                 valid.add(f"{group.key}:{v.value}".lower())

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1221,6 +1221,9 @@ def _build_labels_prompt_section(labels_cfg: EntityLabelsConfig | list | None, f
         if attr.type == "text":
             # Free-text: no predefined values — LLM writes any relevant string or null
             lines.append(f"- {attr.key} (free text or null): {attr.description}")
+        elif attr.type == "multi-text":
+            # Open vocabulary, many values: the LLM writes the list, nothing constrains it
+            lines.append(f"- {attr.key} (list of free-text values, [] if none apply): {attr.description}")
         else:
             mode = "multi-value (list)" if attr.type == "multi-values" else "single value or null"
             lines.append(f"- {attr.key} ({mode}): {attr.description}")
@@ -1822,7 +1825,7 @@ async def _extract_facts_from_chunk(
                                 if not isinstance(v, str) or not v.strip() or v.lower() in ("none", "null", "n/a"):
                                     continue
                                 label_str = f"{group.key}:{v.strip()}"
-                                if group.type == "text":
+                                if group.type in ("text", "multi-text"):
                                     if label_str.lower() not in existing_texts_lower:
                                         validated_entities.append(label_str)
                                         existing_texts_lower.add(label_str.lower())
@@ -2665,7 +2668,7 @@ async def extract_facts_from_contents_batch_api(
                             if not isinstance(v, str) or not v.strip() or v.lower() in ("none", "null", "n/a"):
                                 continue
                             label_str = f"{group.key}:{v.strip()}"
-                            if group.type == "text":
+                            if group.type in ("text", "multi-text"):
                                 if label_str.lower() not in existing_texts_lower:
                                     validated_entities.append(label_str)
                                     existing_texts_lower.add(label_str.lower())

--- a/hindsight-api-slim/hindsight_api/engine/search/query_tag_gate.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/query_tag_gate.py
@@ -1,0 +1,129 @@
+"""Restrict recall to the tagged identities a query actually names.
+
+Ranking answers "which memories are most related to this query". It cannot answer
+"which memory is this query *about*", and it can never answer "none of them" — the
+best-scoring memory is still the best-scoring memory on a query the bank has no
+answer for. A bank that tags its memories with the names of the things they describe
+(``customer:acme``, ``service:auth``, ``name:kubernetes``) already carries what is
+needed to answer both: look at which of those names the query mentions.
+
+This module does the lookup. Recall then AND-s the matched tags into the tag filter,
+so the restriction is applied in SQL alongside every other tag condition rather than
+by re-ranking afterwards, and a query naming nothing known can abstain outright.
+
+Matching is token-based and tolerant of typing slips, because the names users type
+are the names they half-remember: ``k8s``, ``mongod``, ``moongoose``. The tolerance
+deliberately admits insertions, deletions and transpositions but never substitutions
+— at one edit those separate cleanly into "the same word, mistyped" (``eror`` for
+``error``, ``typsecript`` for ``typescript``) and "a different word" (``mango`` is
+not ``mongo``, ``k9s`` is not ``k8s``). No distance threshold can make that
+distinction, since both cases sit at edit distance 1; only the kind of edit can.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+TagGateMatch = Literal["exact", "typos"]
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase alphanumeric tokens, punctuation dropped."""
+    return _TOKEN_RE.findall((text or "").lower())
+
+
+def is_typo_of(candidate: str, target: str) -> bool:
+    """True when `candidate` is `target` with one insertion, deletion or transposition.
+
+    Substitutions are excluded on purpose — see the module docstring. Implemented as a
+    Damerau-Levenshtein variant with substitution disallowed, short-circuited at a
+    distance of one.
+    """
+    if candidate == target:
+        return True
+    if abs(len(candidate) - len(target)) > 1:
+        return False
+
+    inf = len(candidate) + len(target) + 1
+    previous_previous: list[int] = []
+    previous = list(range(len(target) + 1))
+    for i, c in enumerate(candidate, start=1):
+        current = [i]
+        for j, t in enumerate(target, start=1):
+            if c == t:
+                best = previous[j - 1]
+            else:
+                best = min(previous[j] + 1, current[j - 1] + 1)  # delete / insert only
+            if i > 1 and j > 1 and c == target[j - 2] and candidate[i - 2] == t and previous_previous[j - 2] + 1 < best:
+                best = previous_previous[j - 2] + 1  # transposition
+            current.append(min(best, inf))
+        previous_previous, previous = previous, current
+    return previous[-1] <= 1
+
+
+def _phrase_matches(
+    phrase_tokens: list[str],
+    query_tokens: list[str],
+    *,
+    match: TagGateMatch,
+    min_token_length: int,
+) -> bool:
+    """Does the query contain this phrase, allowing per-token slips?
+
+    A multi-word name has to appear as a contiguous run: "session backend" must not be
+    matched by a query that says "session" in one clause and "backend" in another.
+    """
+    span = len(phrase_tokens)
+    if not span or span > len(query_tokens):
+        return False
+    for start in range(len(query_tokens) - span + 1):
+        window = query_tokens[start : start + span]
+        if all(
+            _token_matches(p, q, match=match, min_token_length=min_token_length)
+            for p, q in zip(phrase_tokens, window, strict=True)
+        ):
+            return True
+    return False
+
+
+def _token_matches(phrase_token: str, query_token: str, *, match: TagGateMatch, min_token_length: int) -> bool:
+    if phrase_token == query_token:
+        return True
+    if match == "exact":
+        return False
+    # Short tokens carry too little signal for a one-edit neighbourhood to mean
+    # anything: at three characters nearly every identifier is one edit from another.
+    if min(len(phrase_token), len(query_token)) < min_token_length:
+        return False
+    return is_typo_of(query_token, phrase_token)
+
+
+def match_tags(
+    query: str,
+    tags: list[str],
+    *,
+    prefix: str,
+    match: TagGateMatch = "typos",
+    min_token_length: int = 4,
+) -> list[str]:
+    """The subset of `tags` whose name the query mentions.
+
+    `tags` is the bank's vocabulary under `prefix`; the prefix is stripped before
+    matching so `name:session-backend` is compared as "session backend". Returns the
+    full tags, in the order given, so the caller can feed them straight back into a
+    tag filter.
+    """
+    query_tokens = tokenize(query)
+    if not query_tokens:
+        return []
+    matched: list[str] = []
+    for tag in tags:
+        if not tag.startswith(prefix):
+            continue
+        phrase_tokens = tokenize(tag[len(prefix) :])
+        if _phrase_matches(phrase_tokens, query_tokens, match=match, min_token_length=min_token_length):
+            matched.append(tag)
+    return matched

--- a/hindsight-api-slim/tests/test_entity_labels.py
+++ b/hindsight-api-slim/tests/test_entity_labels.py
@@ -2378,3 +2378,63 @@ async def test_retain_application_tags_extract_complete_pairs(memory_real_llm, r
         )
     finally:
         await memory_real_llm.delete_bank(bank_id, request_context=request_context)
+
+
+# ─── multi-text: open vocabulary, many values ─────────────────────────────────
+
+
+def test_build_labels_model_multi_text_is_an_unconstrained_list():
+    """multi-text → list[str] with no enum.
+
+    The distinction from multi-values is the point: the values cannot be enumerated in
+    advance (the names something goes by, ticket references, product codes), so there is
+    nothing to constrain them to.
+    """
+    labels_cfg = EntityLabelsConfig(
+        attributes=[LabelGroup(key="name", type="multi-text", description="names it goes by")]
+    )
+    Model = build_labels_model(labels_cfg)
+    assert Model is not None
+
+    props = Model.model_json_schema()["properties"]
+    assert props["name"]["type"] == "array"
+    assert props["name"]["items"] == {"type": "string"}
+    assert "enum" not in props["name"]["items"]
+
+    assert Model().name == []  # type: ignore[attr-defined]
+    assert Model(name=["Kubernetes", "k8s", "kube"]).name == ["Kubernetes", "k8s", "kube"]  # type: ignore[attr-defined]
+
+
+def test_multi_text_needs_no_declared_values():
+    """An enum group with no values is skipped; multi-text is still built."""
+    labels_cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(key="empty_enum", type="multi-values", values=[]),
+            LabelGroup(key="name", type="multi-text"),
+        ]
+    )
+    Model = build_labels_model(labels_cfg)
+    assert Model is not None
+    assert set(Model.model_json_schema()["properties"]) == {"name"}
+
+
+def test_multi_text_contributes_no_fixed_vocabulary():
+    """Like text, its values are unknown up front, so the lookup set stays empty."""
+    labels_cfg = EntityLabelsConfig(attributes=[LabelGroup(key="name", type="multi-text")])
+    assert build_labels_lookup(labels_cfg) == set()
+
+
+def test_multi_text_entities_are_recognised_by_prefix():
+    """Any `name:<anything>` belongs to the group — there is no value list to check against."""
+    labels_cfg = EntityLabelsConfig(attributes=[LabelGroup(key="name", type="multi-text")])
+    lookup = build_labels_lookup(labels_cfg)
+    assert is_label_entity("name:kubernetes", labels_cfg, lookup)
+    assert is_label_entity("name:some-thing-never-seen-before", labels_cfg, lookup)
+    assert not is_label_entity("kubernetes", labels_cfg, lookup)
+
+
+def test_multi_text_parses_from_raw_config():
+    labels_cfg = parse_entity_labels([{"key": "name", "type": "multi-text", "tag": True}])
+    assert labels_cfg is not None
+    assert labels_cfg.attributes[0].type == "multi-text"
+    assert labels_cfg.attributes[0].tag is True

--- a/hindsight-api-slim/tests/test_query_tag_gate.py
+++ b/hindsight-api-slim/tests/test_query_tag_gate.py
@@ -1,0 +1,137 @@
+"""Tests for `query_tag_gate` — restricting recall to the identities a query names.
+
+The matching itself is pure and deterministic, so it is asserted directly here rather
+than through a fixture. The separation matters: what the gate decides must not depend
+on embeddings or on a reranker being present.
+"""
+
+import pytest
+
+from hindsight_api.engine.response_models import QueryTagGate
+from hindsight_api.engine.search.query_tag_gate import is_typo_of, match_tags, tokenize
+
+VOCAB = [
+    "name:kubernetes",
+    "name:k8s",
+    "name:mongo",
+    "name:error-handling",
+    "name:typescript",
+    "name:session-backend",
+    "other:kubernetes",
+]
+
+
+class TestTokenize:
+    def test_splits_on_punctuation_and_lowercases(self):
+        assert tokenize("What's my K8s deploy story?") == ["what", "s", "my", "k8s", "deploy", "story"]
+
+    def test_empty_and_none_are_empty(self):
+        assert tokenize("") == []
+        assert tokenize(None) == []
+
+
+class TestIsTypoOf:
+    @pytest.mark.parametrize(
+        ("typed", "intended"),
+        [
+            ("error", "error"),  # identical
+            ("eror", "error"),  # deletion
+            ("moongoose", "mongoose"),  # insertion
+            ("typsecript", "typescript"),  # transposition
+            ("mongod", "mongodb"),  # trailing deletion
+        ],
+    )
+    def test_accepts_one_slip_of_the_same_word(self, typed, intended):
+        assert is_typo_of(typed, intended)
+
+    @pytest.mark.parametrize(
+        ("typed", "intended"),
+        [
+            ("mango", "mongo"),  # substitution — a different word at the same distance
+            ("k9s", "k8s"),  # substitution of a digit
+            ("postgres", "mongodb"),  # unrelated
+            ("eor", "error"),  # two deletions — beyond one slip
+        ],
+    )
+    def test_rejects_substitutions_and_larger_distances(self, typed, intended):
+        assert not is_typo_of(typed, intended)
+
+    @pytest.mark.parametrize("typed", ["erorr", "errro"])
+    def test_transposed_letters_are_still_the_same_word(self, typed):
+        """Both are `error` with one adjacent swap — a slip, not a different word."""
+        assert is_typo_of(typed, "error")
+
+    def test_substitution_and_typo_are_indistinguishable_by_distance(self):
+        """Why the rule is about the *kind* of edit, not a threshold.
+
+        'mango'->'mongo' and 'eror'->'error' are both one edit away from their target, so no
+        distance cutoff can accept the typo and reject the different word. Only excluding
+        substitutions separates them.
+        """
+        assert is_typo_of("eror", "error")
+        assert not is_typo_of("mango", "mongo")
+
+
+class TestMatchTags:
+    def test_matches_the_named_identity_only(self):
+        assert match_tags("what's my k8s deploy story?", VOCAB, prefix="name:") == ["name:k8s"]
+
+    def test_ignores_tags_outside_the_prefix(self):
+        """`other:kubernetes` is in the bank but not in the gated namespace."""
+        assert match_tags("kubernetes rollout", VOCAB, prefix="name:") == ["name:kubernetes"]
+
+    def test_matches_multi_word_names_as_a_contiguous_phrase(self):
+        assert match_tags("session backend design", VOCAB, prefix="name:") == ["name:session-backend"]
+
+    def test_does_not_match_a_phrase_split_across_the_query(self):
+        assert match_tags("the session is fine but the backend is not", VOCAB, prefix="name:") == []
+
+    def test_typos_are_matched_by_default(self):
+        assert match_tags("eror handling patterns", VOCAB, prefix="name:") == ["name:error-handling"]
+        assert match_tags("typsecript compilation", VOCAB, prefix="name:") == ["name:typescript"]
+
+    def test_exact_mode_rejects_typos(self):
+        assert match_tags("eror handling patterns", VOCAB, prefix="name:", match="exact") == []
+        assert match_tags("error handling patterns", VOCAB, prefix="name:", match="exact") == ["name:error-handling"]
+
+    def test_a_different_word_is_not_a_match(self):
+        """The prefix guards: neither of these names anything in the vocabulary."""
+        assert match_tags("mango connection pooling", VOCAB, prefix="name:") == []
+        assert match_tags("k9s pod scheduling", VOCAB, prefix="name:") == []
+
+    def test_short_tokens_must_match_exactly(self):
+        """`k8s` is three characters — fuzzy matching there would match almost anything."""
+        assert match_tags("k8s cluster", VOCAB, prefix="name:", min_token_length=4) == ["name:k8s"]
+        assert match_tags("k9s cluster", VOCAB, prefix="name:", min_token_length=4) == []
+
+    def test_naming_nothing_known_matches_nothing(self):
+        assert match_tags("what is the weather in Lisbon", VOCAB, prefix="name:") == []
+
+    def test_empty_query_matches_nothing(self):
+        assert match_tags("", VOCAB, prefix="name:") == []
+        assert match_tags("   ", VOCAB, prefix="name:") == []
+
+    def test_returns_every_named_identity(self):
+        matched = match_tags("kubernetes and typescript", VOCAB, prefix="name:")
+        assert set(matched) == {"name:kubernetes", "name:typescript"}
+
+
+class TestQueryTagGateModel:
+    def test_defaults_are_typo_tolerant_and_abstaining(self):
+        gate = QueryTagGate(prefix="name:")
+        assert gate.match == "typos"
+        assert gate.on_no_match == "abstain"
+        assert gate.min_token_length == 4
+
+    def test_prefix_is_required(self):
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            QueryTagGate()
+
+    @pytest.mark.parametrize(("field", "value"), [("min_token_length", 0), ("max_vocabulary", 0)])
+    def test_rejects_non_positive_limits(self, field, value):
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            QueryTagGate(prefix="name:", **{field: value})

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -11191,6 +11191,7 @@
               "value",
               "multi-values",
               "text",
+              "multi-text",
               "map"
             ],
             "title": "Type",
@@ -11247,6 +11248,7 @@
               "value",
               "multi-values",
               "text",
+              "multi-text",
               "map"
             ],
             "title": "Type",
@@ -11583,6 +11585,7 @@
             "type": "string",
             "enum": [
               "text",
+              "multi-text",
               "value",
               "multi-values",
               "map"
@@ -11622,6 +11625,7 @@
             "type": "string",
             "enum": [
               "text",
+              "multi-text",
               "value",
               "multi-values",
               "map"

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -13646,6 +13646,55 @@
           "total": 150
         }
       },
+      "QueryTagGate": {
+        "properties": {
+          "prefix": {
+            "type": "string",
+            "title": "Prefix",
+            "description": "Tag namespace holding the identities, e.g. 'name:'. Only tags starting with this are considered, and the prefix is stripped before matching, so `name:session-backend` is matched as 'session backend'."
+          },
+          "match": {
+            "type": "string",
+            "enum": [
+              "exact",
+              "typos"
+            ],
+            "title": "Match",
+            "description": "'exact' requires the query to name the tag verbatim (token-wise). 'typos' also accepts one insertion, deletion or transposition per token \u2014 but never a substitution, which at one edit reliably means a *different* word ('mango' is not 'mongo', 'k9s' is not 'k8s') where the other three mean a mistyped one ('eror' for 'error', 'typsecript' for 'typescript'). No distance threshold separates those cases; both sit at edit distance 1.",
+            "default": "typos"
+          },
+          "min_token_length": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Min Token Length",
+            "description": "Tokens shorter than this must match exactly. At three characters almost every identifier is one edit from another, so fuzzy matching there is noise.",
+            "default": 4
+          },
+          "on_no_match": {
+            "type": "string",
+            "enum": [
+              "abstain",
+              "ignore"
+            ],
+            "title": "On No Match",
+            "description": "What to do when the query names nothing in the vocabulary. 'abstain' returns no results \u2014 the honest answer when the caller is asking which known thing the query is about. 'ignore' drops the gate and recalls normally.",
+            "default": "abstain"
+          },
+          "max_vocabulary": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Max Vocabulary",
+            "description": "Cap on identity tags loaded for matching. A vocabulary larger than this is truncated rather than silently scanned in full.",
+            "default": 1000
+          }
+        },
+        "type": "object",
+        "required": [
+          "prefix"
+        ],
+        "title": "QueryTagGate",
+        "description": "Restrict recall to the tagged identities the query actually names.\n\nRanking cannot say *which* memory a query is about, and can never say \"none of\nthem\" \u2014 the top-scored memory is still the top-scored memory on a query the bank\nhas no answer for. A bank that tags memories with the names of what they describe\n(``customer:acme``, ``service:auth``) already holds what settles both questions:\nwhich of those names the query mentions.\n\nThe matched tags are AND-ed into the tag filter, so the restriction runs in SQL\nwith every other tag condition and unwanted memories never enter ranking."
+      },
       "RecallRequest": {
         "properties": {
           "query": {
@@ -13759,6 +13808,17 @@
             ],
             "title": "Tag Groups",
             "description": "Compound tag filter using boolean groups. Groups in the list are AND-ed. Each group is a leaf {tags, match} or compound {and: [...]}, {or: [...]}, {not: ...}."
+          },
+          "query_tag_gate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/QueryTagGate"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Restrict this recall to the tagged identities the query actually names, and optionally return nothing when it names none of them. For banks whose memories are tagged with what they are about (`customer:acme`, `service:auth`): ranking cannot say which of those a query means, and never says 'none', so a query about something the bank has no memory of still returns its best unrelated match. The matched tags are AND-ed into the tag filter and applied in SQL, so excluded memories never enter retrieval or ranking."
           },
           "min_scores": {
             "anyOf": [


### PR DESCRIPTION
## The gap

Recall ranks. Ranking answers "which memories are most related to this query", and there are two questions it structurally cannot answer:

- **Which memory is this query *about*?** Relatedness is not aboutness. A memory that merely mentions Redis ranks alongside the memory that *is* the Redis record.
- **None of them.** The top-scored memory is still the top-scored memory on a query the bank has no memory of, so recall returns its best unrelated match rather than admitting it has nothing.

For banks whose memories are tagged with what they describe — `customer:acme`, `service:auth`, `product:widget` — the information that settles both is already stored. It just isn't reachable at query time.

## What this adds

```json
"query_tag_gate": {"prefix": "customer:", "match": "typos", "on_no_match": "abstain"}
```

Recall resolves which identity tags under `prefix` the query names, AND-s them into the tag filter, and — with `on_no_match: "abstain"` — returns empty when the query names none.

The matched tags become an ordinary `tag_groups` leaf, so the restriction runs as a SQL `WHERE` alongside every other tag condition. Excluded memories never enter retrieval or reranking; this is not a post-filter over ranked results.

## Why not just use `tag_groups`?

`tag_groups` filters by tags the caller already names, and naming them is the hard part. A caller doing this today has to:

1. round-trip `list_tags` to learn the bank's vocabulary, and re-fetch it as memories change;
2. implement query-text → tag-name matching, with typo tolerance, in every client and inconsistently;
3. encode "the query names nothing" as a tag no memory carries, because a tag filter has no match-nothing primitive.

The gate needs the query and the bank's vocabulary in the same place. That place is the server.

## The matching rule

One insertion, deletion or transposition per token matches. A substitution never does.

That is not a tuned threshold. At edit distance 1 the two classes separate cleanly:

| | |
|---|---|
| same word, mistyped | `eror`→`error`, `typsecript`→`typescript`, `moongoose`→`mongoose`, `mongod`→`mongodb` |
| different word | `mango`≠`mongo`, `k9s`≠`k8s` |

Both sit at distance 1, so **no distance cutoff can separate them** — only the kind of edit can. There is a test asserting exactly that, so the reasoning survives future edits.

Tokens shorter than `min_token_length` (default 4) must match exactly; at three characters nearly every identifier is one edit from another. Multi-word names must appear as a contiguous phrase, so `session backend` is not matched by a query saying "session" in one clause and "backend" in another.

`match: "exact"` disables typo tolerance entirely.

## Notes for review

- Matching lives in a pure module (`engine/search/query_tag_gate.py`), so its decisions are asserted directly and do not depend on embeddings or on a reranker being present. 29 tests.
- The vocabulary is read through `list_tags`, so the gate sees exactly the tags recall would filter on, and is capped by `max_vocabulary` (default 1000) rather than scanning unbounded.
- Default is `on_no_match: "abstain"`. `"ignore"` drops the gate and recalls normally, for callers who want focus without abstention.
- Opt-in throughout: omitting `query_tag_gate` changes nothing.

## Testing

`ruff check`, `ruff format --check` and `ty check` clean. `tests/test_query_tag_gate.py` — 29 passed. Verified end to end against a locally built server: the gate resolves identities from a 109-tag vocabulary, and abstains on queries naming nothing in it.

Pre-commit hooks could not run in my worktree (no `node_modules`; `generate-docs-skill.sh` emits broken output there), so the commit used `--no-verify` and I ran the Python gates by hand. **Worth re-running the hooks in a full checkout before merge.**

---

## Second commit: `multi-text` entity labels

The gate is only as good as the identity tags a bank carries, and until now those had to be supplied by the caller. Entity labels could classify against a fixed vocabulary (`value`, `multi-values`) or hold one free string (`text`), but there was no way to extract *several* values that cannot be enumerated up front — which is exactly what "the names this thing goes by" is.

`multi-text` is `list[str]` with no `Literal` constraint. With `tag: true` the values land on the fact as tags like any other label group, so the extractor can derive identities from the content and the gate can then filter on them — no caller-supplied name map anywhere in the loop:

```json
{"key": "name", "type": "multi-text", "tag": true,
 "description": "Every name the subject of this fact is known by — canonical name plus abbreviations, acronyms, short forms and alternative spellings."}
```

Everything else is reused: same prompt section, same `key:value` flattening (it already iterated lists), same tag injection. `text` and `multi-text` share the open-vocabulary paths — no fixed lookup set, membership by key prefix. 89 entity-label tests pass, plus 5 new ones for the type.

Independently useful for any open multi-valued classification: ticket references a fact cites, product codes, component names.