### PR TITLE
fix(coding-agents): recover cursor after rejected retain

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { RateLimitedError, type HindsightClient } from "./hindsight";
+import { HttpResponseError, RateLimitedError, type HindsightClient } from "./hindsight";
 import { ingestChats, renderSessionJsonl, retainLiveSession, type TransportTurn } from "./chat";
 import { memoryCursorStore, type RetainCursorStore } from "./retain-cursor";
 
@@ -432,6 +432,36 @@ describe("retainLiveSession — incremental write-back", () => {
 
     await expect(write(client, turns(3), memoryCursorStore())).rejects.toThrow("500 boom");
     expect(retain).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores the acknowledged cursor after a definitive rejection", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    const initial = turns(2);
+    await write(client, initial, cursors);
+    const acknowledged = cursors.read("s1");
+    retain.mockRejectedValueOnce(new HttpResponseError(401, "unauthorized"));
+
+    await expect(write(client, turns(3), cursors)).rejects.toBeInstanceOf(HttpResponseError);
+
+    expect(cursors.read("s1")).toEqual(acknowledged);
+    retain.mockResolvedValueOnce(undefined);
+    await write(client, turns(4), cursors);
+    expect(retain.mock.calls.at(-1)?.[5].updateMode).toBe("append");
+    expect(retain.mock.calls.at(-1)?.[0]).toBe(
+      JSON.stringify(turns(4)[2]) + "\n" + JSON.stringify(turns(4)[3])
+    );
+  });
+
+  it("keeps the cursor dirty when the failure outcome is indeterminate", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    await write(client, turns(2), cursors);
+    retain.mockRejectedValueOnce(new HttpResponseError(500, "server error"));
+
+    await expect(write(client, turns(3), cursors)).rejects.toBeInstanceOf(HttpResponseError);
+
+    expect(cursors.read("s1")?.dirty).toBe(true);
   });
 
   it("keeps the write-back when the capability probe itself fails", async () => {

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -308,7 +308,8 @@ async function writeSession(
     // the rest of the session. Ambiguous client statuses, timeouts and server failures remain
     // dirty because their commit outcome is unknown.
     const definitivelyRejected =
-      error instanceof HttpResponseError && [400, 401, 403, 405, 413, 415, 422].includes(error.status);
+      error instanceof HttpResponseError &&
+      [400, 401, 403, 405, 413, 415, 422].includes(error.status);
     const current = cursors?.read(sessionId);
     const stillOurs =
       current?.turns === claimed.turns && current?.fingerprint === claimed.fingerprint;

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -3,7 +3,7 @@
  * backfill (ingest past sessions) and the live runtime write-back. A leading `system` turn carries
  * the REF-ID tracer; every turn gets an ABSOLUTE timestamp.
  */
-import { RateLimitedError, type HindsightClient } from "./hindsight";
+import { HttpResponseError, RateLimitedError, type HindsightClient } from "./hindsight";
 import { fingerprintTurns, planRetain, type RetainCursorStore } from "./retain-cursor";
 import type { RetainStamp } from "./retain-stamp";
 import type { ChatSession } from "./types";
@@ -240,7 +240,8 @@ async function writeSession(
 ): Promise<void> {
   const refId = `conversation:${sessionId}`;
   const appendSupported = Boolean(cursors) && (await supportsAppend(client));
-  const plan = planRetain(turns, cursors?.read(sessionId), { appendSupported, bank: client.bank });
+  const acknowledged = cursors?.read(sessionId);
+  const plan = planRetain(turns, acknowledged, { appendSupported, bank: client.bank });
   if (plan.mode === "skip") return;
 
   const content =
@@ -261,44 +262,59 @@ async function writeSession(
   cursors?.write(sessionId, { ...next, dirty: true });
 
   const claimed = { ...next, dirty: true };
-  await submitWithRetry(
-    () =>
-      client.retain(
-        content,
-        "coding agent session",
-        refId,
-        // Configured tags first, built-ins last and deduped: `source:chat` and `harness:<id>` are what
-        // the documents list filters and draws its agent logo from, so a template cannot displace them.
-        [
-          ...new Set([
-            ...(stamp?.tags ?? []),
-            "source:chat",
-            ...(harness ? [`harness:${harness}`] : []),
-          ]),
-        ],
-        "conversation",
-        {
-          timestamp: startTs,
-          updateMode: plan.mode === "append" ? "append" : undefined,
-          // Identity of THIS payload: a resubmission of the same bytes is collapsed server-side into
-          // the original operation instead of extracting (or appending) twice.
-          operationId: uuidV5(`${client.bank}\n${refId}\n${plan.mode}\n${content}`),
-          metadata: {
-            ...stamp?.metadata, // configured first: the built-ins below win on any key collision
-            source: "chat",
-            session_id: sessionId,
-            ref_id: refId,
-            ...(harness ? { harness } : {}),
-          },
-        }
-      ),
-    // Still ours to retry only while the cursor holds the claim we wrote above.
-    () => {
-      if (!cursors) return true;
-      const now = cursors.read(sessionId);
-      return now?.turns === claimed.turns && now?.fingerprint === claimed.fingerprint;
-    },
-    retryUntil
-  );
+  try {
+    await submitWithRetry(
+      () =>
+        client.retain(
+          content,
+          "coding agent session",
+          refId,
+          // Configured tags first, built-ins last and deduped: `source:chat` and `harness:<id>` are what
+          // the documents list filters and draws its agent logo from, so a template cannot displace them.
+          [
+            ...new Set([
+              ...(stamp?.tags ?? []),
+              "source:chat",
+              ...(harness ? [`harness:${harness}`] : []),
+            ]),
+          ],
+          "conversation",
+          {
+            timestamp: startTs,
+            updateMode: plan.mode === "append" ? "append" : undefined,
+            // Identity of THIS payload: a resubmission of the same bytes is collapsed server-side into
+            // the original operation instead of extracting (or appending) twice.
+            operationId: uuidV5(`${client.bank}\n${refId}\n${plan.mode}\n${content}`),
+            metadata: {
+              ...stamp?.metadata, // configured first: the built-ins below win on any key collision
+              source: "chat",
+              session_id: sessionId,
+              ref_id: refId,
+              ...(harness ? { harness } : {}),
+            },
+          }
+        ),
+      // Still ours to retry only while the cursor holds the claim we wrote above.
+      () => {
+        if (!cursors) return true;
+        const now = cursors.read(sessionId);
+        return now?.turns === claimed.turns && now?.fingerprint === claimed.fingerprint;
+      },
+      retryUntil
+    );
+  } catch (error) {
+    // These responses prove the API rejected the request before accepting it. Restore the last
+    // server-confirmed cursor so an auth/validation failure does not force full replacement for
+    // the rest of the session. Ambiguous client statuses, timeouts and server failures remain
+    // dirty because their commit outcome is unknown.
+    const definitivelyRejected =
+      error instanceof HttpResponseError && [400, 401, 403, 405, 413, 415, 422].includes(error.status);
+    const current = cursors?.read(sessionId);
+    const stillOurs =
+      current?.turns === claimed.turns && current?.fingerprint === claimed.fingerprint;
+    if (definitivelyRejected && acknowledged && cursors && stillOurs)
+      cursors.write(sessionId, acknowledged);
+    throw error;
+  }
   cursors?.write(sessionId, next);
 }

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -141,6 +141,17 @@ export class RateLimitedError extends Error {
   }
 }
 
+/** An HTTP response that the API rejected after any credential refresh was attempted. */
+export class HttpResponseError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = "HttpResponseError";
+  }
+}
+
 /** Parse a `Retry-After` header (delta-seconds or HTTP-date) into ms; 0 when absent or unusable. */
 export function retryAfterMs(header: string | null | undefined): number {
   if (!header) return 0;
@@ -284,7 +295,8 @@ export class HindsightClient {
     if (r.status === 429 && !tolerate.includes(429))
       throw new RateLimitedError(retryAfterMs(r.headers.get("retry-after")));
     if (!r.ok && r.status !== 404 && !tolerate.includes(r.status))
-      throw new Error(
+      throw new HttpResponseError(
+        r.status,
         `${method} ${url} -> ${r.status} ${await r.text()}${this.authHint(r.status)}`
       );
     return r;


### PR DESCRIPTION
## Problem

A rejected live-session retain leaves the cursor marked dirty. Every later Stop hook therefore replaces and re-extracts the full transcript, even when the server explicitly rejected the request and could not have committed it.

## Fix

- Preserve HTTP response status in a typed client error.
- Restore the last acknowledged cursor after a definitive authentication, validation, media-type, or payload rejection.
- Keep the cursor dirty for ambiguous statuses, timeouts, and server failures.
- Restore only while the dirty claim is still current, so a newer writer is not overwritten.

## Test

- `npm test` — 847 passed
- `npm run build`
- `git diff --check`

The regression verifies that a 401 restores the acknowledged cursor and the next write appends only the new tail. A 500 remains dirty and continues to force conservative replacement.

## Risk

Low and bounded to coding-agent live-session write-back. The rejection list is intentionally conservative; statuses with uncertain commit semantics retain the existing replace behavior.

Fixes #3989.
