### PR TITLE
fix(retain): enforce generated language integrity

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -36,6 +36,14 @@ from ...config import get_config
 from ...worker.stage import set_stage
 from ..db import DatabaseBackend
 from ..db_utils import acquire_with_retry
+from ..language_validation import (
+    GeneratedLanguageMismatch,
+    LanguageValidationOutcome,
+    build_language_retry_instruction,
+    record_language_validation,
+    should_validate_language,
+    validate_output_language,
+)
 from ..llm_interface import OutputTooLongError, ProviderRateLimitResetError
 from ..llm_trace import (
     record_created_memory_ids,
@@ -3059,7 +3067,7 @@ def _classify_batch_failure(exc: Exception) -> _BatchFailureClass:
     # front (openai, anthropic) exposes the HTTP status this way.
     if getattr(exc, "status_code", None) in (401, 403):
         return _BatchFailureClass.PROPAGATE
-    if isinstance(exc, json.JSONDecodeError | ValidationError | OutputTooLongError):
+    if isinstance(exc, json.JSONDecodeError | ValidationError | OutputTooLongError | GeneratedLanguageMismatch):
         return _BatchFailureClass.FAIL_FAST
     # Providers that surface an empty/unusable body flag their own retryability.
     if getattr(exc, "retryable", None) is False:
@@ -3162,18 +3170,23 @@ async def _consolidate_batch_with_llm(
     # "LLM batch call failed" line gives operators no way to find the offending
     # input until adaptive bisection narrows the batch down to a single memory.
     memory_ids = [str(m.get("id")) for m in memories]
+    source_text_by_id = {str(m.get("id")): str(m.get("text") or "") for m in memories}
     if len(memory_ids) <= 5:
         ids_label = ", ".join(memory_ids)
     else:
         ids_label = f"{', '.join(memory_ids[:3])}, ... +{len(memory_ids) - 3} more"
     batch_label = f"{len(memory_ids)} memories [{ids_label}]"
-    for attempt in range(1, max_attempts + 1):
+    language_retry_used = False
+    language_retry_instruction = ""
+    # The extra slot is reachable only after a language mismatch. Ordinary
+    # transport failures retain the configured max_attempts budget below.
+    for attempt in range(1, max_attempts + 2):
         attempts_made = attempt
         try:
             call_kwargs: dict[str, Any] = {
                 "messages": [
                     {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_content},
+                    {"role": "user", "content": user_content + language_retry_instruction},
                 ],
                 "response_format": response_model,
                 "temperature": config.llm_temperature_consolidation,
@@ -3205,6 +3218,61 @@ async def _consolidate_batch_with_llm(
                     )
                     creates = creates[:remaining_observation_slots]
             updates = _dedupe_updates(response.updates, batch_label=batch_label)
+            validations = []
+            mismatches = []
+            validation_enabled = should_validate_language(llm_config)
+            actions_to_validate = (("create", creates), ("update", updates)) if validation_enabled else ()
+            for action_kind, actions in actions_to_validate:
+                for action in actions:
+                    source_text = "\n".join(
+                        source_text_by_id[source_id]
+                        for source_id in action.source_fact_ids
+                        if source_text_by_id.get(source_id)
+                    )
+                    if not source_text:
+                        continue
+                    validation = validate_output_language(
+                        source_text=source_text,
+                        output_text=action.text,
+                        output_language=getattr(config, "llm_output_language", None),
+                    )
+                    validations.append(validation)
+                    if validation.outcome is LanguageValidationOutcome.MISMATCH:
+                        mismatches.append((action_kind, action.source_fact_ids, validation))
+            if mismatches:
+                expected = sorted({code for _, _, result in mismatches for code in result.expected_languages})
+                actual = sorted({result.output_language or "unknown" for _, _, result in mismatches})
+                if not language_retry_used:
+                    record_language_validation("consolidation", "mismatch_retry", llm_config)
+                    language_retry_used = True
+                    language_retry_instruction = build_language_retry_instruction(
+                        output_language=getattr(config, "llm_output_language", None),
+                        expected_languages=expected,
+                        actual_languages=actual,
+                        per_source=True,
+                    )
+                    logger.warning(
+                        "generated_language_mismatch stage=consolidation expected=%s actual=%s retry=1 actions=%s",
+                        ",".join(expected),
+                        ",".join(actual),
+                        len(mismatches),
+                    )
+                    continue
+                record_language_validation("consolidation", "mismatch_terminal", llm_config)
+                raise GeneratedLanguageMismatch(
+                    "generated_language_mismatch: consolidation output remained incompatible after corrective retry "
+                    f"(expected={','.join(expected)}, actual={','.join(actual)})"
+                )
+            if validation_enabled and validations:
+                if language_retry_used:
+                    validation_outcome = "retry_recovered"
+                elif any(
+                    result.outcome is LanguageValidationOutcome.MATCH for result in validations
+                ):
+                    validation_outcome = LanguageValidationOutcome.MATCH.value
+                else:
+                    validation_outcome = LanguageValidationOutcome.INDETERMINATE.value
+                record_language_validation("consolidation", validation_outcome, llm_config)
             return _BatchLLMResult(
                 creates=creates,
                 updates=updates,
@@ -3232,11 +3300,13 @@ async def _consolidate_batch_with_llm(
             logger.warning(
                 f"[CONSOLIDATION] LLM batch call failed (attempt {attempt}/{max_attempts}) for {batch_label}: {exc}"
             )
+            permitted_attempts = max_attempts + int(language_retry_used)
+            if attempt >= permitted_attempts:
+                break
             # Backoff on the outer ladder too. Without it a rate limit or a transient
             # overload was re-sent immediately, three times, defeating the point of the
             # provider's own backoff. Skipped after the final attempt — nothing follows it.
-            if attempt < max_attempts:
-                await asyncio.sleep(min(_OUTER_RETRY_INITIAL_BACKOFF * (2 ** (attempt - 1)), _OUTER_RETRY_MAX_BACKOFF))
+            await asyncio.sleep(min(_OUTER_RETRY_INITIAL_BACKOFF * (2 ** (attempt - 1)), _OUTER_RETRY_MAX_BACKOFF))
 
     logger.error(
         f"[CONSOLIDATION] LLM batch call failed after {attempts_made}/{max_attempts} attempt(s) for "

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -3266,9 +3266,7 @@ async def _consolidate_batch_with_llm(
             if validation_enabled and validations:
                 if language_retry_used:
                     validation_outcome = "retry_recovered"
-                elif any(
-                    result.outcome is LanguageValidationOutcome.MATCH for result in validations
-                ):
+                elif any(result.outcome is LanguageValidationOutcome.MATCH for result in validations):
                     validation_outcome = LanguageValidationOutcome.MATCH.value
                 else:
                     validation_outcome = LanguageValidationOutcome.INDETERMINATE.value

--- a/hindsight-api-slim/hindsight_api/engine/language_validation.py
+++ b/hindsight-api-slim/hindsight_api/engine/language_validation.py
@@ -1,0 +1,310 @@
+"""Conservative source/output language compatibility checks.
+
+The LLM remains responsible for generating text. This module only rejects a
+response when both sides are long enough and the detector is confident that the
+generated language is unsupported by its source. Ambiguous, technical, short,
+and language-neutral text stays indeterminate rather than becoming a false
+failure.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from langdetect import DetectorFactory, LangDetectException, detect_langs
+
+_MIN_ANALYZABLE_CHARS = 48
+_MIN_CONFIDENCE = 0.92
+_MIN_MARGIN = 0.20
+_MIN_MIXED_SHARE = 0.20
+
+_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+_URL_RE = re.compile(r"(?:https?://|www\.)\S+", re.IGNORECASE)
+_UUID_RE = re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b", re.IGNORECASE)
+_IDENTIFIER_RE = re.compile(r"\b(?=\w*[A-Z_0-9])(?=\w*[_0-9])[A-Za-z_][A-Za-z0-9_.:/-]{5,}\b")
+_SEGMENT_RE = re.compile(r"(?:\n\s*\n|(?<=[.!?。！？])\s+)")
+_JAPANESE_RE = re.compile(r"[\u3040-\u30ff]")
+_KOREAN_RE = re.compile(r"[\uac00-\ud7af]")
+_WORD_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
+_ENGLISH_MARKERS = frozenset(
+    {
+        "and",
+        "are",
+        "by",
+        "for",
+        "from",
+        "is",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "this",
+        "to",
+        "was",
+        "were",
+        "with",
+    }
+)
+
+# langdetect otherwise samples features randomly. A fixed seed makes the guard
+# repeatable across workers and test runs.
+DetectorFactory.seed = 0
+
+_LANGUAGE_NAMES = {
+    "arabic": "ar",
+    "bulgarian": "bg",
+    "catalan": "ca",
+    "chinese": "zh-cn",
+    "croatian": "hr",
+    "czech": "cs",
+    "danish": "da",
+    "dutch": "nl",
+    "english": "en",
+    "estonian": "et",
+    "finnish": "fi",
+    "french": "fr",
+    "german": "de",
+    "greek": "el",
+    "hebrew": "he",
+    "hindi": "hi",
+    "hungarian": "hu",
+    "indonesian": "id",
+    "italian": "it",
+    "japanese": "ja",
+    "korean": "ko",
+    "latvian": "lv",
+    "lithuanian": "lt",
+    "norwegian": "no",
+    "persian": "fa",
+    "polish": "pl",
+    "portuguese": "pt",
+    "romanian": "ro",
+    "russian": "ru",
+    "slovak": "sk",
+    "slovenian": "sl",
+    "spanish": "es",
+    "swahili": "sw",
+    "swedish": "sv",
+    "thai": "th",
+    "turkish": "tr",
+    "ukrainian": "uk",
+    "urdu": "ur",
+    "vietnamese": "vi",
+}
+_SUPPORTED_LANGUAGE_CODES = frozenset({*_LANGUAGE_NAMES.values(), "zh"})
+
+
+class LanguageValidationOutcome(str, Enum):
+    MATCH = "match"
+    MISMATCH = "mismatch"
+    INDETERMINATE = "indeterminate"
+
+
+class GeneratedLanguageMismatch(RuntimeError):
+    """A model response confidently changed language after one correction."""
+
+    retryable = False
+
+
+@dataclass(frozen=True)
+class LanguageProfile:
+    primary: str | None
+    allowed: frozenset[str]
+    confidence: float
+    margin: float
+    analyzable_chars: int
+    mixed: bool
+
+
+@dataclass(frozen=True)
+class LanguageValidationResult:
+    outcome: LanguageValidationOutcome
+    expected_languages: frozenset[str]
+    output_language: str | None
+    source_profile: LanguageProfile
+    output_profile: LanguageProfile
+
+
+def _normalize_code(code: str) -> str:
+    return "zh" if code in {"zh-cn", "zh-tw"} else code
+
+
+def _clean(text: str) -> str:
+    text = _CODE_BLOCK_RE.sub(" ", text)
+    text = _INLINE_CODE_RE.sub(" ", text)
+    text = _URL_RE.sub(" ", text)
+    text = _UUID_RE.sub(" ", text)
+    text = _IDENTIFIER_RE.sub(" ", text)
+    return " ".join(text.split())
+
+
+def _analyzable_chars(text: str) -> int:
+    return sum(char.isalpha() for char in text)
+
+
+def _classify(text: str) -> tuple[str | None, float, float]:
+    words = [word.casefold() for word in _WORD_RE.findall(text)]
+    english_markers = [word for word in words if word in _ENGLISH_MARKERS]
+    if len(english_markers) >= 3 and len(set(english_markers)) >= 3:
+        return "en", 1.0, 1.0
+    try:
+        values = detect_langs(text)
+    except LangDetectException:
+        return None, 0.0, 0.0
+    if not values:
+        return None, 0.0, 0.0
+    top = values[0]
+    runner_up = values[1].prob if len(values) > 1 else 0.0
+    return _normalize_code(top.lang), float(top.prob), float(top.prob - runner_up)
+
+
+def _confident(code: str | None, confidence: float, margin: float, chars: int) -> bool:
+    return bool(
+        code
+        and chars >= _MIN_ANALYZABLE_CHARS
+        and confidence >= _MIN_CONFIDENCE
+        and margin >= _MIN_MARGIN
+    )
+
+
+def profile_language(text: str) -> LanguageProfile:
+    cleaned = _clean(text)
+    chars = _analyzable_chars(cleaned)
+    # Kana and Hangul are language-specific enough to classify short OCR safely;
+    # Latin-script prose needs the normal conservative length/confidence gates.
+    for script, code in ((_JAPANESE_RE, "ja"), (_KOREAN_RE, "ko")):
+        if len(script.findall(cleaned)) >= 4:
+            return LanguageProfile(code, frozenset({code}), 1.0, 1.0, chars, False)
+    if chars < _MIN_ANALYZABLE_CHARS:
+        return LanguageProfile(None, frozenset(), 0.0, 0.0, chars, False)
+    words = [word.casefold() for word in _WORD_RE.findall(cleaned)]
+    if len(words) >= 20 and len(set(words)) / len(words) < 0.20:
+        return LanguageProfile(None, frozenset(), 0.0, 0.0, chars, False)
+
+    primary, confidence, margin = _classify(cleaned)
+
+    segments = [_clean(segment) for segment in _SEGMENT_RE.split(text)]
+    eligible_segments = [(segment, _analyzable_chars(segment)) for segment in segments]
+    eligible_segments = [(segment, count) for segment, count in eligible_segments if count >= _MIN_ANALYZABLE_CHARS]
+    if len(eligible_segments) > 1:
+        weighted: dict[str, int] = {}
+        segment_scores: list[tuple[float, float]] = []
+        for segment, count in eligible_segments:
+            code, segment_confidence, segment_margin = _classify(segment)
+            if _confident(code, segment_confidence, segment_margin, count):
+                assert code is not None
+                weighted[code] = weighted.get(code, 0) + count
+                segment_scores.append((segment_confidence, segment_margin))
+        if weighted:
+            classified_chars = sum(weighted.values())
+            allowed = frozenset(
+                code for code, count in weighted.items() if count / classified_chars >= _MIN_MIXED_SHARE
+            )
+            primary = max(weighted, key=lambda code: weighted[code])
+            confidence = min(score[0] for score in segment_scores)
+            margin = min(score[1] for score in segment_scores)
+            return LanguageProfile(primary, allowed, confidence, margin, chars, len(allowed) > 1)
+
+    if not _confident(primary, confidence, margin, chars):
+        return LanguageProfile(None, frozenset(), confidence, margin, chars, False)
+    assert primary is not None
+    return LanguageProfile(primary, frozenset({primary}), confidence, margin, chars, False)
+
+
+def _configured_language_code(output_language: str) -> str | None:
+    normalized = output_language.strip().casefold().replace("-", "_").replace(" ", "_")
+    parts = normalized.split("_")
+    # langdetect reports base ISO-639-1 codes, not locale tags. Resolve the
+    # base first so `en-US` and `pt-BR` compare as `en` and `pt`.
+    candidates = (parts[0], normalized, parts[-1])
+    for candidate in candidates:
+        code = _LANGUAGE_NAMES.get(candidate, candidate if candidate in _SUPPORTED_LANGUAGE_CODES else None)
+        if code:
+            return _normalize_code(code.replace("_", "-"))
+    return None
+
+
+def build_language_retry_instruction(
+    *,
+    output_language: str | None,
+    expected_languages: list[str] | tuple[str, ...],
+    actual_languages: list[str] | tuple[str, ...],
+    per_source: bool = False,
+) -> str:
+    """Build a correction that cannot contradict an explicit output language."""
+    expected = ",".join(expected_languages)
+    actual = ",".join(actual_languages)
+    prefix = (
+        "\n\nCORRECTION: Your previous response was rejected because its generated "
+        f"language ({actual}) did not match the required language ({expected}). "
+    )
+    if output_language:
+        return (
+            prefix
+            + f"Regenerate the entire structured response in the configured output language: {output_language}. "
+            "Translate source prose when required by that setting, while preserving proper nouns, identifiers, "
+            "commands, paths, and quotations exactly."
+        )
+    per_source_note = " Preserve the language associated with each source_fact_ids set." if per_source else ""
+    return (
+        prefix
+        + "Regenerate the entire structured response in the source language. Do not translate the source."
+        + per_source_note
+        + " Preserve proper nouns, identifiers, commands, paths, and quotations exactly."
+    )
+
+
+def validate_output_language(
+    *,
+    source_text: str,
+    output_text: str,
+    output_language: str | None = None,
+) -> LanguageValidationResult:
+    source = profile_language(source_text)
+    output = profile_language(output_text)
+
+    if output_language:
+        configured = _configured_language_code(output_language)
+        expected = frozenset({configured}) if configured else frozenset()
+    else:
+        expected = source.allowed
+
+    if not expected or output.primary is None:
+        outcome = LanguageValidationOutcome.INDETERMINATE
+    elif not output.allowed.issubset(expected):
+        outcome = LanguageValidationOutcome.MISMATCH
+    else:
+        outcome = LanguageValidationOutcome.MATCH
+
+    return LanguageValidationResult(
+        outcome=outcome,
+        expected_languages=expected,
+        output_language=output.primary,
+        source_profile=source,
+        output_profile=output,
+    )
+
+
+def record_language_validation(stage: str, outcome: str, llm_config) -> None:
+    """Emit bounded, text-free validation telemetry without affecting work."""
+    try:
+        from ..metrics import get_metrics_collector
+
+        get_metrics_collector().record_language_validation(
+            stage=stage,
+            outcome=outcome,
+            provider=str(getattr(llm_config, "provider", "unknown")),
+            model=str(getattr(llm_config, "model", "unknown")),
+        )
+    except Exception:
+        # Metrics must never turn an indeterminate check into an ingestion failure.
+        pass
+
+
+def should_validate_language(llm_config) -> bool:
+    """The deterministic test provider does not generate source-faithful prose."""
+    return str(getattr(llm_config, "provider", "")).casefold() != "mock"

--- a/hindsight-api-slim/hindsight_api/engine/language_validation.py
+++ b/hindsight-api-slim/hindsight_api/engine/language_validation.py
@@ -163,12 +163,7 @@ def _classify(text: str) -> tuple[str | None, float, float]:
 
 
 def _confident(code: str | None, confidence: float, margin: float, chars: int) -> bool:
-    return bool(
-        code
-        and chars >= _MIN_ANALYZABLE_CHARS
-        and confidence >= _MIN_CONFIDENCE
-        and margin >= _MIN_MARGIN
-    )
+    return bool(code and chars >= _MIN_ANALYZABLE_CHARS and confidence >= _MIN_CONFIDENCE and margin >= _MIN_MARGIN)
 
 
 def profile_language(text: str) -> LanguageProfile:
@@ -244,8 +239,7 @@ def build_language_retry_instruction(
     )
     if output_language:
         return (
-            prefix
-            + f"Regenerate the entire structured response in the configured output language: {output_language}. "
+            prefix + f"Regenerate the entire structured response in the configured output language: {output_language}. "
             "Translate source prose when required by that setting, while preserving proper nouns, identifiers, "
             "commands, paths, and quotations exactly."
         )

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -63,6 +63,7 @@ from .db.ops_postgresql import pg_search_vector_expr
 from .db.postgresql import PostgreSQLBackend
 from .db.postgresql import apply_session_settings as _apply_session_settings
 from .db_budget import budgeted_operation
+from .language_validation import GeneratedLanguageMismatch
 from .llm_interface import ProviderContentPolicyError, ProviderRateLimitResetError
 from .llm_trace import (
     LLMRequestEntry,
@@ -1265,6 +1266,9 @@ def _is_non_retryable_task_error(e: Exception) -> bool:
         # the moment: re-running the task feeds the same chunk to the same model
         # and earns the same refusal (issue #3690).
         or isinstance(e, ProviderContentPolicyError)
+        # A corrected response that still changes language is deterministic for
+        # this source/model pair. Worker retries would resend the same content.
+        or isinstance(e, GeneratedLanguageMismatch)
     )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -15,6 +15,14 @@ from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator
 
+from ..language_validation import (
+    GeneratedLanguageMismatch,
+    LanguageValidationOutcome,
+    build_language_retry_instruction,
+    record_language_validation,
+    should_validate_language,
+    validate_output_language,
+)
 from ..llm_interface import ProviderContentPolicyError, ProviderRateLimitResetError
 from ..llm_wrapper import LLMConfig, OutputTooLongError, parse_llm_json, sanitize_llm_output, sanitize_llm_value
 from ..operation_metadata import RetainExtractionErrors
@@ -1561,6 +1569,9 @@ async def _extract_facts_from_chunk(
     config,
     agent_name: str | None = None,
     metadata: dict[str, str] | None = None,
+    language_retry_already_used: bool = False,
+    initial_language_correction: str = "",
+    language_validation_stage: str = "retain",
 ) -> tuple[list[dict[str, str]], TokenUsage]:
     """
     Extract facts from a single chunk (internal helper for parallel processing).
@@ -1624,10 +1635,15 @@ async def _extract_facts_from_chunk(
     # the initial request — so a zero budget still performs one request (#2731). The raw
     # budget is forwarded unchanged to llm_config.call(), which owns transport retries.
     outer_attempts = llm_max_retries + 1
+    # One additional attempt is reserved exclusively for a confident language
+    # mismatch. It is independent of malformed-output and transport retry budgets.
+    max_loop_attempts = outer_attempts + 1
+    language_retry_used = language_retry_already_used
+    language_retry_instruction = initial_language_correction
     last_error: Exception | None = None
 
     usage = TokenUsage()  # Track cumulative usage across retries
-    for attempt in range(outer_attempts):
+    for attempt in range(max_loop_attempts):
         try:
             initial_backoff = (
                 config.retain_llm_initial_backoff
@@ -1639,7 +1655,10 @@ async def _extract_facts_from_chunk(
             )
 
             call_kwargs: dict[str, Any] = dict(
-                messages=[{"role": "system", "content": prompt}, {"role": "user", "content": user_message}],
+                messages=[
+                    {"role": "system", "content": prompt},
+                    {"role": "user", "content": user_message + language_retry_instruction},
+                ],
                 response_format=response_schema,
                 scope="retain_extract_facts",
                 temperature=config.llm_temperature_retain,
@@ -1916,6 +1935,57 @@ async def _extract_facts_from_chunk(
                     f"Model '{llm_config.model}' may not honour the extraction schema — consider enabling "
                     f"HINDSIGHT_API_LLM_STRICT_SCHEMA_RETAIN or using a model with strict schema support."
                 )
+
+            if extraction_mode != "verbatim" and chunk_facts and should_validate_language(llm_config):
+                language_results = [
+                    validate_output_language(
+                        source_text=chunk,
+                        output_text=fact.fact,
+                        output_language=config.llm_output_language,
+                    )
+                    for fact in chunk_facts
+                    if fact.fact
+                ]
+                language_result = next(
+                    (
+                        result
+                        for result in language_results
+                        if result.outcome is LanguageValidationOutcome.MISMATCH
+                    ),
+                    None,
+                )
+                if language_result is not None:
+                    expected = ",".join(sorted(language_result.expected_languages))
+                    actual = language_result.output_language or "unknown"
+                    if not language_retry_used:
+                        record_language_validation(language_validation_stage, "mismatch_retry", llm_config)
+                        language_retry_used = True
+                        language_retry_instruction = build_language_retry_instruction(
+                            output_language=config.llm_output_language,
+                            expected_languages=[expected],
+                            actual_languages=[actual],
+                        )
+                        logger.warning(
+                            "generated_language_mismatch stage=retain expected=%s actual=%s retry=1",
+                            expected,
+                            actual,
+                        )
+                        continue
+                    record_language_validation(language_validation_stage, "mismatch_terminal", llm_config)
+                    raise GeneratedLanguageMismatch(
+                        "generated_language_mismatch: retain output remained incompatible after corrective retry "
+                        f"(expected={expected}, actual={actual})"
+                    )
+
+                if language_retry_used:
+                    validation_outcome = "retry_recovered"
+                elif any(
+                    result.outcome is LanguageValidationOutcome.MATCH for result in language_results
+                ):
+                    validation_outcome = LanguageValidationOutcome.MATCH.value
+                else:
+                    validation_outcome = LanguageValidationOutcome.INDETERMINATE.value
+                record_language_validation(language_validation_stage, validation_outcome, llm_config)
 
             return chunk_facts, usage
 
@@ -2724,6 +2794,78 @@ async def extract_facts_from_contents_batch_api(
                 logger.error(message)
                 extraction_errors.add(message)
                 continue
+
+        if chunk_facts and should_validate_language(llm_config):
+            language_results = [
+                validate_output_language(
+                    source_text=chunk_content,
+                    output_text=fact.fact,
+                    output_language=config.llm_output_language,
+                )
+                for fact in chunk_facts
+                if fact.fact
+            ]
+            language_result = next(
+                (
+                    result
+                    for result in language_results
+                    if result.outcome is LanguageValidationOutcome.MISMATCH
+                ),
+                None,
+            )
+            if language_result is not None:
+                expected = ",".join(sorted(language_result.expected_languages))
+                actual = language_result.output_language or "unknown"
+                correction = build_language_retry_instruction(
+                    output_language=config.llm_output_language,
+                    expected_languages=[expected],
+                    actual_languages=[actual],
+                )
+                logger.warning(
+                    "generated_language_mismatch stage=retain_batch expected=%s actual=%s retry=1",
+                    expected,
+                    actual,
+                )
+                record_language_validation("retain_batch", "mismatch_retry", llm_config)
+                try:
+                    content = contents[content_index]
+                    total_content_chunks = sum(
+                        1 for info in all_chunks_info if info[1] == content_index
+                    )
+                    chunk_facts, retry_usage = await _extract_facts_from_chunk(
+                        chunk=chunk_content,
+                        chunk_index=chunk_index_in_content,
+                        total_chunks=total_content_chunks,
+                        event_date=event_date,
+                        context=context,
+                        llm_config=llm_config,
+                        config=config,
+                        metadata=content.metadata or None,
+                        language_retry_already_used=True,
+                        initial_language_correction=correction,
+                        language_validation_stage="retain_batch",
+                    )
+                    total_usage = total_usage + retry_usage
+                except GeneratedLanguageMismatch as e:
+                    message = f"{custom_id}: {e}"
+                    logger.error(message)
+                    extraction_errors.add(message)
+                    chunk_facts = []
+                except Exception as e:
+                    message = f"{custom_id}: corrective language retry failed: {e}"
+                    logger.error(message)
+                    extraction_errors.add(message)
+                    chunk_facts = []
+            else:
+                validation_outcome = (
+                    LanguageValidationOutcome.MATCH.value
+                    if any(
+                        result.outcome is LanguageValidationOutcome.MATCH
+                        for result in language_results
+                    )
+                    else LanguageValidationOutcome.INDETERMINATE.value
+                )
+                record_language_validation("retain_batch", validation_outcome, llm_config)
 
         all_facts_from_llm.extend(chunk_facts)
         chunks_metadata.append(

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1947,11 +1947,7 @@ async def _extract_facts_from_chunk(
                     if fact.fact
                 ]
                 language_result = next(
-                    (
-                        result
-                        for result in language_results
-                        if result.outcome is LanguageValidationOutcome.MISMATCH
-                    ),
+                    (result for result in language_results if result.outcome is LanguageValidationOutcome.MISMATCH),
                     None,
                 )
                 if language_result is not None:
@@ -1979,9 +1975,7 @@ async def _extract_facts_from_chunk(
 
                 if language_retry_used:
                     validation_outcome = "retry_recovered"
-                elif any(
-                    result.outcome is LanguageValidationOutcome.MATCH for result in language_results
-                ):
+                elif any(result.outcome is LanguageValidationOutcome.MATCH for result in language_results):
                     validation_outcome = LanguageValidationOutcome.MATCH.value
                 else:
                     validation_outcome = LanguageValidationOutcome.INDETERMINATE.value
@@ -2806,11 +2800,7 @@ async def extract_facts_from_contents_batch_api(
                 if fact.fact
             ]
             language_result = next(
-                (
-                    result
-                    for result in language_results
-                    if result.outcome is LanguageValidationOutcome.MISMATCH
-                ),
+                (result for result in language_results if result.outcome is LanguageValidationOutcome.MISMATCH),
                 None,
             )
             if language_result is not None:
@@ -2829,9 +2819,7 @@ async def extract_facts_from_contents_batch_api(
                 record_language_validation("retain_batch", "mismatch_retry", llm_config)
                 try:
                     content = contents[content_index]
-                    total_content_chunks = sum(
-                        1 for info in all_chunks_info if info[1] == content_index
-                    )
+                    total_content_chunks = sum(1 for info in all_chunks_info if info[1] == content_index)
                     chunk_facts, retry_usage = await _extract_facts_from_chunk(
                         chunk=chunk_content,
                         chunk_index=chunk_index_in_content,
@@ -2859,10 +2847,7 @@ async def extract_facts_from_contents_batch_api(
             else:
                 validation_outcome = (
                     LanguageValidationOutcome.MATCH.value
-                    if any(
-                        result.outcome is LanguageValidationOutcome.MATCH
-                        for result in language_results
-                    )
+                    if any(result.outcome is LanguageValidationOutcome.MATCH for result in language_results)
                     else LanguageValidationOutcome.INDETERMINATE.value
                 )
                 record_language_validation("retain_batch", validation_outcome, llm_config)

--- a/hindsight-api-slim/hindsight_api/metrics.py
+++ b/hindsight-api-slim/hindsight_api/metrics.py
@@ -296,6 +296,10 @@ class MetricsCollectorBase:
         """Record the fact-extraction outcome of one document processed by retain."""
         raise NotImplementedError
 
+    def record_language_validation(self, stage: str, outcome: str, provider: str, model: str):
+        """Record one generated/source language-integrity decision."""
+        raise NotImplementedError
+
     def record_db_acquire_wait(self, wait_seconds: float):
         """Record how long a caller waited to acquire a pooled DB connection."""
         raise NotImplementedError
@@ -375,6 +379,9 @@ class NoOpMetricsCollector(MetricsCollectorBase):
 
     def record_retain_document(self, bank_id: str, memory_unit_count: int):
         """No-op retain document outcome recording."""
+        pass
+
+    def record_language_validation(self, stage: str, outcome: str, provider: str, model: str):
         pass
 
     def record_db_acquire_wait(self, wait_seconds: float):
@@ -470,6 +477,11 @@ class MetricsCollector(MetricsCollectorBase):
             name="hindsight.retain.documents.total",
             description="Documents processed by retain, labelled by extraction outcome (facts/no_facts)",
             unit="documents",
+        )
+        self.language_validation_total = self.meter.create_counter(
+            name="hindsight.language_validation.total",
+            description="Generated/source language integrity checks by stage and outcome",
+            unit="checks",
         )
 
         # HTTP request metrics
@@ -675,6 +687,18 @@ class MetricsCollector(MetricsCollectorBase):
             attributes["bank_id"] = bank_id
 
         self.retain_documents_total.add(1, attributes)
+
+    def record_language_validation(self, stage: str, outcome: str, provider: str, model: str):
+        self.language_validation_total.add(
+            1,
+            {
+                "stage": stage,
+                "outcome": outcome,
+                "provider": provider,
+                "model": model,
+                "tenant": _get_tenant(),
+            },
+        )
 
     def record_llm_call(
         self,

--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -99,6 +99,7 @@ dependencies = [
     "boto3>=1.42.74",
     "croniter>=2.0.0", # Cron parsing for scheduled mental model refresh
     "json-repair>=0.63.2", # Structural repair of malformed LLM JSON (last-resort parse fallback); >=0.60.1 also fixes the circular-$ref unbounded-CPU DoS
+    "langdetect>=1.0.9,<2", # Deterministic source/output language-integrity guard
     "numpy>=1.26.0", # Core vector/array math for pgvector, embeddings, and link graph operations
 ]
 

--- a/hindsight-api-slim/tests/test_batch_api.py
+++ b/hindsight-api-slim/tests/test_batch_api.py
@@ -17,7 +17,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from hindsight_api.config import HindsightConfig
+from hindsight_api.engine.response_models import TokenUsage
 from hindsight_api.engine.retain.fact_extraction import (
+    Fact,
     RetainContent,
     extract_facts_from_contents,
     extract_facts_from_contents_batch_api,
@@ -216,6 +218,84 @@ async def test_batch_api_normal_flow(mock_llm_config, test_contents, hindsight_c
             await memory.delete_bank(bank_id, request_context=request_context)
         except Exception:
             pass
+
+
+@pytest.mark.asyncio
+async def test_batch_api_retries_only_a_mismatching_chunk_synchronously(
+    mock_llm_config, test_contents, hindsight_config
+):
+    """A bad completed batch item gets one corrective call, not a whole new batch."""
+    batch_id = "batch_language_mismatch"
+    mock_llm_config._provider_impl.supports_batch_api = AsyncMock(return_value=True)
+    mock_llm_config._provider_impl.submit_batch = AsyncMock(
+        return_value={
+            "batch_id": batch_id,
+            "status": "validating",
+            "request_counts": {"total": 1, "completed": 0, "failed": 0},
+        }
+    )
+    mock_llm_config._provider_impl.get_batch_status = AsyncMock(
+        return_value={"status": "completed", "request_counts": {"total": 1, "completed": 1, "failed": 0}}
+    )
+    spanish = (
+        "Alicia es una ingeniera principal de software en TechCorp y se especializa "
+        "en sistemas distribuidos para servicios empresariales críticos."
+    )
+    mock_llm_config._provider_impl.retrieve_batch_results = AsyncMock(
+        return_value=[
+            {
+                "custom_id": "chunk_0",
+                "response": {
+                    "body": {
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": json.dumps(
+                                        {
+                                            "facts": [
+                                                {
+                                                    "what": spanish,
+                                                    "fact_type": "world",
+                                                    "fact_kind": "conversation",
+                                                }
+                                            ]
+                                        }
+                                    )
+                                }
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+                    }
+                },
+            }
+        ]
+    )
+    corrected = Fact(
+        fact="Alice is a senior software engineer at TechCorp specializing in distributed systems.",
+        fact_type="world",
+        where=None,
+    )
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._extract_facts_from_chunk",
+        new=AsyncMock(return_value=([corrected], TokenUsage(input_tokens=20, output_tokens=10, total_tokens=30))),
+    ) as retry:
+        facts, chunks, usage = await extract_facts_from_contents_batch_api(
+            contents=[test_contents[0]],
+            llm_config=mock_llm_config,
+            config=hindsight_config,
+        )
+
+    assert len(facts) == 1
+    assert facts[0].fact_text == corrected.fact
+    assert chunks[0].fact_count == 1
+    assert usage.total_tokens == 180
+    assert retry.await_count == 1
+    assert retry.await_args is not None
+    kwargs = retry.await_args.kwargs
+    assert kwargs["language_retry_already_used"] is True
+    assert "CORRECTION" in kwargs["initial_language_correction"]
+    assert kwargs["language_validation_stage"] == "retain_batch"
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_language_validation.py
+++ b/hindsight-api-slim/tests/test_language_validation.py
@@ -42,13 +42,9 @@ def test_one_translated_fact_cannot_hide_inside_an_english_response():
         "La actualización del sistema debe conservar cada identificador original y nunca "
         "traducir los datos antes de almacenarlos en la base de conocimiento."
     )
-    results = [
-        validate_output_language(source_text=ENGLISH, output_text=output)
-        for output in (ENGLISH, translated)
-    ]
+    results = [validate_output_language(source_text=ENGLISH, output_text=output) for output in (ENGLISH, translated)]
     assert results[0].outcome is LanguageValidationOutcome.MATCH
     assert results[1].outcome is LanguageValidationOutcome.MISMATCH
-
 
 
 def test_matching_non_english_output_is_accepted():

--- a/hindsight-api-slim/tests/test_language_validation.py
+++ b/hindsight-api-slim/tests/test_language_validation.py
@@ -1,0 +1,370 @@
+import dataclasses
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine.language_validation import (
+    LanguageValidationOutcome,
+    profile_language,
+    validate_output_language,
+)
+from hindsight_api.engine.response_models import TokenUsage
+
+ENGLISH = (
+    "The deployment process must preserve the source language and reject generated facts "
+    "that silently translate the original evidence into another language."
+)
+SPANISH = (
+    "El proceso de despliegue debe conservar el idioma de origen y rechazar los hechos "
+    "generados que traduzcan silenciosamente la evidencia original a otro idioma."
+)
+PORTUGUESE = (
+    "O processo de implantação deve preservar o idioma de origem e rejeitar fatos gerados "
+    "que traduzam silenciosamente a evidência original para outro idioma."
+)
+CHINESE = (
+    "部署过程必须保留原始来源的语言，并拒绝把证据悄悄翻译成其他语言的生成事实，"
+    "这样每一条记忆都能忠实反映输入内容并保持可追溯性。"
+)
+JAPANESE = "この文章は日本語で書かれており、生成された記憶も元の日本語のまま保存されなければなりません。"
+
+
+def test_confident_cross_language_output_is_rejected():
+    result = validate_output_language(source_text=ENGLISH, output_text=SPANISH)
+    assert result.outcome is LanguageValidationOutcome.MISMATCH
+    assert result.expected_languages == frozenset({"en"})
+    assert result.output_language == "es"
+
+
+def test_one_translated_fact_cannot_hide_inside_an_english_response():
+    translated = (
+        "La actualización del sistema debe conservar cada identificador original y nunca "
+        "traducir los datos antes de almacenarlos en la base de conocimiento."
+    )
+    results = [
+        validate_output_language(source_text=ENGLISH, output_text=output)
+        for output in (ENGLISH, translated)
+    ]
+    assert results[0].outcome is LanguageValidationOutcome.MATCH
+    assert results[1].outcome is LanguageValidationOutcome.MISMATCH
+
+
+
+def test_matching_non_english_output_is_accepted():
+    result = validate_output_language(source_text=JAPANESE, output_text=JAPANESE)
+
+    assert result.outcome is LanguageValidationOutcome.MATCH
+    assert result.expected_languages == frozenset({"ja"})
+    assert result.output_language == "ja"
+
+
+def test_explicit_output_language_overrides_source():
+    result = validate_output_language(
+        source_text=SPANISH,
+        output_text=ENGLISH,
+        output_language="English",
+    )
+
+    assert result.outcome is LanguageValidationOutcome.MATCH
+    assert result.expected_languages == frozenset({"en"})
+
+
+@pytest.mark.parametrize(
+    ("configured", "output", "expected"),
+    [
+        ("en-US", ENGLISH, "en"),
+        ("pt-BR", PORTUGUESE, "pt"),
+        ("Portuguese (Brazil)", PORTUGUESE, "pt"),
+        ("zh-TW", CHINESE, "zh"),
+    ],
+)
+def test_explicit_output_language_locales_resolve_to_detector_base_codes(configured, output, expected):
+    result = validate_output_language(
+        source_text=SPANISH,
+        output_text=output,
+        output_language=configured,
+    )
+
+    assert result.outcome is LanguageValidationOutcome.MATCH
+    assert result.expected_languages == frozenset({expected})
+
+
+def test_short_or_language_neutral_text_is_indeterminate():
+    result = validate_output_language(
+        source_text="Run `docker --debug` for https://example.com/a/123.",
+        output_text="Ejecuta `docker --debug`.",
+    )
+
+    assert result.outcome is LanguageValidationOutcome.INDETERMINATE
+    assert profile_language("A half emoji slipped into the transcript.").primary is None
+
+
+def test_mixed_source_allows_each_confident_source_language():
+    source = f"{ENGLISH}\n\n{SPANISH}"
+
+    assert validate_output_language(source_text=source, output_text=ENGLISH).outcome is LanguageValidationOutcome.MATCH
+    assert validate_output_language(source_text=source, output_text=SPANISH).outcome is LanguageValidationOutcome.MATCH
+
+
+def test_profile_strips_code_urls_and_identifiers_before_detection():
+    profile = profile_language(
+        "The deployment failed after dependency resolution and should be retried with diagnostics. "
+        "`Effect.tryPromise({ token: API_KEY_1234 })` https://example.com/abc 9dbd7f4a-0ad2-4eb8-9398-acde12345678"
+    )
+
+    assert profile.primary == "en"
+    assert profile.analyzable_chars >= 70
+
+
+def test_english_grammar_prevents_a_dutch_proper_noun_false_positive():
+    text = (
+        "Zoekt is a collection of Go programs: zoekt-git-index, zoekt-local-sync, and "
+        "zoekt-indexserver | When: Saturday, August 08, 2026 | Involving: Hermes Agent"
+    )
+    assert profile_language(text).primary == "en"
+
+
+def test_repetitive_role_prefixed_text_is_indeterminate():
+    repeated = "\n".join(
+        f"[role: user] turn {i}: alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november"
+        for i in range(27)
+    )
+
+    assert profile_language(repeated).primary is None
+
+
+def _retain_response(what: str) -> tuple[dict, TokenUsage]:
+    return (
+        {
+            "facts": [
+                {
+                    "what": what,
+                    "when": "N/A",
+                    "where": "N/A",
+                    "who": "N/A",
+                    "why": "N/A",
+                    "fact_type": "world",
+                    "fact_kind": "conversation",
+                }
+            ]
+        },
+        TokenUsage(),
+    )
+
+
+def _retain_config(output_language: str | None = None):
+    from hindsight_api.config import _get_raw_config
+
+    return dataclasses.replace(
+        _get_raw_config(),
+        retain_llm_max_retries=0,
+        retain_extraction_mode="concise",
+        retain_extract_causal_links=False,
+        retain_mission=None,
+        llm_temperature_retain=0.0,
+        llm_strict_schema_retain=False,
+        entity_labels=None,
+        entities_allow_free_form=True,
+        llm_output_language=output_language,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retain_retries_mismatch_once_and_never_returns_rejected_fact():
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    llm = MagicMock(spec=LLMProvider)
+    llm.provider = "test-language-drift"
+    llm.model = "mock-language-drift"
+    llm.call = AsyncMock(side_effect=[_retain_response(SPANISH), _retain_response(ENGLISH)])
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _ = await _extract_facts_from_chunk(
+            chunk=ENGLISH,
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2026, 9, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm,
+            config=_retain_config(),
+        )
+
+    assert [getattr(fact, "fact") for fact in facts] == [ENGLISH]
+    assert llm.call.await_count == 2
+    retry_message = llm.call.await_args_list[1].kwargs["messages"][-1]["content"]
+    assert "previous response was rejected" in retry_message.lower()
+
+
+@pytest.mark.asyncio
+async def test_retain_retry_honors_configured_output_language():
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    llm = MagicMock(spec=LLMProvider)
+    llm.provider = "test-language-drift"
+    llm.model = "mock-language-drift"
+    llm.call = AsyncMock(side_effect=[_retain_response(SPANISH), _retain_response(ENGLISH)])
+
+    with patch(
+        "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+        return_value=("system prompt", MagicMock()),
+    ):
+        facts, _ = await _extract_facts_from_chunk(
+            chunk=SPANISH,
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2026, 9, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm,
+            config=_retain_config("English"),
+        )
+
+    assert [getattr(fact, "fact") for fact in facts] == [ENGLISH]
+    retry_message = llm.call.await_args_list[1].kwargs["messages"][-1]["content"]
+    assert "configured output language: English" in retry_message
+    assert "Do not translate the source" not in retry_message
+
+
+@pytest.mark.asyncio
+async def test_retain_fails_closed_after_second_confident_mismatch():
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+    from hindsight_api.engine.retain.fact_extraction import _extract_facts_from_chunk
+
+    llm = MagicMock(spec=LLMProvider)
+    llm.provider = "test-language-drift"
+    llm.model = "mock-language-drift"
+    llm.call = AsyncMock(side_effect=[_retain_response(SPANISH), _retain_response(SPANISH)])
+
+    with (
+        patch(
+            "hindsight_api.engine.retain.fact_extraction._build_extraction_prompt_and_schema",
+            return_value=("system prompt", MagicMock()),
+        ),
+        pytest.raises(RuntimeError, match="generated_language_mismatch"),
+    ):
+        await _extract_facts_from_chunk(
+            chunk=ENGLISH,
+            chunk_index=0,
+            total_chunks=1,
+            event_date=datetime(2026, 9, 1, tzinfo=timezone.utc),
+            context="",
+            llm_config=llm,
+            config=_retain_config(),
+        )
+
+    assert llm.call.await_count == 2
+
+
+def _consolidation_config(output_language: str | None = None):
+    config = MagicMock()
+    config.observations_mission = None
+    config.consolidation_max_attempts = 1
+    config.consolidation_llm_max_retries = None
+    config.consolidation_max_completion_tokens = None
+    config.llm_strict_schema_consolidation = False
+    config.llm_temperature_consolidation = 0.0
+    config.llm_supports_max_items = True
+    config.llm_output_language = output_language
+    return config
+
+
+@pytest.mark.asyncio
+async def test_consolidation_retries_mismatch_atomically():
+    from hindsight_api.engine.consolidation.consolidator import (
+        _consolidate_batch_with_llm,
+        _ConsolidationBatchResponse,
+        _CreateAction,
+    )
+
+    llm = AsyncMock()
+    llm._provider_impl = None
+    llm.provider = "test-language-drift"
+    llm.call.side_effect = [
+        _ConsolidationBatchResponse(creates=[_CreateAction(text=SPANISH, source_fact_ids=["m1"])]),
+        _ConsolidationBatchResponse(creates=[_CreateAction(text=ENGLISH, source_fact_ids=["m1"])]),
+    ]
+
+    result = await _consolidate_batch_with_llm(
+        llm_config=llm,
+        memories=[{"id": "m1", "text": ENGLISH}],
+        union_observations=[],
+        union_source_facts={},
+        config=_consolidation_config(),
+    )
+
+    assert not result.failed
+    assert [create.text for create in result.creates] == [ENGLISH]
+    assert llm.call.await_count == 2
+    retry_message = llm.call.await_args_list[1].kwargs["messages"][-1]["content"]
+    assert "previous response was rejected" in retry_message.lower()
+
+
+@pytest.mark.asyncio
+async def test_consolidation_retry_honors_configured_output_language():
+    from hindsight_api.engine.consolidation.consolidator import (
+        _consolidate_batch_with_llm,
+        _ConsolidationBatchResponse,
+        _CreateAction,
+    )
+
+    llm = AsyncMock()
+    llm._provider_impl = None
+    llm.provider = "test-language-drift"
+    llm.call.side_effect = [
+        _ConsolidationBatchResponse(creates=[_CreateAction(text=SPANISH, source_fact_ids=["m1"])]),
+        _ConsolidationBatchResponse(creates=[_CreateAction(text=ENGLISH, source_fact_ids=["m1"])]),
+    ]
+
+    result = await _consolidate_batch_with_llm(
+        llm_config=llm,
+        memories=[{"id": "m1", "text": SPANISH}],
+        union_observations=[],
+        union_source_facts={},
+        config=_consolidation_config("English"),
+    )
+
+    assert not result.failed
+    assert [create.text for create in result.creates] == [ENGLISH]
+    retry_message = llm.call.await_args_list[1].kwargs["messages"][-1]["content"]
+    assert "configured output language: English" in retry_message
+    assert "Do not translate the source" not in retry_message
+
+
+@pytest.mark.asyncio
+async def test_consolidation_fails_closed_after_second_mismatch():
+    from hindsight_api.engine.consolidation.consolidator import (
+        _consolidate_batch_with_llm,
+        _ConsolidationBatchResponse,
+        _CreateAction,
+    )
+
+    llm = AsyncMock()
+    llm._provider_impl = None
+    llm.provider = "test-language-drift"
+    rejected = _ConsolidationBatchResponse(creates=[_CreateAction(text=SPANISH, source_fact_ids=["m1"])])
+    llm.call.side_effect = [rejected, rejected]
+
+    result = await _consolidate_batch_with_llm(
+        llm_config=llm,
+        memories=[{"id": "m1", "text": ENGLISH}],
+        union_observations=[],
+        union_source_facts={},
+        config=_consolidation_config(),
+    )
+
+    assert result.failed
+    assert not result.creates
+    assert not result.updates
+    assert llm.call.await_count == 2
+
+
+def test_terminal_language_mismatch_is_non_retryable_for_worker():
+    from hindsight_api.engine.language_validation import GeneratedLanguageMismatch
+    from hindsight_api.engine.memory_engine import _is_non_retryable_task_error
+
+    assert _is_non_retryable_task_error(GeneratedLanguageMismatch("still translated"))

--- a/hindsight-api-slim/tests/test_metrics.py
+++ b/hindsight-api-slim/tests/test_metrics.py
@@ -1,7 +1,8 @@
 """Tests for metrics instrumentation."""
 
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from hindsight_api.metrics import (
     MetricsCollector,
@@ -9,8 +10,6 @@ from hindsight_api.metrics import (
     NoOpMetricsCollector,
     get_metrics_collector,
     get_token_bucket,
-    create_metrics_collector,
-    initialize_metrics,
     normalize_http_endpoint,
 )
 
@@ -246,6 +245,18 @@ class TestMetricsCollector:
         count, attributes = collector.retain_documents_total.add.call_args[0]
         assert count == 1
         assert attributes["outcome"] == "no_facts"
+
+    def test_record_language_validation_uses_bounded_dimensions(self, collector):
+        collector.record_language_validation(
+            stage="retain", outcome="mismatch_retry", provider="openai", model="gpt-test"
+        )
+
+        count, attributes = collector.language_validation_total.add.call_args[0]
+        assert count == 1
+        assert attributes["stage"] == "retain"
+        assert attributes["outcome"] == "mismatch_retry"
+        assert attributes["provider"] == "openai"
+        assert attributes["model"] == "gpt-test"
 
     def test_record_operation_includes_bank_id_when_enabled(self):
         """Test that bank_id is included in attributes when metrics_include_bank_id is enabled."""

--- a/hindsight-docs/docs/developer/multilingual.md
+++ b/hindsight-docs/docs/developer/multilingual.md
@@ -23,6 +23,19 @@ When you retain content or reflect on a query, Hindsight:
 3. **Stores entities in their native script** - 张伟 stays 张伟, not "Zhang Wei"
 4. **Responds in the same language** - queries in Chinese get Chinese answers
 
+For fact extraction and observation consolidation, Hindsight also performs a
+conservative output-integrity check before persistence. A confident language
+mismatch is regenerated once from the original source. If the correction still
+mismatches, the generated fact or observation is rejected. Short, code-heavy,
+language-neutral, and low-confidence text remains indeterminate instead of being
+rejected. If a completed Batch API item mismatches, only that chunk is
+regenerated through the ordinary provider path with the same one-correction
+budget. Other successful batch items are preserved.
+
+If `llm_output_language` is explicitly configured, that language is the expected
+output. Otherwise the applicable source language is expected. Mixed-language
+sources may retain any materially represented source language.
+
 ---
 
 ## Retain with Non-English Content

--- a/uv.lock
+++ b/uv.lock
@@ -1707,6 +1707,7 @@ dependencies = [
     { name = "greenlet" },
     { name = "httpx" },
     { name = "json-repair" },
+    { name = "langdetect" },
     { name = "litellm", version = "1.91.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "litellm", version = "1.93.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
     { name = "markitdown", extra = ["docx", "pdf", "pptx", "xls", "xlsx"] },
@@ -1848,6 +1849,7 @@ requires-dist = [
     { name = "json-repair", specifier = ">=0.63.2" },
     { name = "langchain-core", marker = "extra == 'test'", specifier = ">=1.2.22" },
     { name = "langchain-text-splitters", marker = "extra == 'test'", specifier = ">=0.3.0" },
+    { name = "langdetect", specifier = ">=1.0.9,<2" },
     { name = "langsmith", marker = "extra == 'test'", specifier = ">=0.8.18" },
     { name = "litellm", marker = "sys_platform != 'darwin'", specifier = ">=1.93.0" },
     { name = "litellm", marker = "sys_platform == 'darwin'", specifier = ">=1.91.3,<1.92" },
@@ -2481,6 +2483,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00d
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/26/1ef06f56198d631296d646a6223de35bcc6cf9795ceb2442816bc963b84c/langchain_text_splitters-1.1.2-py3-none-any.whl", hash = "sha256:a2de0d799ff31886429fd6e2e0032df275b60ec817c19059a7b46181cc1c2f10", size = 35903, upload-time = "2026-04-16T14:20:38.243Z" },
 ]
+
+[[package]]
+name = "langdetect"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2569554f7c70f4a3c27712f40e3284d483e88094cc0e/langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0", size = 981474, upload-time = "2021-05-07T07:54:13.562Z" }
 
 [[package]]
 name = "langsmith"


### PR DESCRIPTION
## Summary

- add a conservative, deterministic source/output language validator shared by retain extraction and observation consolidation
- allow one corrective regeneration, then fail closed without worker retry when the generated language still conflicts
- preserve configured output-language overrides, mixed/short/technical inputs, Batch API chunk isolation, and bounded telemetry

## Why

Hindsight's prompts already tell models not to translate, but prompt compliance is not an integrity boundary. A private production audit found confident language drift at both extraction and consolidation. The guard catches model output before it is persisted rather than relying on another prompt-only mitigation.

A sanitized corpus canary against the audited rows detected 10,660 of 10,733 known drift records (99.32%) while rejecting 0 of 31 legitimate multilingual records and 0 of 220 detector false-positive controls. The remaining 73 drift rows are intentionally indeterminate or conservative false negatives, not false accepts mislabeled as validated matches.

## Design

- seed `langdetect` for repeatable results and normalize detector/locale codes
- strip code, URLs, UUIDs, and identifier-heavy tokens before classification
- abstain on short, repetitive, mixed, or low-confidence text
- validate each fact and each consolidation action independently
- regenerate only the mismatching Batch API chunk through the normal provider path
- respect `HINDSIGHT_API_LLM_OUTPUT_LANGUAGE`, including locale forms such as `en-US`, `pt-BR`, and `zh-TW`
- emit text-free counters by stage, outcome, provider, and model
- classify a second confident mismatch as non-retryable so workers do not resend the same payload indefinitely

## Validation

- `170 passed`: broad impacted suite covering validation, retain robustness, Batch API, multi-provider batching, chunk coverage, consolidation atomicity/retry budgets, worker retries, and metrics
- Ruff, lockfile validation, compileall, and wheel build pass
- audited corpus canary: 10,660/10,733 drift detected, 0/31 legitimate mismatches, 0/220 control mismatches
- independent blocker review: no unresolved blockers

## Risk

The guard is deliberately conservative. Indeterminate output remains accepted, so this reduces known corruption without turning language detection uncertainty into ingestion failures. The change does not repair historical memories.

Closes #4016
