### PR TITLE
fix(retain): invalidate observations when a re-retain changes a document's scoping

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -400,18 +400,38 @@ async def _upsert_document_row(
     )
 
 
+def _normalize_scopes(value: list | str | None) -> list | str | None:
+    """Compare-ready form of an ``observation_scopes`` value.
+
+    The column is JSONB, so a read can hand it back as a JSON string
+    (``'"per_tag"'`` / ``'[["a"]]'``) while the retain call site supplies the
+    parsed value. Normalizing both through ``json.loads`` keeps the comparison
+    from reporting a change on the encoding alone. A bare word that is not JSON
+    ("per_tag" written unquoted) is already in compare-ready form.
+    """
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (ValueError, TypeError):
+            return value
+    return value
+
+
 async def update_memory_units_metadata_and_tags(
     conn,
     bank_id: str,
     document_id: str,
     tags: list[str],
     metadata: dict[str, Any],
+    *,
+    observation_scopes: list | str | None = None,
+    ops=None,
 ) -> int:
     """Update document-level attributes on existing memory units.
 
     Delta retain preserves unchanged chunks and their facts. Propagate the
-    current document tags and metadata so its optimized result matches a full
-    replace.
+    current document tags, metadata and observation scoping so its optimized
+    result matches a full replace.
 
     ``metadata`` arrives as the raw retain_params bag (the document row keeps
     the caller's input verbatim), so null-valued keys are dropped here — the
@@ -419,11 +439,24 @@ async def update_memory_units_metadata_and_tags(
     (issue #3209). Without it a re-retain would leave surviving units carrying
     nulls while the units around them do not.
 
+    Relabelling is not only a labelling change: consolidation scopes a memory by
+    its tag set and routes it by ``observation_scopes``, so an observation built
+    over these facts under the OLD scoping is no longer valid the moment either
+    one changes. ``MemoryEngine.update_document`` (the tags PATCH) has always run
+    that cascade; a re-retain carrying narrower tags took this path instead and
+    ran none of it, leaving observations — and the mental models citing them —
+    visible to a tag no live fact carries any more. So when the scoping of a
+    surviving unit actually changes, delete the observations standing on it and
+    requeue it (and their co-sources, which ``delete_stale_observations`` does)
+    for re-consolidation under the new scoping. Units whose scoping is unchanged
+    keep their observations: an ordinary delta edit must not re-consolidate the
+    whole document.
+
     Returns:
         Number of memory units updated.
     """
     from ..memories import MemoryPatch, get_memories
-    from ..memories.base import META_METADATA_JSON
+    from ..memories.base import META_METADATA_JSON, META_OBSERVATION_SCOPES
 
     store = get_memories()
     if store.store_owned_for(bank_id):
@@ -451,25 +484,77 @@ async def update_memory_units_metadata_and_tags(
             MemoryPatch(
                 unit_id=m.unit_id,
                 tags=list(tags or []),
-                metadata={META_METADATA_JSON: json.dumps(drop_null_values(metadata or {}))},
+                metadata={
+                    META_METADATA_JSON: json.dumps(drop_null_values(metadata or {})),
+                    META_OBSERVATION_SCOPES: json.dumps(observation_scopes),
+                },
             )
             for m in page.memories
         ]
         if patches:
             await store.update_memories(bank_id, patches)
+        rescoped = [
+            m.unit_id
+            for m in page.memories
+            if m.fact_type in ("experience", "world")
+            and (
+                set(m.tags or []) != set(tags or [])
+                or _normalize_scopes(m.observation_scopes) != _normalize_scopes(observation_scopes)
+            )
+        ]
+        if rescoped:
+            await delete_stale_observations_for_memories(conn, bank_id, rescoped, ops=ops)
+            # The rescoped units survive, so `delete_stale_observations` (which requeues only
+            # an observation's OTHER sources, the ones not being deleted) does not reach them.
+            await store.mark_consolidated(conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=rescoped, when=None)
         return len(patches)
+
+    # Read the scoping the survivors carry BEFORE overwriting it — the cascade below has to
+    # know which units actually moved, and after the UPDATE that is no longer answerable.
+    prior = await conn.fetch(
+        f"""
+        SELECT id, fact_type, tags, observation_scopes
+        FROM {fq_table("memory_units")}
+        WHERE bank_id = $1 AND document_id = $2
+        """,
+        bank_id,
+        document_id,
+    )
+    rescoped_ids = [
+        row["id"]
+        for row in prior
+        if row["fact_type"] in ("experience", "world")
+        and (
+            set(row["tags"] or []) != set(tags or [])
+            or _normalize_scopes(row["observation_scopes"]) != _normalize_scopes(observation_scopes)
+        )
+    ]
 
     result = await conn.execute(
         f"""
         UPDATE {fq_table("memory_units")}
-        SET tags = $3, metadata = $4, updated_at = NOW()
+        SET tags = $3, metadata = $4, observation_scopes = $5, updated_at = NOW()
         WHERE bank_id = $1 AND document_id = $2
         """,
         bank_id,
         document_id,
         tags or [],
         json.dumps(drop_null_values(metadata)),
+        json.dumps(observation_scopes) if observation_scopes is not None else None,
     )
+
+    if rescoped_ids:
+        await delete_stale_observations_for_memories(conn, bank_id, rescoped_ids, ops=ops)
+        # The rescoped units survive this write, so the requeue inside
+        # `delete_stale_observations` — which only covers an observation's OTHER sources,
+        # the ones being deleted — skips them. Reset them here or they stay marked
+        # consolidated against an observation that no longer exists and are never selected
+        # into a batch again. Through the store's `mark_consolidated` rather than a raw
+        # UPDATE, the same call the store-owned branch and `update_document` make.
+        await store.mark_consolidated(
+            conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=[str(uid) for uid in rescoped_ids], when=None
+        )
+
     # result is a status string like "UPDATE 5"
     try:
         return int(result.split()[-1])

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -3884,6 +3884,8 @@ async def _try_delta_retain(
                     effective_doc_id,
                     merged_tags,
                     retain_params.get("metadata", {}),
+                    observation_scopes=retain_params.get("observation_scopes"),
+                    ops=pool.ops,
                 )
                 log_buffer.append(
                     f"  Updated tags and metadata on {updated_count} existing memory units "
@@ -4038,10 +4040,21 @@ async def _delta_metadata_only(
         # re-retain relabelled the document and left every unit on the OLD tags and metadata —
         # measured, v2 units still read ['team-a'] after a retain carrying ['team-b', 'important'].
         # This is the whole work of a metadata-only retain for such a bank, not a detail of it.
+        # In a transaction: relabelling can cascade into an observation sweep (see
+        # update_memory_units_metadata_and_tags), and that delete plus the requeue of the
+        # co-sources it strands has to land atomically or a crash between them leaves facts
+        # marked consolidated against observations that are gone.
         async with acquire_with_retry(pool) as conn:
-            await fact_storage.update_memory_units_metadata_and_tags(
-                conn, bank_id, document_id, merged_tags, retain_params.get("metadata", {})
-            )
+            async with conn.transaction():
+                await fact_storage.update_memory_units_metadata_and_tags(
+                    conn,
+                    bank_id,
+                    document_id,
+                    merged_tags,
+                    retain_params.get("metadata", {}),
+                    observation_scopes=retain_params.get("observation_scopes"),
+                    ops=pool.ops,
+                )
         if outbox_callback is not None:
             # The outbox is still SQL for every deployment, so it keeps its own connection.
             async with acquire_with_retry(pool) as conn:
@@ -4086,6 +4099,8 @@ async def _delta_metadata_only(
                 document_id,
                 merged_tags,
                 retain_params.get("metadata", {}),
+                observation_scopes=retain_params.get("observation_scopes"),
+                ops=pool.ops,
             )
             if outbox_callback is not None:
                 await outbox_callback(conn)

--- a/hindsight-api-slim/tests/test_retain_tag_change_observations.py
+++ b/hindsight-api-slim/tests/test_retain_tag_change_observations.py
@@ -1,0 +1,259 @@
+"""Re-retaining a document under a NARROWER tag set must invalidate its observations.
+
+The reporter's shape: one document ("mobile room key is available") is tagged with the
+18 hotels it applies to. One of those hotels stops offering it, so the document is
+re-ingested — same body, ``tags`` now listing 17 hotels. The world facts are relabelled
+correctly, but the mental model for the dropped hotel keeps citing the *observation*
+built over those facts, because that observation still carries the old tag.
+
+``MemoryEngine.update_document`` (the tags PATCH) already runs the cascade this needs —
+delete the observations built over the document's memories and requeue their surviving
+co-sources so consolidation rebuilds them under the new tags. Retain does not: the delta
+path relabels surviving memory units through
+``fact_storage.update_memory_units_metadata_and_tags`` and stops there. So the same tag
+change invalidates observations when it arrives as a PATCH and does not when it arrives
+as an upsert.
+
+These tests drive the public retain API on the three shapes an upsert can take:
+tags-only (identical body), tags plus a partial edit (unchanged chunks survive and get
+relabelled), and a change to ``observation_scopes`` rather than to the tags themselves.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api import RequestContext
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.memories import FactRecord, get_memories
+from hindsight_api.engine.memory_engine import MemoryEngine, fq_table
+
+# Two chunk-sized blocks (chunk size is 3000 chars). Keeping BLOCK_A byte-identical
+# across a re-ingest is what keeps the second retain on the delta path: chunking is
+# greedy from the start of the text, so an edit after chunk 0's boundary cannot move it.
+_BLOCK_A = " ".join(
+    f"The Grandview property offers mobile room key access on floor {i} of the north tower." for i in range(40)
+)
+_BLOCK_B = " ".join(f"Front desk staff issue physical keycards at kiosk {i} during check-in." for i in range(40))
+_BLOCK_B_EDITED = " ".join(f"Front desk staff issue wristbands at kiosk {i} during check-in." for i in range(40))
+
+_DOCUMENT_V1 = f"{_BLOCK_A} {_BLOCK_B}"
+_DOCUMENT_V2_PARTIAL_EDIT = f"{_BLOCK_A} {_BLOCK_B_EDITED}"
+
+_KEPT_HOTEL = "hotel-1234"
+_DROPPED_HOTEL = "hotel-5720"
+
+
+@pytest.fixture(autouse=True)
+def enable_observations():
+    config = _get_raw_config()
+    original = config.enable_observations
+    config.enable_observations = True
+    yield
+    config.enable_observations = original
+
+
+async def _scan(memory: MemoryEngine, bank_id: str, fact_types: list[str]) -> list[FactRecord]:
+    """Every stored memory of these types, read through whichever store holds them."""
+    store = get_memories()
+    pool = await memory._get_pool()
+    async with pool.acquire() as conn:
+        page = await store.scan_memories(
+            conn=conn,
+            fq_table=fq_table,
+            bank_id=bank_id,
+            fact_types=fact_types,
+            limit=1_000_000,
+        )
+    return list(page.memories)
+
+
+async def _facts(memory: MemoryEngine, bank_id: str) -> list[FactRecord]:
+    return await _scan(memory, bank_id, ["experience", "world"])
+
+
+async def _observations(memory: MemoryEngine, bank_id: str) -> list[FactRecord]:
+    return await _scan(memory, bank_id, ["observation"])
+
+
+async def _retain(
+    memory: MemoryEngine,
+    bank_id: str,
+    document_id: str,
+    content: str,
+    tags: list[str],
+    request_context: RequestContext,
+    observation_scopes: str | None = None,
+) -> None:
+    item: dict = {"content": content, "context": "hotel amenities", "document_id": document_id, "tags": list(tags)}
+    if observation_scopes is not None:
+        item["observation_scopes"] = observation_scopes
+    await memory.retain_batch_async(
+        bank_id=bank_id,
+        contents=[item],  # type: ignore[list-item]
+        document_tags=list(tags),
+        request_context=request_context,
+    )
+
+
+def _facts_by_chunk(facts: list[FactRecord]) -> dict[str, set[str]]:
+    by_chunk: dict[str, set[str]] = {}
+    for fact in facts:
+        if fact.chunk_id:
+            by_chunk.setdefault(fact.chunk_id, set()).add(fact.unit_id)
+    return by_chunk
+
+
+def _stale_scoped(observations: list[FactRecord], dropped_tag: str) -> list[tuple[str, list[str]]]:
+    """Observations still visible to a tag no live fact carries any more."""
+    return [(o.unit_id, list(o.tags or [])) for o in observations if dropped_tag in (o.tags or [])]
+
+
+@pytest.mark.asyncio
+async def test_tags_only_re_retain_invalidates_observations(memory: MemoryEngine, request_context: RequestContext):
+    """The reporter's case: same body, one tag removed.
+
+    The body is byte-identical, so retain takes the "no chunks changed" path and does
+    nothing but relabel. The facts end up scoped to the 1 remaining hotel while the
+    observation built over them is still scoped to the dropped one — which is exactly
+    what that hotel's mental model keeps reading.
+    """
+    bank_id = f"test_retag_obs_tags_only_{uuid.uuid4().hex[:8]}"
+    document_id = "mobile-room-key"
+
+    try:
+        await _retain(memory, bank_id, document_id, _DOCUMENT_V1, [_KEPT_HOTEL, _DROPPED_HOTEL], request_context)
+        await memory.run_consolidation(bank_id=bank_id, request_context=request_context)
+
+        observations_v1 = await _observations(memory, bank_id)
+        assert observations_v1, "Setup: consolidation should have produced observations"
+        assert any(_DROPPED_HOTEL in (o.tags or []) for o in observations_v1), (
+            "Setup: the observations should be scoped to the hotel that is about to be dropped"
+        )
+
+        # The upsert: identical body, one tag fewer.
+        await _retain(memory, bank_id, document_id, _DOCUMENT_V1, [_KEPT_HOTEL], request_context)
+
+        facts_v2 = await _facts(memory, bank_id)
+        assert facts_v2, "Setup: the facts should have survived a tags-only re-ingest"
+        assert all(_DROPPED_HOTEL not in (f.tags or []) for f in facts_v2), (
+            "Setup: the world facts should have been relabelled to the narrower tag set"
+        )
+
+        stale = _stale_scoped(await _observations(memory, bank_id), _DROPPED_HOTEL)
+        assert stale == [], (
+            f"{len(stale)} observation(s) are still scoped to {_DROPPED_HOTEL} after the document "
+            f"was re-retained without it. The facts underneath them are no longer tagged with it, "
+            f"so that hotel's mental model keeps citing an observation nothing supports: {stale[:5]}"
+        )
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_tag_change_with_partial_edit_invalidates_unchanged_chunks_observations(
+    memory: MemoryEngine, request_context: RequestContext
+):
+    """A narrower tag set arriving alongside a body edit.
+
+    Delta sweeps the observations of the chunks it *deletes*, so a tag change that
+    happens to land on an edited chunk is covered by accident. The unchanged chunk is
+    the gap: its facts are relabelled in place and their observations are left alone.
+    """
+    bank_id = f"test_retag_obs_partial_{uuid.uuid4().hex[:8]}"
+    document_id = "mobile-room-key"
+
+    try:
+        await _retain(memory, bank_id, document_id, _DOCUMENT_V1, [_KEPT_HOTEL, _DROPPED_HOTEL], request_context)
+        await memory.run_consolidation(bank_id=bank_id, request_context=request_context)
+
+        facts_v1 = await _facts(memory, bank_id)
+        by_chunk_v1 = _facts_by_chunk(facts_v1)
+        assert len(by_chunk_v1) >= 2, f"Setup: the document should span several chunks, got {list(by_chunk_v1)}"
+        first_chunk = sorted(by_chunk_v1)[0]
+        kept_fact_ids = by_chunk_v1[first_chunk]
+
+        observations_v1 = await _observations(memory, bank_id)
+        obs_only_over_kept = {
+            o.unit_id
+            for o in observations_v1
+            if o.source_memory_ids and set(o.source_memory_ids).issubset(kept_fact_ids)
+        }
+        assert obs_only_over_kept, "Setup: the unchanged chunk should have observations of its own"
+
+        # Edit the tail AND narrow the tags in the same upsert.
+        await _retain(memory, bank_id, document_id, _DOCUMENT_V2_PARTIAL_EDIT, [_KEPT_HOTEL], request_context)
+
+        surviving_fact_ids = {f.unit_id for f in await _facts(memory, bank_id)}
+        assert kept_fact_ids.issubset(surviving_fact_ids), (
+            "The unchanged chunk's facts should survive — if they did not, this test fell back to "
+            "the full-replace path and no longer covers the retag gap"
+        )
+
+        stale = _stale_scoped(await _observations(memory, bank_id), _DROPPED_HOTEL)
+        assert stale == [], (
+            f"{len(stale)} observation(s) over the UNCHANGED chunk are still scoped to "
+            f"{_DROPPED_HOTEL}; delta relabelled their source facts but never invalidated them: "
+            f"{stale[:5]}"
+        )
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_observation_scopes_change_re_retain_invalidates_observations(
+    memory: MemoryEngine, request_context: RequestContext
+):
+    """Changing how a document's facts are scoped is a change to the observations too.
+
+    ``observation_scopes`` decides which passes a fact is consolidated under: "combined"
+    folds all its tags into one observation, "per_tag" produces one per tag. Switching it
+    on a re-retain has to rebuild the observations, the same way narrowing the tags does —
+    otherwise the bank keeps the observations of the OLD scoping alongside the new ones.
+    """
+    bank_id = f"test_retag_obs_scopes_{uuid.uuid4().hex[:8]}"
+    document_id = "mobile-room-key"
+
+    try:
+        await _retain(
+            memory,
+            bank_id,
+            document_id,
+            _DOCUMENT_V1,
+            [_KEPT_HOTEL, _DROPPED_HOTEL],
+            request_context,
+            observation_scopes="combined",
+        )
+        await memory.run_consolidation(bank_id=bank_id, request_context=request_context)
+
+        observations_v1 = {o.unit_id for o in await _observations(memory, bank_id)}
+        assert observations_v1, "Setup: consolidation should have produced observations"
+
+        # Same body, same tags, different scoping.
+        await _retain(
+            memory,
+            bank_id,
+            document_id,
+            _DOCUMENT_V1,
+            [_KEPT_HOTEL, _DROPPED_HOTEL],
+            request_context,
+            observation_scopes="per_tag",
+        )
+
+        facts_v2 = await _facts(memory, bank_id)
+        assert facts_v2, "Setup: the facts should have survived a metadata-only re-ingest"
+        assert all(f.observation_scopes == "per_tag" for f in facts_v2), (
+            "Surviving facts should carry the observation_scopes the re-retain supplied, "
+            f"got {[f.observation_scopes for f in facts_v2[:5]]}"
+        )
+
+        surviving_obs = {o.unit_id for o in await _observations(memory, bank_id)}
+        assert not surviving_obs.intersection(observations_v1), (
+            "Observations built under the previous observation_scopes should have been "
+            "invalidated so consolidation can rebuild them under the new scoping"
+        )
+
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## The report

A document that applies to many tenants — "mobile room key is available", tagged with the 18 hotels it covers — stops applying to one of them. The document is re-ingested with the remaining 17 tags. The world facts are relabelled correctly, but the dropped hotel's mental model goes on citing the **observation** built over those facts, because the observation still carries the old tag. The reporter could see it directly in the UI: the hotel is gone from the world fact and still present on the observation.

## Why

`MemoryEngine.update_document` — the tags **PATCH** — has always run the cascade this needs: delete the observations built over the document's memories and requeue their surviving co-sources, so consolidation rebuilds them under the new tags.

Retain ran none of it. The delta path relabels surviving memory units through `fact_storage.update_memory_units_metadata_and_tags` and stops there, so the very same tag change invalidated observations when it arrived as a PATCH and did not when it arrived as an upsert. Delta *does* sweep the observations of chunks it deletes, which is why an edit that happened to land on the right chunk was covered by accident — a tags-only upsert deletes no chunk at all and swept nothing.

Measured on the reporter's shape:

| upsert | before |
|---|---|
| tags-only (identical body) | **21** observations still scoped to the dropped hotel |
| tags narrowed + partial body edit | **10** observations over the *unchanged* chunk still scoped to it |
| `observation_scopes` changed | survivors never received the new value at all |

## The fix

`update_memory_units_metadata_and_tags` now reads the scoping the survivors carry **before** overwriting it, and for each unit whose tag set or `observation_scopes` actually changed, deletes the observations standing on it and requeues it.

The requeue has to be explicit: `delete_stale_observations` resets only an observation's *other* sources — the ones being deleted — so a rescoped survivor would otherwise stay marked consolidated against an observation that no longer exists and never be selected into a batch again. Units whose scoping is unchanged keep their observations; an ordinary delta edit must not re-consolidate the whole document.

`observation_scopes` is propagated to survivors too, which it never was: a re-retain switching a document from `combined` to `per_tag` left every surviving unit on the old value, so the new routing applied only to facts the same retain happened to re-extract. It is now written with tags and metadata, unconditionally, on the same "a survivor must match a full replace" rule those two already follow.

Both branches are covered — the SQL one and the store-owned one — and the store-owned metadata-only path is now wrapped in a transaction, since the observation delete and the requeue of the co-sources it strands have to land together.

## Tests

Three regression tests on the shapes an upsert can take, driven through the public retain API: tags-only with an identical body, tags narrowed alongside a partial edit (the unchanged chunk is the gap), and a change to `observation_scopes` rather than to the tags. All three fail on `main`.

## Note for reviewers

`observation_scopes` is now written unconditionally, so a re-retain that omits it clears it from survivors — the same way `tags` and `metadata` already behave here. `reprocess_document` replays it via `retain_params`, so that round-trip is intact.

https://claude.ai/code/session_01F3i5UVdZRK16AZ9oFQqsg4