### PR TITLE
fix(local-models): copy misaligned weights out of mapped storage, and fail fast

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -38,6 +38,8 @@ from ..config import (
 )
 from .bank_attribution import reranker_bank_attribution_headers
 from .local_device import (
+    align_local_model_weights,
+    assert_finite_local_output,
     release_local_inference_memory,
     resolve_model_device_type,
     select_local_device,
@@ -230,6 +232,12 @@ class LocalSTCrossEncoder(CrossEncoderModel):
                 # Restore original logging level
                 transformers_logger.setLevel(original_level)
 
+        # Safetensors weights are mapped zero-copy and can land on a byte offset that
+        # is not a multiple of the dtype size, which makes torch's vectorized CPU matmul
+        # return corrupt scores. See engine/local_device.py. The default reranker
+        # (ms-marco-MiniLM-L-6-v2) is one of the affected files.
+        align_local_model_weights(self._model.model, label=f"Reranker[{self.model_name}]")
+
         self._device_type = resolve_model_device_type(self._model)
 
         # FP16 inference: convert model weights to half precision.
@@ -237,6 +245,14 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         if self.fp16 and self._device_type != "cpu":
             self._model.model.half()
             logger.info("Reranker: FP16 inference enabled")
+
+        # Smoke-test the fully configured model (after any FP16 conversion). NaN logits
+        # are sanitized to 0.0 downstream, so startup is the last point at which a model
+        # that computes garbage is still observable.
+        assert_finite_local_output(
+            self._model.predict([("hindsight startup probe", "hindsight startup probe")]),
+            label=f"Reranker[{self.model_name}]",
+        )
 
         # Initialize shared executor (limited workers naturally limits concurrency)
         if LocalSTCrossEncoder._executor is None:

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -60,6 +60,8 @@ from ..config import (
 )
 from .bank_attribution import apply_bank_attribution
 from .local_device import (
+    align_local_model_weights,
+    assert_finite_local_output,
     release_local_inference_memory,
     resolve_model_device_type,
     select_local_device,
@@ -460,8 +462,21 @@ class LocalSTEmbeddings(Embeddings):
                 # Restore original logging level
                 transformers_logger.setLevel(original_level)
 
+        # See engine/local_device.py: zero-copy safetensors weights can land unaligned,
+        # which silently corrupts the CPU matmul. Whether a model file is affected is a
+        # property of its header length, so check every model rather than a known list.
+        align_local_model_weights(self._model, label=f"Embeddings[{self.model_name}]")
+
         self._dimension = self._model.get_sentence_embedding_dimension()
         self._device_type = resolve_model_device_type(self._model)
+
+        # Smoke-test before serving: a NaN embedding is invisible downstream (it
+        # normalizes away and pgvector stores it), so fail startup instead.
+        assert_finite_local_output(
+            self._model.encode(["hindsight startup probe"]),
+            label=f"Embeddings[{self.model_name}]",
+        )
+
         logger.info(f"Embeddings: local provider initialized (dim: {self._dimension}, device: {self._device_type})")
 
     def encode(self, texts: list[str]) -> list[list[float]]:

--- a/hindsight-api-slim/hindsight_api/engine/local_device.py
+++ b/hindsight-api-slim/hindsight_api/engine/local_device.py
@@ -29,6 +29,28 @@ No released mitigation exists today: empty_cache(), synchronize(),
 PYTORCH_MPS_HIGH_WATERMARK_RATIO, and autorelease pools were all confirmed
 ineffective upstream. Revisit MPS-as-default once one of those knobs lands.
 
+**3. Weight alignment — safetensors tensors can land unaligned.**
+``transformers`` loads safetensors zero-copy: each parameter is a view onto the
+mapped file, so it inherits the byte offset of the file's data section. That
+offset is ``8 + len(json_header)``, which is not guaranteed to be a multiple of
+the dtype's size. When it is not, torch's vectorized CPU matmul reads the operand
+misaligned and returns wrong values — on arm64 with torch 2.10 a float32 matmul
+against a 2-byte-misaligned weight corrupts ~6% of the output columns, a few of
+which surface as NaN and the rest as plausible-looking finite garbage.
+
+The default reranker hits this: ``cross-encoder/ms-marco-MiniLM-L-6-v2`` has a
+12090-byte header, so its data starts at byte 12098 and every parameter lands at
+``ptr % 4 == 2``. Every logit came back NaN, which the reranker then sanitizes to
+0.0 — so reranking appeared to run, every score was 0, ranking silently fell back
+to fusion order (the ``is_passthrough_reranker`` seed does not fire for a real
+reranker), and any ``min_scores.reranker`` floor above 0 dropped every result.
+Whether a given model is affected is a property of its file, not of the model or
+the platform: ``BAAI/bge-small-en-v1.5`` has a 22200-byte header, lands at
+``ptr % 4 == 0``, and is fine — until someone re-uploads it with different
+metadata. So we normalize alignment at load for every local torch model, and
+smoke-test the loaded model so a NaN-producing one fails at startup instead of
+silently degrading recall.
+
 **2. Memory release after each batch.**
 Local CPU inference allocates large transient numpy/tensor buffers per call. The
 allocator keeps those freed pages as a high-water mark, so RSS grows monotonically
@@ -174,3 +196,80 @@ def release_local_inference_memory(device_type: str | None = None) -> None:
         gc.collect()
     _heap_trim()
     _empty_gpu_cache(device_type)
+
+
+def _misaligned(tensor) -> bool:
+    """True if ``tensor``'s data pointer is not a multiple of its element size.
+
+    Natural alignment is the boundary torch itself enforces (``Tensor.view`` to a
+    wider dtype refuses a storage offset that is not divisible by the target
+    element size) and the one the vectorized CPU kernels assume. Anything at or
+    above it was verified correct; only sub-element offsets corrupt results.
+    """
+    return tensor.data_ptr() % tensor.element_size() != 0
+
+
+def align_local_model_weights(model: object, *, label: str) -> int:
+    """Copy any misaligned parameter or buffer of ``model`` into owned memory.
+
+    Safetensors weights are mapped zero-copy and can land on a sub-element byte
+    offset, which makes torch's vectorized CPU matmul return wrong values (see the
+    module docstring). Cloning the affected tensors moves them onto freshly
+    allocated, naturally aligned storage.
+
+    Only misaligned tensors are copied, so the common case costs a pointer check
+    per tensor and no extra memory. Returns the number of tensors copied, and
+    raises ``RuntimeError`` if any tensor is still misaligned afterwards rather
+    than letting a model that would compute garbage reach production traffic.
+    """
+    named_parameters = getattr(model, "named_parameters", None)
+    named_buffers = getattr(model, "named_buffers", None)
+    if named_parameters is None or named_buffers is None:
+        raise TypeError(f"{label}: expected a torch module, got {type(model).__name__}")
+
+    tensors = list(named_parameters()) + list(named_buffers())
+    copied = 0
+    for _name, tensor in tensors:
+        if _misaligned(tensor):
+            # Reassigning .data rebinds the storage in place, so the module keeps
+            # holding the same Parameter/buffer object.
+            tensor.data = tensor.data.clone()
+            copied += 1
+
+    still_misaligned = [name for name, tensor in tensors if _misaligned(tensor)]
+    if still_misaligned:
+        raise RuntimeError(
+            f"{label}: {len(still_misaligned)} tensor(s) remain misaligned after copying "
+            f"(e.g. {still_misaligned[0]}). Local inference would return wrong values; "
+            f"refusing to serve with this model."
+        )
+
+    if copied:
+        logger.warning(
+            "%s: copied %d/%d misaligned tensor(s) out of memory-mapped storage. The "
+            "model file's data section is not naturally aligned; without this copy the "
+            "CPU matmul would return corrupt scores.",
+            label,
+            copied,
+            len(tensors),
+        )
+    return copied
+
+
+def assert_finite_local_output(values: object, *, label: str) -> None:
+    """Fail startup if a local model's smoke-test output is not all finite.
+
+    A healthy model always produces finite numbers for ordinary text. NaN here means
+    the loaded weights compute garbage, and every downstream consumer masks it —
+    reranking sanitizes NaN to 0.0, embeddings normalize it away — so the only place
+    it is still visible is right here at load time.
+    """
+    import numpy as np
+
+    array = np.asarray(values, dtype=np.float64)
+    if not np.isfinite(array).all():
+        raise RuntimeError(
+            f"{label}: smoke test produced {int((~np.isfinite(array)).sum())} non-finite "
+            f"value(s) of {array.size}. The loaded weights compute garbage; refusing to "
+            f"serve with this model."
+        )

--- a/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
+++ b/hindsight-api-slim/hindsight_api/engine/query_analyzer.py
@@ -455,11 +455,17 @@ class TransformerQueryAnalyzer(QueryAnalyzer):
                 "transformers is required for TransformerQueryAnalyzer. Install it with: pip install transformers"
             )
 
+        from .local_device import align_local_model_weights
+
         logger.info(f"Loading query analyzer model: {self.model_name}...")
         self._tokenizer = AutoTokenizer.from_pretrained(self.model_name)
         self._model = AutoModelForSeq2SeqLM.from_pretrained(self.model_name)
         self._model.to(self.device)
         self._model.eval()
+        # Zero-copy safetensors weights can land on a sub-element byte offset, which
+        # corrupts the CPU matmul (see engine/local_device.py). `.to()` is a no-op for a
+        # CPU model, so it does not launder the alignment.
+        align_local_model_weights(self._model, label=f"QueryAnalyzer[{self.model_name}]")
         logger.info("Query analyzer model loaded")
 
     def _load_model(self):

--- a/hindsight-api-slim/tests/test_local_model_alignment.py
+++ b/hindsight-api-slim/tests/test_local_model_alignment.py
@@ -1,0 +1,256 @@
+"""Tests for the weight-alignment guard in engine/local_device.py.
+
+``transformers`` maps safetensors weights zero-copy, so every parameter is a view
+onto the file at ``8 + len(json_header)`` bytes. When that offset is not a multiple
+of the dtype size, torch's vectorized CPU matmul reads the operand misaligned and
+returns wrong values — on arm64 with torch 2.10 a float32 matmul against a
+2-byte-misaligned weight corrupts ~6% of the output columns, only a few of which
+show up as NaN. The default reranker (ms-marco-MiniLM-L-6-v2, 12090-byte header →
+``ptr % 4 == 2``) returned NaN for every pair, which reranking sanitizes to 0.0.
+
+Whether a model file is affected depends on its header length, so these tests build
+the misaligned case explicitly rather than relying on a particular model or platform.
+"""
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from hindsight_api.engine import local_device  # noqa: E402
+from hindsight_api.engine.local_device import (  # noqa: E402
+    align_local_model_weights,
+    assert_finite_local_output,
+)
+
+
+def _misaligned_tensor(values: "torch.Tensor", byte_offset: int = 2) -> "torch.Tensor":
+    """Return a tensor holding ``values`` at a deliberate sub-element byte offset.
+
+    torch's own APIs refuse to create this (``Tensor.view`` requires the storage
+    offset to divide the element size), which is exactly why it only ever arises
+    from a zero-copy map of an external buffer. numpy allows it, and
+    ``torch.from_numpy`` keeps the pointer, so this reproduces what safetensors
+    hands transformers.
+    """
+    payload = values.contiguous().numpy().tobytes()
+    buffer = bytearray(byte_offset) + bytearray(payload) + bytearray(64)
+    array = np.frombuffer(memoryview(buffer), dtype=np.float32, count=values.numel(), offset=byte_offset).reshape(
+        values.shape
+    )
+    tensor = torch.from_numpy(array)
+    # Keep the backing bytearray alive for as long as the tensor is.
+    tensor._test_backing_buffer = buffer  # type: ignore[attr-defined]
+    return tensor
+
+
+class _Tiny(torch.nn.Module):
+    """A one-linear-layer module whose weight/buffer alignment the test controls."""
+
+    def __init__(self, *, misaligned: bool):
+        super().__init__()
+        torch.manual_seed(0)
+        weight = torch.randn(64, 64) * 0.05
+        scale = torch.randn(64)
+        if misaligned:
+            weight = _misaligned_tensor(weight)
+            scale = _misaligned_tensor(scale)
+        self.weight = torch.nn.Parameter(weight)
+        self.register_buffer("scale", scale)
+
+    def forward(self, x: "torch.Tensor") -> "torch.Tensor":
+        return (x @ self.weight.T) * self.scale
+
+
+def _all_tensors(module: "torch.nn.Module") -> list["torch.Tensor"]:
+    return [t for _, t in list(module.named_parameters()) + list(module.named_buffers())]
+
+
+class TestAlignLocalModelWeights:
+    def test_misaligned_parameter_and_buffer_are_copied(self):
+        model = _Tiny(misaligned=True)
+        assert all(t.data_ptr() % t.element_size() != 0 for t in _all_tensors(model))
+
+        copied = align_local_model_weights(model, label="Test")
+
+        assert copied == 2  # the parameter and the buffer
+        assert all(t.data_ptr() % t.element_size() == 0 for t in _all_tensors(model))
+
+    def test_aligned_model_is_not_copied(self):
+        """The common case must cost a pointer check, not a duplicate of the model."""
+        model = _Tiny(misaligned=False)
+        pointers_before = [t.data_ptr() for t in _all_tensors(model)]
+
+        copied = align_local_model_weights(model, label="Test")
+
+        assert copied == 0
+        assert [t.data_ptr() for t in _all_tensors(model)] == pointers_before
+
+    def test_values_are_preserved_exactly(self):
+        """Copying must move the bytes, not reinterpret them."""
+        model = _Tiny(misaligned=True)
+        weight_before = np.array(model.weight.detach().tolist())
+        scale_before = np.array(model.scale.detach().tolist())
+
+        align_local_model_weights(model, label="Test")
+
+        np.testing.assert_array_equal(np.array(model.weight.detach().tolist()), weight_before)
+        np.testing.assert_array_equal(np.array(model.scale.detach().tolist()), scale_before)
+
+    def test_forward_matches_reference_after_alignment(self):
+        """The regression: a misaligned weight makes the CPU matmul return garbage.
+
+        The reference is computed in float64 from the same values, which is immune to
+        the misaligned-operand path. Asserting only the post-alignment result keeps
+        this meaningful on platforms whose kernels tolerate the misalignment.
+        """
+        model = _Tiny(misaligned=True)
+        x = torch.randn(16, 64)
+        weight = torch.tensor(model.weight.detach().tolist(), dtype=torch.float64)
+        scale = torch.tensor(model.scale.detach().tolist(), dtype=torch.float64)
+        expected = ((x.double() @ weight.T) * scale).float()
+
+        align_local_model_weights(model, label="Test")
+
+        with torch.no_grad():
+            actual = model(x)
+        assert torch.isfinite(actual).all()
+        torch.testing.assert_close(actual, expected, rtol=1e-4, atol=1e-4)
+
+    def test_raises_when_alignment_cannot_be_fixed(self):
+        """A model that would compute garbage must not reach production traffic."""
+        model = _Tiny(misaligned=True)
+        with patch.object(local_device, "_misaligned", return_value=True):
+            with pytest.raises(RuntimeError, match="remain misaligned after copying"):
+                align_local_model_weights(model, label="Reranker[some-model]")
+
+    def test_rejects_non_module(self):
+        with pytest.raises(TypeError, match="expected a torch module"):
+            align_local_model_weights(object(), label="Test")
+
+
+class TestAssertFiniteLocalOutput:
+    def test_accepts_finite_values(self):
+        assert_finite_local_output([1.0, -11.4, 0.0], label="Test")
+        assert_finite_local_output(np.array([[0.1, 0.2], [0.3, 0.4]]), label="Test")
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite_values(self, bad):
+        with pytest.raises(RuntimeError, match="smoke test produced"):
+            assert_finite_local_output([1.0, bad, 2.0], label="Reranker[some-model]")
+
+    def test_message_names_the_model_and_the_count(self):
+        with pytest.raises(RuntimeError) as exc:
+            assert_finite_local_output([float("nan"), float("nan"), 1.0], label="Embeddings[bge]")
+        assert "Embeddings[bge]" in str(exc.value)
+        assert "2 non-finite value(s) of 3" in str(exc.value)
+
+
+class TestLoadersGuardTheirWeights:
+    """The guard has to run at the call sites, not just exist."""
+
+    async def test_reranker_aligns_and_smoke_tests(self):
+        from hindsight_api.engine.cross_encoder import LocalSTCrossEncoder
+
+        fake = MagicMock()
+        fake.model = _Tiny(misaligned=True)
+        fake.predict.return_value = [2.25]
+        encoder = LocalSTCrossEncoder(model_name="test-model", force_cpu=True)
+
+        with patch("sentence_transformers.CrossEncoder", return_value=fake):
+            await encoder.initialize()
+
+        assert all(t.data_ptr() % t.element_size() == 0 for t in _all_tensors(fake.model))
+        fake.predict.assert_called_once()
+
+    async def test_reranker_refuses_a_nan_producing_model(self):
+        from hindsight_api.engine.cross_encoder import LocalSTCrossEncoder
+
+        fake = MagicMock()
+        fake.model = _Tiny(misaligned=False)
+        fake.predict.return_value = [float("nan")]
+        encoder = LocalSTCrossEncoder(model_name="test-model", force_cpu=True)
+
+        with patch("sentence_transformers.CrossEncoder", return_value=fake):
+            with pytest.raises(RuntimeError, match="smoke test produced"):
+                await encoder.initialize()
+
+    async def test_embeddings_align_and_smoke_test(self):
+        from hindsight_api.engine.embeddings import LocalSTEmbeddings
+
+        fake = _Tiny(misaligned=True)
+        fake.get_sentence_embedding_dimension = lambda: 64  # type: ignore[method-assign]
+        fake.encode = lambda texts: np.zeros((len(texts), 64), dtype=np.float32)  # type: ignore[method-assign]
+        embeddings = LocalSTEmbeddings(model_name="test-model", force_cpu=True)
+
+        with patch("sentence_transformers.SentenceTransformer", return_value=fake):
+            await embeddings.initialize()
+
+        assert all(t.data_ptr() % t.element_size() == 0 for t in _all_tensors(fake))
+        assert embeddings.dimension == 64
+
+    def test_query_analyzer_aligns_its_weights(self):
+        """The T5 analyzer loads the same way; `.to("cpu")` does not launder alignment."""
+        from hindsight_api.engine.query_analyzer import TransformerQueryAnalyzer
+
+        fake = _Tiny(misaligned=True)
+        analyzer = TransformerQueryAnalyzer(model_name="test-model")
+
+        with (
+            patch("transformers.AutoModelForSeq2SeqLM.from_pretrained", return_value=fake),
+            patch("transformers.AutoTokenizer.from_pretrained", return_value=MagicMock()),
+        ):
+            analyzer.load()
+
+        assert all(t.data_ptr() % t.element_size() == 0 for t in _all_tensors(fake))
+
+    async def test_embeddings_refuse_a_nan_producing_model(self):
+        from hindsight_api.engine.embeddings import LocalSTEmbeddings
+
+        fake = _Tiny(misaligned=False)
+        fake.get_sentence_embedding_dimension = lambda: 64  # type: ignore[method-assign]
+        fake.encode = lambda texts: np.full((len(texts), 64), np.nan, dtype=np.float32)  # type: ignore[method-assign]
+        embeddings = LocalSTEmbeddings(model_name="test-model", force_cpu=True)
+
+        with patch("sentence_transformers.SentenceTransformer", return_value=fake):
+            with pytest.raises(RuntimeError, match="smoke test produced"):
+                await embeddings.initialize()
+
+
+class TestEveryLocalTorchLoaderIsGuarded:
+    """Family guard: the defect this fixes is a loader that *doesn't* call the helper.
+
+    A fourth local torch model added later would silently reintroduce the bug, and no
+    test for it would exist by construction — so assert over the whole family rather
+    than over the three loaders that happen to exist today. ONNX and MLX providers are
+    deliberately out of scope: they don't map safetensors into torch tensors.
+    """
+
+    # Constructing a torch model from a HuggingFace checkpoint — the operation that
+    # can hand back zero-copy, potentially misaligned weights.
+    _LOADER_PATTERNS = (
+        r"=\s*CrossEncoder\(",
+        r"=\s*SentenceTransformer\(",
+        r"AutoModel\w*\.from_pretrained\(",
+    )
+
+    def test_every_torch_model_loader_aligns_its_weights(self):
+        engine_dir = Path(local_device.__file__).parent
+        loaders = {
+            path.name: source
+            for path in sorted(engine_dir.rglob("*.py"))
+            if any(re.search(p, source := path.read_text()) for p in self._LOADER_PATTERNS)
+        }
+
+        assert loaders, "found no local torch model loaders — has the detection pattern gone stale?"
+
+        unguarded = [name for name, source in loaders.items() if "align_local_model_weights" not in source]
+        assert not unguarded, (
+            f"{unguarded} load a torch model without calling align_local_model_weights. "
+            f"Zero-copy safetensors weights can land misaligned, which silently corrupts "
+            f"the CPU matmul (see engine/local_device.py)."
+        )


### PR DESCRIPTION
## The symptom

On arm64 with torch 2.10 / transformers 5.x, the default local reranker
(`cross-encoder/ms-marco-MiniLM-L-6-v2`) returns `nan` for **every** pair:

```
predict() -> [nan nan nan]
```

Nothing raises. `reranking.py` sanitizes NaN to `0.0`, so reranking appears to run and
logs its candidate count, every score is `0`, and:

- **Ranking silently degrades to fusion order.** Not via the `is_passthrough_reranker`
  seed — that is gated on an explicit flag and does not fire for a real reranker. It
  happens by accident, because `scored_results.sort(key=weight)` is stable and every
  weight is `0.0`.
- **`min_scores.reranker` becomes a cliff, not a no-op.** Any floor `> 0` drops *every*
  result (recall returns empty); a floor of exactly `0` keeps everything.

## The cause: pointer alignment, not the model

`transformers` maps safetensors zero-copy, so each parameter is a view onto the file at
`8 + len(json_header)` bytes — and that offset is not guaranteed to be a multiple of the
dtype size.

| | |
|---|---|
| MiniLM header | 12090 bytes → data starts at **12098**, `% 4 == 2` |
| Its 105 params | all at `data_ptr() % 4 == 2` |
| In-memory offset vs in-file offset | **0 mismatches** — confirms the zero-copy view |

`untyped_storage().filename` reads `None` here because torch only records it for
`from_file`, not `from_blob` — so that is not a usable signal for detecting this.
`low_cpu_mem_usage: False` was already set at both call sites and does not prevent it.

## Misalignment is worse than the NaN suggested

A float32 matmul against a 2-byte-misaligned weight corrupts a **fixed 6% of output
columns** — 624 of 9984 in every trial with a random operand — and only 0–52 of those
surface as NaN:

```
trial0: aligned nan/inf/wrong=(0,0,0)   MISALIGNED nan/inf/wrong=(0,  0, 624)
trial1: aligned nan/inf/wrong=(0,0,0)   MISALIGNED nan/inf/wrong=(0,  7, 624)
trial2: aligned nan/inf/wrong=(0,0,0)   MISALIGNED nan/inf/wrong=(26, 3, 624)
trial3: aligned nan/inf/wrong=(0,0,0)   MISALIGNED nan/inf/wrong=(52,13, 624)
```

In the failing model only 2 columns went NaN; the rest propagated finite garbage through
all 6 layers unnoticed. So a NaN check alone is not a sufficient guard — the alignment
itself has to be fixed.

## Scope: a property of the file, not the platform

`BAAI/bge-small-en-v1.5` (default embeddings) has a 22200-byte header, lands at
`% 4 == 0`, and is **fine today** — until it is re-uploaded with different metadata.
So this normalizes alignment for **all three** local torch loaders rather than
special-casing known-bad models:

- `engine/cross_encoder.py` — `LocalSTCrossEncoder`
- `engine/embeddings.py` — `LocalSTEmbeddings`
- `engine/query_analyzer.py` — `TransformerQueryAnalyzer` (`.to("cpu")` is a no-op, so it does not launder alignment)

ONNX and MLX providers are out of scope — they do not map safetensors into torch tensors.

## The fix

`align_local_model_weights()` in `engine/local_device.py` copies only the tensors that are
actually misaligned (the aligned case costs one pointer check per tensor and no memory),
then **raises** if any remain misaligned rather than serving a model that computes garbage.

`assert_finite_local_output()` smoke-tests the loaded reranker and embedder, because
startup is the last point at which a broken model is still observable — reranking
sanitizes NaN to `0.0` and embeddings normalize it away.

```
Reranker before: predict() -> [nan, nan, nan]
Reranker after:  predict() -> [-2.55, -11.44, -11.43]
```
(Kubernetes query vs. a Kubernetes memory, unrelated prose, and a Redis memory — the
relevant one now wins.)

## Tests

17 tests, no network or model downloads, 0.2s. The misaligned case is built explicitly
via numpy — torch's own APIs refuse to create it, which is why it only ever arises from a
zero-copy map — so the tests are meaningful on every platform rather than only on affected ones.

- The forward-pass regression **fails without the fix**: 64 of 1024 elements wrong, and
  **zero NaN** — which is the point.
- Values are asserted byte-preserved, and the aligned path is asserted to copy nothing.
- All three call sites are covered, including that each refuses a NaN-producing model.
- A **family guard** enumerates every local torch loader from the filesystem and asserts
  each calls the helper — verified to fail when a loader is unhooked. The next loader added
  is the one that would otherwise silently reintroduce this.

`./scripts/hooks/lint.sh`, `ty check`, and the surrounding reranker/embeddings/device
suites (67 tests) all pass.