### PR TITLE
fix(loop-watchdog): don't report the stall that stop() itself causes

### DIFF
--- a/hindsight-api-slim/hindsight_api/loop_watchdog.py
+++ b/hindsight-api-slim/hindsight_api/loop_watchdog.py
@@ -120,10 +120,26 @@ class LoopWatchdog:
             except RuntimeError:
                 return  # loop closed — nothing left to watch
             if not serviced.wait(self._stall_threshold_s):
+                # A stop() requested while this ping was outstanding is not a stall to
+                # report: stop() runs on the loop thread and its join() blocks that
+                # thread for up to poll_interval + threshold + 1s, so the loop cannot
+                # service an in-flight ping — the watchdog would be reporting a stall it
+                # caused itself, with the shutdown frame as the named culprit. In
+                # production that lands a spurious "EVENT LOOP BLOCKED" warning at every
+                # clean shutdown, pointing at watchdog.stop(); in tests it made the
+                # "quiet on a responsive loop" case fail ~5% of runs (measured 11/200
+                # locally, and on CI shard 2). Re-checked here rather than before the
+                # wait: only the outcome of the wait tells us the ping went unserviced.
+                if self._stop.is_set():
+                    return
                 self._report(sent_at)
                 # Block until the loop finally services the ping so we emit one
-                # report per stall, not one per poll while it stays blocked.
-                serviced.wait()
+                # report per stall, not one per poll while it stays blocked. Bounded by
+                # stop() so a loop that never comes back cannot pin the thread here and
+                # make stop()'s join() wait out its full timeout.
+                while not serviced.wait(self._poll_interval_s):
+                    if self._stop.is_set():
+                        return
 
     def _report(self, sent_at: float) -> None:
         frame = sys._current_frames().get(self._loop_thread_id or -1)

--- a/hindsight-api-slim/tests/test_loop_watchdog.py
+++ b/hindsight-api-slim/tests/test_loop_watchdog.py
@@ -6,6 +6,7 @@ genuinely off-loop work does not trip it.
 """
 
 import asyncio
+import threading
 import time
 
 from hindsight_api.loop_watchdog import LoopWatchdog
@@ -36,9 +37,14 @@ async def test_watchdog_detects_on_loop_block():
 
 async def test_watchdog_ignores_offloop_work():
     stalls: list[tuple[float, str]] = []
+    # 0.3s, not the 0.1s this used to use: the assertion is "no stall", so the threshold
+    # is also the margin against ordinary scheduling jitter, and 0.1s is inside what a CI
+    # runner hosting eight xdist workers hands out. It must still stay BELOW the 0.5s of
+    # offloaded work below — at a threshold above it the test would pass even if that work
+    # ran on the loop, which is the whole thing it exists to catch.
     wd = LoopWatchdog(
         asyncio.get_running_loop(),
-        stall_threshold_s=0.1,
+        stall_threshold_s=0.3,
         poll_interval_s=0.02,
         on_stall=lambda dur, stack: stalls.append((dur, stack)),
     )
@@ -57,9 +63,12 @@ async def test_watchdog_ignores_offloop_work():
 
 async def test_watchdog_quiet_when_loop_responsive():
     stalls: list[tuple[float, str]] = []
+    # 1.0s for the same reason as above, and here nothing caps it: the loop below only
+    # ever awaits, so any threshold far above one iteration proves the point. At 0.1s this
+    # was asserting that the host never hiccups for 100ms, which a loaded CI runner does.
     wd = LoopWatchdog(
         asyncio.get_running_loop(),
-        stall_threshold_s=0.1,
+        stall_threshold_s=1.0,
         poll_interval_s=0.02,
         on_stall=lambda dur, stack: stalls.append((dur, stack)),
     )
@@ -71,3 +80,39 @@ async def test_watchdog_quiet_when_loop_responsive():
         wd.stop()
 
     assert not stalls, f"watchdog reported a stall on a responsive loop: {stalls}"
+
+
+async def test_watchdog_stop_does_not_report_its_own_join_as_a_stall():
+    """Regression: ``stop()`` must not be reported as the stall it causes.
+
+    ``stop()`` runs on the loop thread and joins the watchdog thread, blocking the loop
+    for up to ``poll_interval + stall_threshold + 1s``. A ping already in flight when
+    that happens can never be serviced, so the watchdog used to report a stall whose
+    named culprit was ``watchdog.stop()`` itself — a spurious "EVENT LOOP BLOCKED"
+    warning at every clean shutdown, landing precisely when someone is reading the logs
+    to diagnose one. It also made the two "no stall" tests above fail ~5% of runs
+    (measured 11/200 locally; seen on CI shard 2).
+
+    Reproduced deterministically rather than by retrying a responsive loop until the
+    race lands. ``stop()`` is exactly two things — set the flag, then block the loop
+    thread — so they are staged apart here: the sleep blocks the loop so the in-flight
+    ping cannot be serviced, and the timer sets the flag partway through that block,
+    inside the window between the ping going out and the threshold expiring. The
+    watchdog therefore always reaches its report decision with the stop already
+    requested, which is the state the assertion is about. Margins are wide (flag at
+    ~0.02s, threshold 0.2s, block 0.5s) so the ordering does not depend on scheduling.
+    """
+    stalls: list[tuple[float, str]] = []
+    wd = LoopWatchdog(
+        asyncio.get_running_loop(),
+        stall_threshold_s=0.2,
+        poll_interval_s=0.01,
+        on_stall=lambda dur, stack: stalls.append((dur, stack)),
+    )
+    wd.start()
+    await asyncio.sleep(0.05)  # let the watchdog settle into steady polling
+    threading.Timer(0.02, wd._stop.set).start()
+    time.sleep(0.5)  # the loop thread is blocked, exactly as stop()'s join() blocks it
+    wd.stop()
+
+    assert not stalls, f"watchdog reported a stall caused by its own shutdown: {stalls}"


### PR DESCRIPTION
Investigating the two CI flakes seen on #4019. This PR fixes the first one, which turned out to be a real (if minor) product defect rather than just a flaky test.

## The bug

`LoopWatchdog.stop()` runs on the loop thread and joins the watchdog thread, blocking the loop for up to `poll_interval + stall_threshold + 1s`. A ping already in flight when that happens can never be serviced — so the watchdog reported a stall whose named culprit was `watchdog.stop()`. The watchdog reporting itself.

In production that is a spurious `EVENT LOOP BLOCKED` warning at every clean shutdown, naming the shutdown frame, landing exactly when someone is reading the logs to work out why a shutdown misbehaved. The watchdog exists to attribute a stuck `/health` to a blocked loop; a false positive at teardown is the one place it can actively mislead.

It also made `tests/test_loop_watchdog.py` flaky — **measured 11/200 locally** on `test_watchdog_quiet_when_loop_responsive`, and observed on CI shard 2 with the identical stack:

```
threading.join -> _wait_for_tstate_lock -> lock.acquire
```

## The fix

`_run` re-checks `_stop` after the ping wait times out and returns instead of reporting. Re-checked *after* the wait rather than before it, because only the outcome of the wait tells us the ping went unserviced.

The follow-up "block until the loop finally services the ping" wait is now bounded by `_stop` for the same reason: unbounded, a loop that never comes back pins that thread and makes `stop()`'s join sit out its full timeout.

## Test thresholds

Two negative tests also raised, because in a test asserting **no** stall the threshold is also the margin against ordinary scheduling jitter, and 0.1s is inside what a CI runner hosting eight xdist workers hands out:

- `quiet_when_loop_responsive`: 0.1s → 1.0s (nothing caps it; the loop only awaits)
- `ignores_offloop_work`: 0.1s → 0.3s, deliberately still **below** the 0.5s of offloaded work. Above it, the test would pass even if that work ran on the loop — which is the whole thing it exists to catch.

## Tests

A regression test that stages the two halves of `stop()` apart — the loop blocked so the in-flight ping cannot be serviced, and a timer setting the flag inside the window between the ping going out and the threshold expiring — so it reproduces the race deterministically instead of retrying until it lands.

Fails on the unfixed watchdog; 12/12 green with the fix; the 11/200 probe is now 0/200.

## Not in this PR

The other flake from #4019, `test_llm_trace::test_disabled_writes_no_rows`, is **not** fixed here — see the PR discussion. Four isolated `-n 8` runs of that file did not reproduce it, and the cause previously assumed for it does not survive reading the code.

https://claude.ai/code/session_01F3i5UVdZRK16AZ9oFQqsg4