### PR TITLE
fix(cursor): init registers sessionStart hooks + ships rules_file.py

### DIFF
--- a/hindsight-integrations/cursor/README.md
+++ b/hindsight-integrations/cursor/README.md
@@ -42,6 +42,7 @@ hindsight-cursor init --api-url http://localhost:8888
 ### What `init` does
 
 - Copies plugin files into `.cursor-plugin/hindsight-memory/`
+- Writes/merges project `.cursor/hooks.json` so Cursor registers `sessionStart` / `stop` (workspace-relative commands — plugin-dir hooks alone are not loaded by the IDE)
 - Creates `~/.hindsight/cursor.json` with your connection settings (if the file does not already exist)
 - Writes `.cursor/mcp.json` with the Hindsight MCP endpoint for on-demand recall/retain/reflect tools
 - Use `--force` to overwrite an existing installation
@@ -109,6 +110,7 @@ The agent can use these tools mid-session when it needs memory beyond what was i
 | `lib/bank.py` | Bank ID derivation + mission management |
 | `lib/content.py` | Content processing (transcript parsing, memory formatting, tag stripping) |
 | `lib/state.py` | File-based state persistence with `fcntl` locking |
+| `lib/rules_file.py` | Writes `.cursor/rules/hindsight-session.mdc` (sessionStart additionalContext workaround) |
 | `lib/llm.py` | LLM provider auto-detection for daemon mode |
 
 ## Connection Modes

--- a/hindsight-integrations/cursor/hindsight_cursor/cli.py
+++ b/hindsight-integrations/cursor/hindsight_cursor/cli.py
@@ -19,12 +19,17 @@ _PLUGIN_FILES = [
     "scripts/lib/content.py",
     "scripts/lib/daemon.py",
     "scripts/lib/llm.py",
+    "scripts/lib/rules_file.py",
     "scripts/lib/state.py",
     "scripts/session_start.py",
     "scripts/retain.py",
     "settings.json",
     "skills/hindsight-recall/SKILL.md",
 ]
+
+# Marker used to identify Hindsight's own entries when merging/stripping
+# project .cursor/hooks.json. Commands point at this install path.
+_HOOK_MARKER = ".cursor-plugin/hindsight-memory"
 
 _USER_CONFIG_DIR = Path.home() / ".hindsight"
 _USER_CONFIG_FILE = _USER_CONFIG_DIR / "cursor.json"
@@ -102,6 +107,107 @@ def _setup_mcp(project: Path, api_url: str | None, api_token: str | None, bank_i
     print(f"  MCP config written to {mcp_file}")
 
 
+def _hindsight_hook_entry(definition: dict) -> bool:
+    """True if a hooks.json entry belongs to this plugin install."""
+    return _HOOK_MARKER in json.dumps(definition)
+
+
+def _project_hooks_block() -> dict:
+    """Hooks Cursor loads from the project ``.cursor/hooks.json``.
+
+    Paths are workspace-relative so they work without ``CURSOR_PLUGIN_ROOT``
+    (which is only set for packages installed under ``~/.cursor/plugins``).
+    """
+    return {
+        "version": 1,
+        "hooks": {
+            "sessionStart": [
+                {
+                    "command": f"python3 {_HOOK_MARKER}/scripts/session_start.py",
+                    "timeout": 15,
+                }
+            ],
+            "stop": [
+                {
+                    "command": f"python3 {_HOOK_MARKER}/scripts/retain.py",
+                    "timeout": 15,
+                }
+            ],
+        },
+    }
+
+
+def _setup_hooks(project: Path) -> None:
+    """Write/merge project ``.cursor/hooks.json`` so Cursor registers the hooks.
+
+    Dropping files under ``.cursor-plugin/`` alone does not register hooks with
+    the IDE; Cursor only loads ``.cursor/hooks.json`` (workspace) or
+    ``~/.cursor/hooks.json`` (user). Idempotent: existing Hindsight entries are
+    replaced, other hooks are preserved.
+    """
+    cursor_dir = project / ".cursor"
+    hooks_file = cursor_dir / "hooks.json"
+    hooks_block = _project_hooks_block()
+
+    existing: dict = {}
+    if hooks_file.exists():
+        try:
+            existing = json.loads(hooks_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+
+    existing.setdefault("version", hooks_block.get("version", 1))
+    existing.setdefault("hooks", {})
+
+    for event, definitions in hooks_block.get("hooks", {}).items():
+        bucket = [d for d in existing["hooks"].get(event, []) if not _hindsight_hook_entry(d)]
+        bucket.extend(definitions)
+        existing["hooks"][event] = bucket
+
+    cursor_dir.mkdir(parents=True, exist_ok=True)
+    hooks_file.write_text(json.dumps(existing, indent=2) + "\n")
+    print(f"  Hooks registered in {hooks_file}")
+
+
+def _remove_hooks(project: Path) -> None:
+    """Strip this plugin's entries from project ``.cursor/hooks.json``."""
+    hooks_file = project / ".cursor" / "hooks.json"
+    if not hooks_file.exists():
+        return
+    try:
+        data = json.loads(hooks_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return
+
+    hooks = data.get("hooks", {})
+    changed = False
+    for event, definitions in list(hooks.items()):
+        kept = [d for d in definitions if not _hindsight_hook_entry(d)]
+        if len(kept) != len(definitions):
+            changed = True
+        if kept:
+            hooks[event] = kept
+        else:
+            del hooks[event]
+
+    if not changed:
+        return
+
+    if hooks:
+        data["hooks"] = hooks
+        hooks_file.write_text(json.dumps(data, indent=2) + "\n")
+        print(f"  Removed hindsight hooks from {hooks_file}")
+    else:
+        other_keys = {k for k in data if k not in ("version", "hooks")}
+        if other_keys:
+            data["hooks"] = {}
+            hooks_file.write_text(json.dumps(data, indent=2) + "\n")
+            print(f"  Removed hindsight hooks from {hooks_file}")
+        else:
+            hooks_file.unlink()
+            print(f"  Removed {hooks_file}")
+
+
 def cmd_init(args: argparse.Namespace) -> None:
     """Install the Hindsight plugin into a Cursor project."""
     project = Path(args.project).resolve()
@@ -118,6 +224,11 @@ def cmd_init(args: argparse.Namespace) -> None:
     print(f"Installing Hindsight plugin into {dest} ...")
     _copy_plugin(dest)
     print("  Plugin files copied.")
+
+    # Register hooks with Cursor IDE (project .cursor/hooks.json).
+    # The bundled hooks/hooks.json alone is not enough — Cursor only loads
+    # workspace/user hooks.json, not files under .cursor-plugin/.
+    _setup_hooks(project)
 
     _scaffold_config(args.api_url, args.api_token, args.bank_id)
 
@@ -156,6 +267,8 @@ def cmd_uninstall(args: argparse.Namespace) -> None:
                     print(f"  Removed {mcp_file}")
         except (json.JSONDecodeError, OSError):
             pass
+
+    _remove_hooks(project)
 
 
 def main() -> None:

--- a/hindsight-integrations/cursor/tests/test_cli.py
+++ b/hindsight-integrations/cursor/tests/test_cli.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from hindsight_cursor.cli import _plugin_data_dir, cmd_init, cmd_uninstall
+from hindsight_cursor.cli import _PLUGIN_FILES, _plugin_data_dir, cmd_init, cmd_uninstall
 
 
 @pytest.fixture()
@@ -22,6 +22,7 @@ def fake_plugin_data(tmp_path):
     (data_dir / "settings.json").write_text('{"bankId": "cursor"}')
     (data_dir / "scripts" / "lib").mkdir(parents=True)
     (data_dir / "scripts" / "lib" / "__init__.py").write_text("")
+    (data_dir / "scripts" / "lib" / "rules_file.py").write_text("# rules_file")
     (data_dir / "scripts" / "session_start.py").write_text("# session_start")
     (data_dir / "scripts" / "retain.py").write_text("# retain")
     (data_dir / "rules").mkdir()
@@ -55,6 +56,7 @@ class TestInit:
         assert (dest / "hooks" / "hooks.json").exists()
         assert (dest / "settings.json").exists()
         assert (dest / "scripts" / "session_start.py").exists()
+        assert (dest / "scripts" / "lib" / "rules_file.py").exists()
         assert (dest / "rules" / "hindsight-memory.mdc").exists()
 
     def test_refuses_overwrite_without_force(self, tmp_path, fake_plugin_data, capsys):
@@ -227,6 +229,91 @@ class TestInit:
         assert "hindsight" in mcp["mcpServers"]
 
 
+    def test_copies_rules_file(self, tmp_path, fake_plugin_data):
+        """session_start imports lib.rules_file — init must ship it (#3864)."""
+        project = tmp_path / "my-project"
+        project.mkdir()
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False)
+            )
+
+        assert (project / ".cursor-plugin" / "hindsight-memory" / "scripts" / "lib" / "rules_file.py").exists()
+
+    def test_plugin_files_lists_rules_file(self):
+        assert "scripts/lib/rules_file.py" in _PLUGIN_FILES
+
+    def test_writes_project_hooks_json(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "my-project"
+        project.mkdir()
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False)
+            )
+
+        hooks_file = project / ".cursor" / "hooks.json"
+        assert hooks_file.exists()
+        hooks = json.loads(hooks_file.read_text())
+        assert hooks["version"] == 1
+        assert "sessionStart" in hooks["hooks"]
+        assert "stop" in hooks["hooks"]
+        session_cmd = hooks["hooks"]["sessionStart"][0]["command"]
+        stop_cmd = hooks["hooks"]["stop"][0]["command"]
+        assert "session_start.py" in session_cmd
+        assert "retain.py" in stop_cmd
+        assert ".cursor-plugin/hindsight-memory" in session_cmd
+        assert "${CURSOR_PLUGIN_ROOT}" not in session_cmd
+
+    def test_merges_with_existing_hooks_json(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "my-project"
+        project.mkdir()
+        cursor_dir = project / ".cursor"
+        cursor_dir.mkdir()
+        (cursor_dir / "hooks.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "hooks": {
+                        "sessionStart": [{"command": "echo other-start", "timeout": 5}],
+                        "stop": [{"command": "echo other-stop"}],
+                    },
+                }
+            )
+        )
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False)
+            )
+
+        hooks = json.loads((cursor_dir / "hooks.json").read_text())
+        session = hooks["hooks"]["sessionStart"]
+        stop = hooks["hooks"]["stop"]
+        assert any("echo other-start" in d.get("command", "") for d in session)
+        assert any("hindsight-memory" in d.get("command", "") for d in session)
+        assert any("echo other-stop" in d.get("command", "") for d in stop)
+        assert any("retain.py" in d.get("command", "") for d in stop)
+
+    def test_hooks_merge_is_idempotent(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "my-project"
+        project.mkdir()
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=True)
+            )
+            cmd_init(
+                _Args(project=str(project), force=True, api_url=None, api_token=None, bank_id="cursor", no_mcp=True)
+            )
+
+        hooks = json.loads((project / ".cursor" / "hooks.json").read_text())
+        assert len(hooks["hooks"]["sessionStart"]) == 1
+        assert len(hooks["hooks"]["stop"]) == 1
+
+
+
 class TestUninstall:
     def test_removes_plugin(self, tmp_path, fake_plugin_data):
         project = tmp_path / "my-project"
@@ -270,3 +357,35 @@ class TestUninstall:
         mcp = json.loads((mcp_dir / "mcp.json").read_text())
         assert "hindsight" not in mcp["mcpServers"]
         assert "other" in mcp["mcpServers"]
+
+    def test_cleans_up_hooks_json(self, tmp_path):
+        project = tmp_path / "my-project"
+        dest = project / ".cursor-plugin" / "hindsight-memory"
+        dest.mkdir(parents=True)
+        (dest / "x.txt").write_text("x")
+
+        cursor_dir = project / ".cursor"
+        cursor_dir.mkdir()
+        (cursor_dir / "hooks.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "hooks": {
+                        "sessionStart": [
+                            {"command": "echo other"},
+                            {"command": "python3 .cursor-plugin/hindsight-memory/scripts/session_start.py"},
+                        ],
+                        "stop": [
+                            {"command": "python3 .cursor-plugin/hindsight-memory/scripts/retain.py"},
+                        ],
+                    },
+                }
+            )
+        )
+
+        cmd_uninstall(_Args(project=str(project)))
+
+        hooks = json.loads((cursor_dir / "hooks.json").read_text())
+        assert hooks["hooks"]["sessionStart"] == [{"command": "echo other"}]
+        assert "stop" not in hooks["hooks"]
+


### PR DESCRIPTION
## Summary

`hindsight-cursor init` was copying the plugin into `.cursor-plugin/hindsight-memory/`, but Cursor never actually ran the hooks. Two packing/install bugs:

1. `scripts/lib/rules_file.py` is imported by `session_start.py` but was missing from `_PLUGIN_FILES`, so init never copied it.
2. init never wrote a project `.cursor/hooks.json`. Cursor only loads hooks from `.cursor/hooks.json` (workspace) or `~/.cursor/hooks.json` (user) — dropping files under `.cursor-plugin/` does not register them.

## Changes

- Add `scripts/lib/rules_file.py` to `_PLUGIN_FILES`
- Have `init` write/merge project `.cursor/hooks.json` with workspace-relative commands (no `${CURSOR_PLUGIN_ROOT}`)
- `uninstall` strips those hook entries (same idea as the MCP cleanup)
- README notes the hooks registration step
- Unit tests for copy / write / merge / idempotency / uninstall

## Test plan

- [x] `pytest tests/test_cli.py` (19 passed)
- [x] `pytest tests/test_cli.py tests/test_hooks.py tests/test_rules_file.py tests/test_config.py` (60 passed)
- [ ] Fresh `hindsight-cursor init` in an empty project → `.cursor/hooks.json` present, `rules_file.py` under `.cursor-plugin/hindsight-memory/scripts/lib/`
- [ ] Quit/reopen Cursor, new Agent chat → `sessionStart` fires (e.g. `last_recall.json` / `.cursor/rules/hindsight-session.mdc`)

Fixes #3864