### PR TITLE
fix(mental-models): return 409 on a duplicate mental-model id

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14818,6 +14818,8 @@ class MemoryEngine(MemoryEngineInterface):
             # and a cross-process CREATE INDEX race collides in pg_class, not here.
             if getattr(exc, "table_name", None) != "mental_models":
                 raise
+            # Local, like every other OperationValidationError import in this module: the
+            # extensions package pulls in MCPExtension, which imports MemoryEngine back.
             from hindsight_api.extensions import OperationValidationError
 
             raise OperationValidationError(

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14786,29 +14786,44 @@ class MemoryEngine(MemoryEngineInterface):
         # pinned model creation must do the same. The lazy bank-create runs inside
         # the same transaction as the INSERT below, so a freshly-created bank never
         # outlives a mental-model insert that ultimately fails.
-        async with acquire_with_retry(backend) as conn:
-            async with conn.transaction():
-                created = await self._ensure_bank_exists(
-                    bank_id,
-                    request_context,
-                    conn=conn,
-                )
-                row = await self._insert_pinned_mental_model(
-                    conn,
-                    mental_model_id=mental_model_id,
-                    bank_id=bank_id,
-                    name=name,
-                    source_query=source_query,
-                    content=content,
-                    embedding=embedding,
-                    tags=tags,
-                    max_tokens=max_tokens,
-                    trigger=trigger,
-                )
-            # After the transaction commits: the index is derived from a row that must already
-            # exist, and indexing inside the transaction would publish a page a rollback then
-            # un-creates.
-            await self._index_knowledge_page(conn, bank_id, mental_model_id, embedding=embedding_vec)
+        try:
+            async with acquire_with_retry(backend) as conn:
+                async with conn.transaction():
+                    created = await self._ensure_bank_exists(
+                        bank_id,
+                        request_context,
+                        conn=conn,
+                    )
+                    row = await self._insert_pinned_mental_model(
+                        conn,
+                        mental_model_id=mental_model_id,
+                        bank_id=bank_id,
+                        name=name,
+                        source_query=source_query,
+                        content=content,
+                        embedding=embedding,
+                        tags=tags,
+                        max_tokens=max_tokens,
+                        trigger=trigger,
+                    )
+                # After the transaction commits: the index is derived from a row that must already
+                # exist, and indexing inside the transaction would publish a page a rollback then
+                # un-creates.
+                await self._index_knowledge_page(conn, bank_id, mental_model_id, embedding=embedding_vec)
+        except asyncpg.UniqueViolationError as exc:
+            # mental_models_pkey is the table's only unique constraint, so a violation naming
+            # this table is the caller's id colliding with a model that already exists. Anything
+            # else is a real failure and must not be reported as a duplicate model:
+            # _ensure_bank_exists creates this bank's vector indexes in the same transaction,
+            # and a cross-process CREATE INDEX race collides in pg_class, not here.
+            if getattr(exc, "table_name", None) != "mental_models":
+                raise
+            from hindsight_api.extensions import OperationValidationError
+
+            raise OperationValidationError(
+                f"Mental model '{mental_model_id}' already exists in bank '{bank_id}'",
+                status_code=409,
+            ) from exc
 
         # Best-effort default-template hook runs after the bank-create commits
         # (it opens its own connections and can create pinned models).

--- a/hindsight-api-slim/tests/test_mental_model_duplicate_id_409.py
+++ b/hindsight-api-slim/tests/test_mental_model_duplicate_id_409.py
@@ -24,13 +24,14 @@ async def test_duplicate_mental_model_id_raises_conflict(memory: MemoryEngine, r
         mental_model_id=mental_model_id,
         request_context=request_context,
     )
+    # Outside the try: the bank only exists once this has returned, and cleaning up
+    # a bank that was never created would mask whatever made the first create fail.
+    first = await memory.create_mental_model(**create)
+    assert first["id"] == mental_model_id
     try:
-        first = await memory.create_mental_model(**create)
-        assert first["id"] == mental_model_id
-
         with pytest.raises(OperationValidationError) as excinfo:
             await memory.create_mental_model(**create)
         assert excinfo.value.status_code == 409
-        assert mental_model_id in excinfo.value.reason
+        assert "already exists" in excinfo.value.reason
     finally:
         await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_mental_model_duplicate_id_409.py
+++ b/hindsight-api-slim/tests/test_mental_model_duplicate_id_409.py
@@ -1,0 +1,36 @@
+"""A duplicate mental-model id is a conflict, not an unhandled 500.
+
+Clients that sweep a list of external ids and create a model for each one re-POST
+ids they already created. Before this was handled, every such call propagated the
+raw ``mental_models_pkey`` violation out of the engine and surfaced as a 500.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.extensions import OperationValidationError
+
+
+async def test_duplicate_mental_model_id_raises_conflict(memory: MemoryEngine, request_context):
+    bank_id = f"test-mm-dup-{uuid.uuid4().hex[:8]}"
+    mental_model_id = "account-0013a00001aATOhAAO"
+    create = dict(
+        bank_id=bank_id,
+        name="Account standing",
+        source_query="what is the standing of this account",
+        content="Generating content...",
+        mental_model_id=mental_model_id,
+        request_context=request_context,
+    )
+    try:
+        first = await memory.create_mental_model(**create)
+        assert first["id"] == mental_model_id
+
+        with pytest.raises(OperationValidationError) as excinfo:
+            await memory.create_mental_model(**create)
+        assert excinfo.value.status_code == 409
+        assert mental_model_id in excinfo.value.reason
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
## Problem

`create_mental_model` accepts a caller-supplied `id`. When that id already exists the `INSERT` in `_insert_pinned_mental_model` violates `mental_models_pkey`, and nothing between there and the API catches it — `api_create_mental_model` (`http.py`) falls through to its generic `except Exception` and returns **500 with a traceback**.

`CreateMentalModelRequest.id` has no validator, `precheck_for(PrecheckOperation.MENTAL_MODEL_CREATE)` resolves before body deserialization so it never sees the id, and there is no idempotency layer. A duplicate id is reachable in normal operation and always produces a 500.

We hit this in production: an agent sweeps a list of external account ids and creates a model for each one on every pass, so every already-created id returns a 500. Several hundred over a few hours, indistinguishable in the logs and error metrics from a real server fault.

## Fix

Catch the violation in the engine and raise `OperationValidationError` with `status_code=409`. `http.py` already maps that exception to `HTTPException(e.status_code, e.reason)` in this handler, so the API layer is unchanged — and the MCP callers (`mcp_tools.py`) get the fix for free.

This mirrors `submit_async_retain`, which already catches a `UniqueViolationError` on a caller-supplied operation id and surfaces a 409.

### Why filter on the table rather than catching the class

`_ensure_bank_exists` runs inside this same transaction. Its bank insert uses `ON CONFLICT (bank_id) DO NOTHING` and cannot collide, but on a fresh bank it also runs a non-concurrent `CREATE INDEX IF NOT EXISTS` for the bank's vector indexes, serialized only by an in-process lock. A cross-process race there surfaces as a unique violation on `pg_class_relname_nsp_index` — a real failure that must not be reported to the client as "mental model already exists". `mental_models_pkey` is the only unique constraint on `mental_models`, so `exc.table_name` is a sufficient and stable discriminator.

### Why the fix is in `create_mental_model` and not `_insert_pinned_mental_model`

`_insert_pinned_mental_model` is shared with `create_knowledge_page`, and `test_duplicate_mental_model_id_is_not_reported_as_duplicate_page` deliberately asserts that a duplicate mental-model id there propagates as `asyncpg.UniqueViolationError` rather than being reported as a page conflict. Scoping to `create_mental_model` keeps that behaviour intact.

### Considered and rejected

- **Pre-`INSERT` existence check** to avoid the wasted embedding on a conflict — adds a pool acquire (and its session-setup round trips) to every *successful* create in order to skip one short embedding of `"Generating content..."` on the failure path, and it is TOCTOU-racy, so this catch is required either way. `create_knowledge_page` deliberately doesn't pre-check either.
- **`ON CONFLICT ... DO NOTHING`** — the primary key is composite `(bank_id, id)`, it lands in the shared `_insert_pinned_mental_model`, and it would silently swallow the conflict instead of typing it.

### Not covered

Oracle. The constraint is `pk_mental_models` there and `oracledb.IntegrityError` carries no table name to discriminate on, so that path keeps its current behaviour — the same gap `create_knowledge_page` has today.

## Tests

`tests/test_mental_model_duplicate_id_409.py` — creates a model with an explicit id, then creates it again and asserts a 409. Verified it fails on `main` with the raw `UniqueViolationError` and passes with the fix. `tests/test_knowledge_base.py` create/duplicate/mental-model cases all still pass.