### PR TITLE
feat(entity-labels): add an open-vocabulary multi-valued label type (multi-text)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/entity_labels.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/entity_labels.py
@@ -21,7 +21,7 @@ class LabelValue(BaseModel):
 class MapField(BaseModel):
     """A field within a map-type entity label group. Supports recursion via type='map'."""
 
-    type: Literal["text", "value", "multi-values", "map"] = "text"
+    type: Literal["text", "multi-text", "value", "multi-values", "map"] = "text"
     description: str = ""
     values: list[LabelValue] = []
     fields: dict[str, "MapField"] = {}
@@ -35,7 +35,7 @@ class LabelGroup(BaseModel):
 
     key: str
     description: str = ""
-    type: Literal["value", "multi-values", "text", "map"] = "value"
+    type: Literal["value", "multi-values", "text", "multi-text", "map"] = "value"
     optional: bool = True
     tag: bool = False
     values: list[LabelValue] = []
@@ -110,6 +110,7 @@ def _build_map_fields_model(fields: dict[str, MapField], model_name: str) -> typ
 
     Each field becomes a typed Pydantic field based on its type:
     - text         → str | None
+    - multi-text   → list[str]  (open vocabulary)
     - value        → Literal[...] | None
     - multi-values → list[Literal[...]]
     - map          → list[NestedModel] (recursive)
@@ -132,6 +133,9 @@ def _build_map_fields_model(fields: dict[str, MapField], model_name: str) -> typ
                 )
         elif map_field.type == "text":
             model_fields[field_name] = (str | None, Field(default=None, description=description))
+        elif map_field.type == "multi-text":
+            # Open vocabulary: as many free-form strings as the content warrants
+            model_fields[field_name] = (list[str], Field(default_factory=list, description=description))
         else:
             # value / multi-values — enum-constrained
             if not map_field.values:
@@ -175,6 +179,7 @@ def build_labels_model(labels_cfg: EntityLabelsConfig) -> type[BaseModel] | None
 
     Each LabelGroup becomes a typed field based on its type:
     - type="text"                        → str | None  (always optional)
+    - type="multi-text"                  → list[str]    (open vocabulary, always optional)
     - type="value",   optional=True      → Literal["v1","v2"] | None
     - type="value",   optional=False     → Literal["v1","v2"]  (required)
     - type="multi-values"                → list[Literal["v1","v2"]]
@@ -202,6 +207,9 @@ def build_labels_model(labels_cfg: EntityLabelsConfig) -> type[BaseModel] | None
         elif group.type == "text":
             # Free-form: any string value accepted, always optional
             fields[group.key] = (str | None, Field(default=None, description=description))
+        elif group.type == "multi-text":
+            # Open vocabulary: any number of free-form strings, no Literal constraint
+            fields[group.key] = (list[str], Field(default_factory=list, description=description))
         else:
             # Enum-constrained: must have defined values
             if not group.values:
@@ -250,13 +258,13 @@ def is_label_entity(text: str, labels_cfg: EntityLabelsConfig, labels_lookup: se
     Return True if entity text belongs to any configured label group.
 
     For enum groups: checks the pre-built lookup set.
-    For text groups: checks that the text starts with a known key prefix.
+    For text/multi-text groups: checks that the text starts with a known key prefix.
     For map groups: recursively checks ``key:field:...:value`` patterns.
     """
     if text.lower() in labels_lookup:
         return True
     for group in labels_cfg.attributes:
-        if group.type == "text" and group.key and text.lower().startswith(f"{group.key.lower()}:"):
+        if group.type in ("text", "multi-text") and group.key and text.lower().startswith(f"{group.key.lower()}:"):
             return True
         if group.type == "map" and group.key and group.fields:
             prefix = f"{group.key.lower()}:"
@@ -289,8 +297,8 @@ def build_labels_lookup(labels_cfg: EntityLabelsConfig | list | None) -> set[str
 
     valid = set()
     for group in labels_cfg.attributes:
-        if group.type in ("text", "map"):
-            continue  # text: no fixed vocabulary; map: uses three-level key:field:value strings
+        if group.type in ("text", "multi-text", "map"):
+            continue  # text/multi-text: no fixed vocabulary; map: uses three-level key:field:value strings
         for v in group.values:
             if group.key and v.value:
                 valid.add(f"{group.key}:{v.value}".lower())

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -54,7 +54,7 @@ def _extract_map_entities(
                         validated_entities,
                         existing_texts_lower,
                     )
-        elif map_field.type == "multi-values":
+        elif map_field.type in ("multi-values", "multi-text"):
             vals = field_val if isinstance(field_val, list) else [field_val]
             for v in vals:
                 if not isinstance(v, str) or not v.strip() or v.lower() in ("none", "null", "n/a"):
@@ -1167,6 +1167,8 @@ def _append_map_fields_prompt(fields: dict[str, "MapField"], lines: list[str], i
         if map_field.type == "map" and map_field.fields:
             lines.append(f"{pad}• {field_name} (object){field_desc}")
             _append_map_fields_prompt(map_field.fields, lines, indent + 4)
+        elif map_field.type == "multi-text":
+            lines.append(f"{pad}• {field_name} (list of free text, [] if none){field_desc}")
         elif map_field.type == "multi-values":
             vals = ", ".join(v.value for v in map_field.values if v.value)
             type_hint = f"multi-values: {vals}" if vals else "multi-values"
@@ -1221,6 +1223,9 @@ def _build_labels_prompt_section(labels_cfg: EntityLabelsConfig | list | None, f
         if attr.type == "text":
             # Free-text: no predefined values — LLM writes any relevant string or null
             lines.append(f"- {attr.key} (free text or null): {attr.description}")
+        elif attr.type == "multi-text":
+            # Open vocabulary: no predefined values — LLM writes as many strings as the content warrants
+            lines.append(f"- {attr.key} (list of free text, empty list if none): {attr.description}")
         else:
             mode = "multi-value (list)" if attr.type == "multi-values" else "single value or null"
             lines.append(f"- {attr.key} ({mode}): {attr.description}")
@@ -1822,7 +1827,7 @@ async def _extract_facts_from_chunk(
                                 if not isinstance(v, str) or not v.strip() or v.lower() in ("none", "null", "n/a"):
                                     continue
                                 label_str = f"{group.key}:{v.strip()}"
-                                if group.type == "text":
+                                if group.type in ("text", "multi-text"):
                                     if label_str.lower() not in existing_texts_lower:
                                         validated_entities.append(label_str)
                                         existing_texts_lower.add(label_str.lower())
@@ -2665,7 +2670,7 @@ async def extract_facts_from_contents_batch_api(
                             if not isinstance(v, str) or not v.strip() or v.lower() in ("none", "null", "n/a"):
                                 continue
                             label_str = f"{group.key}:{v.strip()}"
-                            if group.type == "text":
+                            if group.type in ("text", "multi-text"):
                                 if label_str.lower() not in existing_texts_lower:
                                     validated_entities.append(label_str)
                                     existing_texts_lower.add(label_str.lower())

--- a/hindsight-api-slim/tests/test_entity_labels.py
+++ b/hindsight-api-slim/tests/test_entity_labels.py
@@ -612,7 +612,7 @@ def _run_label_post_processing(labels_cfg, labels_data: dict) -> set[str]:
                 if not isinstance(v, str) or not v.strip() or v.lower() in ("none", "null", "n/a"):
                     continue
                 label_str = f"{group.key}:{v.strip()}"
-                if group.type == "text":
+                if group.type in ("text", "multi-text"):
                     if label_str.lower() not in existing_texts_lower:
                         validated_entities.append(label_str)
                         existing_texts_lower.add(label_str.lower())
@@ -2378,3 +2378,219 @@ async def test_retain_application_tags_extract_complete_pairs(memory_real_llm, r
         )
     finally:
         await memory_real_llm.delete_bank(bank_id, request_context=request_context)
+
+
+# ─── multi-text (open-vocabulary multi-valued labels, issue #4025) ────────────
+
+
+def test_parse_entity_labels_multi_text_type():
+    """type='multi-text' round-trips through parse_entity_labels."""
+    cfg = parse_entity_labels(
+        [
+            {
+                "key": "name",
+                "type": "multi-text",
+                "tag": True,
+                "description": "Every name the subject is known by",
+            }
+        ]
+    )
+    assert cfg is not None
+    assert cfg.attributes[0].type == "multi-text"
+    assert cfg.attributes[0].tag is True
+
+
+def test_build_labels_model_multi_text_is_unconstrained_list():
+    """type='multi-text' → list[str] with no enum constraint and an empty-list default."""
+    cfg = parse_entity_labels([{"key": "name", "type": "multi-text", "description": "Names"}])
+    Model = build_labels_model(cfg)
+    assert Model is not None
+
+    prop = Model.model_json_schema()["properties"]["name"]
+    assert prop["type"] == "array"
+    assert prop["items"] == {"type": "string"}, f"multi-text items must be unconstrained strings, got: {prop['items']}"
+
+    # Any strings are accepted, and the field is optional (defaults to []).
+    assert Model(name=["Kubernetes", "k8s", "kube"]).name == ["Kubernetes", "k8s", "kube"]
+    assert Model().name == []
+
+
+def test_build_labels_model_multi_text_ignores_declared_values():
+    """A multi-text group with example values still produces an unconstrained list."""
+    cfg = parse_entity_labels([{"key": "name", "type": "multi-text", "values": [{"value": "kubernetes"}]}])
+    Model = build_labels_model(cfg)
+    assert Model is not None
+    assert Model.model_json_schema()["properties"]["name"]["items"] == {"type": "string"}
+
+
+def test_build_labels_lookup_skips_multi_text():
+    """multi-text has no fixed vocabulary, so nothing enters the lookup set."""
+    cfg = parse_entity_labels(
+        [
+            {"key": "name", "type": "multi-text", "values": [{"value": "kubernetes"}]},
+            {"key": "topic", "type": "value", "values": [{"value": "infra"}]},
+        ]
+    )
+    lookup = build_labels_lookup(cfg)
+    assert "name:kubernetes" not in lookup
+    assert lookup == {"topic:infra"}
+
+
+def test_is_label_entity_multi_text_prefix_match():
+    """multi-text label entities are recognised by their key prefix, like text."""
+    cfg = parse_entity_labels([{"key": "name", "type": "multi-text"}])
+    lookup = build_labels_lookup(cfg)
+    assert is_label_entity("name:k8s", cfg, lookup)
+    assert is_label_entity("Name:Kube", cfg, lookup)
+    assert not is_label_entity("Kubernetes", cfg, lookup)
+    assert not is_label_entity("other:k8s", cfg, lookup)
+
+
+def test_build_labels_prompt_section_multi_text():
+    """multi-text groups are described as an open list, with no value enumeration."""
+    from hindsight_api.engine.retain.fact_extraction import _build_labels_prompt_section
+
+    cfg = EntityLabelsConfig(
+        attributes=[
+            LabelGroup(key="name", type="multi-text", description="Every name the subject is known by"),
+        ]
+    )
+    result = _build_labels_prompt_section(cfg)
+    assert "CLASSIFICATION ATTRIBUTES" in result
+    assert "- name (list of free text, empty list if none): Every name the subject is known by" in result
+
+
+def test_multi_text_post_processing_keeps_every_value():
+    """Every extracted multi-text value becomes a key:value entity, bypassing the enum lookup."""
+    cfg = parse_entity_labels([{"key": "name", "type": "multi-text"}])
+    entity_texts = _run_label_post_processing(cfg, {"name": ["Kubernetes", "k8s", "kube"]})
+    assert entity_texts == {"name:Kubernetes", "name:k8s", "name:kube"}
+
+
+def test_multi_text_post_processing_rejects_sentinels_and_blanks():
+    """'None'/'null'/'n/a' and blank strings never become entities."""
+    cfg = parse_entity_labels([{"key": "name", "type": "multi-text"}])
+    entity_texts = _run_label_post_processing(cfg, {"name": ["None", "null", "n/a", "  ", "k8s"]})
+    assert entity_texts == {"name:k8s"}
+
+
+def test_multi_text_post_processing_empty_list_produces_no_entity():
+    cfg = parse_entity_labels([{"key": "name", "type": "multi-text"}])
+    assert _run_label_post_processing(cfg, {"name": []}) == set()
+
+
+def test_inject_label_tags_covers_multi_text():
+    """tag=True on a multi-text group writes every extracted value to the fact's tags."""
+    from hindsight_api.engine.retain.fact_extraction import _inject_label_tags
+
+    class _Fact:
+        def __init__(self, entities, tags):
+            self.entities = entities
+            self.tags = tags
+
+    class _Config:
+        entity_labels = [{"key": "name", "type": "multi-text", "tag": True}]
+
+    fact = _Fact(entities=["Kubernetes", "name:kubernetes", "name:k8s", "name:kube"], tags=[])
+    _inject_label_tags([fact], _Config())
+    assert fact.tags == ["name:kubernetes", "name:k8s", "name:kube"]
+
+
+def test_build_map_fields_model_multi_text_field():
+    """multi-text is available inside map groups too, as an unconstrained list field."""
+    from hindsight_api.engine.retain.entity_labels import _build_map_fields_model
+
+    Model = _build_map_fields_model(
+        {"name": MapField(type="text"), "aliases": MapField(type="multi-text", description="Other names")},
+        "PersonEntity",
+    )
+    assert Model is not None
+    props = Model.model_json_schema()["properties"]
+    assert props["aliases"]["type"] == "array"
+    assert props["aliases"]["items"] == {"type": "string"}
+
+
+def test_map_entity_post_processing_multi_text_field():
+    """A multi-text map field flattens to one key:field:value entity per value."""
+    from hindsight_api.engine.retain.fact_extraction import _extract_map_entities
+
+    fields = {"name": MapField(type="text"), "aliases": MapField(type="multi-text")}
+    validated: list[str] = []
+    existing: set[str] = set()
+    _extract_map_entities({"name": "Kubernetes", "aliases": ["k8s", "kube"]}, fields, "tool:", validated, existing)
+
+    assert set(validated) == {"tool:name:Kubernetes", "tool:aliases:k8s", "tool:aliases:kube"}
+
+
+def test_append_map_fields_prompt_multi_text():
+    """multi-text map fields are described as a free-text list in the prompt."""
+    from hindsight_api.engine.retain.fact_extraction import _append_map_fields_prompt
+
+    lines: list[str] = []
+    _append_map_fields_prompt({"aliases": MapField(type="multi-text", description="Other names")}, lines)
+    assert lines == ["    • aliases (list of free text, [] if none): Other names"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.hs_llm_core
+async def test_retain_extracts_multi_text_label(memory_real_llm, request_context):
+    """
+    End-to-end (issue #4025): a tag=True multi-text group lets the bank derive an
+    open vocabulary from the content — the alternative names are stated in the text,
+    not supplied by the caller — and every extracted value becomes a filterable tag.
+    """
+    memory = memory_real_llm
+
+    bank_id = f"test-labels-multi-text-{uuid.uuid4().hex[:8]}"
+    try:
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        await memory._config_resolver.update_bank_config(
+            bank_id=bank_id,
+            updates={
+                "entity_labels": [
+                    {
+                        "key": "name",
+                        "type": "multi-text",
+                        "tag": True,
+                        "description": (
+                            "Every name the subject of this fact is known by — its canonical name "
+                            "plus abbreviations, acronyms, short forms and alternative spellings."
+                        ),
+                    }
+                ],
+            },
+            context=request_context,
+        )
+
+        unit_ids = await memory.retain_async(
+            bank_id=bank_id,
+            content=(
+                "We deploy services to a Kubernetes cluster on EKS — the team usually just says "
+                "k8s, or kube. Helm charts live in the monorepo."
+            ),
+            request_context=request_context,
+        )
+        assert len(unit_ids) > 0, "Should have extracted at least one fact"
+
+        entities = await memory.list_entities(bank_id, search="name:", limit=100, request_context=request_context)
+        name_labels = {e["canonical_name"].lower() for e in entities["items"]}
+        # More than one value under a single key — the thing a `text` group cannot express.
+        assert len(name_labels) > 1, f"multi-text must produce several values for one key. Got: {sorted(name_labels)}"
+        abbreviations = {n for n in name_labels if "k8s" in n or "kube" in n}
+        assert abbreviations, (
+            f"Expected an abbreviation from the content among the name labels. Got: {sorted(name_labels)}"
+        )
+
+        # tag=True makes each extracted value filterable at recall time.
+        page = await memory.list_memory_units(
+            bank_id,
+            tags=[sorted(abbreviations)[0]],
+            tags_match="any_strict",
+            request_context=request_context,
+        )
+        assert page["total"] > 0, (
+            f"tag=True must make '{sorted(abbreviations)[0]}' filterable; no unit carried it. Labels: {sorted(name_labels)}"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -7615,6 +7615,7 @@ components:
           - value
           - multi-values
           - text
+          - multi-text
           - map
           title: Type
           type: string
@@ -7655,6 +7656,7 @@ components:
           - value
           - multi-values
           - text
+          - multi-text
           - map
           title: Type
           type: string
@@ -7921,6 +7923,7 @@ components:
           default: text
           enum:
           - text
+          - multi-text
           - value
           - multi-values
           - map
@@ -7949,6 +7952,7 @@ components:
           default: text
           enum:
           - text
+          - multi-text
           - value
           - multi-values
           - map

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -1954,7 +1954,7 @@ class Hindsight:
         retain_default_strategy: str | None = None,
         retain_strategies: dict[str, Any] | None = None,
         # Entity settings
-        entity_labels: list[str] | None = None,
+        entity_labels: list[dict[str, Any]] | None = None,
         entities_allow_free_form: bool | None = None,
         # Observation / consolidation settings
         enable_observations: bool | None = None,
@@ -1993,8 +1993,12 @@ class Hindsight:
                 turn to keep whole during retain. Defaults to retain_chunk_size when unset.
             retain_default_strategy: Default retain strategy name.
             retain_strategies: Named strategy definitions (dict of strategy name to config).
-            entity_labels: Controlled vocabulary for entity type classification.
-                When set, extracted entities are classified into these labels.
+            entity_labels: Controlled vocabulary for entity labels — a list of label-group
+                dicts, each with a ``key`` and a ``type``: ``"value"``/``"multi-values"`` pick
+                from the group's declared ``values``, while ``"text"``/``"multi-text"`` are
+                open-vocabulary (one string / any number of strings). With ``tag: True`` the
+                extracted ``key:value`` labels are also written as tags, so they are
+                filterable via ``tags``/``tags_match`` at recall.
             entities_allow_free_form: Whether to allow entity types outside entity_labels (default: True).
             enable_observations: Toggle automatic observation consolidation after retain().
             observations_mission: Controls what gets synthesised into observations.

--- a/hindsight-clients/python/hindsight_client_api/models/label_group_input.py
+++ b/hindsight-clients/python/hindsight_client_api/models/label_group_input.py
@@ -43,8 +43,8 @@ class LabelGroupInput(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['value', 'multi-values', 'text', 'map']):
-            raise ValueError("must be one of enum values ('value', 'multi-values', 'text', 'map')")
+        if value not in set(['value', 'multi-values', 'text', 'multi-text', 'map']):
+            raise ValueError("must be one of enum values ('value', 'multi-values', 'text', 'multi-text', 'map')")
         return value
 
     model_config = ConfigDict(

--- a/hindsight-clients/python/hindsight_client_api/models/label_group_output.py
+++ b/hindsight-clients/python/hindsight_client_api/models/label_group_output.py
@@ -43,8 +43,8 @@ class LabelGroupOutput(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['value', 'multi-values', 'text', 'map']):
-            raise ValueError("must be one of enum values ('value', 'multi-values', 'text', 'map')")
+        if value not in set(['value', 'multi-values', 'text', 'multi-text', 'map']):
+            raise ValueError("must be one of enum values ('value', 'multi-values', 'text', 'multi-text', 'map')")
         return value
 
     model_config = ConfigDict(

--- a/hindsight-clients/python/hindsight_client_api/models/map_field_input.py
+++ b/hindsight-clients/python/hindsight_client_api/models/map_field_input.py
@@ -39,8 +39,8 @@ class MapFieldInput(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['text', 'value', 'multi-values', 'map']):
-            raise ValueError("must be one of enum values ('text', 'value', 'multi-values', 'map')")
+        if value not in set(['text', 'multi-text', 'value', 'multi-values', 'map']):
+            raise ValueError("must be one of enum values ('text', 'multi-text', 'value', 'multi-values', 'map')")
         return value
 
     model_config = ConfigDict(

--- a/hindsight-clients/python/hindsight_client_api/models/map_field_output.py
+++ b/hindsight-clients/python/hindsight_client_api/models/map_field_output.py
@@ -39,8 +39,8 @@ class MapFieldOutput(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['text', 'value', 'multi-values', 'map']):
-            raise ValueError("must be one of enum values ('text', 'value', 'multi-values', 'map')")
+        if value not in set(['text', 'multi-text', 'value', 'multi-values', 'map']):
+            raise ValueError("must be one of enum values ('text', 'multi-text', 'value', 'multi-values', 'map')")
         return value
 
     model_config = ConfigDict(

--- a/hindsight-clients/python/tests/test_bank_config_update_payload.py
+++ b/hindsight-clients/python/tests/test_bank_config_update_payload.py
@@ -178,3 +178,55 @@ def test_create_bank_omits_recall_pipeline_toggles_when_unset(monkeypatch):
     body = captured["body"]
     for name in ("enable_text_search", "enable_temporal_retrieval", "enable_graph_retrieval", "enable_reranking"):
         assert name not in body
+
+
+def test_update_bank_config_forwards_entity_labels(monkeypatch):
+    """Entity-label groups must reach the request body unflattened.
+
+    The wrapper enumerates config fields, so a label group that never lands in
+    `updates` is silently dropped — the bank keeps extracting nothing. The
+    TypeScript wrapper has the mirror of this test in
+    tests/bank_config_entity_labels_mapping.test.ts; the two must stay in step.
+    """
+    captured: dict[str, object] = {}
+
+    async def fake_update(self, bank_id, updates):
+        captured["updates"] = updates
+        return {"bank_id": bank_id, "config": {}, "overrides": updates}
+
+    monkeypatch.setattr(Hindsight, "_aupdate_bank_config", fake_update)
+
+    labels = [
+        {
+            "key": "name",
+            "type": "multi-text",
+            "tag": True,
+            "description": "Every name the subject of this fact is known by.",
+        },
+        {"key": "topic", "type": "value", "values": [{"value": "infra"}]},
+    ]
+
+    client = Hindsight(base_url="http://example.invalid")
+    client.update_bank_config("test-bank", entity_labels=labels, entities_allow_free_form=False)
+
+    assert captured["updates"] == {
+        "entity_labels": labels,
+        "entities_allow_free_form": False,
+    }
+
+
+def test_update_bank_config_omits_entity_labels_when_unset(monkeypatch):
+    """An unset entity_labels must not clear the bank's existing vocabulary."""
+    captured: dict[str, object] = {}
+
+    async def fake_update(self, bank_id, updates):
+        captured["updates"] = updates
+        return {"bank_id": bank_id, "config": {}, "overrides": updates}
+
+    monkeypatch.setattr(Hindsight, "_aupdate_bank_config", fake_update)
+
+    client = Hindsight(base_url="http://example.invalid")
+    client.update_bank_config("test-bank", retain_chunk_size=1000)
+
+    assert "entity_labels" not in captured["updates"]
+    assert "entities_allow_free_form" not in captured["updates"]

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -2670,7 +2670,7 @@ export type LabelGroupInput = {
   /**
    * Type
    */
-  type?: "value" | "multi-values" | "text" | "map";
+  type?: "value" | "multi-values" | "text" | "multi-text" | "map";
   /**
    * Optional
    */
@@ -2708,7 +2708,7 @@ export type LabelGroupOutput = {
   /**
    * Type
    */
-  type?: "value" | "multi-values" | "text" | "map";
+  type?: "value" | "multi-values" | "text" | "multi-text" | "map";
   /**
    * Optional
    */
@@ -2913,7 +2913,7 @@ export type MapFieldInput = {
   /**
    * Type
    */
-  type?: "text" | "value" | "multi-values" | "map";
+  type?: "text" | "multi-text" | "value" | "multi-values" | "map";
   /**
    * Description
    */
@@ -2939,7 +2939,7 @@ export type MapFieldOutput = {
   /**
    * Type
    */
-  type?: "text" | "value" | "multi-values" | "map";
+  type?: "text" | "multi-text" | "value" | "multi-values" | "map";
   /**
    * Description
    */

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -64,6 +64,7 @@ import type {
   KnowledgePageResponse,
   KnowledgePageSearchResponse,
   KnowledgeTreeResponse,
+  LabelGroupInput,
   ListDocumentsResponse,
   MentalModelListResponse,
   MentalModelResponse,
@@ -737,6 +738,16 @@ export class HindsightClient {
       retainCustomInstructions?: string;
       retainChunkSize?: number;
       retainStructuredChunkSize?: number;
+      /**
+       * Controlled vocabulary for entity labels. Each group classifies a fact under a
+       * `key`: `"value"`/`"multi-values"` pick from the group's declared `values`, while
+       * `"text"`/`"multi-text"` are open-vocabulary (one string / any number of strings).
+       * With `tag: true` the extracted `key:value` labels are also written as tags, so
+       * they are filterable via `tags`/`tagsMatch` at recall.
+       */
+      entityLabels?: LabelGroupInput[];
+      /** Allow entities outside `entityLabels`. False is labels-only mode. */
+      entitiesAllowFreeForm?: boolean;
       enableObservations?: boolean;
       observationsMission?: string;
       /** Run the keyword (BM25) retrieval arm during recall. False leaves pure vector search. */
@@ -766,6 +777,9 @@ export class HindsightClient {
     if (options.retainChunkSize !== undefined) updates.retain_chunk_size = options.retainChunkSize;
     if (options.retainStructuredChunkSize !== undefined)
       updates.retain_structured_chunk_size = options.retainStructuredChunkSize;
+    if (options.entityLabels !== undefined) updates.entity_labels = options.entityLabels;
+    if (options.entitiesAllowFreeForm !== undefined)
+      updates.entities_allow_free_form = options.entitiesAllowFreeForm;
     if (options.enableObservations !== undefined)
       updates.enable_observations = options.enableObservations;
     if (options.observationsMission !== undefined)
@@ -1591,6 +1605,7 @@ export type {
   KnowledgePageResponse,
   KnowledgePageSearchResponse,
   KnowledgeTreeResponse,
+  LabelGroupInput,
   ListDocumentsResponse,
   MentalModelListResponse,
   MentalModelResponse,

--- a/hindsight-clients/typescript/tests/bank_config_entity_labels_mapping.test.ts
+++ b/hindsight-clients/typescript/tests/bank_config_entity_labels_mapping.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for the entity-labels request mapping on updateBankConfig.
+ *
+ * Like the other *_mapping tests these do NOT require a running server: the
+ * generated sdk layer is mocked so we can assert the camelCase options land on
+ * the snake_case request body.
+ *
+ * updateBankConfig enumerates config fields rather than passing a dict through,
+ * so a field the wrapper doesn't know about is silently dropped for every
+ * consumer of the SDK — with no type error to catch it. `entityLabels` was
+ * exactly that gap: the option did not exist, so TypeScript callers could not
+ * configure a controlled vocabulary at all. The Python wrapper has the mirror of
+ * this file in tests/test_bank_config_update_payload.py; the two must stay in step.
+ */
+
+import { HindsightClient } from "../src";
+import * as sdk from "../generated/sdk.gen";
+import type { LabelGroupInput } from "../generated/types.gen";
+
+jest.mock("../generated/sdk.gen");
+
+const mockedUpdateConfig = sdk.updateBankConfig as jest.MockedFunction<typeof sdk.updateBankConfig>;
+
+describe("entity labels mapping", () => {
+  let client: HindsightClient;
+
+  beforeEach(() => {
+    client = new HindsightClient({ baseUrl: "http://localhost:8888" });
+    mockedUpdateConfig.mockReset();
+    mockedUpdateConfig.mockResolvedValue({
+      data: { bank_id: "bank", config: {}, overrides: {} },
+    } as any);
+  });
+
+  test("updateBankConfig maps entity labels onto the updates map", async () => {
+    const entityLabels: LabelGroupInput[] = [
+      {
+        key: "name",
+        type: "multi-text",
+        tag: true,
+        description: "Every name the subject of this fact is known by.",
+      },
+      { key: "topic", type: "value", values: [{ value: "infra" }] },
+    ];
+
+    await client.updateBankConfig("bank", { entityLabels, entitiesAllowFreeForm: false });
+
+    const body = mockedUpdateConfig.mock.calls[0][0].body as any;
+    expect(body.updates).toEqual({
+      entity_labels: entityLabels,
+      entities_allow_free_form: false,
+    });
+  });
+
+  test("updateBankConfig omits entity labels when unset so the vocabulary survives", async () => {
+    await client.updateBankConfig("bank", { retainChunkSize: 1000 });
+
+    const body = mockedUpdateConfig.mock.calls[0][0].body as any;
+    expect(body.updates.entity_labels).toBeUndefined();
+    expect(body.updates.entities_allow_free_form).toBeUndefined();
+  });
+});

--- a/hindsight-control-plane/src/components/bank-config-view.tsx
+++ b/hindsight-control-plane/src/components/bank-config-view.tsx
@@ -72,7 +72,7 @@ type StrategiesEdits = {
 
 type LabelValue = { value: string; description: string };
 type MapField = {
-  type: "text" | "value" | "multi-values" | "map";
+  type: "text" | "multi-text" | "value" | "multi-values" | "map";
   description: string;
   values?: LabelValue[];
   fields?: Record<string, MapField>;
@@ -80,7 +80,7 @@ type MapField = {
 type LabelGroup = {
   key: string;
   description: string;
-  type: "value" | "multi-values" | "text" | "map";
+  type: "value" | "multi-values" | "text" | "multi-text" | "map";
   optional: boolean;
   tag: boolean;
   values: LabelValue[];
@@ -1735,6 +1735,7 @@ function exampleBadge(
       .map((f) => `${key}:${f}:<value>`)
       .join(", ")}`;
   if (attr.type === "text") return `e.g. ${key}:<any text>`;
+  if (attr.type === "multi-text") return `e.g. ${key}:<any text>, ${key}:<any text>`;
   if ((attr.values?.length ?? 0) > 0) return `e.g. ${key}:${attr.values![0].value || "<value>"}`;
   return `e.g. ${key}:<value>`;
 }
@@ -1755,6 +1756,7 @@ function MapFieldsEditor({
   const t = useTranslations("bankConfig");
   const FIELD_TYPE_LABELS: Record<MapField["type"], string> = {
     text: t("fieldTypeText"),
+    "multi-text": t("fieldTypeMultiText"),
     value: t("fieldTypeValue"),
     "multi-values": t("fieldTypeMultiValues"),
     map: t("fieldTypeMap"),
@@ -1841,7 +1843,9 @@ function MapFieldsEditor({
                   updateField(fieldName, {
                     type: v,
                     ...(v === "map" ? { fields: field.fields ?? {}, values: undefined } : {}),
-                    ...(v === "text" ? { fields: undefined, values: undefined } : {}),
+                    ...(v === "text" || v === "multi-text"
+                      ? { fields: undefined, values: undefined }
+                      : {}),
                     ...(v === "value" || v === "multi-values"
                       ? { fields: undefined, values: field.values ?? [] }
                       : {}),

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -434,6 +434,7 @@
     "deleteStrategyTitle": "Strategie „{name}\" löschen?",
     "deleteStrategyDescription": "Dadurch werden die Strategie und alle ihre Überschreibungen entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
     "fieldTypeText": "Text",
+    "fieldTypeMultiText": "Mehrere Texte",
     "fieldTypeValue": "Einzelwert",
     "fieldTypeMultiValues": "Mehrere Werte",
     "fieldTypeMap": "Karte",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -434,6 +434,7 @@
     "deleteStrategyTitle": "Delete strategy \"{name}\"?",
     "deleteStrategyDescription": "This will remove the strategy and all its overrides. This cannot be undone.",
     "fieldTypeText": "Text",
+    "fieldTypeMultiText": "Multi-text",
     "fieldTypeValue": "Single value",
     "fieldTypeMultiValues": "Multi-values",
     "fieldTypeMap": "Map",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -434,6 +434,7 @@
     "deleteStrategyTitle": "¿Eliminar la estrategia \"{name}\"?",
     "deleteStrategyDescription": "Esto eliminará la estrategia y todas sus anulaciones. Esta acción no se puede deshacer.",
     "fieldTypeText": "Texto",
+    "fieldTypeMultiText": "Múltiples textos",
     "fieldTypeValue": "Valor único",
     "fieldTypeMultiValues": "Múltiples valores",
     "fieldTypeMap": "Mapa",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -434,6 +434,7 @@
     "deleteStrategyTitle": "Supprimer la stratégie « {name} » ?",
     "deleteStrategyDescription": "Cela supprimera la stratégie et tous ses remplacements. Cette action est irréversible.",
     "fieldTypeText": "Texte",
+    "fieldTypeMultiText": "Textes multiples",
     "fieldTypeValue": "Valeur unique",
     "fieldTypeMultiValues": "Valeurs multiples",
     "fieldTypeMap": "Carte",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -434,6 +434,7 @@
     "deleteStrategyTitle": "戦略「{name}」を削除しますか?",
     "deleteStrategyDescription": "この操作で戦略とそのすべての上書きが削除されます。元に戻すことはできません。",
     "fieldTypeText": "テキスト",
+    "fieldTypeMultiText": "複数テキスト",
     "fieldTypeValue": "単一値",
     "fieldTypeMultiValues": "複数値",
     "fieldTypeMap": "マップ",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -434,6 +434,7 @@
     "deleteStrategyTitle": "전략 \"{name}\"을(를) 삭제하시겠습니까?",
     "deleteStrategyDescription": "이 작업으로 전략과 모든 재정의가 제거됩니다. 이 작업은 되돌릴 수 없습니다.",
     "fieldTypeText": "텍스트",
+    "fieldTypeMultiText": "다중 텍스트",
     "fieldTypeValue": "단일 값",
     "fieldTypeMultiValues": "다중 값",
     "fieldTypeMap": "맵",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -434,6 +434,7 @@
     "deleteStrategyTitle": "Excluir a estratégia \"{name}\"?",
     "deleteStrategyDescription": "Isto removerá a estratégia e todas as suas substituições. Esta ação não pode ser desfeita.",
     "fieldTypeText": "Texto",
+    "fieldTypeMultiText": "Múltiplos textos",
     "fieldTypeValue": "Valor único",
     "fieldTypeMultiValues": "Múltiplos valores",
     "fieldTypeMap": "Mapa",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -434,6 +434,7 @@
     "deleteStrategyTitle": "刪除策略\"{name}\"？",
     "deleteStrategyDescription": "將刪除此策略及其所有覆寫。此操作無法撤銷。",
     "fieldTypeText": "文字",
+    "fieldTypeMultiText": "多文字",
     "fieldTypeValue": "單值",
     "fieldTypeMultiValues": "多值",
     "fieldTypeMap": "對應表",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -434,6 +434,7 @@
     "deleteStrategyTitle": "删除策略\"{name}\"？",
     "deleteStrategyDescription": "这将删除该策略及其所有覆盖。此操作无法撤销。",
     "fieldTypeText": "文本",
+    "fieldTypeMultiText": "多文本",
     "fieldTypeValue": "单值",
     "fieldTypeMultiValues": "多值",
     "fieldTypeMap": "映射",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -434,6 +434,7 @@
     "deleteStrategyTitle": "刪除策略\"{name}\"？",
     "deleteStrategyDescription": "這將刪除該策略及其所有覆寫。此操作無法撤銷。",
     "fieldTypeText": "文字",
+    "fieldTypeMultiText": "多文字",
     "fieldTypeValue": "單值",
     "fieldTypeMultiValues": "多值",
     "fieldTypeMap": "對映",

--- a/hindsight-docs/docs/developer/api/memory-banks.mdx
+++ b/hindsight-docs/docs/developer/api/memory-banks.mdx
@@ -137,10 +137,10 @@ Each entry in `entity_labels` is a **label group** — one classification dimens
 |-------|---------|-------------|
 | `key` | — | Label group identifier. Becomes the prefix in `key:value` entities (or `key:field:value` for `"map"`). |
 | `description` | `""` | Shown to the LLM to guide label assignment. |
-| `type` | `"value"` | `"value"` → pick one enum value; `"multi-values"` → pick multiple; `"text"` → free-form string; `"map"` → structured group with named fields. |
-| `values` | `[]` | Allowed values for `"value"` and `"multi-values"` types. Ignored for `"text"` and `"map"`. |
-| `fields` | `{}` | Field definitions for `"map"` types. Each field is itself typed (`"text"`, `"value"`, `"multi-values"`, or nested `"map"`). Ignored for non-map types. |
-| `optional` | `true` | When `true` the LLM may skip the label if not applicable. When `false` the LLM must always assign a value. Has no effect on `"multi-values"` groups (always optional). |
+| `type` | `"value"` | `"value"` → pick one enum value; `"multi-values"` → pick multiple; `"text"` → free-form string; `"multi-text"` → any number of free-form strings; `"map"` → structured group with named fields. |
+| `values` | `[]` | Allowed values for `"value"` and `"multi-values"` types. Ignored for `"text"`, `"multi-text"` and `"map"`. |
+| `fields` | `{}` | Field definitions for `"map"` types. Each field is itself typed (`"text"`, `"multi-text"`, `"value"`, `"multi-values"`, or nested `"map"`). Ignored for non-map types. |
+| `optional` | `true` | When `true` the LLM may skip the label if not applicable. When `false` the LLM must always assign a value. Has no effect on `"multi-values"` or `"multi-text"` groups (always optional). |
 | `tag` | `false` | When `true`, extracted `key:value` labels are also written as tags on the memory unit, enabling filtering via `tags`/`tags_match` in recall/reflect. |
 
 **Enum groups** (`type: "value"` or `type: "multi-values"`): the LLM picks from the predefined `values` list; anything outside the list is silently dropped. Vocabulary stays stable and graph links stay tight. Use `"multi-values"` when a fact can belong to several values at once.
@@ -157,7 +157,20 @@ Each entry in `entity_labels` is a **label group** — one classification dimens
 }
 ```
 
-**Map groups** (`type: "map"`): defines a structured entity type with named fields. Each field is itself typed (`"text"`, `"value"`, `"multi-values"`, or nested `"map"`) so you can describe rich entities like a person with name, role, and organization. Each extracted field is stored as a flat `key:field:value` entity string (e.g. `person:name:Alice`), reusing the existing entity storage with no schema changes — so map fields participate in the knowledge graph and retrieval the same way single-value labels do.
+**Open-vocabulary groups** (`type: "multi-text"`): like `"text"`, but the LLM writes a *list* of strings instead of one — so a single fact can carry several values that nobody enumerated in the bank config. Use it when the interesting values only exist in the content: the names a thing is known by (canonical name plus abbreviations, acronyms and alternative spellings), ticket references a fact cites, product codes or SKUs. Each value becomes its own `key:value` entity, and with `tag: true` each is written as a tag, so a bank can derive a classification from content and then filter on it at recall without the caller supplying the vocabulary.
+
+```json
+{
+  "key": "name",
+  "description": "Every name the subject of this fact is known by — canonical name plus abbreviations, acronyms, short forms and alternative spellings.",
+  "type": "multi-text",
+  "tag": true
+}
+```
+
+Retaining *"We deploy services to a Kubernetes cluster on EKS — the team usually just says k8s, or kube"* yields the entities and tags `name:kubernetes`, `name:k8s` and `name:kube`, so `{"tags": ["name:k8s"], "tags_match": "any_strict"}` finds the fact. A `"text"` group would keep only one of the three.
+
+**Map groups** (`type: "map"`): defines a structured entity type with named fields. Each field is itself typed (`"text"`, `"multi-text"`, `"value"`, `"multi-values"`, or nested `"map"`) so you can describe rich entities like a person with name, role, and organization. Each extracted field is stored as a flat `key:field:value` entity string (e.g. `person:name:Alice`), reusing the existing entity storage with no schema changes — so map fields participate in the knowledge graph and retrieval the same way single-value labels do.
 
 ```json
 {

--- a/hindsight-docs/static/bank-template-schema.json
+++ b/hindsight-docs/static/bank-template-schema.json
@@ -747,6 +747,7 @@
             "value",
             "multi-values",
             "text",
+            "multi-text",
             "map"
           ],
           "title": "Type",
@@ -811,6 +812,7 @@
           "default": "text",
           "enum": [
             "text",
+            "multi-text",
             "value",
             "multi-values",
             "map"

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -11191,6 +11191,7 @@
               "value",
               "multi-values",
               "text",
+              "multi-text",
               "map"
             ],
             "title": "Type",
@@ -11247,6 +11248,7 @@
               "value",
               "multi-values",
               "text",
+              "multi-text",
               "map"
             ],
             "title": "Type",
@@ -11583,6 +11585,7 @@
             "type": "string",
             "enum": [
               "text",
+              "multi-text",
               "value",
               "multi-values",
               "map"
@@ -11622,6 +11625,7 @@
             "type": "string",
             "enum": [
               "text",
+              "multi-text",
               "value",
               "multi-values",
               "map"

--- a/skills/hindsight-docs/references/developer/api/memory-banks.md
+++ b/skills/hindsight-docs/references/developer/api/memory-banks.md
@@ -130,10 +130,10 @@ Each entry in `entity_labels` is a **label group** — one classification dimens
 |-------|---------|-------------|
 | `key` | — | Label group identifier. Becomes the prefix in `key:value` entities (or `key:field:value` for `"map"`). |
 | `description` | `""` | Shown to the LLM to guide label assignment. |
-| `type` | `"value"` | `"value"` → pick one enum value; `"multi-values"` → pick multiple; `"text"` → free-form string; `"map"` → structured group with named fields. |
-| `values` | `[]` | Allowed values for `"value"` and `"multi-values"` types. Ignored for `"text"` and `"map"`. |
-| `fields` | `{}` | Field definitions for `"map"` types. Each field is itself typed (`"text"`, `"value"`, `"multi-values"`, or nested `"map"`). Ignored for non-map types. |
-| `optional` | `true` | When `true` the LLM may skip the label if not applicable. When `false` the LLM must always assign a value. Has no effect on `"multi-values"` groups (always optional). |
+| `type` | `"value"` | `"value"` → pick one enum value; `"multi-values"` → pick multiple; `"text"` → free-form string; `"multi-text"` → any number of free-form strings; `"map"` → structured group with named fields. |
+| `values` | `[]` | Allowed values for `"value"` and `"multi-values"` types. Ignored for `"text"`, `"multi-text"` and `"map"`. |
+| `fields` | `{}` | Field definitions for `"map"` types. Each field is itself typed (`"text"`, `"multi-text"`, `"value"`, `"multi-values"`, or nested `"map"`). Ignored for non-map types. |
+| `optional` | `true` | When `true` the LLM may skip the label if not applicable. When `false` the LLM must always assign a value. Has no effect on `"multi-values"` or `"multi-text"` groups (always optional). |
 | `tag` | `false` | When `true`, extracted `key:value` labels are also written as tags on the memory unit, enabling filtering via `tags`/`tags_match` in recall/reflect. |
 
 **Enum groups** (`type: "value"` or `type: "multi-values"`): the LLM picks from the predefined `values` list; anything outside the list is silently dropped. Vocabulary stays stable and graph links stay tight. Use `"multi-values"` when a fact can belong to several values at once.
@@ -150,7 +150,20 @@ Each entry in `entity_labels` is a **label group** — one classification dimens
 }
 ```
 
-**Map groups** (`type: "map"`): defines a structured entity type with named fields. Each field is itself typed (`"text"`, `"value"`, `"multi-values"`, or nested `"map"`) so you can describe rich entities like a person with name, role, and organization. Each extracted field is stored as a flat `key:field:value` entity string (e.g. `person:name:Alice`), reusing the existing entity storage with no schema changes — so map fields participate in the knowledge graph and retrieval the same way single-value labels do.
+**Open-vocabulary groups** (`type: "multi-text"`): like `"text"`, but the LLM writes a *list* of strings instead of one — so a single fact can carry several values that nobody enumerated in the bank config. Use it when the interesting values only exist in the content: the names a thing is known by (canonical name plus abbreviations, acronyms and alternative spellings), ticket references a fact cites, product codes or SKUs. Each value becomes its own `key:value` entity, and with `tag: true` each is written as a tag, so a bank can derive a classification from content and then filter on it at recall without the caller supplying the vocabulary.
+
+```json
+{
+  "key": "name",
+  "description": "Every name the subject of this fact is known by — canonical name plus abbreviations, acronyms, short forms and alternative spellings.",
+  "type": "multi-text",
+  "tag": true
+}
+```
+
+Retaining *"We deploy services to a Kubernetes cluster on EKS — the team usually just says k8s, or kube"* yields the entities and tags `name:kubernetes`, `name:k8s` and `name:kube`, so `{"tags": ["name:k8s"], "tags_match": "any_strict"}` finds the fact. A `"text"` group would keep only one of the three.
+
+**Map groups** (`type: "map"`): defines a structured entity type with named fields. Each field is itself typed (`"text"`, `"multi-text"`, `"value"`, `"multi-values"`, or nested `"map"`) so you can describe rich entities like a person with name, role, and organization. Each extracted field is stored as a flat `key:field:value` entity string (e.g. `person:name:Alice`), reusing the existing entity storage with no schema changes — so map fields participate in the knowledge graph and retrieval the same way single-value labels do.
 
 ```json
 {

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -11191,6 +11191,7 @@
               "value",
               "multi-values",
               "text",
+              "multi-text",
               "map"
             ],
             "title": "Type",
@@ -11247,6 +11248,7 @@
               "value",
               "multi-values",
               "text",
+              "multi-text",
               "map"
             ],
             "title": "Type",
@@ -11583,6 +11585,7 @@
             "type": "string",
             "enum": [
               "text",
+              "multi-text",
               "value",
               "multi-values",
               "map"
@@ -11622,6 +11625,7 @@
             "type": "string",
             "enum": [
               "text",
+              "multi-text",
               "value",
               "multi-values",
               "map"


### PR DESCRIPTION
Closes #4025.

## Problem

Entity labels could classify a fact against a **fixed vocabulary** (`type: "value"`, `type: "multi-values"`) or capture **one free string** (`type: "text"`). There was no way to extract *several* values that cannot be enumerated when the bank is configured — the names a thing is known by (canonical name plus abbreviations, acronyms, alternative spellings), ticket references a fact cites, product codes.

## What this adds

`type: "multi-text"` — a `list[str]` field with no `Literal` constraint, so the extractor writes as many values as the content warrants and nothing has to be declared up front. Each value becomes its own `key:value` entity and, with `tag: true`, a tag — so a bank can derive a classification from content and then filter on it at recall without the caller supplying the vocabulary.

```json
{ "key": "name", "type": "multi-text", "tag": true,
  "description": "Every name the subject of this fact is known by — canonical name plus abbreviations, acronyms, short forms and alternative spellings." }
```

Retaining *"We deploy services to a Kubernetes cluster on EKS — the team usually just says k8s, or kube. Helm charts live in the monorepo."* now yields, verified against a live server:

```
entities: EKS, Helm charts, Kubernetes, monorepo, name:Kubernetes, name:k8s, name:kube
tags:     ["name:Kubernetes", "name:k8s", "name:kube"]
```

and `tags=name:k8s&tags_match=any_strict` returns only that fact. A `text` group would have kept one of the three.

## Notes on scope

**Added to `MapField` as well as `LabelGroup`.** The control plane renders top-level label groups *through* the map-field editor, so the two type unions have to stay in sync or the UI can emit a shape the server rejects. `multi-text` map fields flatten to `key:field:value` like the other list-shaped field type.

**The client wrappers could not express this — fixed here.** The TypeScript wrapper's `updateBankConfig` had **no `entityLabels` option at all**, so TS consumers could not configure a controlled vocabulary of *any* type; the Python wrapper typed `entity_labels` as `list[str]`, which passes through at runtime but no typed caller can satisfy. Both now take a typed label-group list, with the mirrored mapping regression tests the wrapper-parity rule asks for. (`entities_allow_free_form` came along on the TS side — it is the companion field in the same config group, and a labels workflow reaches for it immediately.)

## Tests

- Unit: parse/round-trip, unconstrained `list[str]` model shape, `build_labels_lookup` skips it, `is_label_entity` prefix match, both prompt builders, post-processing (every value kept, sentinels/blanks rejected, empty list), `tag: true` injection, map-field model + flattening.
- `hs_llm_core` end-to-end on the issue's exact scenario, asserting through `list_entities` / `list_memory_units` rather than raw SQL. It asserts *more than one* value under the key and that an abbreviation appears — no hard assert on a model-decided string.
- Wrapper mapping tests on both sides (`test_bank_config_update_payload.py`, `bank_config_entity_labels_mapping.test.ts`).

Local: 303 passed in the api-slim label/schema/migration suites, 123 Python client, 90 TypeScript client.