### PR TITLE
fix(clients): close the bank-config drift between the wrapper SDKs and the server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5327,6 +5327,47 @@ jobs:
         cd hindsight-dev
         uv run cli-coverage-check
 
+  # The wrapper clients (hindsight_client.py / src/index.ts) are hand-written
+  # convenience layers over the generated SDKs, so nothing regenerates them when
+  # the API gains a field. client-coverage-check has existed for that, but had no
+  # job: it sat red on main with reflect.apply_all_directives missing from both
+  # wrappers, and the bank-config surface had drifted to 22 settings reachable
+  # from neither. See #4029.
+  check-client-coverage:
+    needs: [detect-changes]
+    if: >-
+      (github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.clients-ts == 'true' ||
+      needs.detect-changes.outputs.clients-python == 'true' ||
+      needs.detect-changes.outputs.dev == 'true' ||
+      needs.detect-changes.outputs.ci == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || '' }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version-file: ".python-version"
+
+    - name: Install hindsight-dev dependencies
+      run: |
+        cd hindsight-dev && uv sync --frozen --index-strategy unsafe-best-match
+
+    - name: Check client wrappers cover every request param and bank config field
+      run: |
+        cd hindsight-dev
+        uv run client-coverage-check
+
   # hindsight-dev/tests had no job of its own, so nothing ran it: the benchmark
   # harness was only exercised by the nightly Performance Tests workflow, where a
   # plain construction bug in the answer/judge LLM config surfaced as a red
@@ -5448,6 +5489,7 @@ jobs:
       - verify-generated-files
       - check-openapi-compatibility
       - check-cli-coverage
+      - check-client-coverage
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -564,6 +564,7 @@ class Hindsight:
         include_tool_calls: bool = False,
         include_tool_call_output: bool = True,
         tag_groups: list[dict[str, Any]] | None = None,
+        apply_all_directives: bool = False,
         fact_types: list[str] | None = None,
         exclude_mental_models: bool = False,
         exclude_mental_model_ids: list[str] | None = None,
@@ -593,6 +594,9 @@ class Hindsight:
                 outputs are included in the trace. Set to False for a smaller payload (inputs only).
                 Ignored when ``include_tool_calls`` is False (default: True).
             tag_groups: Optional list of tag group filters for advanced boolean tag matching.
+            apply_all_directives: Apply every active directive regardless of tags. By default
+                directives are tag-scoped like memories: untagged ones always apply, tagged ones
+                only when the request's tags match (default: False).
             fact_types: Optional list of fact types to include (world, experience, observation).
             exclude_mental_models: If True, exclude all mental models from reflection (default: False).
             exclude_mental_model_ids: Optional list of specific mental model IDs to exclude.
@@ -616,6 +620,7 @@ class Hindsight:
                 include_tool_calls=include_tool_calls,
                 include_tool_call_output=include_tool_call_output,
                 tag_groups=tag_groups,
+                apply_all_directives=apply_all_directives,
                 fact_types=fact_types,
                 exclude_mental_models=exclude_mental_models,
                 exclude_mental_model_ids=exclude_mental_model_ids,
@@ -1167,6 +1172,7 @@ class Hindsight:
         include_tool_calls: bool = False,
         include_tool_call_output: bool = True,
         tag_groups: list[dict[str, Any]] | None = None,
+        apply_all_directives: bool = False,
         fact_types: list[str] | None = None,
         exclude_mental_models: bool = False,
         exclude_mental_model_ids: list[str] | None = None,
@@ -1196,6 +1202,9 @@ class Hindsight:
                 outputs are included in the trace. Set to False for a smaller payload (inputs only).
                 Ignored when ``include_tool_calls`` is False (default: True).
             tag_groups: Optional list of tag group filters for advanced boolean tag matching.
+            apply_all_directives: Apply every active directive regardless of tags. By default
+                directives are tag-scoped like memories: untagged ones always apply, tagged ones
+                only when the request's tags match (default: False).
             fact_types: Optional list of fact types to include (world, experience, observation).
             exclude_mental_models: If True, exclude all mental models from reflection (default: False).
             exclude_mental_model_ids: Optional list of specific mental model IDs to exclude.
@@ -1228,6 +1237,7 @@ class Hindsight:
             tags_match=tags_match,
             include=include,
             tag_groups=tag_groups_objs,
+            apply_all_directives=apply_all_directives or None,
             fact_types=fact_types,
             exclude_mental_models=exclude_mental_models or None,
             exclude_mental_model_ids=exclude_mental_model_ids,
@@ -1953,12 +1963,20 @@ class Hindsight:
         retain_structured_chunk_size: int | None = None,
         retain_default_strategy: str | None = None,
         retain_strategies: dict[str, Any] | None = None,
+        retain_chunk_batch_size: int | None = None,
+        store_document_text: bool | None = None,
         # Entity settings
         entity_labels: list[dict[str, Any]] | None = None,
         entities_allow_free_form: bool | None = None,
         # Observation / consolidation settings
         enable_observations: bool | None = None,
         observations_mission: str | None = None,
+        max_observations_per_scope: int | None = None,
+        observation_scope_limits: list[dict[str, Any]] | None = None,
+        enable_auto_consolidation: bool | None = None,
+        consolidation_llm_parallelism: int | None = None,
+        consolidation_max_memories_per_round: int | None = None,
+        mental_model_min_refresh_interval_seconds: int | None = None,
         enable_text_search: bool | None = None,
         enable_temporal_retrieval: bool | None = None,
         enable_graph_retrieval: bool | None = None,
@@ -1966,6 +1984,19 @@ class Hindsight:
         consolidation_llm_batch_size: int | None = None,
         consolidation_source_facts_max_tokens: int | None = None,
         consolidation_source_facts_max_tokens_per_observation: int | None = None,
+        # Recall settings
+        recall_max_tokens: int | None = None,
+        recall_include_chunks: bool | None = None,
+        recall_chunks_max_tokens: int | None = None,
+        recall_budget_function: str | None = None,
+        recall_budget_fixed_low: int | None = None,
+        recall_budget_fixed_mid: int | None = None,
+        recall_budget_fixed_high: int | None = None,
+        recall_budget_adaptive_low: float | None = None,
+        recall_budget_adaptive_mid: float | None = None,
+        recall_budget_adaptive_high: float | None = None,
+        recall_budget_min: int | None = None,
+        recall_budget_max: int | None = None,
         # Disposition settings
         disposition_skepticism: int | None = None,
         disposition_literalism: int | None = None,
@@ -1973,7 +2004,10 @@ class Hindsight:
         # MCP settings
         mcp_enabled_tools: list[str] | None = None,
         # Gemini safety settings
-        llm_gemini_safety_settings: dict[str, str] | None = None,
+        llm_gemini_safety_settings: list[dict[str, str]] | None = None,
+        # Security / audit
+        memory_defense: dict[str, Any] | None = None,
+        audit_log_enabled: bool | None = None,
     ) -> dict[str, Any]:
         """
         Update configuration overrides for a bank (sync wrapper — use ``await client.banks.update_bank_config(...)`` in async code).
@@ -1993,6 +2027,8 @@ class Hindsight:
                 turn to keep whole during retain. Defaults to retain_chunk_size when unset.
             retain_default_strategy: Default retain strategy name.
             retain_strategies: Named strategy definitions (dict of strategy name to config).
+            retain_chunk_batch_size: Number of chunks per sub-batch in chunks extraction mode.
+            store_document_text: Persist the original document text alongside extracted facts.
             entity_labels: Controlled vocabulary for entity labels — a list of label-group
                 dicts, each with a ``key`` and a ``type``: ``"value"``/``"multi-values"`` pick
                 from the group's declared ``values``, while ``"text"``/``"multi-text"`` are
@@ -2000,6 +2036,12 @@ class Hindsight:
                 extracted ``key:value`` labels are also written as tags, so they are
                 filterable via ``tags``/``tags_match`` at recall.
             entities_allow_free_form: Whether to allow entity types outside entity_labels (default: True).
+            max_observations_per_scope: Cap on observations retained per scope (-1 for unlimited).
+            observation_scope_limits: Per-scope observation caps, overriding max_observations_per_scope.
+            enable_auto_consolidation: Consolidate automatically after retain() rather than on demand.
+            consolidation_llm_parallelism: Concurrent LLM calls during consolidation.
+            consolidation_max_memories_per_round: Memories consolidated per round.
+            mental_model_min_refresh_interval_seconds: Debounce between mental-model refreshes.
             enable_observations: Toggle automatic observation consolidation after retain().
             observations_mission: Controls what gets synthesised into observations.
             enable_text_search: Run the keyword (BM25) retrieval arm during recall. False
@@ -2012,11 +2054,26 @@ class Hindsight:
                 in a consolidation pass.
             consolidation_source_facts_max_tokens_per_observation: Max tokens of source facts per
                 individual observation in the consolidation prompt.
+            recall_max_tokens: Token budget for facts returned by recall.
+            recall_include_chunks: Include source chunks in recall results.
+            recall_chunks_max_tokens: Token budget for those chunks.
+            recall_budget_function: How the per-query result budget is derived: 'fixed' or 'adaptive'.
+            recall_budget_fixed_low: Fixed budget for low-breadth queries.
+            recall_budget_fixed_mid: Fixed budget for medium-breadth queries.
+            recall_budget_fixed_high: Fixed budget for high-breadth queries.
+            recall_budget_adaptive_low: Adaptive budget fraction for low-breadth queries.
+            recall_budget_adaptive_mid: Adaptive budget fraction for medium-breadth queries.
+            recall_budget_adaptive_high: Adaptive budget fraction for high-breadth queries.
+            recall_budget_min: Lower clamp on the resolved budget.
+            recall_budget_max: Upper clamp on the resolved budget.
             disposition_skepticism: How skeptical vs trusting (1=trusting, 5=skeptical).
             disposition_literalism: How literally to interpret information (1=flexible, 5=literal).
             disposition_empathy: How much to consider emotional context (1=detached, 5=empathetic).
             mcp_enabled_tools: List of MCP tool names to enable for this bank.
-            llm_gemini_safety_settings: Gemini/VertexAI safety setting overrides (category → threshold).
+            llm_gemini_safety_settings: Gemini/VertexAI safety overrides, as a list of
+                ``{"category": ..., "threshold": ...}`` dicts (the shape the provider takes).
+            memory_defense: Memory-defense (prompt-injection / secret redaction) settings.
+            audit_log_enabled: Write an audit log entry for each operation on this bank.
 
         Returns:
             dict with ``bank_id``, ``config`` (fully resolved), and ``overrides`` (bank-level only)
@@ -2033,10 +2090,18 @@ class Hindsight:
                 "retain_structured_chunk_size": retain_structured_chunk_size,
                 "retain_default_strategy": retain_default_strategy,
                 "retain_strategies": retain_strategies,
+                "retain_chunk_batch_size": retain_chunk_batch_size,
+                "store_document_text": store_document_text,
                 "entity_labels": entity_labels,
                 "entities_allow_free_form": entities_allow_free_form,
                 "enable_observations": enable_observations,
                 "observations_mission": observations_mission,
+                "max_observations_per_scope": max_observations_per_scope,
+                "observation_scope_limits": observation_scope_limits,
+                "enable_auto_consolidation": enable_auto_consolidation,
+                "consolidation_llm_parallelism": consolidation_llm_parallelism,
+                "consolidation_max_memories_per_round": consolidation_max_memories_per_round,
+                "mental_model_min_refresh_interval_seconds": mental_model_min_refresh_interval_seconds,
                 "enable_text_search": enable_text_search,
                 "enable_temporal_retrieval": enable_temporal_retrieval,
                 "enable_graph_retrieval": enable_graph_retrieval,
@@ -2044,11 +2109,25 @@ class Hindsight:
                 "consolidation_llm_batch_size": consolidation_llm_batch_size,
                 "consolidation_source_facts_max_tokens": consolidation_source_facts_max_tokens,
                 "consolidation_source_facts_max_tokens_per_observation": consolidation_source_facts_max_tokens_per_observation,
+                "recall_max_tokens": recall_max_tokens,
+                "recall_include_chunks": recall_include_chunks,
+                "recall_chunks_max_tokens": recall_chunks_max_tokens,
+                "recall_budget_function": recall_budget_function,
+                "recall_budget_fixed_low": recall_budget_fixed_low,
+                "recall_budget_fixed_mid": recall_budget_fixed_mid,
+                "recall_budget_fixed_high": recall_budget_fixed_high,
+                "recall_budget_adaptive_low": recall_budget_adaptive_low,
+                "recall_budget_adaptive_mid": recall_budget_adaptive_mid,
+                "recall_budget_adaptive_high": recall_budget_adaptive_high,
+                "recall_budget_min": recall_budget_min,
+                "recall_budget_max": recall_budget_max,
                 "disposition_skepticism": disposition_skepticism,
                 "disposition_literalism": disposition_literalism,
                 "disposition_empathy": disposition_empathy,
                 "mcp_enabled_tools": mcp_enabled_tools,
                 "llm_gemini_safety_settings": llm_gemini_safety_settings,
+                "memory_defense": memory_defense,
+                "audit_log_enabled": audit_log_enabled,
             }.items()
             if v is not None
         }

--- a/hindsight-clients/python/tests/test_bank_config_update_payload.py
+++ b/hindsight-clients/python/tests/test_bank_config_update_payload.py
@@ -230,3 +230,95 @@ def test_update_bank_config_omits_entity_labels_when_unset(monkeypatch):
 
     assert "entity_labels" not in captured["updates"]
     assert "entities_allow_free_form" not in captured["updates"]
+
+
+def test_update_bank_config_forwards_the_full_configurable_surface(monkeypatch):
+    """Every server-configurable field must reach the request body.
+
+    The wrapper enumerates config fields, so one accepted as a keyword but never
+    written into `updates` is silently dropped — the caller sees a 200 and no
+    change. This covers the groups that were unreachable before #4029: the recall
+    budget, auto-consolidation, memory defense and audit settings. The TypeScript
+    wrapper has the mirror of this test in
+    tests/bank_config_full_surface_mapping.test.ts; the two must stay in step.
+    """
+    captured: dict[str, object] = {}
+
+    async def fake_update(self, bank_id, updates):
+        captured["updates"] = updates
+        return {"bank_id": bank_id, "config": {}, "overrides": updates}
+
+    monkeypatch.setattr(Hindsight, "_aupdate_bank_config", fake_update)
+
+    client = Hindsight(base_url="http://example.invalid")
+    client.update_bank_config(
+        "test-bank",
+        recall_max_tokens=4096,
+        recall_include_chunks=False,
+        recall_chunks_max_tokens=500,
+        recall_budget_function="adaptive",
+        recall_budget_fixed_low=50,
+        recall_budget_fixed_mid=150,
+        recall_budget_fixed_high=500,
+        recall_budget_adaptive_low=0.01,
+        recall_budget_adaptive_mid=0.05,
+        recall_budget_adaptive_high=0.2,
+        recall_budget_min=10,
+        recall_budget_max=1000,
+        enable_auto_consolidation=False,
+        consolidation_llm_parallelism=2,
+        consolidation_max_memories_per_round=50,
+        mental_model_min_refresh_interval_seconds=3600,
+        max_observations_per_scope=25,
+        observation_scope_limits=[{"scope": "team", "limit": 10}],
+        retain_chunk_batch_size=64,
+        store_document_text=False,
+        memory_defense={"redact_secrets": True},
+        audit_log_enabled=True,
+    )
+
+    assert captured["updates"] == {
+        "recall_max_tokens": 4096,
+        "recall_include_chunks": False,
+        "recall_chunks_max_tokens": 500,
+        "recall_budget_function": "adaptive",
+        "recall_budget_fixed_low": 50,
+        "recall_budget_fixed_mid": 150,
+        "recall_budget_fixed_high": 500,
+        "recall_budget_adaptive_low": 0.01,
+        "recall_budget_adaptive_mid": 0.05,
+        "recall_budget_adaptive_high": 0.2,
+        "recall_budget_min": 10,
+        "recall_budget_max": 1000,
+        "enable_auto_consolidation": False,
+        "consolidation_llm_parallelism": 2,
+        "consolidation_max_memories_per_round": 50,
+        "mental_model_min_refresh_interval_seconds": 3600,
+        "max_observations_per_scope": 25,
+        "observation_scope_limits": [{"scope": "team", "limit": 10}],
+        "retain_chunk_batch_size": 64,
+        "store_document_text": False,
+        "memory_defense": {"redact_secrets": True},
+        "audit_log_enabled": True,
+    }
+
+
+def test_update_bank_config_gemini_safety_settings_is_a_list(monkeypatch):
+    """The provider takes a list of {category, threshold}, not a category->threshold map.
+
+    The wrapper used to type this `dict[str, str]`; a caller following that hint
+    sent a shape the Gemini provider rejects.
+    """
+    captured: dict[str, object] = {}
+
+    async def fake_update(self, bank_id, updates):
+        captured["updates"] = updates
+        return {"bank_id": bank_id, "config": {}, "overrides": updates}
+
+    monkeypatch.setattr(Hindsight, "_aupdate_bank_config", fake_update)
+
+    settings = [{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}]
+    client = Hindsight(base_url="http://example.invalid")
+    client.update_bank_config("test-bank", llm_gemini_safety_settings=settings)
+
+    assert captured["updates"] == {"llm_gemini_safety_settings": settings}

--- a/hindsight-clients/typescript/src/index.ts
+++ b/hindsight-clients/typescript/src/index.ts
@@ -514,6 +514,8 @@ export class HindsightClient {
       tagsMatch?: "any" | "all" | "any_strict" | "all_strict" | "exact";
       /** Compound tag filter using boolean groups. Groups are AND-ed. Mutually exclusive with tags/tagsMatch. */
       tagGroups?: Array<TagGroupLeaf | TagGroupAndInput | TagGroupOrInput | TagGroupNotInput>;
+      /** Apply every active directive regardless of tags. By default directives are tag-scoped like memories: untagged ones always apply, tagged ones only when the request's tags match. */
+      applyAllDirectives?: boolean;
       /** Optional JSON Schema for structured output. When provided, the response includes a 'structured_output' field. */
       responseSchema?: Record<string, unknown>;
       /** Filter which fact types are retrieved: 'world', 'experience', 'observation'. None means all. */
@@ -550,6 +552,7 @@ export class HindsightClient {
         tags: options?.tags,
         tags_match: options?.tagsMatch,
         tag_groups: options?.tagGroups,
+        apply_all_directives: options?.applyAllDirectives,
         response_schema: options?.responseSchema,
         fact_types: options?.factTypes,
         exclude_mental_models: options?.excludeMentalModels,
@@ -764,6 +767,66 @@ export class HindsightClient {
       dispositionLiteralism?: number;
       /** How much to consider emotional context (1=detached, 5=empathetic). */
       dispositionEmpathy?: number;
+      /** Default retain strategy name. */
+      retainDefaultStrategy?: string;
+      /** Named strategy definitions (strategy name to config). */
+      retainStrategies?: Record<string, unknown>;
+      /** Number of chunks per sub-batch in chunks extraction mode. */
+      retainChunkBatchSize?: number;
+      /** Persist the original document text alongside extracted facts. */
+      storeDocumentText?: boolean;
+      /** Cap on observations retained per scope (-1 for unlimited). */
+      maxObservationsPerScope?: number;
+      /** Per-scope observation caps, overriding maxObservationsPerScope. */
+      observationScopeLimits?: Record<string, unknown>[];
+      /** Consolidate automatically after retain() rather than on demand. */
+      enableAutoConsolidation?: boolean;
+      /** Number of LLM calls to batch during consolidation. */
+      consolidationLlmBatchSize?: number;
+      /** Concurrent LLM calls during consolidation. */
+      consolidationLlmParallelism?: number;
+      /** Memories consolidated per round. */
+      consolidationMaxMemoriesPerRound?: number;
+      /** Max tokens for source facts across all observations in a pass. */
+      consolidationSourceFactsMaxTokens?: number;
+      /** Max tokens of source facts per observation in the prompt. */
+      consolidationSourceFactsMaxTokensPerObservation?: number;
+      /** Debounce between mental-model refreshes. */
+      mentalModelMinRefreshIntervalSeconds?: number;
+      /** Token budget for source facts during reflect. -1 disables. */
+      reflectSourceFactsMaxTokens?: number;
+      /** Token budget for facts returned by recall. */
+      recallMaxTokens?: number;
+      /** Include source chunks in recall results. */
+      recallIncludeChunks?: boolean;
+      /** Token budget for those chunks. */
+      recallChunksMaxTokens?: number;
+      /** How the per-query result budget is derived: 'fixed' or 'adaptive'. */
+      recallBudgetFunction?: string;
+      /** Fixed budget for low-breadth queries. */
+      recallBudgetFixedLow?: number;
+      /** Fixed budget for medium-breadth queries. */
+      recallBudgetFixedMid?: number;
+      /** Fixed budget for high-breadth queries. */
+      recallBudgetFixedHigh?: number;
+      /** Adaptive budget fraction for low-breadth queries. */
+      recallBudgetAdaptiveLow?: number;
+      /** Adaptive budget fraction for medium-breadth queries. */
+      recallBudgetAdaptiveMid?: number;
+      /** Adaptive budget fraction for high-breadth queries. */
+      recallBudgetAdaptiveHigh?: number;
+      /** Lower clamp on the resolved budget. */
+      recallBudgetMin?: number;
+      /** Upper clamp on the resolved budget. */
+      recallBudgetMax?: number;
+      /** MCP tool names enabled for this bank. */
+      mcpEnabledTools?: string[];
+      /** Gemini/VertexAI safety overrides. */
+      llmGeminiSafetySettings?: { category: string; threshold: string }[];
+      /** Memory-defense (prompt-injection / secret redaction) settings. */
+      memoryDefense?: Record<string, unknown>;
+      /** Write an audit log entry for each operation on this bank. */
+      auditLogEnabled?: boolean;
       signal?: AbortSignal;
     }
   ): Promise<BankConfigResponse> {
@@ -797,6 +860,62 @@ export class HindsightClient {
       updates.disposition_literalism = options.dispositionLiteralism;
     if (options.dispositionEmpathy !== undefined)
       updates.disposition_empathy = options.dispositionEmpathy;
+    if (options.retainDefaultStrategy !== undefined)
+      updates.retain_default_strategy = options.retainDefaultStrategy;
+    if (options.retainStrategies !== undefined)
+      updates.retain_strategies = options.retainStrategies;
+    if (options.retainChunkBatchSize !== undefined)
+      updates.retain_chunk_batch_size = options.retainChunkBatchSize;
+    if (options.storeDocumentText !== undefined)
+      updates.store_document_text = options.storeDocumentText;
+    if (options.maxObservationsPerScope !== undefined)
+      updates.max_observations_per_scope = options.maxObservationsPerScope;
+    if (options.observationScopeLimits !== undefined)
+      updates.observation_scope_limits = options.observationScopeLimits;
+    if (options.enableAutoConsolidation !== undefined)
+      updates.enable_auto_consolidation = options.enableAutoConsolidation;
+    if (options.consolidationLlmBatchSize !== undefined)
+      updates.consolidation_llm_batch_size = options.consolidationLlmBatchSize;
+    if (options.consolidationLlmParallelism !== undefined)
+      updates.consolidation_llm_parallelism = options.consolidationLlmParallelism;
+    if (options.consolidationMaxMemoriesPerRound !== undefined)
+      updates.consolidation_max_memories_per_round = options.consolidationMaxMemoriesPerRound;
+    if (options.consolidationSourceFactsMaxTokens !== undefined)
+      updates.consolidation_source_facts_max_tokens = options.consolidationSourceFactsMaxTokens;
+    if (options.consolidationSourceFactsMaxTokensPerObservation !== undefined)
+      updates.consolidation_source_facts_max_tokens_per_observation =
+        options.consolidationSourceFactsMaxTokensPerObservation;
+    if (options.mentalModelMinRefreshIntervalSeconds !== undefined)
+      updates.mental_model_min_refresh_interval_seconds =
+        options.mentalModelMinRefreshIntervalSeconds;
+    if (options.reflectSourceFactsMaxTokens !== undefined)
+      updates.reflect_source_facts_max_tokens = options.reflectSourceFactsMaxTokens;
+    if (options.recallMaxTokens !== undefined) updates.recall_max_tokens = options.recallMaxTokens;
+    if (options.recallIncludeChunks !== undefined)
+      updates.recall_include_chunks = options.recallIncludeChunks;
+    if (options.recallChunksMaxTokens !== undefined)
+      updates.recall_chunks_max_tokens = options.recallChunksMaxTokens;
+    if (options.recallBudgetFunction !== undefined)
+      updates.recall_budget_function = options.recallBudgetFunction;
+    if (options.recallBudgetFixedLow !== undefined)
+      updates.recall_budget_fixed_low = options.recallBudgetFixedLow;
+    if (options.recallBudgetFixedMid !== undefined)
+      updates.recall_budget_fixed_mid = options.recallBudgetFixedMid;
+    if (options.recallBudgetFixedHigh !== undefined)
+      updates.recall_budget_fixed_high = options.recallBudgetFixedHigh;
+    if (options.recallBudgetAdaptiveLow !== undefined)
+      updates.recall_budget_adaptive_low = options.recallBudgetAdaptiveLow;
+    if (options.recallBudgetAdaptiveMid !== undefined)
+      updates.recall_budget_adaptive_mid = options.recallBudgetAdaptiveMid;
+    if (options.recallBudgetAdaptiveHigh !== undefined)
+      updates.recall_budget_adaptive_high = options.recallBudgetAdaptiveHigh;
+    if (options.recallBudgetMin !== undefined) updates.recall_budget_min = options.recallBudgetMin;
+    if (options.recallBudgetMax !== undefined) updates.recall_budget_max = options.recallBudgetMax;
+    if (options.mcpEnabledTools !== undefined) updates.mcp_enabled_tools = options.mcpEnabledTools;
+    if (options.llmGeminiSafetySettings !== undefined)
+      updates.llm_gemini_safety_settings = options.llmGeminiSafetySettings;
+    if (options.memoryDefense !== undefined) updates.memory_defense = options.memoryDefense;
+    if (options.auditLogEnabled !== undefined) updates.audit_log_enabled = options.auditLogEnabled;
 
     const response = await sdk.updateBankConfig({
       client: this.client,

--- a/hindsight-clients/typescript/tests/bank_config_full_surface_mapping.test.ts
+++ b/hindsight-clients/typescript/tests/bank_config_full_surface_mapping.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the full bank-config request mapping (#4029).
+ *
+ * `updateBankConfig` enumerates config fields rather than passing a dict through,
+ * so a field accepted as an option but never written into `updates` is silently
+ * dropped: the caller gets a 200 and no change. Before #4029 this wrapper reached
+ * only 17 of the server's 47 configurable fields — the whole recall-budget group,
+ * memory defense and the consolidation knobs were unreachable from TypeScript.
+ *
+ * The Python wrapper has the mirror of this file in
+ * tests/test_bank_config_update_payload.py; the two must stay in step.
+ */
+
+import { HindsightClient } from "../src";
+import * as sdk from "../generated/sdk.gen";
+
+jest.mock("../generated/sdk.gen");
+
+const mockedUpdateConfig = sdk.updateBankConfig as jest.MockedFunction<typeof sdk.updateBankConfig>;
+const mockedReflect = sdk.reflect as jest.MockedFunction<typeof sdk.reflect>;
+
+describe("full bank config surface mapping", () => {
+  let client: HindsightClient;
+
+  beforeEach(() => {
+    client = new HindsightClient({ baseUrl: "http://localhost:8888" });
+    mockedUpdateConfig.mockReset();
+    mockedUpdateConfig.mockResolvedValue({
+      data: { bank_id: "bank", config: {}, overrides: {} },
+    } as any);
+    mockedReflect.mockReset();
+    mockedReflect.mockResolvedValue({ data: { text: "ok" } } as any);
+  });
+
+  test("maps the recall budget group onto the updates map", async () => {
+    await client.updateBankConfig("bank", {
+      recallMaxTokens: 4096,
+      recallIncludeChunks: false,
+      recallChunksMaxTokens: 500,
+      recallBudgetFunction: "adaptive",
+      recallBudgetFixedLow: 50,
+      recallBudgetFixedMid: 150,
+      recallBudgetFixedHigh: 500,
+      recallBudgetAdaptiveLow: 0.01,
+      recallBudgetAdaptiveMid: 0.05,
+      recallBudgetAdaptiveHigh: 0.2,
+      recallBudgetMin: 10,
+      recallBudgetMax: 1000,
+    });
+
+    const body = mockedUpdateConfig.mock.calls[0][0].body as any;
+    expect(body.updates).toEqual({
+      recall_max_tokens: 4096,
+      recall_include_chunks: false,
+      recall_chunks_max_tokens: 500,
+      recall_budget_function: "adaptive",
+      recall_budget_fixed_low: 50,
+      recall_budget_fixed_mid: 150,
+      recall_budget_fixed_high: 500,
+      recall_budget_adaptive_low: 0.01,
+      recall_budget_adaptive_mid: 0.05,
+      recall_budget_adaptive_high: 0.2,
+      recall_budget_min: 10,
+      recall_budget_max: 1000,
+    });
+  });
+
+  test("maps the consolidation, retain and security groups onto the updates map", async () => {
+    await client.updateBankConfig("bank", {
+      enableAutoConsolidation: false,
+      consolidationLlmBatchSize: 4,
+      consolidationLlmParallelism: 2,
+      consolidationMaxMemoriesPerRound: 50,
+      consolidationSourceFactsMaxTokens: 2048,
+      consolidationSourceFactsMaxTokensPerObservation: 128,
+      mentalModelMinRefreshIntervalSeconds: 3600,
+      reflectSourceFactsMaxTokens: 1024,
+      maxObservationsPerScope: 25,
+      observationScopeLimits: [{ scope: "team", limit: 10 }],
+      retainDefaultStrategy: "fast",
+      retainStrategies: { fast: { retain_extraction_mode: "concise" } },
+      retainChunkBatchSize: 64,
+      storeDocumentText: false,
+      mcpEnabledTools: ["recall", "reflect"],
+      llmGeminiSafetySettings: [{ category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_NONE" }],
+      memoryDefense: { redact_secrets: true },
+      auditLogEnabled: true,
+    });
+
+    const body = mockedUpdateConfig.mock.calls[0][0].body as any;
+    expect(body.updates).toEqual({
+      enable_auto_consolidation: false,
+      consolidation_llm_batch_size: 4,
+      consolidation_llm_parallelism: 2,
+      consolidation_max_memories_per_round: 50,
+      consolidation_source_facts_max_tokens: 2048,
+      consolidation_source_facts_max_tokens_per_observation: 128,
+      mental_model_min_refresh_interval_seconds: 3600,
+      reflect_source_facts_max_tokens: 1024,
+      max_observations_per_scope: 25,
+      observation_scope_limits: [{ scope: "team", limit: 10 }],
+      retain_default_strategy: "fast",
+      retain_strategies: { fast: { retain_extraction_mode: "concise" } },
+      retain_chunk_batch_size: 64,
+      store_document_text: false,
+      mcp_enabled_tools: ["recall", "reflect"],
+      llm_gemini_safety_settings: [
+        { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_NONE" },
+      ],
+      memory_defense: { redact_secrets: true },
+      audit_log_enabled: true,
+    });
+  });
+
+  test("sends only the fields that were set", async () => {
+    await client.updateBankConfig("bank", { recallMaxTokens: 100 });
+
+    const body = mockedUpdateConfig.mock.calls[0][0].body as any;
+    expect(body.updates).toEqual({ recall_max_tokens: 100 });
+  });
+
+  test("reflect forwards applyAllDirectives", async () => {
+    await client.reflect("bank", "why?", { applyAllDirectives: true });
+
+    const body = mockedReflect.mock.calls[0][0].body as any;
+    expect(body.apply_all_directives).toBe(true);
+  });
+
+  test("reflect omits applyAllDirectives when unset", async () => {
+    await client.reflect("bank", "why?", {});
+
+    const body = mockedReflect.mock.calls[0][0].body as any;
+    expect(body.apply_all_directives).toBeUndefined();
+  });
+});

--- a/hindsight-dev/hindsight_dev/client_coverage_check.py
+++ b/hindsight-dev/hindsight_dev/client_coverage_check.py
@@ -18,6 +18,14 @@ For each client, the script:
      automatic snake_case ↔ camelCase conversion).
   3. Allows explicit skips via per-client ``.openapi-coverage.toml`` files.
 
+Bank config is checked separately.  ``PATCH /banks/{bank_id}/config`` takes a
+free-form ``updates: dict[str, Any]``, so the spec advertises a single ``updates``
+property and every individual setting is invisible to the request-body walk above.
+The wrappers enumerate those settings as keyword arguments, which is exactly where
+they drift, so ``check_bank_config_fields`` reads the server's ``_CONFIGURABLE_FIELDS``
+directly and asserts each one reaches both wrappers.  Skips live in the same manifest
+under ``[bank_config]``.
+
 Usage:
     cd hindsight-dev
     uv run client-coverage-check
@@ -28,6 +36,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 import sys
@@ -202,6 +211,127 @@ def check_client(
     return errors
 
 
+# ── bank config ──────────────────────────────────────────────────────────
+
+
+def load_configurable_fields(config_path: Path) -> list[str]:
+    """Return the server's per-bank overridable config field names.
+
+    Parsed out of ``config.py`` with ast rather than imported: hindsight-dev does
+    not depend on hindsight-api, and this only needs the literal set members.
+    """
+    tree = ast.parse(config_path.read_text())
+    for node in ast.walk(tree):
+        # Bind the value inside each branch: narrowing on `node` does not survive
+        # the if/elif when only `targets` is assigned in them.
+        if isinstance(node, ast.Assign):
+            targets: list[ast.expr] = list(node.targets)
+            value: ast.expr | None = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "_CONFIGURABLE_FIELDS" for t in targets):
+            continue
+        if not isinstance(value, ast.Set | ast.List | ast.Tuple):
+            raise ValueError(f"{config_path}: _CONFIGURABLE_FIELDS is not a literal set/list/tuple")
+        return sorted(elt.value for elt in value.elts if isinstance(elt, ast.Constant) and isinstance(elt.value, str))
+    raise ValueError(f"{config_path}: no _CONFIGURABLE_FIELDS assignment found")
+
+
+def load_bank_config_skips(path: Path) -> dict[str, str]:
+    """Return the ``[bank_config]`` skip table from a client's coverage manifest."""
+    if not path.exists():
+        return {}
+    data = tomllib.loads(path.read_text())
+    raw = data.get("bank_config", {}) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: [bank_config] must be a table")
+    skips: dict[str, str] = {}
+    for field, reason in raw.items():
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError(f"{path}: bank_config.{field} must be a non-empty string reason")
+        skips[field] = reason.strip()
+    return skips
+
+
+def extract_config_method(source: str, client_name: str) -> str:
+    """Return just the wrapper's bank-config update method body.
+
+    Scoped rather than scanning the whole file: these field names also appear in
+    other methods (``recall_max_tokens`` is a recall argument, ``retain_chunk_size``
+    a retain one), so a whole-file search reports a field as reachable when the
+    config method does not actually accept it.
+    """
+    if client_name == "python":
+        start = re.search(r"^    def update_bank_config\(", source, re.M)
+        end_pat = r"^    (?:async )?def "
+    else:
+        start = re.search(r"^  async updateBankConfig\(", source, re.M)
+        end_pat = r"^  (?:async )?\w+\("
+    if start is None:
+        raise ValueError(f"{client_name}: could not locate the bank-config update method")
+    rest = source[start.end() :]
+    end = re.search(end_pat, rest, re.M)
+    return rest[: end.start()] if end else rest
+
+
+def forwarding_pattern(field: str, client_name: str) -> str:
+    """Regex proving a field is written into the PATCH body, not just accepted."""
+    if client_name == "python":
+        # "field_name": field_name,  inside the updates dict comprehension
+        return r'"' + re.escape(field) + r'"\s*:'
+    # updates.field_name = options.fieldName;
+    return r"updates\." + re.escape(field) + r"\s*="
+
+
+def check_bank_config_fields(
+    *,
+    client_name: str,
+    source_path: Path,
+    manifest_path: Path,
+    fields: list[str],
+) -> list[str]:
+    """Check that every server-configurable bank field reaches one client wrapper."""
+    source = extract_config_method(source_path.read_text(), client_name)
+    skips = load_bank_config_skips(manifest_path)
+    errors: list[str] = []
+
+    covered = skipped = 0
+    for field in fields:
+        if field in skips:
+            skipped += 1
+            continue
+        if not field_present_in_source(field, source):
+            errors.append(f"MISSING CONFIG {field}: not accepted by the wrapper's bank-config method")
+            continue
+        # Accepting the argument is not enough — both wrappers build the request
+        # body by enumerating fields, so one that is declared but never written
+        # into that map is accepted and then silently dropped.
+        if not re.search(forwarding_pattern(field, client_name), source):
+            errors.append(
+                f"UNFORWARDED CONFIG {field}: accepted by the wrapper but never "
+                f"written into the request body — it would be silently dropped"
+            )
+            continue
+        covered += 1
+
+    for field in sorted(skips):
+        if field not in fields:
+            errors.append(
+                f"STALE CONFIG  {field}: listed in [bank_config] but not in "
+                f"the server's _CONFIGURABLE_FIELDS. Remove it."
+            )
+
+    print(f"    Bank config:     {len(fields)}")
+    print(f"      covered:       {covered}")
+    print(f"      skipped:       {skipped}")
+    print(f"      missing:       {len(fields) - covered - skipped}")
+
+    return errors
+
+
 # ── TypeScript ───────────────────────────────────────────────────────────
 
 
@@ -257,6 +387,9 @@ def main() -> None:
 
     op_props = load_openapi_operations(spec_path)
 
+    config_path = root / "hindsight-api-slim" / "hindsight_api" / "config.py"
+    bank_config_fields = load_configurable_fields(config_path)
+
     clients: list[dict] = []
 
     if args.client in ("python", "all"):
@@ -282,7 +415,8 @@ def main() -> None:
     all_errors: list[str] = []
 
     print("Client SDK OpenAPI coverage check")
-    print(f"  Spec: {spec_path.relative_to(root)}")
+    print(f"  Spec:        {spec_path.relative_to(root)}")
+    print(f"  Bank config: {config_path.relative_to(root)} ({len(bank_config_fields)} fields)")
     print()
 
     for client_cfg in clients:
@@ -290,6 +424,12 @@ def main() -> None:
             print(f"  [{client_cfg['client_name']}] SKIPPED: source not found at {client_cfg['source_path']}")
             continue
         errs = check_client(op_props=op_props, **client_cfg)
+        errs += check_bank_config_fields(
+            client_name=client_cfg["client_name"],
+            source_path=client_cfg["source_path"],
+            manifest_path=client_cfg["manifest_path"],
+            fields=bank_config_fields,
+        )
         all_errors.extend(f"[{client_cfg['client_name']}] {e}" for e in errs)
         print()
 


### PR DESCRIPTION
Fixes #4029.

## What was wrong

`PATCH /banks/{bank_id}/config` takes a free-form `updates: dict[str, Any]`, so the generated SDKs can send anything. The **wrappers** build that body by enumerating fields by hand, and nothing regenerated or checked that list. Measured against `_CONFIGURABLE_FIELDS` (47 fields):

| | before | after |
|---|---|---|
| Python `update_bank_config` | 25 / 47 | **47 / 47** |
| TypeScript `updateBankConfig` | 17 / 47 | **47 / 47** |

22 fields were reachable from **neither** wrapper — the entire recall-budget group, `memory_defense`, `store_document_text`, the auto-consolidation knobs. 8 more were Python-only. `reflect.apply_all_directives` was missing from both.

## Two wrong type hints

- `llm_gemini_safety_settings` was `dict[str, str]` in Python. The server (`config.py:2540`), the Gemini provider (`gemini_llm.py:237`) and the control plane all take a **list** of `{category, threshold}`. A caller following the hint sent a payload the provider rejects.
- (`entity_labels: list[str]` was the same class of bug, fixed in #4027.)

## The check that should have caught this

`client-coverage-check` exists for exactly this and was **wired into no workflow**. It was red on `main`:

```
FAILED: 2 issue(s):
  [python]     MISSING PARAM reflect.apply_all_directives
  [typescript] MISSING PARAM reflect.apply_all_directives
```

It now runs in CI beside `check-cli-coverage` and gates `report-pr-status`.

It also could not see this drift even if it had run: it walks *typed* request-body properties, and `updateBankConfig` reads as fully covered by its single `updates` property. So the check now reads `_CONFIGURABLE_FIELDS` from `config.py` directly, with `[bank_config]` skips in the existing per-client manifests.

### It verifies forwarding, not just acceptance

I hit this while writing it: after adding the keyword arguments, coverage went green while the payload mapping was still missing — a field accepted and never written into `updates` is silently dropped, and the caller gets a `200` and no change. That is precisely how this bug class presents, so the check requires both. Negative-tested by deleting one mapping line:

```
[python] UNFORWARDED CONFIG audit_log_enabled: accepted by the wrapper but never
         written into the request body — it would be silently dropped
```

The scan is scoped to the config method rather than the whole file: names like `recall_max_tokens` also appear as recall arguments, and a whole-file search reported 19 TS fields covered when the method accepted 17.

## Tests

Mirrored mapping tests on both sides, each naming the other so they stay in step: `test_bank_config_update_payload.py` and `bank_config_full_surface_mapping.test.ts`, covering the recall-budget group, the consolidation/retain/security groups, the `undefined`-is-omitted case, the gemini list shape, and `apply_all_directives` on reflect.

Local: 88 Python and 72 TypeScript pass. The `test_main_operations` suites in both clients need a live API on `:8888` and fail with `ClientConnectorError` / `fetch failed` without one — unrelated to this change.