### PR TITLE
perf(api): stop importing LiteLLM and markitdown on every startup

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/parsers/markitdown.py
+++ b/hindsight-api-slim/hindsight_api/engine/parsers/markitdown.py
@@ -1,6 +1,7 @@
 """Markitdown parser implementation."""
 
 import asyncio
+import importlib.util
 import logging
 import tempfile
 from dataclasses import dataclass
@@ -12,7 +13,7 @@ from hindsight_api.config import DEFAULT_FILE_PARSER_MARKITDOWN_OCR_PROMPT
 from .base import FileParser
 
 if TYPE_CHECKING:
-    from markitdown import StreamInfo
+    from markitdown import MarkItDown, StreamInfo
 
 logger = logging.getLogger(__name__)
 
@@ -74,31 +75,45 @@ class MarkitdownParser(FileParser):
         ocr_prompt: str | None = None,
         ocr_default_headers: dict[str, str] | None = None,
     ):
-        """Initialize markitdown parser."""
-        # Lazy import to avoid requiring markitdown for all users
-        try:
-            from markitdown import MarkItDown
-        except ImportError as e:
-            raise ImportError(
-                "markitdown package is required for file parsing. Install with: pip install markitdown"
-            ) from e
+        """Initialize markitdown parser.
 
+        The ``markitdown`` package itself is NOT imported here -- only checked for.
+        ``MemoryEngine.initialize()`` constructs this parser eagerly at startup, so
+        importing markitdown (which pulls in bs4 -> lxml) cost ~400ms of every server
+        start even when no file was ever converted.
+
+        ``find_spec`` answers "is it installed?" without executing the package, so
+        registration keeps raising ImportError at exactly the same point as before
+        while the import itself is deferred to the first ``convert()`` call.
+        """
+        if importlib.util.find_spec("markitdown") is None:
+            raise ImportError("markitdown package is required for file parsing. Install with: pip install markitdown")
+
+        self._markitdown: "MarkItDown | None" = None
         self._ocr_enabled = ocr_enabled
-        if ocr_enabled:
-            ocr_options = self._build_ocr_options(
-                api_key=ocr_api_key,
-                base_url=ocr_base_url,
-                model=ocr_model,
-                prompt=ocr_prompt,
-                default_headers=ocr_default_headers,
-            )
-            self._markitdown = MarkItDown(
-                llm_client=ocr_options.llm_client,
-                llm_model=ocr_options.llm_model,
-                llm_prompt=ocr_options.llm_prompt,
-            )
-        else:
-            self._markitdown = MarkItDown()
+        self._ocr_kwargs = dict(
+            api_key=ocr_api_key,
+            base_url=ocr_base_url,
+            model=ocr_model,
+            prompt=ocr_prompt,
+            default_headers=ocr_default_headers,
+        )
+
+    def _get_markitdown(self) -> "MarkItDown":
+        """Build the MarkItDown instance on first use (see __init__ for why)."""
+        if self._markitdown is None:
+            from markitdown import MarkItDown
+
+            if self._ocr_enabled:
+                ocr_options = self._build_ocr_options(**self._ocr_kwargs)
+                self._markitdown = MarkItDown(
+                    llm_client=ocr_options.llm_client,
+                    llm_model=ocr_options.llm_model,
+                    llm_prompt=ocr_options.llm_prompt,
+                )
+            else:
+                self._markitdown = MarkItDown()
+        return self._markitdown
 
     def _build_ocr_options(
         self,
@@ -168,7 +183,7 @@ class MarkitdownParser(FileParser):
         try:
             # Parse using markitdown, passing an explicit charset hint for text
             # files to avoid markitdown's sample-based (and crash-prone) detection.
-            result = self._markitdown.convert(tmp_path, stream_info=self._utf8_stream_info(file_data, filename))
+            result = self._get_markitdown().convert(tmp_path, stream_info=self._utf8_stream_info(file_data, filename))
 
             if not result or not result.text_content:
                 raise RuntimeError(f"No content extracted from '{filename}'")

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -18,9 +18,8 @@ import logging
 import os
 import time
 from contextlib import AbstractAsyncContextManager, nullcontext
+from functools import lru_cache
 from typing import Any, Callable
-
-from litellm.exceptions import Timeout as LiteLLMTimeout
 
 from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
 from hindsight_api.engine.llm_interface import (
@@ -37,6 +36,33 @@ from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult,
 from hindsight_api.engine.structured_output import provider_json_schema, strict_json_schema
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
+
+
+@lru_cache(maxsize=1)
+def _litellm_timeout_exc() -> type[BaseException]:
+    """LiteLLM's ``Timeout``, imported on first use rather than at module scope.
+
+    This module was importing the whole of LiteLLM for one exception type used in two
+    ``except`` clauses, and it is imported unconditionally -- so every process paid
+    ~1.3s of LiteLLM import whether or not LiteLLM was the configured provider. That
+    cost lands on each ``--workers`` child and each spawned worker, not once.
+
+    ``except`` tuples are evaluated when an exception propagates, not at definition, so
+    resolving the class lazily here is behaviour-preserving.
+
+    Falls back to a private sentinel when LiteLLM is not installed, so the ``except``
+    tuples below stay valid rather than raising ImportError while handling an error.
+    """
+    try:
+        from litellm.exceptions import Timeout
+    except ImportError:  # pragma: no cover - only when litellm is absent
+
+        class _NeverRaised(Exception):
+            pass
+
+        return _NeverRaised
+    return Timeout
+
 
 logger = logging.getLogger(__name__)
 
@@ -439,7 +465,7 @@ class LiteLLMLLM(LLMInterface):
                     logger.error(f"LiteLLM returned invalid JSON after {max_retries + 1} attempts")
                     raise
 
-            except (TimeoutError, asyncio.TimeoutError, LiteLLMTimeout) as e:
+            except (TimeoutError, asyncio.TimeoutError, _litellm_timeout_exc()) as e:
                 # litellm/httpx don't always honor their own ``timeout=`` (e.g. a connection held
                 # open with no token progress), so ``wait_for`` is the hard cap that cancels a hung
                 # call regardless — otherwise one straggler pins a worker slot and stalls its gather.
@@ -600,7 +626,7 @@ class LiteLLMLLM(LLMInterface):
                     output_tokens=output_tokens,
                 )
 
-            except (TimeoutError, asyncio.TimeoutError, LiteLLMTimeout) as e:
+            except (TimeoutError, asyncio.TimeoutError, _litellm_timeout_exc()) as e:
                 # See ``call`` — hard cap so a hung completion cannot block
                 # forever and pin a worker slot / concurrency permit.
                 last_exception = e


### PR DESCRIPTION
Two eager imports cost ~1.4s of process start regardless of configuration.

**`providers/litellm_llm.py`** imported `litellm.exceptions` at module scope for a single exception type used in two `except` clauses. That module is imported unconditionally, so every process paid ~1.3s of LiteLLM import whether or not LiteLLM was the configured provider. `except` tuples are evaluated when an exception propagates rather than at definition, so resolving the class lazily is behaviour-preserving. It falls back to a private sentinel when LiteLLM is absent, so the tuples stay valid rather than raising ImportError while handling an error.

**`parsers/markitdown.py`** imported markitdown in `__init__`, and `MemoryEngine.initialize()` constructs the parser eagerly — so ~400ms of markitdown (which pulls bs4 → lxml) was spent on every server start even when no file was ever converted. The availability check is now `importlib.util.find_spec`, which answers "is it installed?" without executing the package: registration still raises ImportError at exactly the same point, and the import moves to the first `convert()`.

## Measured

`import hindsight_api.api.http` on 3.11:

| | |
|---|---|
| before | 2361 ms |
| after | **1388 ms** (−41%) |

This is per process, not once — it lands on each `--workers` child and each spawned worker, which rebuild the module tree from scratch.

## Testing

No behaviour change. `tests/test_litellm_timeout.py` exercises the `except` clauses and `tests/test_markitdown_parser.py` the parser — 9 passed.

Split out of a larger free-threading branch, but stands on its own: nothing here is specific to 3.14.