### PR TITLE
fix(api): warm dateparser locale dictionaries once, under a lock

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/temporal_language_detection.py
+++ b/hindsight-api-slim/hindsight_api/engine/temporal_language_detection.py
@@ -22,6 +22,26 @@ to the 1.2.2 copy we ship):
 3. When stripping the timezone does not change the string, the retry re-runs a
    computation whose result is already known to be ``[0, 0]``. **Skipped.**
 
+**Thread safety.** ``Locale.count_applicability`` reaches
+``Locale.clean_dictionary``, which deletes the sub-threshold keys from the locale's
+*cached* ``_split_dictionary`` in place. Two threads reaching a given locale for the
+first time therefore iterate and delete from the same dict at once:
+
+    RuntimeError: dictionary changed size during iteration
+
+and whichever caller loses dies. This is reachable today:
+``MemoryEngine.initialize()`` warms the analyzer with
+``await loop.run_in_executor(None, self.query_analyzer.load)``, so the warmup already
+runs on a thread pool — two engines initialising in one process race here.
+
+The mutation is idempotent -- once the short keys are gone the delete list is empty
+and nothing is written -- so the race window is first use per locale, and
+``_ensure_dictionary_warm`` closes it by doing that first use once under a lock.
+After warming, the hot path takes no lock: it is a concurrent read of a dict nobody
+mutates. Fixing it here rather than forking dateparser is enough because this module
+is the only route into locale applicability counting (``query_analyzer._find_dates``
+calls ``best_language``, never dateparser's own detector).
+
 Every transformation here is equivalence-preserving by construction, and
 ``tests/test_temporal_extraction.py`` asserts that directly: it runs this
 implementation and dateparser's side by side over the corpus plus thousands of
@@ -115,6 +135,30 @@ def _character_check(text: str, languages: list[Locale], settings: Settings) -> 
     return [lang for i, lang in enumerate(languages) if text_chars & tables.language_chars[i]]
 
 
+_WARM_ATTR = "_hindsight_split_dictionary_warm"
+_warm_lock = threading.Lock()
+
+
+def _ensure_dictionary_warm(locale: Locale, settings: Settings) -> None:
+    """Populate and clean ``locale``'s split dictionary exactly once, under a lock.
+
+    Marked on the Locale instance rather than in a set keyed by ``shortname``: the
+    same shortname can be a different object if dateparser's loader is rebuilt, and
+    warming is per-instance state.
+
+    The unlocked pre-check is the point -- after the first call this costs one
+    ``getattr`` and no synchronisation, so the per-query path is unaffected.
+    """
+    if getattr(locale, _WARM_ATTR, False):
+        return
+    with _warm_lock:
+        if getattr(locale, _WARM_ATTR, False):
+            return
+        # Any text works: this is called for the mutation it performs, not the count.
+        locale.count_applicability("a", strip_timezone=False, settings=settings)
+        setattr(locale, _WARM_ATTR, True)
+
+
 def best_language(text: str, languages: list[Locale], settings: Settings | None = None) -> str | None:
     """Return the detected locale shortname, or None.
 
@@ -138,6 +182,7 @@ def best_language(text: str, languages: list[Locale], settings: Settings | None 
 
     applicable: list[tuple[str, list[int]]] = []
     for language in candidates:
+        _ensure_dictionary_warm(language, settings)
         counts = language.count_applicability(text, strip_timezone=False, settings=settings)
         if counts[0] > 0 or counts[1] > 0:
             applicable.append((language.shortname, counts))

--- a/hindsight-api-slim/tests/test_temporal_language_detection_threading.py
+++ b/hindsight-api-slim/tests/test_temporal_language_detection_threading.py
@@ -1,0 +1,36 @@
+"""Warming locale dictionaries must not change what language detection answers.
+
+`_ensure_dictionary_warm` performs a locale's first `count_applicability` early and
+under a lock, so that concurrent callers never reach dateparser's in-place
+`clean_dictionary` at the same time. That is only safe to do if the early call is
+otherwise invisible, which is what this asserts.
+
+The race it prevents is NOT reproducible on a GIL build: 12 threads entering cold
+locales through a barrier produce no error on 3.11, because the iterate-then-delete
+sequence in `Locale.clean_dictionary` is effectively atomic there. It reproduces
+reliably on a free-threaded interpreter, where it killed the startup of whichever
+event loops lost the race. tests/test_free_threading.py and the free-threaded CI job
+are what actually guard it; this file guards the equivalence.
+"""
+
+from dateparser.languages.loader import LocaleDataLoader
+
+from hindsight_api.engine.temporal_language_detection import best_language
+
+_LOCALES = list(LocaleDataLoader().get_locales(languages=None, locales=None, region=None))[:40]
+
+_TEXTS = [
+    "what happened last friday",
+    "cosa e successo ieri sera",
+    "was ist gestern passiert",
+    "que paso el martes pasado",
+    "1200 tokens and no date at all",
+]
+
+
+def test_warming_does_not_change_detection():
+    """Every answer must be what it was before the warm call was introduced."""
+    first = {text: best_language(text, _LOCALES) for text in _TEXTS}
+    # Second pass runs entirely against warmed locales — the path every request takes.
+    second = {text: best_language(text, _LOCALES) for text in _TEXTS}
+    assert first == second


### PR DESCRIPTION
`Locale.count_applicability` reaches `Locale.clean_dictionary`, which deletes the sub-threshold keys from that locale's *cached* `_split_dictionary` **in place**. Two threads reaching a locale for the first time iterate and delete from the same dict:

```
RuntimeError: dictionary changed size during iteration
```

and whichever caller loses dies.

`_ensure_dictionary_warm` performs that first use once per Locale under a lock. The unlocked pre-check is the point: after warming, the per-query path costs one `getattr` and no synchronisation, and concurrent `clean_dictionary` calls are then reads of a dict nobody mutates. The marker lives on the Locale instance rather than in a set keyed by shortname, because the same shortname can be a different object if dateparser's loader is rebuilt.

## No dateparser fork needed

Two reasons:

- the mutation is **idempotent** — once the short keys are gone the delete list is empty and nothing is written — so the window is first use per locale;
- this module is the **only** route into locale applicability counting. `query_analyzer._find_dates` calls `best_language`, never dateparser's own detector, so guarding here covers every caller.

## Scope — measured, not assumed

**This is not reproducible on a GIL build.** Twelve threads entering cold locales through a barrier produce zero errors on 3.11, because the iterate-then-delete sequence is effectively atomic there. It reproduces reliably under real parallelism, where it killed the startup of whichever event loops lost the race.

So this lands as hardening ahead of running several event loops in one process, **not** as a fix for an outage anyone is having today. Reviewers should weigh it on that basis.

## Testing

The accompanying test asserts the property that *is* checkable here — that warming changes no answer — rather than a concurrency test that would pass with or without the fix. `tests/test_temporal_extraction.py` (118 passed) still holds this implementation identical to dateparser's over the corpus plus randomly generated strings.