### PR TITLE
fix(embeddings): support AWS Bedrock application inference profile ARNs in litellm-sdk

### DIFF
--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -474,6 +474,11 @@ ENV_RERANKER_LITELLM_MAX_TOKENS_PER_DOC = "HINDSIGHT_API_RERANKER_LITELLM_MAX_TO
 # LiteLLM SDK configuration (direct API access, no proxy needed)
 ENV_EMBEDDINGS_LITELLM_SDK_API_KEY = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY"
 ENV_EMBEDDINGS_LITELLM_SDK_MODEL = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL"
+# Optional explicit model id/ARN forwarded to litellm as its own `model_id` param
+# (the actual Bedrock invoke target), separate from ENV_EMBEDDINGS_LITELLM_SDK_MODEL
+# (used only for litellm's provider-family detection). Needed for AWS Bedrock
+# application inference profiles — see LiteLLMSDKEmbeddings's own docstring.
+ENV_EMBEDDINGS_LITELLM_SDK_MODEL_ID = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL_ID"
 ENV_EMBEDDINGS_LITELLM_SDK_API_BASE = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_BASE"
 ENV_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS"
 ENV_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT = "HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT"
@@ -2640,6 +2645,7 @@ class HindsightConfig:
     embeddings_litellm_dimensions: int | None
     embeddings_litellm_sdk_api_key: str | None
     embeddings_litellm_sdk_model: str
+    embeddings_litellm_sdk_model_id: str | None
     embeddings_litellm_sdk_api_base: str | None
     embeddings_litellm_sdk_output_dimensions: int | None
     embeddings_litellm_sdk_encoding_format: str | None
@@ -3847,6 +3853,7 @@ class HindsightConfig:
             embeddings_litellm_sdk_model=os.getenv(
                 ENV_EMBEDDINGS_LITELLM_SDK_MODEL, DEFAULT_EMBEDDINGS_LITELLM_SDK_MODEL
             ),
+            embeddings_litellm_sdk_model_id=os.getenv(ENV_EMBEDDINGS_LITELLM_SDK_MODEL_ID) or None,
             embeddings_litellm_sdk_api_base=os.getenv(ENV_EMBEDDINGS_LITELLM_SDK_API_BASE) or None,
             embeddings_litellm_sdk_output_dimensions=int(v)
             if (v := os.getenv(ENV_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS))

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -1650,6 +1650,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
         self,
         api_key: str | None = None,
         model: str = DEFAULT_EMBEDDINGS_LITELLM_SDK_MODEL,
+        model_id: str | None = None,
         api_base: str | None = None,
         output_dimensions: int | None = None,
         batch_size: int = 100,
@@ -1665,7 +1666,22 @@ class LiteLLMSDKEmbeddings(Embeddings):
         Args:
             api_key: API key for the embedding provider (optional — omit for
                      providers that use ambient credentials, e.g. AWS Bedrock with IAM)
-            model: Model name with provider prefix (e.g., "cohere/embed-english-v3.0")
+            model: Model name with provider prefix (e.g., "cohere/embed-english-v3.0").
+                For Bedrock, this must be (or contain) a recognizable provider-family
+                name litellm can pattern-match (e.g. "amazon.titan-embed-text-v2:0") —
+                it's what litellm's own `get_bedrock_embedding_provider` inspects to
+                pick the right request/response shape, separate from `model_id` below.
+            model_id: Optional explicit model id/ARN passed straight through to
+                litellm as its own `model_id` param, used as the ACTUAL Bedrock
+                invoke target instead of `model` (litellm: "unencoded_model_id =
+                optional_params.pop('model_id', None) or model"). Needed for AWS
+                Bedrock application inference profiles: their ARN
+                (arn:aws:bedrock:...:application-inference-profile/<opaque-id>) has
+                no recognizable provider name for `model` to double as, unlike a
+                system cross-region inference profile id (e.g.
+                "eu.anthropic.claude-sonnet-4-5-...") which does. Bedrock chat/
+                Converse models don't need this split (Converse is provider-agnostic),
+                which is why only the embeddings path exposes it.
             api_base: Custom base URL for API (optional)
             output_dimensions: Optional output embedding dimensions (provider-dependent)
             batch_size: Maximum batch size for embedding requests (default: 100)
@@ -1679,6 +1695,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
         """
         self.api_key = api_key
         self.model = model
+        self.model_id = model_id
         self.api_base = api_base
         self.output_dimensions = output_dimensions
         self.batch_size = batch_size
@@ -1725,6 +1742,8 @@ class LiteLLMSDKEmbeddings(Embeddings):
                 # timeout, so a stalled provider would hang startup for minutes.
                 "timeout": self.timeout,
             }
+            if self.model_id:
+                embed_kwargs["model_id"] = self.model_id
             if self.api_key:
                 embed_kwargs["api_key"] = self.api_key
             if self.encoding_format:
@@ -1811,6 +1830,8 @@ class LiteLLMSDKEmbeddings(Embeddings):
                     # synchronous recall far past the retry budget.
                     "timeout": self.timeout,
                 }
+                if self.model_id:
+                    embed_kwargs["model_id"] = self.model_id
                 if self.api_key:
                     embed_kwargs["api_key"] = self.api_key
                 if self.encoding_format:
@@ -2239,6 +2260,7 @@ def create_embeddings_from_env() -> Embeddings:
         return LiteLLMSDKEmbeddings(
             api_key=config.embeddings_litellm_sdk_api_key or None,
             model=config.embeddings_litellm_sdk_model,
+            model_id=config.embeddings_litellm_sdk_model_id,
             api_base=config.embeddings_litellm_sdk_api_base,
             output_dimensions=config.embeddings_litellm_sdk_output_dimensions,
             encoding_format=config.embeddings_litellm_sdk_encoding_format,


### PR DESCRIPTION
Fixes #4034.

## Summary

`LiteLLMSDKEmbeddings` only ever built `embed_kwargs["model"]` from a single configured string. litellm's own bedrock embedding path needs that string to contain a recognizable provider name (`cohere`/`amazon`/`twelvelabs`/`nova`) for `get_bedrock_embedding_provider()` to pick the right request/response shape — which an AWS Bedrock **application inference profile ARN** (an opaque, account-scoped id) never has.

litellm already supports splitting this via its own `model_id` param (`litellm/llms/bedrock/embed/embedding.py`: `unencoded_model_id = optional_params.pop("model_id", None) or model`) — a recognizable `model` for provider detection, a separate `model_id` for the actual invoke target. This PR just wires that existing litellm capability through `LiteLLMSDKEmbeddings`.

## Changes

- `LiteLLMSDKEmbeddings.__init__` gains an optional `model_id: str | None = None` param, threaded into `embed_kwargs["model_id"]` in both places an embedding call is built (dimension-detection in `initialize()`, and the real per-batch call in `_encode_with_input_type()`).
- New `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL_ID` env var (`config.py`) to configure it, wired through `create_embeddings_from_env()`'s `litellm-sdk` branch.
- `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL` keeps its existing meaning (and default) unchanged — it's only ever used for provider detection now when `MODEL_ID` is also set; existing deployments that don't set the new var see no behavior change at all.

## Verification (live)

Built and ran the patched `hindsight-api-slim` in the project's own `docker/standalone/Dockerfile` (`--target api-only`), against a real AWS account with an org-level Bedrock SCP that explicit-denies direct `InvokeModel` on the bare model id once an inference profile exists for it:

```
HINDSIGHT_API_EMBEDDINGS_PROVIDER=litellm-sdk
HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL=bedrock/amazon.titan-embed-text-v2:0
HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL_ID=arn:aws:bedrock:eu-west-1:<account>:application-inference-profile/<id>
```

**Before** (same config, without this PR's `model_id` support — `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL` set directly to the ARN, since there was no other way to route through it at all):

```
RuntimeError: Failed to initialize LiteLLM SDK embeddings: litellm.APIConnectionError:
Unable to determine bedrock embedding provider for model:
arn:aws:bedrock:eu-west-1:<account>:application-inference-profile/<id>.
Supported providers: ['cohere', 'amazon', 'twelvelabs', 'nova']
ERROR:    Application startup failed. Exiting.
```

Container crash-looped on every restart attempt.

**After** (this PR, `MODEL` + `MODEL_ID` split as above) — full startup log:

```
Starting Hindsight API...
  Version: v0.9.2
  Database: postgresql://***:***@XXXX:5432/POSTGRES_app
  LLM: bedrock / bedrock/converse/arn:aws:bedrock:eu-west-1:<account>:application-inference-profile/<id>
  Embeddings: litellm-sdk
  Reranker: rrf
  Extensions: pgvector (vector) / native (text)
  MCP: enabled at /mcp

INFO:     Started server process [10]
INFO:     Waiting for application startup.
... - INFO - hindsight_api.engine.embeddings - Embeddings: initializing LiteLLM SDK provider with model bedrock/amazon.titan-embed-text-v2:0
... - INFO - hindsight_api.engine.embeddings - Embeddings: LiteLLM SDK provider initialized (model: bedrock/amazon.titan-embed-text-v2:0, dim: 1024)
... - INFO - hindsight_api.engine.providers.litellm_llm - LiteLLM connection verified successfully (response truncated)
... - INFO - hindsight_api.engine.memory_engine - Running database migrations...
... - INFO - hindsight_api.migrations - Database migrations completed successfully for schema 'hindsight'
... - INFO - hindsight_api.engine.db.postgresql - PostgreSQL pool created (min=5, max=100, cmd_timeout=60s, acquire_timeout=30s, session_setup_on_acquire=True)
```

`docker ps` confirmed the container stayed up (no restart) well past the point it previously crash-looped.

## Notes

- I wasn't able to run `ruff`/`ty` locally (this machine's Rust/MSVC linker setup can't build `litellm`'s native extension from source on Windows — unrelated to this change), but built and ran the patched `hindsight-api-slim` inside the project's own `docker/standalone/Dockerfile` (Linux, prebuilt wheels) to verify end-to-end.
- No existing behavior changes for anyone not setting the new env var.
