### PR TITLE
fix: two test regressions from #4022 and #4031 (tokenizer cache leak, markitdown OCR fail-fast)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/parsers/markitdown.py
+++ b/hindsight-api-slim/hindsight_api/engine/parsers/markitdown.py
@@ -46,6 +46,30 @@ class MarkitdownOcrOptions:
     llm_prompt: str
 
 
+def _validate_ocr_config(*, api_key: str | None, base_url: str | None, model: str | None) -> None:
+    """Raise if OCR is enabled without the settings it needs.
+
+    Split out of the client construction so it can run at parser construction time
+    (i.e. at startup) while the SDK import stays lazy.
+    """
+    if not model or not model.strip():
+        raise ValueError(
+            "Markitdown OCR is enabled but no model is configured. "
+            "Set HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_MODEL to an OpenAI-compatible OCR/vision model "
+            "with image-input support."
+        )
+    if not api_key:
+        raise ValueError(
+            "Markitdown OCR is enabled but no API key is configured. "
+            "Set HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_API_KEY."
+        )
+    if not base_url or not base_url.strip():
+        raise ValueError(
+            "Markitdown OCR is enabled but no base URL is configured. "
+            "Set HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_BASE_URL to an OpenAI-compatible OCR/vision endpoint."
+        )
+
+
 class MarkitdownParser(FileParser):
     """
     Markitdown file parser.
@@ -89,6 +113,15 @@ class MarkitdownParser(FileParser):
         if importlib.util.find_spec("markitdown") is None:
             raise ImportError("markitdown package is required for file parsing. Install with: pip install markitdown")
 
+        if ocr_enabled:
+            # Validated here, not in _get_markitdown(): these are string checks with
+            # no import cost, and a misconfigured OCR deployment should refuse to
+            # start rather than boot clean and fail on the first image a user
+            # uploads. Deferring the markitdown/openai *imports* is what keeps them
+            # off the startup path (see above); the configuration check does not
+            # need to move with them.
+            _validate_ocr_config(api_key=ocr_api_key, base_url=ocr_base_url, model=ocr_model)
+
         self._markitdown: "MarkItDown | None" = None
         self._ocr_enabled = ocr_enabled
         self._ocr_kwargs = dict(
@@ -124,23 +157,13 @@ class MarkitdownParser(FileParser):
         prompt: str | None,
         default_headers: dict[str, str] | None,
     ) -> MarkitdownOcrOptions:
-        """Build MarkItDown options for OpenAI-compatible image OCR."""
-        if not model or not model.strip():
-            raise ValueError(
-                "Markitdown OCR is enabled but no model is configured. "
-                "Set HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_MODEL to an OpenAI-compatible OCR/vision model "
-                "with image-input support."
-            )
-        if not api_key:
-            raise ValueError(
-                "Markitdown OCR is enabled but no API key is configured. "
-                "Set HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_API_KEY."
-            )
-        if not base_url or not base_url.strip():
-            raise ValueError(
-                "Markitdown OCR is enabled but no base URL is configured. "
-                "Set HINDSIGHT_API_FILE_PARSER_MARKITDOWN_OCR_BASE_URL to an OpenAI-compatible OCR/vision endpoint."
-            )
+        """Build MarkItDown options for OpenAI-compatible image OCR.
+
+        The configuration was already checked in ``__init__``; what is left here is
+        the part that genuinely has to be deferred — importing the OpenAI SDK and
+        constructing the client.
+        """
+        assert model is not None and base_url is not None  # guaranteed by _validate_ocr_config
 
         try:
             from openai import OpenAI

--- a/hindsight-api-slim/tests/test_file_retain.py
+++ b/hindsight-api-slim/tests/test_file_retain.py
@@ -493,7 +493,11 @@ def test_markitdown_converter_does_not_enable_ocr_by_default(monkeypatch):
 
     monkeypatch.setattr(markitdown, "MarkItDown", FakeMarkItDown)
 
-    MarkitdownParser()
+    parser = MarkitdownParser()
+    # markitdown is imported and MarkItDown built on first use, not at construction,
+    # to keep bs4/lxml off the startup path (#4031).
+    assert calls == []
+    parser._get_markitdown()
 
     assert calls == [{}]
 
@@ -542,12 +546,15 @@ def test_markitdown_converter_can_enable_ocr(monkeypatch):
     monkeypatch.setattr(markitdown, "MarkItDown", FakeMarkItDown)
     monkeypatch.setattr(openai, "OpenAI", FakeOpenAI)
 
-    MarkitdownParser(
+    parser = MarkitdownParser(
         ocr_enabled=True,
         ocr_api_key="parser-key",
         ocr_base_url="https://vision.example/v1",
         ocr_model="vision-model",
     )
+    # The OpenAI client is built with MarkItDown on first use, not at construction (#4031).
+    assert openai_calls == []
+    parser._get_markitdown()
 
     assert openai_calls == [
         {
@@ -583,13 +590,14 @@ def test_markitdown_converter_passes_default_headers_when_configured(monkeypatch
     monkeypatch.setattr(openai, "OpenAI", FakeOpenAI)
 
     headers = {"X-Component-Id": "hindsight-ocr", "X-Request-Source": "markitdown"}
-    MarkitdownParser(
+    parser = MarkitdownParser(
         ocr_enabled=True,
         ocr_api_key="parser-key",
         ocr_base_url="https://vision.example/v1",
         ocr_model="vision-model",
         ocr_default_headers=headers,
     )
+    parser._get_markitdown()
 
     assert openai_calls == [
         {
@@ -653,13 +661,16 @@ def test_markitdown_converter_reports_missing_openai_when_ocr_enabled(monkeypatc
     monkeypatch.setattr(markitdown, "MarkItDown", FakeMarkItDown)
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
+    # Construction validates the settings but does not import the SDK, so the
+    # missing-package error surfaces on first use.
+    parser = MarkitdownParser(
+        ocr_enabled=True,
+        ocr_api_key="parser-key",
+        ocr_base_url="https://vision.example/v1",
+        ocr_model="vision-model",
+    )
     with pytest.raises(RuntimeError, match="openai package is required"):
-        MarkitdownParser(
-            ocr_enabled=True,
-            ocr_api_key="parser-key",
-            ocr_base_url="https://vision.example/v1",
-            ocr_model="vision-model",
-        )
+        parser._get_markitdown()
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_reflect_tokenizer_lazy_load.py
+++ b/hindsight-api-slim/tests/test_reflect_tokenizer_lazy_load.py
@@ -1,15 +1,41 @@
+"""The tokenizer encoding must load lazily — on the first count, not on import.
+
+These tests need ``_load_encoding`` to actually call ``toktok._encoding`` while it
+is patched, which means starting from an empty cache. They arrange that by clearing
+the cache, *not* by dropping ``engine.token_encoding`` from ``sys.modules``: a
+reimport under the patch builds a second module object whose ``lru_cache`` then
+holds the MagicMock and stays there after the patch is undone. See
+``test_patched_tokenizer_does_not_leak_into_later_token_calls``.
+"""
+
 import importlib
 import sys
 from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hindsight_api.engine import token_encoding
+from hindsight_api.engine.token_encoding import _load_encoding, truncate_to_tokens
 
 
 def _drop_reflect_modules() -> None:
     for name in list(sys.modules):
         if name == "hindsight_api.engine.reflect" or name.startswith("hindsight_api.engine.reflect."):
             sys.modules.pop(name)
-    # The encoding is cached in engine.token_encoding; drop it too so the fresh
-    # reimport starts with an empty cache and the toktok patch is observed.
-    sys.modules.pop("hindsight_api.engine.token_encoding", None)
+
+
+@pytest.fixture(autouse=True)
+def _empty_encoding_cache():
+    """Give each test an empty cache, and leave one behind.
+
+    Clearing beforehand is what makes the patch observable at all. Clearing
+    afterwards is what keeps a patched tokenizer from outliving its ``with`` block:
+    ``_load_encoding`` is ``lru_cache``d process-wide, so a MagicMock cached here
+    would otherwise serve every later test in the same worker.
+    """
+    _load_encoding.cache_clear()
+    yield
+    _load_encoding.cache_clear()
 
 
 def test_reflect_import_does_not_load_tokenizer_encoding():
@@ -49,3 +75,37 @@ def test_reflect_token_counting_loads_tokenizer_encoding_when_used():
     # Whatever this deployment configured — asserting the literal default would
     # break for anyone with HINDSIGHT_API_TOKENIZER_ENCODING set in their .env.
     load_encoding.assert_called_once_with(_get_raw_config().tokenizer_encoding)
+
+
+def test_patched_tokenizer_does_not_leak_into_later_token_calls():
+    """A patched tokenizer must not outlive its ``with`` block.
+
+    Regression test for a cross-test leak that reddened test-api shards at random.
+    This module used to drop ``engine.token_encoding`` from ``sys.modules`` so that
+    the reimport under ``patch("toktok._encoding")`` would observe the patch. The
+    reimported module stayed in ``sys.modules`` with the MagicMock in its
+    ``lru_cache``, so the next test in the same worker to truncate anything failed
+    with ``KeyError: unknown encoding <MagicMock name='mock.name'>`` out of
+    ``toktok.truncate`` — and anything that merely *counted* got
+    ``len(text.split())`` back with no error at all, which is worse.
+
+    The victim was whichever test the scheduler happened to run next, so it looked
+    like a different flaky test each run and passed in isolation every time.
+    """
+    fake_encoding = MagicMock()
+    fake_encoding.count.side_effect = lambda text: len(text.split())
+
+    _drop_reflect_modules()
+    with patch("toktok._encoding", return_value=fake_encoding):
+        agent = importlib.import_module("hindsight_api.engine.reflect.agent")
+        assert agent._count_messages_tokens([{"role": "user", "content": "one two"}]) == 2
+
+    # No second module object: everything that did `from ..token_encoding import ...`
+    # still points at the one whose cache the fixture clears.
+    assert sys.modules["hindsight_api.engine.token_encoding"] is token_encoding
+
+    # And the real tokenizer is back. This is the call that used to raise.
+    _load_encoding.cache_clear()
+    result = truncate_to_tokens("hello world", 1)
+    assert isinstance(result.original_tokens, int)
+    assert result.original_tokens > 0


### PR DESCRIPTION
Two unrelated regressions that both landed recently and both show up in `test-api`.

---

# 1. Patched tokenizer outliving its `with`-block (from #4022)

Random shard failures with a different victim each run:

```
KeyError: "unknown encoding <MagicMock name='mock.name' id='...'>;
           available: cl100k_base, o200k_base, o200k_harmony"
```

Green in isolation every time, which is what made it read as generic flakiness.

## Cause

`tests/test_reflect_tokenizer_lazy_load.py` dropped `engine.token_encoding` from `sys.modules` so the reimport under `patch("toktok._encoding")` would start with an empty `lru_cache` and observe the patch. Undoing the patch does nothing about a value already *in* that cache, and the reimported module stayed in `sys.modules`:

1. pop `engine.token_encoding`
2. under the patch, import `reflect.agent` -> fresh module, empty cache
3. count something -> the `lru_cache` now holds the MagicMock
4. patch undone; poisoned module still in `sys.modules`
5. next test to truncate passes `MagicMock.name` to `toktok.truncate` -> `KeyError`

Anything that merely *counted* got `len(text.split())` back with **no error at all** — a plausible wrong number feeding a token budget. That half never showed up as a failure.

## Fix

Clear the `lru_cache` around each test instead of deleting the module: same empty start, one module object, so the eight modules that do `from ..token_encoding import ...` keep pointing at the one the fixture controls. Clearing *before* also makes the lazy-load assertion real — with a populated cache, an import that did count tokens would not have called `toktok._encoding` and the test would have passed spuriously.

## Verification

```
$ pytest tests/test_reflect_tokenizer_lazy_load.py tests/test_structured_delta_prompt_budget.py -p no:randomly
2 failed, 2 passed in 0.17s      # reverse order: 4 passed
```

After: 5 passed. The added regression test pins module identity and then does a real truncate; confirmed it fails against the old code (two distinct module objects for the same path), so it is a guard rather than a restatement.

---

# 2. Markitdown OCR config no longer validated at startup (from #4031)

Six tests in `test_file_retain.py` have been red on `main` since #4031, in isolation as well as under xdist.

## Cause

#4031 deferred the whole OCR setup behind the lazy `_get_markitdown()` to keep markitdown (bs4 -> lxml) and the OpenAI SDK off the startup path. The **configuration checks moved with the imports**, which changed behaviour: a deployment with `FILE_PARSER_MARKITDOWN_OCR_ENABLED=true` but no model, API key or base URL used to refuse to start, and instead booted clean and failed on the first image a user uploaded. The tests' own docstrings say "OCR should **fail fast**", so this was collateral damage rather than an intended change.

## Fix

Only the imports need deferring. The three checks are string comparisons with no import cost, so they move back into `__init__` while the SDK import and client construction stay lazy. `MemoryEngine` registration catches only `ImportError`, so a `ValueError` from a misconfigured OCR setup once again stops the server at boot.

Both properties verified to hold together:

```
ValueError at construction: Markitdown OCR is enabled but no model is configured...
openai imported at construction?     False
markitdown imported at construction? False
```

Of the six tests, two asserted the fail-fast this restores and pass unchanged. The other four assert the OpenAI/MarkItDown client construction, which is legitimately lazy now — they drive `_get_markitdown()` and additionally assert that **nothing is built at construction**, pinning the property #4031 introduced, which nothing was holding in place.

## Behaviour change to be aware of

A deployment that sets `FILE_PARSER_MARKITDOWN_OCR_ENABLED=true` without the accompanying model/key/base-url will now fail to start rather than boot and 500 on first image upload. That is the pre-#4031 behaviour and what the error messages are written for (each names the env var to set), but it is user-visible, so worth a deliberate look.

---

Local: 425 passed across the file-retain / parser / token / delta / refresh surface under xdist; three random-order repeats of the tokenizer set green.
