### PR TITLE
fix(cursor): register hooks on init, ship rules_file.py, flush on sessionEnd

### DIFF
--- a/hindsight-docs/docs-integrations/cursor.md
+++ b/hindsight-docs/docs-integrations/cursor.md
@@ -54,10 +54,13 @@ docker run --rm -it --pull always -p 8888:8888 \
 ### What `init` does
 
 - Copies plugin files into `.cursor-plugin/hindsight-memory/`
+- Writes/merges project `.cursor/hooks.json` so Cursor registers the hooks. Cursor only loads hooks from `.cursor/hooks.json` (workspace) or `~/.cursor/hooks.json` (user) — files under `.cursor-plugin/` are not enough on their own. Hooks you already had are preserved, and re-running `init` replaces only Hindsight's own entries.
 - Creates `~/.hindsight/cursor.json` with your connection settings (if the file does not already exist)
 - Writes `.cursor/mcp.json` with the Hindsight MCP endpoint for on-demand tools
 - Use `--force` to overwrite an existing installation
 - Use `--no-mcp` to skip the MCP configuration
+
+`hindsight-cursor uninstall` reverses all of it: the plugin directory, Hindsight's `.cursor/hooks.json` entries, the MCP server entry, the generated session rules file, and its `.gitignore` line.
 
 :::caution
 If you add the plugin to an already-open workspace, **fully quit Cursor and reopen it**. Plugins are loaded at startup — a simple window reload is not enough.
@@ -81,8 +84,11 @@ The plugin uses Cursor's hook system:
 |------|-------|---------|
 | `session_start.py` | `sessionStart` | **Session recall** — query memories, inject as `additionalContext` |
 | `retain.py` | `stop` | **Auto-retain** — extract transcript, POST to Hindsight |
+| `retain.py` | `sessionEnd` | **Final flush** — retain whatever the turn window never got to |
 
 The `sessionStart` hook fires once when a new Cursor session begins. It performs a broad project-level recall and injects relevant memories as hidden context.
+
+`retain.py` runs on `sessionEnd` as well. Without that, every conversation shorter than `retainEveryNTurns` is lost outright: at the default of 10, a seven-turn chat fires `stop` seven times, the turn gate rejects all seven, and the session is never stored. `sessionEnd` bypasses the turn window so the tail of a session is always retained. The plugin tracks how many transcript messages it has already retained per session, so the overlap between the two events cannot double-store.
 
 The `init` command also configures Cursor's MCP support (`.cursor/mcp.json`) to connect to Hindsight's MCP endpoint, giving the agent explicit `recall`, `retain`, and `reflect` tools for mid-session use.
 

--- a/hindsight-integrations/cursor/README.md
+++ b/hindsight-integrations/cursor/README.md
@@ -42,6 +42,7 @@ hindsight-cursor init --api-url http://localhost:8888
 ### What `init` does
 
 - Copies plugin files into `.cursor-plugin/hindsight-memory/`
+- Writes/merges project `.cursor/hooks.json` so Cursor registers `sessionStart` / `stop` (workspace-relative commands — plugin-dir hooks alone are not loaded by the IDE)
 - Creates `~/.hindsight/cursor.json` with your connection settings (if the file does not already exist)
 - Writes `.cursor/mcp.json` with the Hindsight MCP endpoint for on-demand recall/retain/reflect tools
 - Use `--force` to overwrite an existing installation
@@ -109,6 +110,7 @@ The agent can use these tools mid-session when it needs memory beyond what was i
 | `lib/bank.py` | Bank ID derivation + mission management |
 | `lib/content.py` | Content processing (transcript parsing, memory formatting, tag stripping) |
 | `lib/state.py` | File-based state persistence with `fcntl` locking |
+| `lib/rules_file.py` | Writes `.cursor/rules/hindsight-session.mdc` (sessionStart additionalContext workaround) |
 | `lib/llm.py` | LLM provider auto-detection for daemon mode |
 
 ## Connection Modes

--- a/hindsight-integrations/cursor/README.md
+++ b/hindsight-integrations/cursor/README.md
@@ -42,11 +42,13 @@ hindsight-cursor init --api-url http://localhost:8888
 ### What `init` does
 
 - Copies plugin files into `.cursor-plugin/hindsight-memory/`
-- Writes/merges project `.cursor/hooks.json` so Cursor registers `sessionStart` / `stop` (workspace-relative commands — plugin-dir hooks alone are not loaded by the IDE)
+- Writes/merges project `.cursor/hooks.json` so Cursor registers `sessionStart` / `stop` / `sessionEnd` (workspace-relative commands — plugin-dir hooks alone are not loaded by the IDE). Hooks you already had are preserved, and re-running `init` replaces only Hindsight's own entries.
 - Creates `~/.hindsight/cursor.json` with your connection settings (if the file does not already exist)
 - Writes `.cursor/mcp.json` with the Hindsight MCP endpoint for on-demand recall/retain/reflect tools
 - Use `--force` to overwrite an existing installation
 - Use `--no-mcp` to skip the MCP configuration
+
+`hindsight-cursor uninstall` reverses all of it: the plugin directory, Hindsight's `.cursor/hooks.json` entries, the MCP server entry, the generated session rules file, and its `.gitignore` line.
 
 After installing, **fully quit and reopen Cursor**. The plugin activates automatically.
 
@@ -70,10 +72,17 @@ The plugin uses two complementary mechanisms:
 |------|-------|---------|
 | `session_start.py` | `sessionStart` | **Session recall** — query memories, write `<workspace>/.cursor/rules/hindsight-session.mdc` so the agent gets memory in its system context, *and* emit `additionalContext` JSON (forward-compat). |
 | `retain.py` | `stop` | **Auto-retain** — extract transcript, POST to Hindsight |
+| `retain.py` | `sessionEnd` | **Final flush** — retain whatever the turn window never got to |
 
 The `sessionStart` hook fires when the agent processes the first prompt of each new chat. It performs a broad project-level recall and surfaces the result two ways — see ["How session memory reaches the agent"](#how-session-memory-reaches-the-agent) below for why both.
 
 The `stop` hook fires when the agent completes a task. It reads the conversation transcript and retains it to Hindsight for future recall.
+
+`retain.py` is also registered on `sessionEnd`, which fires once when the conversation ends and acts as a **final flush**.
+
+Without it, every conversation shorter than `retainEveryNTurns` is lost outright. At the default of 10, a seven-turn chat fires `stop` seven times, the turn gate rejects all seven, and the session is never stored. `sessionEnd` bypasses the turn window so the tail of a session is always retained.
+
+The two events overlap at the end of a conversation. The plugin records how many transcript messages it has already retained per session, so a run with nothing new is a no-op — the overlap cannot double-store.
 
 ### How session memory reaches the agent
 

--- a/hindsight-integrations/cursor/hindsight_cursor/cli.py
+++ b/hindsight-integrations/cursor/hindsight_cursor/cli.py
@@ -19,12 +19,17 @@ _PLUGIN_FILES = [
     "scripts/lib/content.py",
     "scripts/lib/daemon.py",
     "scripts/lib/llm.py",
+    "scripts/lib/rules_file.py",
     "scripts/lib/state.py",
     "scripts/session_start.py",
     "scripts/retain.py",
     "settings.json",
     "skills/hindsight-recall/SKILL.md",
 ]
+
+# Marker used to identify Hindsight's own entries when merging/stripping
+# project .cursor/hooks.json. Commands point at this install path.
+_HOOK_MARKER = ".cursor-plugin/hindsight-memory"
 
 _USER_CONFIG_DIR = Path.home() / ".hindsight"
 _USER_CONFIG_FILE = _USER_CONFIG_DIR / "cursor.json"
@@ -102,6 +107,107 @@ def _setup_mcp(project: Path, api_url: str | None, api_token: str | None, bank_i
     print(f"  MCP config written to {mcp_file}")
 
 
+def _hindsight_hook_entry(definition: dict) -> bool:
+    """True if a hooks.json entry belongs to this plugin install."""
+    return _HOOK_MARKER in json.dumps(definition)
+
+
+def _project_hooks_block() -> dict:
+    """Hooks Cursor loads from the project ``.cursor/hooks.json``.
+
+    Paths are workspace-relative so they work without ``CURSOR_PLUGIN_ROOT``
+    (which is only set for packages installed under ``~/.cursor/plugins``).
+    """
+    return {
+        "version": 1,
+        "hooks": {
+            "sessionStart": [
+                {
+                    "command": f"python3 {_HOOK_MARKER}/scripts/session_start.py",
+                    "timeout": 15,
+                }
+            ],
+            "stop": [
+                {
+                    "command": f"python3 {_HOOK_MARKER}/scripts/retain.py",
+                    "timeout": 15,
+                }
+            ],
+        },
+    }
+
+
+def _setup_hooks(project: Path) -> None:
+    """Write/merge project ``.cursor/hooks.json`` so Cursor registers the hooks.
+
+    Dropping files under ``.cursor-plugin/`` alone does not register hooks with
+    the IDE; Cursor only loads ``.cursor/hooks.json`` (workspace) or
+    ``~/.cursor/hooks.json`` (user). Idempotent: existing Hindsight entries are
+    replaced, other hooks are preserved.
+    """
+    cursor_dir = project / ".cursor"
+    hooks_file = cursor_dir / "hooks.json"
+    hooks_block = _project_hooks_block()
+
+    existing: dict = {}
+    if hooks_file.exists():
+        try:
+            existing = json.loads(hooks_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+
+    existing.setdefault("version", hooks_block.get("version", 1))
+    existing.setdefault("hooks", {})
+
+    for event, definitions in hooks_block.get("hooks", {}).items():
+        bucket = [d for d in existing["hooks"].get(event, []) if not _hindsight_hook_entry(d)]
+        bucket.extend(definitions)
+        existing["hooks"][event] = bucket
+
+    cursor_dir.mkdir(parents=True, exist_ok=True)
+    hooks_file.write_text(json.dumps(existing, indent=2) + "\n")
+    print(f"  Hooks registered in {hooks_file}")
+
+
+def _remove_hooks(project: Path) -> None:
+    """Strip this plugin's entries from project ``.cursor/hooks.json``."""
+    hooks_file = project / ".cursor" / "hooks.json"
+    if not hooks_file.exists():
+        return
+    try:
+        data = json.loads(hooks_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return
+
+    hooks = data.get("hooks", {})
+    changed = False
+    for event, definitions in list(hooks.items()):
+        kept = [d for d in definitions if not _hindsight_hook_entry(d)]
+        if len(kept) != len(definitions):
+            changed = True
+        if kept:
+            hooks[event] = kept
+        else:
+            del hooks[event]
+
+    if not changed:
+        return
+
+    if hooks:
+        data["hooks"] = hooks
+        hooks_file.write_text(json.dumps(data, indent=2) + "\n")
+        print(f"  Removed hindsight hooks from {hooks_file}")
+    else:
+        other_keys = {k for k in data if k not in ("version", "hooks")}
+        if other_keys:
+            data["hooks"] = {}
+            hooks_file.write_text(json.dumps(data, indent=2) + "\n")
+            print(f"  Removed hindsight hooks from {hooks_file}")
+        else:
+            hooks_file.unlink()
+            print(f"  Removed {hooks_file}")
+
+
 def cmd_init(args: argparse.Namespace) -> None:
     """Install the Hindsight plugin into a Cursor project."""
     project = Path(args.project).resolve()
@@ -118,6 +224,11 @@ def cmd_init(args: argparse.Namespace) -> None:
     print(f"Installing Hindsight plugin into {dest} ...")
     _copy_plugin(dest)
     print("  Plugin files copied.")
+
+    # Register hooks with Cursor IDE (project .cursor/hooks.json).
+    # The bundled hooks/hooks.json alone is not enough — Cursor only loads
+    # workspace/user hooks.json, not files under .cursor-plugin/.
+    _setup_hooks(project)
 
     _scaffold_config(args.api_url, args.api_token, args.bank_id)
 
@@ -156,6 +267,8 @@ def cmd_uninstall(args: argparse.Namespace) -> None:
                     print(f"  Removed {mcp_file}")
         except (json.JSONDecodeError, OSError):
             pass
+
+    _remove_hooks(project)
 
 
 def main() -> None:

--- a/hindsight-integrations/cursor/hindsight_cursor/cli.py
+++ b/hindsight-integrations/cursor/hindsight_cursor/cli.py
@@ -31,6 +31,13 @@ _PLUGIN_FILES = [
 # project .cursor/hooks.json. Commands point at this install path.
 _HOOK_MARKER = ".cursor-plugin/hindsight-memory"
 
+# Artefacts the sessionStart hook writes into the workspace. Kept in sync with
+# scripts/lib/rules_file.py by hand — the CLI deliberately does not import the
+# plugin scripts, which ship as data rather than as an importable package.
+_SESSION_RULES_RELPATH = Path(".cursor") / "rules" / "hindsight-session.mdc"
+_GITIGNORE_COMMENT = "# Added by hindsight-cursor plugin"
+_GITIGNORE_LINE = "/.cursor/rules/hindsight-session.mdc"
+
 _USER_CONFIG_DIR = Path.home() / ".hindsight"
 _USER_CONFIG_FILE = _USER_CONFIG_DIR / "cursor.json"
 
@@ -41,16 +48,35 @@ def _plugin_data_dir() -> Path:
 
 
 def _copy_plugin(dest: Path) -> None:
-    """Copy plugin files into *dest*, creating directories as needed."""
+    """Copy plugin files into *dest*, creating directories as needed.
+
+    Aborts if anything is missing from the bundled payload. A partial copy is
+    never useful — ``session_start.py`` imports every ``lib/`` module, so a
+    single absent file turns each hook invocation into a silent ImportError.
+    Reporting "Done!" over an install that copied nothing is how #3864 stayed
+    invisible for so long.
+    """
     src_root = _plugin_data_dir()
+    missing = [rel for rel in _PLUGIN_FILES if not (src_root / rel).exists()]
+    if missing:
+        print(
+            f"Error: bundled plugin payload is incomplete ({len(missing)} of "
+            f"{len(_PLUGIN_FILES)} files missing under {src_root}):",
+            file=sys.stderr,
+        )
+        for rel in missing:
+            print(f"  - {rel}", file=sys.stderr)
+        print(
+            "This build is broken. Install the published package "
+            "(`pip install hindsight-cursor`) rather than a source checkout.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     for rel in _PLUGIN_FILES:
-        src = src_root / rel
-        if not src.exists():
-            print(f"  warning: missing bundled file {rel}, skipping", file=sys.stderr)
-            continue
         dst = dest / rel
         dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dst)
+        shutil.copy2(src_root / rel, dst)
 
 
 def _scaffold_config(api_url: str | None, api_token: str | None, bank_id: str) -> None:
@@ -112,24 +138,57 @@ def _hindsight_hook_entry(definition: dict) -> bool:
     return _HOOK_MARKER in json.dumps(definition)
 
 
+def _hook_interpreter() -> str:
+    """Interpreter name to invoke the hook scripts with.
+
+    Windows ships ``python.exe`` and has no ``python3`` on PATH, so a
+    hardcoded ``python3`` makes every hook a silent no-op there. Cursor runs
+    hooks through the shell, so a bare name (resolved off PATH) is what we
+    want — not ``sys.executable``, which points at whatever interpreter
+    happened to run ``init`` and may live in a throwaway virtualenv.
+    """
+    return "python" if sys.platform == "win32" else "python3"
+
+
 def _project_hooks_block() -> dict:
     """Hooks Cursor loads from the project ``.cursor/hooks.json``.
 
     Paths are workspace-relative so they work without ``CURSOR_PLUGIN_ROOT``
     (which is only set for packages installed under ``~/.cursor/plugins``).
+
+    ``retain.py`` is registered on both ``stop`` and ``sessionEnd``:
+
+    * ``stop`` fires each time an agent loop ends — the granularity that
+      periodic auto-retain wants.
+    * ``sessionEnd`` fires once when the conversation ends, and carries the
+      same ``transcript_path``. It is the final flush.
+
+    Without the flush, every conversation shorter than ``retainEveryNTurns``
+    is lost outright: at the default of 10, a seven-turn chat fires ``stop``
+    seven times, the turn gate rejects all seven, and nothing is ever stored.
+
+    Both events land in the same script; ``retain.py`` skips a run with no
+    new messages since the last retain, so the overlap cannot double-store.
     """
+    python = _hook_interpreter()
     return {
         "version": 1,
         "hooks": {
             "sessionStart": [
                 {
-                    "command": f"python3 {_HOOK_MARKER}/scripts/session_start.py",
+                    "command": f"{python} {_HOOK_MARKER}/scripts/session_start.py",
                     "timeout": 15,
                 }
             ],
             "stop": [
                 {
-                    "command": f"python3 {_HOOK_MARKER}/scripts/retain.py",
+                    "command": f"{python} {_HOOK_MARKER}/scripts/retain.py",
+                    "timeout": 15,
+                }
+            ],
+            "sessionEnd": [
+                {
+                    "command": f"{python} {_HOOK_MARKER}/scripts/retain.py",
                     "timeout": 15,
                 }
             ],
@@ -208,6 +267,46 @@ def _remove_hooks(project: Path) -> None:
             print(f"  Removed {hooks_file}")
 
 
+def _remove_session_rules(project: Path) -> None:
+    """Delete the generated session rules file and its .gitignore entry.
+
+    ``sessionStart`` regenerates the rules file on every run, so leaving it
+    behind after ``uninstall`` would keep injecting a dead session's memories
+    into every agent turn — the file is ``alwaysApply: true``.
+    """
+    rules_file = project / _SESSION_RULES_RELPATH
+    if rules_file.exists():
+        try:
+            rules_file.unlink()
+            print(f"  Removed {rules_file}")
+        except OSError:
+            pass
+
+    gitignore = project / ".gitignore"
+    if not gitignore.exists():
+        return
+    try:
+        lines = gitignore.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+
+    kept = [
+        line for line in lines if line.strip() != _GITIGNORE_LINE and not line.strip().startswith(_GITIGNORE_COMMENT)
+    ]
+    if len(kept) == len(lines):
+        return
+
+    # Drop a trailing blank run left behind by removing the block.
+    while kept and not kept[-1].strip():
+        kept.pop()
+
+    try:
+        gitignore.write_text(("\n".join(kept) + "\n") if kept else "", encoding="utf-8")
+        print(f"  Removed hindsight entry from {gitignore}")
+    except OSError:
+        pass
+
+
 def cmd_init(args: argparse.Namespace) -> None:
     """Install the Hindsight plugin into a Cursor project."""
     project = Path(args.project).resolve()
@@ -269,6 +368,7 @@ def cmd_uninstall(args: argparse.Namespace) -> None:
             pass
 
     _remove_hooks(project)
+    _remove_session_rules(project)
 
 
 def main() -> None:

--- a/hindsight-integrations/cursor/hooks/hooks.json
+++ b/hindsight-integrations/cursor/hooks/hooks.json
@@ -12,6 +12,12 @@
         "command": "python3 \"${CURSOR_PLUGIN_ROOT}/scripts/retain.py\"",
         "timeout": 15
       }
+    ],
+    "sessionEnd": [
+      {
+        "command": "python3 \"${CURSOR_PLUGIN_ROOT}/scripts/retain.py\"",
+        "timeout": 15
+      }
     ]
   }
 }

--- a/hindsight-integrations/cursor/scripts/lib/state.py
+++ b/hindsight-integrations/cursor/scripts/lib/state.py
@@ -72,6 +72,15 @@ def write_state(name: str, data):
             pass
 
 
+def _prune(mapping: dict) -> dict:
+    """Bound an unbounded session-keyed map, dropping the oldest half."""
+    if len(mapping) > 10000:
+        sorted_keys = sorted(mapping.keys())
+        for k in sorted_keys[: len(sorted_keys) // 2]:
+            del mapping[k]
+    return mapping
+
+
 def increment_turn_count(session_id: str) -> int:
     """Increment and return the turn count for a session.
 
@@ -86,11 +95,7 @@ def increment_turn_count(session_id: str) -> int:
             try:
                 turns = read_state("turns.json", {})
                 turns[session_id] = turns.get(session_id, 0) + 1
-                if len(turns) > 10000:
-                    sorted_keys = sorted(turns.keys())
-                    for k in sorted_keys[: len(sorted_keys) // 2]:
-                        del turns[k]
-                write_state("turns.json", turns)
+                write_state("turns.json", _prune(turns))
                 return turns[session_id]
             finally:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
@@ -100,9 +105,22 @@ def increment_turn_count(session_id: str) -> int:
 
     turns = read_state("turns.json", {})
     turns[session_id] = turns.get(session_id, 0) + 1
-    if len(turns) > 10000:
-        sorted_keys = sorted(turns.keys())
-        for k in sorted_keys[: len(sorted_keys) // 2]:
-            del turns[k]
-    write_state("turns.json", turns)
+    write_state("turns.json", _prune(turns))
     return turns[session_id]
+
+
+def get_retained_message_count(session_id: str) -> int:
+    """Messages already retained for *session_id* (0 if never retained).
+
+    retain.py runs from both the ``stop`` and ``sessionEnd`` hooks, which
+    overlap at the end of a conversation. This watermark is what keeps the
+    overlap from storing the same transcript twice.
+    """
+    return read_state("retained.json", {}).get(session_id, 0)
+
+
+def set_retained_message_count(session_id: str, count: int) -> None:
+    """Record how many transcript messages have been retained for a session."""
+    retained = read_state("retained.json", {})
+    retained[session_id] = count
+    write_state("retained.json", _prune(retained))

--- a/hindsight-integrations/cursor/scripts/retain.py
+++ b/hindsight-integrations/cursor/scripts/retain.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
-"""Auto-retain hook for Cursor's stop event.
+"""Auto-retain hook for Cursor's ``stop`` and ``sessionEnd`` events.
+
+Registered on both because ``stop`` alone silently drops short sessions:
+
+* ``stop`` fires each time an agent loop ends -- the right granularity for
+  periodic retains, but every firing is subject to the turn window. At the
+  default ``retainEveryNTurns`` of 10, a conversation that ends at turn 7
+  fires ``stop`` seven times, is gated seven times, and is never stored.
+* ``sessionEnd`` fires once when the conversation ends. It is treated as a
+  *final flush*: it bypasses the turn window so the tail of a session is
+  retained no matter where in the window it ended.
+
+The two overlap at the end of a conversation. A watermark of the messages
+already retained per session (``retained.json``) makes a run with nothing
+new a no-op, so the overlap cannot double-store.
 
 Flow:
   1. Read hook input from stdin (conversation_id, transcript_path, status)
@@ -29,7 +43,12 @@ from lib.content import (
     slice_last_turns_by_user_boundary,
 )
 from lib.daemon import get_api_url
-from lib.state import increment_turn_count, write_state
+from lib.state import (
+    get_retained_message_count,
+    increment_turn_count,
+    set_retained_message_count,
+    write_state,
+)
 
 LAST_RETAIN_STATE = "last_retain.json"
 
@@ -166,21 +185,42 @@ def main():
 
     debug_log(config, f"Read {len(all_messages)} messages from transcript")
 
+    # sessionEnd is the last chance to store this conversation, so it flushes
+    # whatever the turn window has not retained yet.
+    is_session_end = hook_input.get("hook_event_name") == "sessionEnd"
+
+    # Nothing new since the last retain: the other hook already stored this
+    # transcript. Checked before the turn counter so an overlapping sessionEnd
+    # does not consume a turn either.
+    already_retained = get_retained_message_count(session_id)
+    if len(all_messages) <= already_retained:
+        debug_log(config, f"No new messages since last retain ({already_retained}), skipping")
+        _write_retain_status("skipped", reason="no_new_messages", message_count=len(all_messages))
+        return
+
     # Retention mode: full session (default) or chunked
     retain_mode = config.get("retainMode", "full-session")
     retain_every_n = max(1, config.get("retainEveryNTurns", 10))
     retain_full_window = False
     messages_to_retain = all_messages
 
-    if retain_every_n > 1:
+    if retain_every_n > 1 and not is_session_end:
         turn_count = increment_turn_count(session_id)
         if turn_count % retain_every_n != 0:
             next_at = ((turn_count // retain_every_n) + 1) * retain_every_n
             debug_log(config, f"Turn {turn_count}/{retain_every_n}, skipping retain (next at turn {next_at})")
             _write_retain_status("skipped", reason="turn_window", turn=turn_count, next_at=next_at)
             return
+    elif is_session_end:
+        debug_log(config, "sessionEnd: flushing regardless of turn window")
 
-    if retain_mode == "chunked" and retain_every_n > 1:
+    if retain_mode == "chunked" and is_session_end:
+        # A flush has no turn window to slice against; store exactly the tail
+        # the periodic retains never got to, so chunks stay non-overlapping.
+        messages_to_retain = all_messages[already_retained:]
+        retain_full_window = True
+        debug_log(config, f"Chunked sessionEnd flush ({len(messages_to_retain)} new messages)")
+    elif retain_mode == "chunked" and retain_every_n > 1:
         overlap_turns = config.get("retainOverlapTurns", 0)
         window_turns = retain_every_n + overlap_turns
         messages_to_retain = slice_last_turns_by_user_boundary(all_messages, window_turns)
@@ -275,7 +315,10 @@ def main():
             tags=tags,
             timeout=15,
         )
-        debug_log(config, f"Retain response: {json.dumps(response)[:200]}")
+        # Watermark first: the content is stored, so a later sessionEnd must
+        # not re-store it even if something below this line raises.
+        set_retained_message_count(session_id, len(all_messages))
+        debug_log(config, f"Retain response: {response}")
         _write_retain_status(
             "success",
             bank_id=bank_id,

--- a/hindsight-integrations/cursor/tests/test_cli.py
+++ b/hindsight-integrations/cursor/tests/test_cli.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from hindsight_cursor.cli import _plugin_data_dir, cmd_init, cmd_uninstall
+from hindsight_cursor.cli import _PLUGIN_FILES, _plugin_data_dir, cmd_init, cmd_uninstall
 
 
 @pytest.fixture()
@@ -22,6 +22,7 @@ def fake_plugin_data(tmp_path):
     (data_dir / "settings.json").write_text('{"bankId": "cursor"}')
     (data_dir / "scripts" / "lib").mkdir(parents=True)
     (data_dir / "scripts" / "lib" / "__init__.py").write_text("")
+    (data_dir / "scripts" / "lib" / "rules_file.py").write_text("# rules_file")
     (data_dir / "scripts" / "session_start.py").write_text("# session_start")
     (data_dir / "scripts" / "retain.py").write_text("# retain")
     (data_dir / "rules").mkdir()
@@ -55,6 +56,7 @@ class TestInit:
         assert (dest / "hooks" / "hooks.json").exists()
         assert (dest / "settings.json").exists()
         assert (dest / "scripts" / "session_start.py").exists()
+        assert (dest / "scripts" / "lib" / "rules_file.py").exists()
         assert (dest / "rules" / "hindsight-memory.mdc").exists()
 
     def test_refuses_overwrite_without_force(self, tmp_path, fake_plugin_data, capsys):
@@ -227,6 +229,91 @@ class TestInit:
         assert "hindsight" in mcp["mcpServers"]
 
 
+    def test_copies_rules_file(self, tmp_path, fake_plugin_data):
+        """session_start imports lib.rules_file — init must ship it (#3864)."""
+        project = tmp_path / "my-project"
+        project.mkdir()
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False)
+            )
+
+        assert (project / ".cursor-plugin" / "hindsight-memory" / "scripts" / "lib" / "rules_file.py").exists()
+
+    def test_plugin_files_lists_rules_file(self):
+        assert "scripts/lib/rules_file.py" in _PLUGIN_FILES
+
+    def test_writes_project_hooks_json(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "my-project"
+        project.mkdir()
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False)
+            )
+
+        hooks_file = project / ".cursor" / "hooks.json"
+        assert hooks_file.exists()
+        hooks = json.loads(hooks_file.read_text())
+        assert hooks["version"] == 1
+        assert "sessionStart" in hooks["hooks"]
+        assert "stop" in hooks["hooks"]
+        session_cmd = hooks["hooks"]["sessionStart"][0]["command"]
+        stop_cmd = hooks["hooks"]["stop"][0]["command"]
+        assert "session_start.py" in session_cmd
+        assert "retain.py" in stop_cmd
+        assert ".cursor-plugin/hindsight-memory" in session_cmd
+        assert "${CURSOR_PLUGIN_ROOT}" not in session_cmd
+
+    def test_merges_with_existing_hooks_json(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "my-project"
+        project.mkdir()
+        cursor_dir = project / ".cursor"
+        cursor_dir.mkdir()
+        (cursor_dir / "hooks.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "hooks": {
+                        "sessionStart": [{"command": "echo other-start", "timeout": 5}],
+                        "stop": [{"command": "echo other-stop"}],
+                    },
+                }
+            )
+        )
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=False)
+            )
+
+        hooks = json.loads((cursor_dir / "hooks.json").read_text())
+        session = hooks["hooks"]["sessionStart"]
+        stop = hooks["hooks"]["stop"]
+        assert any("echo other-start" in d.get("command", "") for d in session)
+        assert any("hindsight-memory" in d.get("command", "") for d in session)
+        assert any("echo other-stop" in d.get("command", "") for d in stop)
+        assert any("retain.py" in d.get("command", "") for d in stop)
+
+    def test_hooks_merge_is_idempotent(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "my-project"
+        project.mkdir()
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=True)
+            )
+            cmd_init(
+                _Args(project=str(project), force=True, api_url=None, api_token=None, bank_id="cursor", no_mcp=True)
+            )
+
+        hooks = json.loads((project / ".cursor" / "hooks.json").read_text())
+        assert len(hooks["hooks"]["sessionStart"]) == 1
+        assert len(hooks["hooks"]["stop"]) == 1
+
+
+
 class TestUninstall:
     def test_removes_plugin(self, tmp_path, fake_plugin_data):
         project = tmp_path / "my-project"
@@ -270,3 +357,35 @@ class TestUninstall:
         mcp = json.loads((mcp_dir / "mcp.json").read_text())
         assert "hindsight" not in mcp["mcpServers"]
         assert "other" in mcp["mcpServers"]
+
+    def test_cleans_up_hooks_json(self, tmp_path):
+        project = tmp_path / "my-project"
+        dest = project / ".cursor-plugin" / "hindsight-memory"
+        dest.mkdir(parents=True)
+        (dest / "x.txt").write_text("x")
+
+        cursor_dir = project / ".cursor"
+        cursor_dir.mkdir()
+        (cursor_dir / "hooks.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "hooks": {
+                        "sessionStart": [
+                            {"command": "echo other"},
+                            {"command": "python3 .cursor-plugin/hindsight-memory/scripts/session_start.py"},
+                        ],
+                        "stop": [
+                            {"command": "python3 .cursor-plugin/hindsight-memory/scripts/retain.py"},
+                        ],
+                    },
+                }
+            )
+        )
+
+        cmd_uninstall(_Args(project=str(project)))
+
+        hooks = json.loads((cursor_dir / "hooks.json").read_text())
+        assert hooks["hooks"]["sessionStart"] == [{"command": "echo other"}]
+        assert "stop" not in hooks["hooks"]
+

--- a/hindsight-integrations/cursor/tests/test_cli.py
+++ b/hindsight-integrations/cursor/tests/test_cli.py
@@ -7,28 +7,33 @@ from unittest.mock import patch
 
 import pytest
 
-from hindsight_cursor.cli import _PLUGIN_FILES, _plugin_data_dir, cmd_init, cmd_uninstall
+from hindsight_cursor.cli import (
+    _PLUGIN_FILES,
+    _hook_interpreter,
+    _plugin_data_dir,
+    _project_hooks_block,
+    cmd_init,
+    cmd_uninstall,
+)
 
 
 @pytest.fixture()
 def fake_plugin_data(tmp_path):
-    """Create a minimal set of plugin data files for testing."""
+    """A complete stand-in payload: every file the CLI declares it ships.
+
+    Built from ``_PLUGIN_FILES`` rather than a hand-picked subset so a new
+    entry in that list cannot silently go untested — and so the fixture keeps
+    exercising the success path of ``_copy_plugin``, which now aborts on an
+    incomplete payload.
+    """
     data_dir = tmp_path / "plugin_data"
-    # Create a few representative files
-    (data_dir / ".cursor-plugin").mkdir(parents=True)
+    for rel in _PLUGIN_FILES:
+        path = data_dir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"# {rel}")
     (data_dir / ".cursor-plugin" / "plugin.json").write_text('{"name": "test"}')
-    (data_dir / "hooks").mkdir()
     (data_dir / "hooks" / "hooks.json").write_text('{"version": 1}')
     (data_dir / "settings.json").write_text('{"bankId": "cursor"}')
-    (data_dir / "scripts" / "lib").mkdir(parents=True)
-    (data_dir / "scripts" / "lib" / "__init__.py").write_text("")
-    (data_dir / "scripts" / "lib" / "rules_file.py").write_text("# rules_file")
-    (data_dir / "scripts" / "session_start.py").write_text("# session_start")
-    (data_dir / "scripts" / "retain.py").write_text("# retain")
-    (data_dir / "rules").mkdir()
-    (data_dir / "rules" / "hindsight-memory.mdc").write_text("# rule")
-    (data_dir / "skills" / "hindsight-recall").mkdir(parents=True)
-    (data_dir / "skills" / "hindsight-recall" / "SKILL.md").write_text("# skill")
     return data_dir
 
 
@@ -228,7 +233,6 @@ class TestInit:
         assert "other-server" in mcp["mcpServers"]
         assert "hindsight" in mcp["mcpServers"]
 
-
     def test_copies_rules_file(self, tmp_path, fake_plugin_data):
         """session_start imports lib.rules_file — init must ship it (#3864)."""
         project = tmp_path / "my-project"
@@ -313,7 +317,6 @@ class TestInit:
         assert len(hooks["hooks"]["stop"]) == 1
 
 
-
 class TestUninstall:
     def test_removes_plugin(self, tmp_path, fake_plugin_data):
         project = tmp_path / "my-project"
@@ -389,3 +392,119 @@ class TestUninstall:
         assert hooks["hooks"]["sessionStart"] == [{"command": "echo other"}]
         assert "stop" not in hooks["hooks"]
 
+
+class TestSessionEndHook:
+    """`stop` is turn-window gated; sessionEnd is the flush that can't be."""
+
+    def test_registers_retain_on_both_stop_and_session_end(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=True)
+            )
+
+        hooks = json.loads((project / ".cursor" / "hooks.json").read_text())["hooks"]
+        assert set(hooks) == {"sessionStart", "stop", "sessionEnd"}
+        assert "retain.py" in hooks["stop"][0]["command"]
+        assert "retain.py" in hooks["sessionEnd"][0]["command"]
+        assert "session_start.py" in hooks["sessionStart"][0]["command"]
+
+    def test_uninstall_strips_session_end_too(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=True)
+            )
+        cmd_uninstall(_Args(project=str(project)))
+
+        assert not (project / ".cursor" / "hooks.json").exists()
+
+
+class TestHookInterpreter:
+    """Windows has no `python3` on PATH -- a hardcoded one is a silent no-op."""
+
+    def test_posix_uses_python3(self):
+        with patch("hindsight_cursor.cli.sys.platform", "darwin"):
+            assert _hook_interpreter() == "python3"
+
+    def test_windows_uses_python(self):
+        with patch("hindsight_cursor.cli.sys.platform", "win32"):
+            assert _hook_interpreter() == "python"
+
+    def test_commands_use_the_platform_interpreter(self):
+        with patch("hindsight_cursor.cli.sys.platform", "win32"):
+            hooks = _project_hooks_block()["hooks"]
+        for definitions in hooks.values():
+            for definition in definitions:
+                assert definition["command"].startswith("python ")
+
+
+class TestIncompletePayload:
+    """A partial copy is never useful -- every hook would ImportError."""
+
+    def test_init_aborts_when_bundled_files_are_missing(self, tmp_path, fake_plugin_data, capsys):
+        (fake_plugin_data / "scripts" / "lib" / "rules_file.py").unlink()
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            with pytest.raises(SystemExit) as exc:
+                cmd_init(
+                    _Args(
+                        project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=True
+                    )
+                )
+
+        assert exc.value.code == 1
+        assert "scripts/lib/rules_file.py" in capsys.readouterr().err
+        # No half-installed state, and no hooks pointing at scripts that are absent.
+        assert not (project / ".cursor" / "hooks.json").exists()
+
+
+class TestSessionRulesCleanup:
+    """sessionStart writes an alwaysApply rules file -- uninstall must remove it."""
+
+    def _install(self, project, fake_plugin_data):
+        with patch("hindsight_cursor.cli._plugin_data_dir", return_value=fake_plugin_data):
+            cmd_init(
+                _Args(project=str(project), force=False, api_url=None, api_token=None, bank_id="cursor", no_mcp=True)
+            )
+
+    def test_removes_rules_file_and_gitignore_entry(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "proj"
+        project.mkdir()
+        self._install(project, fake_plugin_data)
+
+        rules = project / ".cursor" / "rules" / "hindsight-session.mdc"
+        rules.parent.mkdir(parents=True, exist_ok=True)
+        rules.write_text("---\nalwaysApply: true\n---\nold memories\n")
+        (project / ".gitignore").write_text(
+            "node_modules/\n\n"
+            "# Added by hindsight-cursor plugin — session rules are regenerated each session.\n"
+            "/.cursor/rules/hindsight-session.mdc\n"
+        )
+
+        cmd_uninstall(_Args(project=str(project)))
+
+        assert not rules.exists()
+        assert (project / ".gitignore").read_text() == "node_modules/\n"
+
+    def test_leaves_unrelated_gitignore_untouched(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "proj"
+        project.mkdir()
+        self._install(project, fake_plugin_data)
+        (project / ".gitignore").write_text("node_modules/\ndist/\n")
+
+        cmd_uninstall(_Args(project=str(project)))
+
+        assert (project / ".gitignore").read_text() == "node_modules/\ndist/\n"
+
+    def test_tolerates_missing_rules_file(self, tmp_path, fake_plugin_data):
+        project = tmp_path / "proj"
+        project.mkdir()
+        self._install(project, fake_plugin_data)
+        cmd_uninstall(_Args(project=str(project)))  # must not raise

--- a/hindsight-integrations/cursor/tests/test_hooks.py
+++ b/hindsight-integrations/cursor/tests/test_hooks.py
@@ -254,6 +254,131 @@ class TestRetainHook:
         assert call_kwargs[1]["context"] == "cursor"
 
 
+class TestRetainTriggers:
+    """`stop` and `sessionEnd` both run retain.py -- they must not double-store.
+
+    `stop` gives the right granularity but is gated by the turn window, so a
+    session ending inside that window is never stored. `sessionEnd` flushes
+    the tail. They overlap at the end of a conversation.
+    """
+
+    def _transcript(self, tmp_path, count):
+        path = tmp_path / "transcript.jsonl"
+        messages = []
+        for i in range(count):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({"role": role, "content": f"message {i}"})
+        path.write_text("\n".join(json.dumps(m) for m in messages))
+        return path
+
+    def _run(self, monkeypatch, tmp_path, hook_input, mock_client):
+        monkeypatch.setenv("CURSOR_PLUGIN_ROOT", "/nonexistent")
+        monkeypatch.setenv("CURSOR_PLUGIN_DATA", str(tmp_path / "data"))
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(hook_input)))
+
+        import retain
+
+        importlib.reload(retain)
+        with (
+            patch.object(retain, "get_api_url", return_value="http://localhost:8888"),
+            patch.object(retain, "HindsightClient", return_value=mock_client),
+            patch.object(retain, "ensure_bank_mission"),
+        ):
+            retain.main()
+        return retain
+
+    def test_session_end_flushes_inside_the_turn_window(self, monkeypatch, tmp_path):
+        """A 2-turn session ends: `stop` would never retain, `sessionEnd` must."""
+        monkeypatch.setenv("HINDSIGHT_RETAIN_EVERY_N_TURNS", "10")
+        transcript = self._transcript(tmp_path, 4)
+
+        stop_client = MagicMock()
+        self._run(
+            monkeypatch,
+            tmp_path,
+            {"conversation_id": "conv-1", "transcript_path": str(transcript), "hook_event_name": "stop"},
+            stop_client,
+        )
+        stop_client.retain.assert_not_called()
+
+        end_client = MagicMock()
+        self._run(
+            monkeypatch,
+            tmp_path,
+            {"conversation_id": "conv-1", "transcript_path": str(transcript), "hook_event_name": "sessionEnd"},
+            end_client,
+        )
+        end_client.retain.assert_called_once()
+
+    def test_session_end_after_a_retain_is_a_noop(self, monkeypatch, tmp_path):
+        """The stop/sessionEnd overlap must not store the transcript twice."""
+        monkeypatch.setenv("HINDSIGHT_RETAIN_EVERY_N_TURNS", "1")
+        transcript = self._transcript(tmp_path, 4)
+
+        stop_client = MagicMock()
+        self._run(
+            monkeypatch,
+            tmp_path,
+            {"conversation_id": "conv-2", "transcript_path": str(transcript), "hook_event_name": "stop"},
+            stop_client,
+        )
+        stop_client.retain.assert_called_once()
+
+        end_client = MagicMock()
+        self._run(
+            monkeypatch,
+            tmp_path,
+            {"conversation_id": "conv-2", "transcript_path": str(transcript), "hook_event_name": "sessionEnd"},
+            end_client,
+        )
+        end_client.retain.assert_not_called()
+
+    def test_session_end_retains_again_once_the_transcript_grows(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HINDSIGHT_RETAIN_EVERY_N_TURNS", "1")
+        transcript = self._transcript(tmp_path, 2)
+
+        first = MagicMock()
+        self._run(
+            monkeypatch,
+            tmp_path,
+            {"conversation_id": "conv-3", "transcript_path": str(transcript), "hook_event_name": "stop"},
+            first,
+        )
+        first.retain.assert_called_once()
+
+        self._transcript(tmp_path, 6)
+        second = MagicMock()
+        self._run(
+            monkeypatch,
+            tmp_path,
+            {"conversation_id": "conv-3", "transcript_path": str(transcript), "hook_event_name": "sessionEnd"},
+            second,
+        )
+        second.retain.assert_called_once()
+
+    def test_watermark_is_per_session(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HINDSIGHT_RETAIN_EVERY_N_TURNS", "1")
+        transcript = self._transcript(tmp_path, 4)
+
+        first = MagicMock()
+        self._run(
+            monkeypatch,
+            tmp_path,
+            {"conversation_id": "conv-a", "transcript_path": str(transcript), "hook_event_name": "stop"},
+            first,
+        )
+        first.retain.assert_called_once()
+
+        other = MagicMock()
+        self._run(
+            monkeypatch,
+            tmp_path,
+            {"conversation_id": "conv-b", "transcript_path": str(transcript), "hook_event_name": "sessionEnd"},
+            other,
+        )
+        other.retain.assert_called_once()
+
+
 class TestManifest:
     def test_plugin_json_valid(self):
         plugin_path = os.path.join(os.path.dirname(__file__), "..", ".cursor-plugin", "plugin.json")
@@ -273,6 +398,8 @@ class TestManifest:
         assert hooks["version"] == 1
         assert "sessionStart" in hooks["hooks"]
         assert "stop" in hooks["hooks"]
+        # sessionEnd is the final flush for sessions that end mid turn-window.
+        assert "sessionEnd" in hooks["hooks"]
         # beforeSubmitPrompt should NOT be present (it doesn't support additionalContext)
         assert "beforeSubmitPrompt" not in hooks["hooks"]
 

--- a/skills/hindsight-docs/references/sdks/integrations/cursor.md
+++ b/skills/hindsight-docs/references/sdks/integrations/cursor.md
@@ -49,10 +49,13 @@ docker run --rm -it --pull always -p 8888:8888 \
 ### What `init` does
 
 - Copies plugin files into `.cursor-plugin/hindsight-memory/`
+- Writes/merges project `.cursor/hooks.json` so Cursor registers the hooks. Cursor only loads hooks from `.cursor/hooks.json` (workspace) or `~/.cursor/hooks.json` (user) — files under `.cursor-plugin/` are not enough on their own. Hooks you already had are preserved, and re-running `init` replaces only Hindsight's own entries.
 - Creates `~/.hindsight/cursor.json` with your connection settings (if the file does not already exist)
 - Writes `.cursor/mcp.json` with the Hindsight MCP endpoint for on-demand tools
 - Use `--force` to overwrite an existing installation
 - Use `--no-mcp` to skip the MCP configuration
+
+`hindsight-cursor uninstall` reverses all of it: the plugin directory, Hindsight's `.cursor/hooks.json` entries, the MCP server entry, the generated session rules file, and its `.gitignore` line.
 
 > **🚨 Caution**
 >
@@ -75,8 +78,11 @@ The plugin uses Cursor's hook system:
 |------|-------|---------|
 | `session_start.py` | `sessionStart` | **Session recall** — query memories, inject as `additionalContext` |
 | `retain.py` | `stop` | **Auto-retain** — extract transcript, POST to Hindsight |
+| `retain.py` | `sessionEnd` | **Final flush** — retain whatever the turn window never got to |
 
 The `sessionStart` hook fires once when a new Cursor session begins. It performs a broad project-level recall and injects relevant memories as hidden context.
+
+`retain.py` runs on `sessionEnd` as well. Without that, every conversation shorter than `retainEveryNTurns` is lost outright: at the default of 10, a seven-turn chat fires `stop` seven times, the turn gate rejects all seven, and the session is never stored. `sessionEnd` bypasses the turn window so the tail of a session is always retained. The plugin tracks how many transcript messages it has already retained per session, so the overlap between the two events cannot double-store.
 
 The `init` command also configures Cursor's MCP support (`.cursor/mcp.json`) to connect to Hindsight's MCP endpoint, giving the agent explicit `recall`, `retain`, and `reflect` tools for mid-session use.
 


### PR DESCRIPTION
Supersedes #4023, keeping @leilei3167's commit intact and adding the fixes found while testing it against a real Cursor install.

Fixes #3864.

## The original two bugs (#4023, unchanged)

`hindsight-cursor init` copied the plugin into `.cursor-plugin/hindsight-memory/`, but Cursor never ran the hooks:

1. `scripts/lib/rules_file.py` is imported by `session_start.py` but was missing from `_PLUGIN_FILES`, so `init` never copied it — every hook invocation died on `ImportError`.
2. `init` never wrote a project `.cursor/hooks.json`. Cursor only loads hooks from `.cursor/hooks.json` (workspace) or `~/.cursor/hooks.json` (user); dropping files under `.cursor-plugin/` does not register them.

## Verification

Built the wheel, installed it into a clean venv, ran `init` in a fresh git project against a local `hindsight-embed`, and drove the real Cursor agent against it. Both fixes hold: all 16 files land (including `rules_file.py`), `.cursor/hooks.json` is written and loaded, `sessionStart` fires, and the rules file is generated and gitignored.

The proof it reaches the model — a fact seeded into the bank that exists nowhere in the project (the README is just `# demo project`):

> **Q:** What is the codename of this project and the deploy command?
> **A:** The project codename is **BLUE-OTTER-42**, and the deploy command is `make ship-otter`.

Four gaps surfaced during that testing.

## 1. Short sessions were never retained

`stop` was the only retain trigger, and every firing is subject to the turn window. At the default `retainEveryNTurns: 10`, a seven-turn conversation fires `stop` seven times, the turn gate rejects all seven, and the session is **never stored**.

`retain.py` is now registered on `sessionEnd` as well and treats it as a final flush that bypasses the turn window. The two events overlap at the end of a conversation, so retains are made idempotent: a per-session watermark of messages already retained (`retained.json`) turns a run with nothing new into a no-op. In chunked mode the flush stores only the tail past the watermark, so chunks stay non-overlapping.

Confirmed live — a 1-turn session at the default `retainEveryNTurns: 10`, which stores nothing on `main`:

```
[Hindsight] Retaining to bank 'cursor-flush-test', 3 messages
{"status": "success", "message_count": 3}
```

and replaying either event afterwards is correctly a no-op:

```
[Hindsight] No new messages since last retain (3), skipping
```

## 2. `python3` was hardcoded into the hook commands

Windows has no `python3` on PATH, and the plugin explicitly supports Windows (`state.py` carries a `win32` branch) — so every hook was a silent no-op there. The interpreter is now chosen per platform.

## 3. `init` reported success over an install that copied nothing

With an incomplete bundled payload it warned per file, then printed `Plugin files copied.` and `Done!` anyway — the same silent-no-op shape as #3864, and what a source checkout hits today. It now aborts with a non-zero exit and leaves no half-installed state (in particular, no hooks pointing at scripts that were never copied).

## 4. `uninstall` left the session rules file behind

`.cursor/rules/hindsight-session.mdc` is written with `alwaysApply: true`, so after uninstalling, a dead session's memories kept being injected into every agent turn. It and its `.gitignore` line are now removed.

## Tests

101 passing (up from 88). New coverage for: `sessionEnd` registration and removal, the platform interpreter, the incomplete-payload abort, session-rules cleanup (including leaving an unrelated `.gitignore` untouched), and the retain triggers — flush inside the turn window, no double-store on the overlap, re-retain once the transcript grows, and per-session watermark isolation.

The `fake_plugin_data` fixture is now generated from `_PLUGIN_FILES` rather than a hand-picked subset, so a new entry in that list cannot silently go untested — which is the exact shape of bug #1.

README and `docs-integrations/cursor.md` updated to match.

https://claude.ai/code/session_01F3i5UVdZRK16AZ9oFQqsg4