### PR TITLE
fix(recall): score fuzzy tag similarity on the value, not the namespaced tag

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/tag_resolution.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/tag_resolution.py
@@ -72,6 +72,20 @@ def _normalize(value: str) -> str:
     return value.strip().casefold()
 
 
+def _split_namespace(tag: str) -> tuple[str, str]:
+    """``("name", "k8s")`` for ``name:k8s``; ``("", tag)`` when there is no namespace.
+
+    Similarity must be measured on the value alone. A namespace is shared by every
+    candidate in it, so its trigrams count as agreement between tags that have nothing
+    else in common — and the shorter the value, the larger that shared share is. Scored
+    whole, ``name:the`` and ``name:ts`` reach 0.545 while ``the`` and ``ts`` score 0.167,
+    so every short tag in a namespace resolves to every other. Longer namespaces
+    (``customer:``, ``component:``) make it worse.
+    """
+    namespace, separator, value = tag.partition(":")
+    return (namespace, value) if separator else ("", tag)
+
+
 def expand_token(token: str, vocabulary: list[str]) -> list[str]:
     """The tags ``token`` should match, given the bank's tag vocabulary.
 
@@ -89,7 +103,15 @@ def expand_token(token: str, vocabulary: list[str]) -> list[str]:
     if exact:
         return exact
 
-    scored = [(tag, trigram_similarity(normalized, _normalize(tag))) for tag in vocabulary]
+    token_namespace, token_value = _split_namespace(normalized)
+    scored = [
+        (tag, trigram_similarity(token_value, tag_value))
+        for tag in vocabulary
+        # Only within the same namespace: a `name:` token has no business resolving to a
+        # `scope:` tag just because the values look alike.
+        for tag_namespace, tag_value in [_split_namespace(_normalize(tag))]
+        if tag_namespace == token_namespace
+    ]
     # Closest tag first; ties keep vocabulary order, which list_tags returns by usage count.
     matches = [tag for tag, score in sorted(scored, key=lambda pair: -pair[1]) if score >= MIN_SIMILARITY]
     return matches or [token]

--- a/hindsight-api-slim/tests/test_tag_resolution.py
+++ b/hindsight-api-slim/tests/test_tag_resolution.py
@@ -26,7 +26,7 @@ from hindsight_api.engine.search.tags import (
     filter_results_by_tag_groups,
 )
 
-VOCABULARY = ["typescript", "javascript", "kubernetes", "mongodb", "mongoose", "user:alice"]
+VOCABULARY = ["typescript", "javascript", "kubernetes", "mongodb", "mongoose", "user:alice", "user:kubernetes"]
 
 
 class _Result:
@@ -47,7 +47,7 @@ class _Result:
         ("typsecript", "typescript"),  # transposition, 0.47
         ("typescropt", "typescript"),  # substitution, 0.57
         ("kubernets", "kubernetes"),  # deletion, 0.62
-        ("user:alcie", "user:alice"),  # transposition inside a namespaced tag, 0.47
+        ("user:kubernets", "user:kubernetes"),  # deletion inside a namespaced tag, 0.62
     ],
 )
 def test_typos_resolve(token, tag):
@@ -74,6 +74,40 @@ def test_similarity_is_length_sensitive_so_short_tags_barely_tolerate_typos():
     assert expand_token("kakfa", ["kafka"]) == ["kakfa"]
     # The same class of edit in a longer tag resolves fine.
     assert expand_token("kubernets", ["kubernetes"]) == ["kubernetes"]
+
+
+def test_a_namespace_does_not_make_short_values_similar():
+    """The namespace is shared by every candidate, so it must not count as agreement.
+
+    Scored over the whole tag, `name:the` and `name:ts` reach 0.545 and resolve to each
+    other, while the values `the` and `ts` score 0.167 — every short tag in a namespace
+    would resolve to every other, and the longer the namespace the worse it gets.
+    """
+    vocabulary = ["name:ts", "name:fp", "name:dlq", "name:auth"]
+    for token in ("name:the", "name:a", "name:my", "name:does"):
+        assert expand_token(token, vocabulary) == [token], f"{token} should resolve to nothing"
+
+
+def test_namespaced_typos_still_resolve_when_the_value_is_long_enough():
+    """The guard above must not cost real typo tolerance inside a namespace."""
+    assert expand_token("name:typsecript", ["name:typescript", "name:ts"]) == ["name:typescript"]
+    assert expand_token("name:eror", ["name:error", "name:fp"]) == ["name:error"]
+
+
+def test_length_sensitivity_does_not_depend_on_being_namespaced():
+    """`alcie`/`alice` and `kakfa`/`kafka` are the same edit at the same length (both 0.20).
+
+    Scoring the whole tag made the first resolve and the second not, purely because one
+    sat in a namespace. Neither resolves now.
+    """
+    assert expand_token("user:alcie", ["user:alice"]) == ["user:alcie"]
+    assert expand_token("kakfa", ["kafka"]) == ["kakfa"]
+
+
+def test_a_token_does_not_resolve_across_namespaces():
+    """A `name:` token has no business reaching a `scope:` tag because the values match."""
+    assert expand_token("name:kubernets", ["scope:kubernetes"]) == ["name:kubernets"]
+    assert expand_token("kubernets", ["name:kubernetes"]) == ["kubernets"]
 
 
 def test_exact_hit_wins_over_similar_tags():


### PR DESCRIPTION
Fixes #4044.

## The bug

`expand_token` scored similarity over the **whole tag, namespace included**:

```python
scored = [(tag, trigram_similarity(normalized, _normalize(tag))) for tag in vocabulary]
```

A namespace is shared by every candidate in it, so its trigrams count as agreement between tags that have nothing else in common. The shorter the value, the larger the namespace's share of the string — and the longer the namespace (`customer:`, `component:`), the worse it gets.

| pair | value only | with `name:` | at `MIN_SIMILARITY = 0.45` |
|---|---|---|---|
| `the` / `ts` | 0.167 | **0.545** | rejected → **matched** |
| `tell` / `ts` | 0.143 | **0.500** | rejected → **matched** |
| `a` / `fp` | 0.000 | **0.500** | rejected → **matched** |
| `does` / `dlq` | 0.125 | **0.462** | rejected → **matched** |
| `my` / `mongo` | 0.125 | **0.462** | rejected → **matched** |

A caller passing query words as candidate tags — the usage the feature exists for — pulls in an unrelated memory for every common short word in the query, and the tag filter stops excluding much of anything. It is silent: the resolved leaf looks reasonable, and only reading the expansion shows `name:a` → `[name:auth, name:fp, name:ts, name:dlq]`.

## The fix

Score the value, and only within the same namespace. Cross-namespace resolution was never intended — a `name:` token has no business reaching a `scope:` tag because the values look alike — so that is now explicit rather than incidental.

Real typos are unaffected, because they are long enough not to have depended on the prefix: `eror`/`error` 0.571, `typsecript`/`typescript` 0.467, `mongod`/`mongodb` 0.667, `reedis`/`redis` 0.625.

## A contradiction this removes

The suite pinned both of these:

- `user:alcie` → `user:alice` **resolves**
- `kakfa` → `kafka` **does not resolve** (documented as the length-sensitivity limit)

Same edit, same length — both score **0.20** on the value. The only difference was that one sat in a namespace, so the prefix carried it over the threshold. The namespaced typo case is now `user:kubernets` → `user:kubernetes`, a value long enough to resolve on its own merits, and the length limit now behaves the same inside and outside a namespace.

## Tests

Four added, plus the amended case:

- short values in a namespace resolve to nothing
- namespaced typos still resolve when the value is long enough
- length sensitivity no longer depends on being namespaced
- no resolution across namespaces

30 passed. `ruff check`, `ruff format --check`, `ty check` clean.
