### PR TITLE
fix(docker): drop unused libxml2 from runtime images

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -170,7 +170,6 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y \
     curl \
     procps \
-    libxml2 \
     libssl3 \
     libgssapi-krb5-2 \
     libossp-uuid16 \
@@ -330,7 +329,6 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y \
     curl \
     procps \
-    libxml2 \
     libssl3 \
     libgssapi-krb5-2 \
     libossp-uuid16 \


### PR DESCRIPTION
## What this fixes

The Debian `api-only` and `standalone` runtime stages explicitly install the system `libxml2` package. The current `lxml` wheel is self-contained, and both runtime shapes start successfully without the system package.

A Trivy 0.74.0 scan of a fresh `api-only` build from current `main` reported:

| Artifact | Critical | High |
| --- | ---: | ---: |
| Before | 4 | 22 |
| After | 3 | 22 |

The removed finding is `CVE-2026-6653` against system `libxml2`. Debian currently provides no fixed package version, so removing the unused runtime component is the available remediation.

## Change

Remove `libxml2` from the `apt-get install` lists for the `api-only` and `standalone` final stages. Builder stages and application dependencies are unchanged.

## Verification

- Fresh `api-only` image built from current `main` with local models disabled
- Trivy 0.74.0: 4 Critical / 22 High before, 3 Critical / 22 High after, zero fix-available findings in both scans
- Modified `api-only` image reached `/health` with the database connected
- Embedded PostgreSQL initialized and every migration completed
- `import lxml.etree` and `import hindsight_api.main` succeeded
- Equivalent package removal on the published combined `0.9.2-slim` image started both the API and control plane