### PR TITLE
fix(docker): drop runtime curl and NodeSource bootstrap

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -168,7 +168,6 @@ WORKDIR /app
 # commit can now resolve different package versions.
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y \
-    curl \
     procps \
     libxml2 \
     libssl3 \
@@ -275,8 +274,10 @@ WORKDIR /app
 COPY docker/standalone/start-all.sh /app/start-all.sh
 RUN chmod +x /app/start-all.sh
 
-# Install curl for health checks. `apk upgrade` first, for the same reason the
-# Debian stages run `apt-get upgrade` - see the comment on the api-only stage.
+# Install bash for the shared startup script. HTTP readiness probes use wget
+# from the Alpine base, so curl and its transitive dependencies do not ship.
+# `apk upgrade` runs first for the same reason the Debian stages run
+# `apt-get upgrade` - see the comment on the api-only stage.
 # npm is removed for the same reason the Debian stages remove pip's build
 # tooling: nothing invokes it at runtime - start-all.sh launches the pre-built
 # Next standalone bundle with `node server.js` - and dropping it leaves no
@@ -287,7 +288,7 @@ RUN chmod +x /app/start-all.sh
 # The `[ -e ]` guard is deliberate: a bare `rm -rf` on a path a future base
 # image no longer uses succeeds silently and npm quietly ships again. Fail the
 # build instead, so the path assumption has to be revisited on a base bump.
-RUN apk upgrade --no-cache && apk add --no-cache curl bash \
+RUN apk upgrade --no-cache && apk add --no-cache bash \
     && [ -e /usr/local/lib/node_modules/npm ] \
     && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
     && ! command -v npm
@@ -308,19 +309,10 @@ FROM python:3.11-slim AS standalone
 
 WORKDIR /app
 
-# Install Node.js, curl, uv, and system dependencies
+# Install uv and system dependencies.
 # Note: libicu version varies by Debian version - try common versions in order
 # Runtime images use uv directly; remove pip build tooling after installation so
 # vulnerable setuptools-vendored packages and wheel are not shipped in production.
-# npm goes the same way: nothing invokes it at runtime - start-all.sh launches
-# the pre-built Next standalone bundle with `node server.js` - and dropping it
-# leaves no scannable vulnerable tar component in the stage. corepack is
-# deliberately kept: it has no node_modules tree and ships no tar package
-# metadata, so a scanner reports nothing for it. npm is not installed as a
-# separate apt package here - NodeSource's `nodejs` package ships it
-# (`dpkg -S /usr/bin/npm` resolves to `nodejs`), so `apt-get remove npm` is a
-# no-op and removal by path is the only option. The `[ -e ]` guard fails the
-# build if a base bump moves that path, rather than silently shipping npm.
 # `upgrade` before `install`: without it the image ships whatever package
 # snapshot the base image was cut with, so security updates published since
 # never reach the runtime layers - that is how 0.9.2 shipped openssl 3.5.6 with
@@ -328,21 +320,22 @@ WORKDIR /app
 # commit can now resolve different package versions.
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y \
-    curl \
     procps \
     libxml2 \
     libssl3 \
     libgssapi-krb5-2 \
     libossp-uuid16 \
     && (apt-get install -y libicu72 2>/dev/null || apt-get install -y libicu74 2>/dev/null || apt-get install -y libicu76 2>/dev/null || true) \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs \
-    && [ -e /usr/lib/node_modules/npm ] \
-    && rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx \
-    && ! command -v npm \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir uv \
     && pip uninstall --yes setuptools wheel
+
+# The control plane is a pre-built Next standalone bundle launched with
+# `node server.js`. Reuse that builder's Node binary instead of installing the
+# NodeSource package and its build-only GnuPG, curl, and system-Python chain.
+COPY --from=cp-builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=cp-builder /usr/local/LICENSE /usr/local/LICENSE
+RUN node --version && ! command -v npm && ! command -v curl
 
 RUN useradd -m -s /bin/bash hindsight
 

--- a/docker/standalone/start-all.sh
+++ b/docker/standalone/start-all.sh
@@ -124,6 +124,41 @@ resolve_api_startup_wait_seconds() {
     echo "$DEFAULT_API_STARTUP_WAIT_SECONDS"
 }
 
+# Use runtimes already required by each final image instead of shipping curl
+# solely for readiness checks. API images always have Python; the Alpine
+# control-plane image already has BusyBox wget. Keep the implementations
+# equivalent: follow redirects, accept only successful HTTP responses, and stop
+# a stalled request after the timeout.
+http_probe() {
+    local url="$1"
+    local timeout_seconds="${2:-5}"
+
+    if command -v python3 >/dev/null 2>&1; then
+        HTTP_PROBE_URL="$url" HTTP_PROBE_TIMEOUT_SECONDS="$timeout_seconds" python3 -c '
+import os
+import urllib.request
+
+try:
+    with urllib.request.urlopen(
+        os.environ["HTTP_PROBE_URL"],
+        timeout=float(os.environ["HTTP_PROBE_TIMEOUT_SECONDS"]),
+    ):
+        pass
+except Exception:
+    raise SystemExit(1)
+'
+        return $?
+    fi
+
+    if command -v wget >/dev/null 2>&1; then
+        wget -q -T "$timeout_seconds" -O /dev/null "$url" 2>/dev/null
+        return $?
+    fi
+
+    echo "No HTTP probe runtime is available (expected python3 or wget)." >&2
+    return 127
+}
+
 if [ "${HINDSIGHT_START_ALL_SOURCE_ONLY:-false}" = "true" ]; then
     return 0 2>/dev/null || exit 0
 fi
@@ -167,7 +202,7 @@ if [ "${HINDSIGHT_WAIT_FOR_DEPS:-false}" = "true" ]; then
     }
 
     check_llm() {
-        curl -sf "${LLM_BASE_URL}/models" --connect-timeout 5 &>/dev/null
+        http_probe "${LLM_BASE_URL}/models" 5 &>/dev/null
     }
 
     echo "⏳ Waiting for dependencies to be ready..."
@@ -279,7 +314,7 @@ if [ "$ENABLE_API" = "true" ]; then
             wait "$API_PID"
             exit $?
         fi
-        if curl -sf "$API_HEALTH_URL" &>/dev/null; then
+        if http_probe "$API_HEALTH_URL" 5 &>/dev/null; then
             api_ready=true
             break
         fi

--- a/docker/standalone/test-start-all.sh
+++ b/docker/standalone/test-start-all.sh
@@ -8,7 +8,17 @@ source "$SCRIPT_DIR/start-all.sh"
 unset HINDSIGHT_START_ALL_SOURCE_ONLY
 
 TMP_DIR="$(mktemp -d)"
-trap 'chmod -R u+rwx "$TMP_DIR" 2>/dev/null || true; rm -rf "$TMP_DIR"' EXIT
+HTTP_SERVER_PID=""
+
+cleanup() {
+    if [ -n "$HTTP_SERVER_PID" ]; then
+        kill "$HTTP_SERVER_PID" 2>/dev/null || true
+        wait "$HTTP_SERVER_PID" 2>/dev/null || true
+    fi
+    chmod -R u+rwx "$TMP_DIR" 2>/dev/null || true
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
 
 assert_contains() {
     local output="$1"
@@ -43,6 +53,78 @@ assert_empty() {
         exit 1
     fi
 }
+
+# =============================================================================
+# http_probe
+# =============================================================================
+HTTP_PORT_FILE="$TMP_DIR/http-port"
+if python3 -c 'import sys; sys.exit(0)' >/dev/null 2>&1; then
+    TEST_PYTHON_BIN="$(command -v python3)"
+elif python -c 'import sys; sys.exit(0)' >/dev/null 2>&1; then
+    TEST_PYTHON_BIN="$(command -v python)"
+else
+    echo "A working Python interpreter is required for HTTP probe tests"
+    exit 1
+fi
+
+"$TEST_PYTHON_BIN" - "$HTTP_PORT_FILE" <<'PY' &
+import http.server
+import pathlib
+import sys
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(204 if self.path == "/ok" else 404)
+        self.end_headers()
+
+    def log_message(self, *_args):
+        pass
+
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+pathlib.Path(sys.argv[1]).write_text(str(server.server_port), encoding="ascii")
+for _ in range(4):
+    server.handle_request()
+PY
+HTTP_SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+    [ -s "$HTTP_PORT_FILE" ] && break
+    sleep 0.1
+done
+if [ ! -s "$HTTP_PORT_FILE" ]; then
+    echo "HTTP probe test server did not start"
+    exit 1
+fi
+
+HTTP_TEST_URL="http://127.0.0.1:$(cat "$HTTP_PORT_FILE")"
+PYTHON_BIN="$TEST_PYTHON_BIN"
+WGET_BIN="$(command -v wget)"
+
+(
+    PATH="$TMP_DIR/empty-path"
+    python3() { "$PYTHON_BIN" "$@"; }
+    http_probe "$HTTP_TEST_URL/ok" 2
+    if http_probe "$HTTP_TEST_URL/missing" 2; then
+        echo "Python HTTP probe should fail on a 404 response"
+        exit 1
+    fi
+)
+
+(
+    PATH="$TMP_DIR/empty-path"
+    wget() { "$WGET_BIN" "$@"; }
+    http_probe "$HTTP_TEST_URL/ok" 2
+    if http_probe "$HTTP_TEST_URL/missing" 2; then
+        echo "wget HTTP probe should fail on a 404 response"
+        exit 1
+    fi
+)
+
+wait "$HTTP_SERVER_PID"
+HTTP_SERVER_PID=""
+echo "start-all HTTP probe checks passed"
 
 mkdir -p "$TMP_DIR/empty"
 assert_empty "$(check_pg0_data_integrity "$TMP_DIR/empty")"


### PR DESCRIPTION
## Summary

- replace runtime curl health checks with a small helper that uses Python in API images and BusyBox wget in the Alpine control-plane image
- reuse the Node binary and license from the existing control-plane builder in the standalone image
- remove the NodeSource bootstrap and its runtime-only GnuPG, system Python 3.13, and curl dependency chains
- cover both HTTP probe implementations, including non-success responses, in the standalone startup tests

## Security impact

Trivy 0.74.0 scans with the current database showed:

- API-only: 4 Critical / 25 High with curl added back to the exact artifact, versus 4 Critical / 16 High without it - 9 High findings removed
- cp-only: 0 Critical / 0 High
- standalone: 4 Critical / 39 High with the NodeSource bootstrap, versus 4 Critical / 16 High when reusing the builder Node binary - 23 High findings removed

The remaining findings are unrelated base-image or Python dependency findings and are not suppressed by this change.

## Verification

- `docker/standalone/test-start-all.sh` passes in Alpine with Python and BusyBox wget
- API-only health reports the database connected
- cp-only health passes
- standalone API and control-plane health both pass
- final standalone image contains Node 20.20.2 and excludes curl, npm, GnuPG, and Debian Python 3.13
- `git diff --check` passes

The full local lint hook was also run. Its only failures were existing host-environment issues: the local control-plane install lacks `@eslint/js`, and Windows type analysis cannot resolve optional Unix/macOS modules and APIs.