### PR TITLE
chore(deps): bump qs to 6.16.0 in the coding-agents lock

### DIFF
--- a/hindsight-integrations/coding-agents/package-lock.json
+++ b/hindsight-integrations/coding-agents/package-lock.json
@@ -3532,9 +3532,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/hindsight-integrations/coding-agents/package.json
+++ b/hindsight-integrations/coding-agents/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/vectorize-io/hindsight.git",
     "directory": "hindsight-integrations/coding-agents"
   },
-  "description": "Reflect-only Hindsight long-term memory for coding agents (harness-pluggable: opencode, …), with automatic background ingestion (no setup CLI).",
+  "description": "Reflect-only Hindsight long-term memory for coding agents (harness-pluggable: opencode, \u2026), with automatic background ingestion (no setup CLI).",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -98,6 +98,7 @@
     "hono": ">=4.12.34 <5.0.0",
     "ip-address": ">=10.3.1 <11.0.0",
     "postcss": ">=8.5.23 <9.0.0",
+    "qs": ">=6.16.0 <7.0.0",
     "vite": ">=6.4.3 <7.0.0"
   }
 }


### PR DESCRIPTION
Closes 2 Dependabot alerts in `hindsight-integrations/coding-agents/package-lock.json`: **#1439, #1438** (`qs`).

> **Stacked on #4053.** This branch touches the coding-agents lockfile, the same lockfile as the fast-uri sweep, so it is based on that branch rather than `main` to avoid two PRs colliding. **Merge #4053 first** (which itself follows #4050), after which this retargets to `main` cleanly.

## The bump

`qs` 6.15.3 → **6.16.0**, as a bounded override (`>=6.16.0 <7.0.0`).

Both parents in the tree already admit the fixed version (`^6.15.2` and `^6.14.0`), so this needs no parent bump. It does still need the override: `npm install --package-lock-only qs@6.16.0` is a **no-op** here, because 6.15.3 already satisfies both caret ranges and npm sees no reason to move. The override is what actually raises the floor.

Result is a single hoisted `qs` at 6.16.0 — no nested copies, nothing else in the tree moved. The lockfile diff is 6 lines.

## Verification

Reproduced CI's steps rather than approximating them:

| Check | Result |
|---|---|
| `npm ci` | clean |
| `npm run build` (tsup, 8 entry points + DTS) | success |
| `npx tsc --noEmit` | clean |
| `npm test` | **845 passed** (64 files) |

Installed `node_modules/qs` confirmed at 6.16.0 after `npm ci`.
