### PR TITLE
chore(deps): bump banks to 2.4.5 in the llamaindex lock

### DIFF
--- a/hindsight-integrations/llamaindex/uv.lock
+++ b/hindsight-integrations/llamaindex/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "banks"
-version = "2.4.2"
+version = "2.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
@@ -248,9 +248,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/51/08fb68d23f4b0f6256fe85dc86e9576941550f890b079352fba719e07b39/banks-2.4.2.tar.gz", hash = "sha256:cda6013bd377ea7b701933578bfb9370fc21ad70bc13cedfc3f5cb2c034ca3dc", size = 188633, upload-time = "2026-04-27T12:15:22.021Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b5/4784ee9518b97f9f69c714a4303f9a6186a7e4ff2349f89e24767e9754d9/banks-2.4.5.tar.gz", hash = "sha256:ff575732fc67d5493a73c21e0d7268bc49e86fff02b0b8735e8efb9fcb9af3a4", size = 190822, upload-time = "2026-07-07T08:14:12.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/b6/8dc5477681b782e2f99de703e7a99828883364b9e03a60d3e2c47053d56a/banks-2.4.2-py3-none-any.whl", hash = "sha256:5fe407cc48c101f3e13d1cf732b83b8246003337612f13c0705d2e81f6faffb7", size = 35050, upload-time = "2026-04-27T12:15:20.785Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b0/4d34cb2fe538aeb6d4b0723b3339cb932120db084a5c9a3c6966a26bbe1b/banks-2.4.5-py3-none-any.whl", hash = "sha256:ac2e0091b4c79379d4773c9d04a138a0d937ee27c5803bf0142acc6d6769eea1", size = 36145, upload-time = "2026-07-07T08:14:10.974Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes 1 Dependabot alert in `hindsight-integrations/llamaindex/uv.lock`: **#1437** (`banks`).

> **Stacked on #4051.** This branch touches the llamaindex lockfile, the same lockfile as the nltk bump, so it is based on that branch rather than `main` to avoid two PRs colliding. **Merge #4051 first**, after which this retargets to `main` cleanly.

## The bump

`banks` 2.4.2 → **2.4.5**.

`banks` is purely transitive via `llama-index-core`, which declares no upper bound on it, so this is a scoped `uv lock --upgrade-package banks==2.4.5` — **no manifest change, no parent bump**. A 6-line diff confined to the one lockfile.

Pinned to 2.4.5, the advisory floor, rather than letting the resolver take the available 2.5.0 — keeping the jump as small as the fix allows.

## Verification

Reproduced CI's exact steps (`uv build`, `uv sync --frozen`, `uv run pytest tests`):

- `uv build` — sdist + wheel built
- `uv sync --frozen` — clean
- **92 passed**

Nothing outside `banks` moved in the lock.
