### PR TITLE
fix(cli): print the server's 404 detail instead of "API endpoint not found"

### DIFF
--- a/hindsight-cli/src/errors.rs
+++ b/hindsight-cli/src/errors.rs
@@ -5,6 +5,19 @@ pub fn handle_api_error(err: anyhow::Error, api_url: &str) -> ! {
     std::process::exit(1);
 }
 
+/// The server's own explanation out of an error body, i.e. FastAPI's `{"detail": "..."}`.
+///
+/// The error text these branches match on is `API request failed (<status>): <body>` (see
+/// api.rs::humanize_client_error), so the body is whatever JSON the server sent — or nothing at
+/// all, which is what a genuine unknown-route 404 looks like. Returns None unless a non-empty
+/// string `detail` is actually there, so callers can keep their generic guidance for that case.
+fn server_detail(err_str: &str) -> Option<String> {
+    let body = &err_str[err_str.find('{')?..];
+    let parsed: serde_json::Value = serde_json::from_str(body.trim()).ok()?;
+    let detail = parsed.get("detail")?.as_str()?.trim();
+    (!detail.is_empty()).then(|| detail.to_string())
+}
+
 fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
     let err_str = err.to_string();
 
@@ -94,6 +107,19 @@ fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
                     .bright_white(),
                 "Note:".bright_cyan(),
                 "This allows per-bank LLM configuration overrides via API".bright_white()
+            );
+        }
+
+        // An absent resource and an unknown route are both 404, and only the second one is about
+        // API paths and versions. The server distinguishes them for us: `document get` on a
+        // missing document answers `{"detail":"Document not found"}`, so printing the endpoint/
+        // version guidance over that body sends the operator after an API breakage that isn't
+        // there (#4049) — the same swallowed-body class #2912 fixed for 400.
+        if let Some(detail) = server_detail(&err_str) {
+            return format!(
+                "{} {}",
+                "✗".bright_red().bold(),
+                format!("Not found (404): {}", detail).bright_red().bold()
             );
         }
 
@@ -259,5 +285,44 @@ mod tests {
 
         assert!(message.contains("Batch operations will timeout in synchronous mode"));
         assert!(!message.contains("Request timed out"));
+    }
+
+    #[test]
+    fn http_404_with_a_detail_reports_the_absent_resource_not_a_missing_endpoint() {
+        // `document get` on a document that never landed: the server already says why, and
+        // operators read this as the landing witness for async retains (#4049).
+        let error = anyhow::anyhow!(
+            "API request failed (404 Not Found): {{\"detail\":\"Document not found\"}}"
+        );
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("Not found (404): Document not found"));
+        assert!(!message.contains("API endpoint not found"));
+        assert!(!message.contains("incompatible API version"));
+    }
+
+    #[test]
+    fn http_404_without_a_body_keeps_the_unknown_route_guidance() {
+        // A true unknown route has no detail to print — that is the case the endpoint-path and
+        // version hints were written for, so they must survive.
+        let error = anyhow::anyhow!("API request failed (404 Not Found)");
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("API endpoint not found (404)"));
+        assert!(message.contains("incompatible API version"));
+    }
+
+    #[test]
+    fn http_404_for_a_disabled_feature_still_explains_how_to_enable_it() {
+        let error = anyhow::anyhow!(
+            "API request failed (404 Not Found): \
+             {{\"detail\":\"Bank configuration API is disabled\"}}"
+        );
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("HINDSIGHT_API_ENABLE_BANK_CONFIG_API=true"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4049. `hindsight document get <bank> <missing-doc>` printed the fixed `API endpoint not found (404)` text with endpoint-path/version guidance and threw away the server's `{"detail":"Document not found"}`, sending the operator after an API breakage that isn't there.

An absent resource and an unknown route are both 404, but only the second one is about paths and versions — and the server already distinguishes them: it sends a `detail` for the first and nothing for the second. So the 404 branch now prints the detail when there is one and keeps the existing hints for a body-less 404.

```
✗ Not found (404): Document not found
```

## Changes

`hindsight-cli/src/errors.rs`:

- `server_detail()` pulls a non-empty string `detail` out of the error body. It returns `None` for a body-less or detail-less 404, which is what keeps the unknown-route guidance intact for the case it was written for.
- The 404 branch prints `Not found (404): <detail>` when a detail is present. The `Bank configuration API is disabled` branch is checked first and keeps its own message.

Why the raw body is available here: the document endpoints declare only `200`/`422` in the OpenAPI spec, so a 404 is undeclared and arrives as progenitor's `UnexpectedResponse`; `api.rs::humanize_client_error` then formats the error as `API request failed (404 Not Found): <raw body>`. A typed error body would serialize to the same `{"detail":...}` shape, so both paths parse.

The change is in the shared formatter, so every command benefits — a missing bank now reads `Not found (404): Bank not found` rather than "the endpoint moved".

## Testing

`cargo test` in `hindsight-cli`: 152 passed (106 unit + 25 + 13 + 8 integration), including three new cases:

- 404 with a `detail` reports the absent resource and no longer mentions the endpoint path or API version.
- 404 with no body still prints `API endpoint not found (404)` and the version hint.
- 404 for the disabled bank-config API still explains `HINDSIGHT_API_ENABLE_BANK_CONFIG_API=true` (regression guard for the branch above it).

`cargo fmt --check` clean; `cargo clippy --all-targets` reports nothing on `errors.rs` (the repo's pre-existing warnings elsewhere are untouched); `./scripts/hooks/lint.sh` passes.

Not exercised against a live server — the fix is in error-string formatting, and the tests feed it the exact strings `api.rs` produces for the reported case (`404 Not Found` + `{"detail":"Document not found"}`, as observed via curl in the issue).
