### PR TITLE
fix(cli): preserve not-found response details

### DIFF
--- a/hindsight-cli/src/errors.rs
+++ b/hindsight-cli/src/errors.rs
@@ -97,6 +97,18 @@ fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
             );
         }
 
+        if let Some(detail) = response_detail(&err_str) {
+            return format!(
+                "{} {}\n\n{}\n  {}\n\n{}\n  {}",
+                "✗".bright_red().bold(),
+                "Not found (404)".bright_red().bold(),
+                "API URL:".bright_yellow(),
+                api_url.bright_white(),
+                "Server response:".bright_yellow(),
+                detail.bright_white()
+            );
+        }
+
         return format!(
             "{} {}\n\n{}\n  {}\n\n{}\n  • {}\n  • {}\n\n{}\n  {}",
             "✗".bright_red().bold(),
@@ -226,6 +238,16 @@ fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
     )
 }
 
+fn response_detail(err: &str) -> Option<String> {
+    let body = err.get(err.find('{')?..)?;
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()?
+        .get("detail")?
+        .as_str()
+        .filter(|detail| !detail.is_empty())
+        .map(str::to_owned)
+}
+
 pub fn print_config_help() {
     println!("\n{}", "Configuration:".bright_cyan().bold());
     println!("  Run the configure command to set the API URL:");
@@ -259,5 +281,51 @@ mod tests {
 
         assert!(message.contains("Batch operations will timeout in synchronous mode"));
         assert!(!message.contains("Request timed out"));
+    }
+
+    #[test]
+    fn http_404_preserves_structured_detail() {
+        let error = anyhow::anyhow!(
+            "{}",
+            "API request failed (404 Not Found): {\"detail\":\"Document not found\"}"
+        );
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("Not found (404)"));
+        assert!(message.contains("Document not found"));
+        assert!(!message.contains("incompatible API version"));
+    }
+
+    #[test]
+    fn http_404_without_detail_keeps_endpoint_guidance() {
+        for error in [
+            anyhow::anyhow!("API request failed (404 Not Found)"),
+            anyhow::anyhow!("API request failed (404 Not Found): not JSON"),
+            anyhow::anyhow!(
+                "{}",
+                "API request failed (404 Not Found): {\"message\":\"missing\"}"
+            ),
+        ] {
+            let message = format_error_message(&error, "http://localhost:8888");
+
+            assert!(message.contains("API endpoint not found (404)"));
+            assert!(message.contains("incompatible API version"));
+        }
+    }
+
+    #[test]
+    fn disabled_bank_api_keeps_specialized_guidance() {
+        let error = anyhow::anyhow!(
+            "{}",
+            "API request failed (404 Not Found): \
+             {\"detail\":\"Bank configuration API is disabled\"}"
+        );
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("Bank configuration API is disabled"));
+        assert!(message.contains("HINDSIGHT_API_ENABLE_BANK_CONFIG_API=true"));
+        assert!(!message.contains("Not found (404)"));
     }
 }


### PR DESCRIPTION
## What changed

- surface a structured `detail` from 404 responses instead of replacing it with endpoint/version guidance
- keep the existing disabled-bank message and the generic fallback for unknown, malformed, or detail-less 404 responses
- add focused coverage for each branch

Closes #4049.

## Why

`hindsight document get` is often used to check whether an async retain has landed. The API already distinguishes an absent document with `{"detail":"Document not found"}`, but the CLI currently discards that evidence and reports an endpoint mismatch.

## Verification

- `cargo test --manifest-path hindsight-cli/Cargo.toml --bin hindsight errors::tests` (4 passed)
- `cargo fmt --manifest-path hindsight-cli/Cargo.toml -- --check`
- `git diff --check`

The repository-wide pre-commit lint could not complete in this fresh worktree because control-plane JavaScript dependencies were not installed (`@eslint/js` and `vitest/config`). The Rust-focused tests pass; a full strict Clippy run also reaches pre-existing warnings outside this change.

## Risk

Only a non-empty string-valued JSON `detail` is surfaced. Arbitrary or malformed bodies retain the current safe endpoint/version fallback.
