### PR TITLE
fix(cache): preserve force refresh across event loops

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/bank_stats_cache.py
+++ b/hindsight-api-slim/hindsight_api/engine/bank_stats_cache.py
@@ -108,8 +108,11 @@ class BankStatsCache:
             value = await loader()
             with self._lock:
                 self._store_unlocked(key, value)
-                # Supersede any loader that was in flight for this key.
-                self._in_flight.pop(self._flight_key(key), None)
+                # Supersede every loader that was in flight for this key. Flights
+                # are loop-scoped, so removing only this loop's slot lets an older
+                # loader on another loop overwrite the force-refreshed value later.
+                for flight_key in [fk for fk in self._in_flight if fk[1] == key]:
+                    self._in_flight.pop(flight_key, None)
             return value
 
         with self._lock:

--- a/hindsight-api-slim/tests/test_bank_stats_cache.py
+++ b/hindsight-api-slim/tests/test_bank_stats_cache.py
@@ -7,11 +7,49 @@ directly so the semantics are checked in isolation from `MemoryEngine`.
 from __future__ import annotations
 
 import asyncio
+import threading
 from typing import Any
 
 import pytest
 
 from hindsight_api.engine.bank_stats_cache import BankStatsCache
+
+
+def test_force_refresh_supersedes_in_flight_loader_on_another_loop() -> None:
+    cache = BankStatsCache(ttl_seconds=60, max_entries=100)
+    old_started = threading.Event()
+    release_old = threading.Event()
+    errors: list[BaseException] = []
+
+    async def old_loader() -> dict[str, str]:
+        old_started.set()
+        while not release_old.is_set():
+            await asyncio.sleep(0.001)
+        return {"value": "old"}
+
+    def load_old() -> None:
+        try:
+            asyncio.run(cache.get_or_load("schema", "bank", old_loader))
+        except BaseException as exc:
+            errors.append(exc)
+
+    old_thread = threading.Thread(target=load_old)
+    old_thread.start()
+    assert old_started.wait(timeout=2)
+
+    async def new_loader() -> dict[str, str]:
+        return {"value": "new"}
+
+    assert asyncio.run(cache.get_or_load("schema", "bank", new_loader, force_refresh=True)) == {"value": "new"}
+    release_old.set()
+    old_thread.join(timeout=2)
+    assert not old_thread.is_alive()
+    assert not errors
+
+    async def should_not_run() -> dict[str, str]:
+        raise AssertionError("fresh force-refresh result should remain cached")
+
+    assert asyncio.run(cache.get_or_load("schema", "bank", should_not_run)) == {"value": "new"}
 
 
 def make_loader(return_value: dict[str, Any]) -> tuple[Any, list[int]]:


### PR DESCRIPTION
## Summary

- detach every loop-scoped in-flight bank-stats load when a force refresh completes
- prevent an older loader on another event loop from overwriting the force-refreshed value
- add a deterministic two-thread / two-loop regression

This follows the multi-loop cache changes merged in #4037 and the finding recorded in [this review](https://github.com/vectorize-io/hindsight/pull/4037#pullrequestreview-5096781949).

## Reproduction

Before the fix:

1. loop A starts a normal load and pauses;
2. loop B completes a forced refresh with a newer value;
3. loop A completes;
4. the next cache hit returns loop A's older value.

The force-refresh path removed only its own `(loop, key)` flight, so the older flight on loop A remained authorized to populate the shared cache.

## Validation

- `test_bank_stats_cache.py` + `test_multi_loop_conformance.py`: 18 passed
- focused regression after formatting: 1 passed
- Ruff check and format check pass for both changed files
- `git diff --check` passes

The repository-wide lint wrapper reached ESLint without the control-plane Node dependencies installed in the isolated checkout (`@eslint/js` missing). No TypeScript files are changed; the Python Ruff gates pass directly.
