### PR TITLE
perf(db): bind pgvector values in binary instead of a text literal

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/postgresql.py
@@ -157,6 +157,19 @@ def application_name_from_dsn(dsn: str) -> str | None:
     return values[-1] or None
 
 
+def _vector_codec_init(next_callback: Any | None) -> Any:
+    """Wrap a pool ``init`` callback so the binary vector codec is installed first."""
+
+    async def init(conn: Any) -> None:
+        from .vector_codec import register_vector_codec
+
+        await register_vector_codec(conn)
+        if next_callback is not None:
+            await next_callback(conn)
+
+    return init
+
+
 def _application_name_setup(app_name: str, init_callback: Any | None) -> Callable[[Any], Awaitable[None]]:
     """Wrap ``init_callback`` so every acquire re-asserts ``application_name``.
 
@@ -241,7 +254,13 @@ class PostgreSQLBackend(DatabaseBackend):
         # connection; behind pgbouncer it has to be re-asserted per acquire
         # (see _application_name_setup).
         app_name = application_name_from_dsn(dsn)
-        pool_init = _application_name_setup(app_name, init_callback) if app_name else init_callback
+        # Every connection gets pgvector's binary codec before anything else runs on it,
+        # so embeddings are bound as float32 rather than a ~12-bytes-per-dimension text
+        # literal the server has to parse. See engine/db/vector_codec.py for the
+        # measurement and for why a connection that cannot register it (a database that
+        # has not been migrated yet, so the `vector` type does not exist) still works.
+        pool_init = _vector_codec_init(init_callback)
+        pool_init = _application_name_setup(app_name, pool_init) if app_name else pool_init
 
         # init runs once per new connection; setup runs on every acquire, after
         # asyncpg's release-time RESET ALL. Re-running the session GUCs

--- a/hindsight-api-slim/hindsight_api/engine/db/vector_codec.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/vector_codec.py
@@ -1,0 +1,97 @@
+"""Bind ``vector`` values in pgvector's binary format instead of a text literal.
+
+An embedding rendered as ``'[0.1,0.2,...]'`` costs ~12 bytes per dimension on the
+wire and a float parse per dimension on the server. The binary format is 4 bytes per
+dimension and no parse at all. Measured on Postgres 18 + pgvector, 2000 rows x 384d,
+with the statement shape held identical (COPY into a staging table, then
+``INSERT ... SELECT ... RETURNING``):
+
+    COPY text literal -> ::vector    471 ms
+    COPY binary vector                22 ms      21.7x
+
+Against what shipped before (a single ``INSERT ... SELECT unnest($n::vector[])`` of
+text literals, 242 ms) the end-to-end retain write is ~6.5x faster at that size, and
+~1.7x at 50 rows.
+
+**The encoder is deliberately tolerant.** ``set_type_codec`` replaces the codec for
+the whole connection, so once this is registered a caller that still passes a rendered
+literal would otherwise fail with ``DataError`` at runtime. Accepting ``str`` means a
+site that was missed keeps working at exactly its old cost rather than raising —
+the conversion of call sites is then an optimisation, not a correctness cliff.
+
+Only PostgreSQL uses this. Oracle 23ai has no pgvector wire format and keeps the
+text rendering in ``retain.types.embedding_to_pgvector``.
+"""
+
+from __future__ import annotations
+
+import logging
+from array import array
+from struct import pack
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def encode_vector(value: Any) -> bytes | None:
+    """Render an embedding in pgvector's binary wire format: ``dim, 0, float32be...``.
+
+    Accepts every form a caller may hold — the packed ``array('f')`` retain carries, a
+    plain float list, a NumPy array, or an already-rendered literal (see the module
+    docstring for why the literal is still accepted).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        # The slow path, kept only so an unconverted call site cannot fail. Same cost
+        # as before this codec existed, plus one parse.
+        value = _parse_literal(value)
+    elif isinstance(value, array):
+        value = np.frombuffer(value, dtype=np.float32) if value.typecode == "f" else np.asarray(value)
+    values = np.asarray(value, dtype=">f4")
+    if values.ndim != 1:
+        raise ValueError(f"expected a 1-d embedding, got {values.ndim} dimensions")
+    return pack(">HH", values.shape[0], 0) + values.tobytes()
+
+
+def _parse_literal(literal: str) -> np.ndarray:
+    inner = literal.strip()[1:-1]
+    if not inner:
+        return np.empty(0, dtype=np.float32)
+    return np.array(inner.split(","), dtype=np.float32)
+
+
+def decode_vector(value: bytes) -> np.ndarray:
+    """Decode the same wire format back to float32.
+
+    Nothing in the engine currently selects a raw ``vector`` column — the two read
+    sites cast to text explicitly (``embedding::text``) — but a codec must be
+    symmetric, and a future reader should get an array rather than bytes.
+    """
+    return np.frombuffer(value, dtype=">f4", count=-1, offset=4).astype(np.float32)
+
+
+async def register_vector_codec(conn: Any) -> bool:
+    """Install the binary codec on one connection. Returns whether it took.
+
+    Returning False rather than raising is what keeps a database without the pgvector
+    extension usable. ``MemoryEngine.initialize`` runs migrations before it creates the
+    pool, so normally the type exists by the time this runs; the exception is a process
+    started with ``run_migrations=False`` against a database that has not been migrated
+    yet. Those connections keep binding text literals, which the tolerant encoder still
+    accepts, so the failure mode is "no speedup", not "cannot connect".
+    """
+    try:
+        await conn.set_type_codec(
+            "vector",
+            schema="public",
+            encoder=encode_vector,
+            decoder=decode_vector,
+            format="binary",
+        )
+    except Exception as exc:  # noqa: BLE001 - any failure here must degrade, not crash
+        logger.debug("pgvector binary codec not registered (%s); binding text literals", exc)
+        return False
+    return True

--- a/hindsight-api-slim/tests/test_vector_codec.py
+++ b/hindsight-api-slim/tests/test_vector_codec.py
@@ -1,0 +1,74 @@
+"""The pgvector binary codec must accept every form a call site may hold.
+
+``set_type_codec`` replaces the codec for the whole connection, so once the binary
+codec is registered a caller still passing a rendered ``'[0.1,...]'`` literal would
+fail with ``DataError`` at runtime unless the encoder accepts it. These tests pin
+that tolerance — it is what makes the call-site conversion an optimisation rather
+than a correctness cliff.
+"""
+
+from array import array
+
+import numpy as np
+import pytest
+
+from hindsight_api.engine.db.vector_codec import decode_vector, encode_vector
+from hindsight_api.engine.retain.types import embedding_to_pgvector
+
+VALUES = [0.1, -2.5, 3.0, 4.25, 0.0]
+
+
+def _forms(values: list[float]) -> dict[str, object]:
+    """Every representation an embedding reaches the database as."""
+    return {
+        "list": list(values),
+        "ndarray-f32": np.asarray(values, dtype=np.float32),
+        "ndarray-f64": np.asarray(values, dtype=np.float64),
+        "array-f": array("f", values),
+        "literal": embedding_to_pgvector(np.asarray(values, dtype=np.float32)),
+    }
+
+
+def test_every_input_form_encodes_to_the_same_bytes():
+    encoded = {name: encode_vector(v) for name, v in _forms(VALUES).items()}
+    assert len(set(encoded.values())) == 1, f"forms disagree: { {k: len(v) for k, v in encoded.items()} }"
+
+
+def test_wire_format_is_dim_then_float32_big_endian():
+    """4-byte header (dim, unused) + 4 bytes per dimension — pgvector's binary layout."""
+    raw = encode_vector(VALUES)
+    assert len(raw) == 4 + 4 * len(VALUES)
+    assert raw[:4] == bytes([0, len(VALUES), 0, 0])
+
+
+def test_round_trips_through_decode():
+    assert np.allclose(decode_vector(encode_vector(VALUES)), np.asarray(VALUES, dtype=np.float32))
+
+
+def test_binary_is_smaller_than_the_literal_it_replaces():
+    """The reason this exists: ~4 bytes per dimension instead of ~12."""
+    values = np.random.default_rng(0).standard_normal(384).astype(np.float32)
+    assert len(encode_vector(values)) * 3 < len(embedding_to_pgvector(values))
+
+
+def test_none_passes_through():
+    """A NULL embedding must stay NULL rather than become an empty vector."""
+    assert encode_vector(None) is None
+
+
+def test_empty_literal_is_an_empty_vector():
+    assert len(encode_vector("[]")) == 4
+
+
+def test_rejects_a_2d_array():
+    """An array of vectors cannot be bound: asyncpg hands the whole list to this
+    encoder rather than each element, so failing loudly beats silently storing the
+    first row. See the module docstring on `unnest($n::vector[])`."""
+    with pytest.raises(ValueError, match="1-d"):
+        encode_vector(np.zeros((2, 4), dtype=np.float32))
+
+
+def test_float64_is_narrowed_the_same_way_the_column_stores_it():
+    """float32 is the column's width; a value must land on the same float32 either way."""
+    values = np.random.default_rng(1).standard_normal(64)
+    assert encode_vector(values) == encode_vector(values.astype(np.float32))


### PR DESCRIPTION
**Draft** — this is the enabling half. It makes binary binds possible and safe; it does not yet convert the call site where the win lives (see *What this does not do*).

## Measurement

Postgres 18 + pgvector, 2000 rows x 384d, **statement shape held identical** (COPY into a staging table, then `INSERT … SELECT … RETURNING`), so the codec is the only variable:

| | time |
|---|---|
| COPY text literal → `::vector` | 471 ms |
| COPY binary vector | **22 ms** (21.7x) |

An embedding as `'[0.1,...]'` is ~12 bytes/dimension plus a server-side float parse per dimension; binary is 4 bytes/dimension and no parse.

## What this does not do — both decided by measurement, not taste

- **Single-vector binds are left alone.** 21 of the 22 `$n::vector` sites bind one query vector. There binary saves **34 µs per query** (0.147 ms → 0.114 ms) — about 0.1% of a recall. Not worth the call-site churn.
- **The bulk insert is left alone.** An array of vectors **cannot** be bound in binary at all — asyncpg hands the whole list to the scalar encoder. Capturing the win on `insert_facts_batch` means restructuring it into COPY-to-staging + `INSERT … SELECT` (with an explicit `ORDER BY ord`, since the caller maps `RETURNING id` by position). That is a change to retain's central write path and belongs in its own PR, with its own measurement of what share of a real run it moves — in the pipelines I sampled, `db_write` is ~5% of a run, so this is a bulk-ingest win and close to nothing elsewhere.

## Why the encoder is tolerant

`set_type_codec` replaces the codec for the **whole connection** — it is all-or-nothing. Once registered, any caller still passing a rendered literal would fail with `DataError` at runtime. So the encoder accepts `str` as well as ndarray / list / `array('f')`. A site that was missed keeps working at exactly its old cost; conversion becomes an optimisation rather than a correctness cliff.

Verified against a real Postgres:
- ndarray, list and text literal all bind through one connection and store **identical bytes**
- the existing `unnest($n::vector[])` batch insert is **unaffected**
- binary `COPY` into a `vector` column works

## Safety

- **Reads are untouched.** Nothing selects a raw `vector` column — both read sites cast with `embedding::text` — so the decoder is not on any current path.
- **A database without the extension still works.** `register_vector_codec` returns `False` instead of raising, and those connections bind text literals. Migrations run before the pool is created, so this only affects a process started with `run_migrations=False` against an unmigrated database.
- **Oracle is unaffected** — it keeps the text rendering in `retain.types.embedding_to_pgvector`; there is no pgvector wire format there.
- `pgvector` is already a dependency and is pure Python, so no free-threading risk on the `-py3.14t` image.

8 unit tests pin the tolerance contract (every input form encodes to identical bytes, the wire layout, `None` passthrough, and that a 2-d array fails loudly rather than silently storing one row).

https://claude.ai/code/session_018HDqrzHgqZqsGc7EDqoTEu