### PR TITLE
fix(api): paginate GET /observations/scopes and GET /webhooks

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1596,12 +1596,18 @@ class ObservationScopesResponse(BaseModel):
                     {"tags": ["user:alice"], "count": 12},
                     {"tags": ["user:alice", "project:apollo"], "count": 4},
                     {"tags": [], "count": 2},
-                ]
+                ],
+                "total": 3,
+                "limit": 100,
+                "offset": 0,
             }
         }
     )
 
     scopes: list[ObservationScope] = Field(description="Distinct observation scopes, most populous first")
+    total: int = Field(description="Total number of distinct scopes in the bank (ignores limit/offset)")
+    limit: int = Field(description="Maximum number of scopes returned in this page")
+    offset: int = Field(description="Offset this page started at")
 
 
 class ListMemoryUnitsResponse(BaseModel):
@@ -3739,6 +3745,9 @@ class WebhookListResponse(BaseModel):
     """Response model for listing webhooks."""
 
     items: list[WebhookResponse]
+    total: int = Field(description="Total number of webhooks on the bank (ignores limit/offset)")
+    limit: int = Field(description="Maximum number of webhooks returned in this page")
+    offset: int = Field(description="Offset this page started at")
 
 
 class WebhookDeliveryResponse(BaseModel):
@@ -7733,15 +7742,23 @@ def _register_routes(app: FastAPI):
             "under a scope: the exact set of tags it was consolidated with. Returns every distinct "
             "scope (tag order normalized) with the number of observations in it; the empty tag list "
             "is the global/untagged scope. Use a returned scope with the graph endpoint "
-            "(tags=<scope> & tags_match=exact) to filter observations to exactly that scope."
+            "(tags=<scope> & tags_match=exact) to filter observations to exactly that scope. "
+            "Paged: `total` reports every distinct scope in the bank."
         ),
         operation_id="list_observation_scopes",
         tags=["Memory"],
     )
-    async def api_list_observation_scopes(bank_id: str, request_context: RequestContext = Depends(get_request_context)):
+    async def api_list_observation_scopes(
+        bank_id: str,
+        limit: int = Query(default=100, ge=0, le=1000, description="Maximum number of scopes to return"),
+        offset: int = Query(default=0, ge=0, description="Offset for pagination"),
+        request_context: RequestContext = Depends(get_request_context),
+    ):
         """List the distinct observation scopes (exact tag sets) for a bank."""
         try:
-            return await app.state.memory.list_observation_scopes(bank_id, request_context=request_context)
+            return await app.state.memory.list_observation_scopes(
+                bank_id, limit=limit, offset=offset, request_context=request_context
+            )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):
@@ -8056,18 +8073,23 @@ def _register_routes(app: FastAPI):
         "/v1/default/banks/{bank_id}/webhooks",
         response_model=WebhookListResponse,
         summary="List webhooks",
-        description="List all webhooks registered for a bank.",
+        description="List the webhooks registered for a bank, oldest first. "
+        "Paged: `total` reports every webhook on the bank.",
         operation_id="list_webhooks",
         tags=["Webhooks"],
     )
     async def api_list_webhooks(
         bank_id: str,
+        limit: int = Query(default=100, ge=0, le=1000, description="Maximum number of webhooks to return"),
+        offset: int = Query(default=0, ge=0, description="Offset for pagination"),
         request_context: RequestContext = Depends(get_request_context),
     ):
         """List webhooks for a bank."""
         try:
-            rows = await app.state.memory.list_webhooks(
+            data = await app.state.memory.list_webhooks(
                 bank_id,
+                limit=limit,
+                offset=offset,
                 request_context=request_context,
             )
 
@@ -8096,7 +8118,12 @@ def _register_routes(app: FastAPI):
                     else str(row["updated_at"]),
                 )
 
-            return WebhookListResponse(items=[_parse_webhook_row(row) for row in rows])
+            return WebhookListResponse(
+                items=[_parse_webhook_row(row) for row in data["items"]],
+                total=data["total"],
+                limit=data["limit"],
+                offset=data["offset"],
+            )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):

--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -614,8 +614,24 @@ class DataAccessOps(ABC):
         conn: DatabaseConnection,
         table: str,
         bank_id: str,
+        limit: int,
+        offset: int,
     ) -> list[ResultRow]:
-        """List all webhooks for a bank, ordered by created_at."""
+        """One page of a bank's webhooks, ordered by created_at then id.
+
+        The id breaks ties so a page boundary never falls inside a group of rows
+        that share a created_at.
+        """
+        ...
+
+    @abstractmethod
+    async def count_webhooks_for_bank(
+        self,
+        conn: DatabaseConnection,
+        table: str,
+        bank_id: str,
+    ) -> int:
+        """Total number of webhooks registered for a bank."""
         ...
 
     @abstractmethod

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -914,17 +914,24 @@ class OracleOps(DataAccessOps):
             http_config_json,
         )
 
-    async def list_webhooks_for_bank(self, conn, table, bank_id):
+    async def list_webhooks_for_bank(self, conn, table, bank_id, limit, offset):
         return await conn.fetch(
             f"""
             SELECT id, bank_id, url, secret, event_types, enabled,
                    http_config::text, created_at::text, updated_at::text
             FROM {table}
             WHERE bank_id = $1
-            ORDER BY created_at
+            ORDER BY created_at, id
+            LIMIT $2 OFFSET $3
             """,
             bank_id,
+            limit,
+            offset,
         )
+
+    async def count_webhooks_for_bank(self, conn, table, bank_id):
+        row = await conn.fetchrow(f"SELECT COUNT(*) AS total FROM {table} WHERE bank_id = $1", bank_id)
+        return int(row["total"]) if row else 0
 
     async def get_webhooks_for_dispatch(self, conn, webhook_table, bank_id):
         return await conn.fetch(

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -1166,17 +1166,24 @@ class PostgreSQLOps(DataAccessOps):
             http_config_json,
         )
 
-    async def list_webhooks_for_bank(self, conn, table, bank_id):
+    async def list_webhooks_for_bank(self, conn, table, bank_id, limit, offset):
         return await conn.fetch(
             f"""
             SELECT id, bank_id, url, secret, event_types, enabled,
                    http_config::text, created_at::text, updated_at::text
             FROM {table}
             WHERE bank_id = $1
-            ORDER BY created_at
+            ORDER BY created_at, id
+            LIMIT $2 OFFSET $3
             """,
             bank_id,
+            limit,
+            offset,
         )
+
+    async def count_webhooks_for_bank(self, conn, table, bank_id):
+        row = await conn.fetchrow(f"SELECT COUNT(*) AS total FROM {table} WHERE bank_id = $1", bank_id)
+        return int(row["total"]) if row else 0
 
     async def get_webhooks_for_dispatch(self, conn, webhook_table, bank_id):
         return await conn.fetch(

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -1613,11 +1613,18 @@ class MemoriesExtension(Extension, ABC):
         """
         raise NotImplementedError
 
-    async def observation_scope_counts(self, *, conn, fq_table, bank_id: str) -> list[dict[str, Any]]:
-        """``[{"tags": list[str], "count": int}]`` — observations grouped by scope.
+    async def observation_scope_counts(
+        self, *, conn, fq_table, bank_id: str, limit: int = 100, offset: int = 0
+    ) -> dict[str, Any]:
+        """One page of the observation scope histogram, paged by the store.
 
-        A scope is the sorted set of tags an observation was consolidated with;
-        ``[]`` is the global (untagged) scope. Most-populous first.
+        Returns ``{"scopes": [{"tags": list[str], "count": int}], "total",
+        "limit", "offset"}``. A scope is the sorted set of tags an observation
+        was consolidated with; ``[]`` is the global (untagged) scope.
+        Most-populous first, then scope ascending. ``total`` counts every
+        distinct scope, not just the page — a bank has as many scopes as it has
+        distinct tag sets, so the store must not ship them all for the caller
+        to trim.
         """
         raise NotImplementedError
 

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/counts.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/counts.py
@@ -141,22 +141,54 @@ async def memories_timeseries(
     return [{"bucket": r["bucket"], "fact_type": r["fact_type"], "count": r["count"]} for r in rows]
 
 
-async def observation_scope_counts(*, conn, fq_table: Callable[[str], str], bank_id: str) -> list[dict[str, Any]]:
-    """Observations grouped by scope (their sorted tag set), most-populous first."""
-    rows = await conn.fetch(
+async def observation_scope_counts(
+    *,
+    conn,
+    fq_table: Callable[[str], str],
+    bank_id: str,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """One page of the bank's observation scope histogram.
+
+    Returns ``{"scopes": [{tags, count}], "total", "limit", "offset"}``. A bank
+    can hold as many distinct scopes as it has distinct tag sets, so the
+    grouping, the ``count DESC, scope ASC`` ordering and the paging all run in
+    SQL — the whole histogram never crosses the wire.
+    """
+    scopes_select = f"""
+        SELECT COALESCE(ARRAY(SELECT unnest(tags) ORDER BY 1), '{{}}'::text[]) AS scope
+        FROM {fq_table("memory_units")}
+        WHERE bank_id = $1 AND fact_type = 'observation'
+    """
+
+    total_row = await conn.fetchrow(
         f"""
-        SELECT scope, COUNT(*) AS count
-        FROM (
-            SELECT COALESCE(ARRAY(SELECT unnest(tags) ORDER BY 1), '{{}}'::text[]) AS scope
-            FROM {fq_table("memory_units")}
-            WHERE bank_id = $1 AND fact_type = 'observation'
-        ) s
-        GROUP BY scope
-        ORDER BY count DESC, scope
+        SELECT COUNT(*) AS total
+        FROM (SELECT DISTINCT scope FROM ({scopes_select}) s) d
         """,
         bank_id,
     )
-    return [{"tags": list(r["scope"]), "count": r["count"]} for r in rows]
+    total = int(total_row["total"]) if total_row else 0
+
+    rows = await conn.fetch(
+        f"""
+        SELECT scope, COUNT(*) AS count
+        FROM ({scopes_select}) s
+        GROUP BY scope
+        ORDER BY count DESC, scope
+        LIMIT $2 OFFSET $3
+        """,
+        bank_id,
+        limit,
+        offset,
+    )
+    return {
+        "scopes": [{"tags": list(r["scope"]), "count": int(r["count"])} for r in rows],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
 
 
 __all__ = [

--- a/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
@@ -451,8 +451,12 @@ class PostgresMemories(MemoriesExtension):
             conn=conn, fq_table=fq_table, bank_id=bank_id, time_field=time_field, trunc=trunc, since=since
         )
 
-    async def observation_scope_counts(self, *, conn, fq_table, bank_id: str) -> list[dict[str, Any]]:
-        return await counts.observation_scope_counts(conn=conn, fq_table=fq_table, bank_id=bank_id)
+    async def observation_scope_counts(
+        self, *, conn, fq_table, bank_id: str, limit: int = 100, offset: int = 0
+    ) -> dict[str, Any]:
+        return await counts.observation_scope_counts(
+            conn=conn, fq_table=fq_table, bank_id=bank_id, limit=limit, offset=offset
+        )
 
     # ------------------------------------------------------------------ observations
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -9669,6 +9669,8 @@ class MemoryEngine(MemoryEngineInterface):
         self,
         bank_id: str,
         *,
+        limit: int = 100,
+        offset: int = 0,
         request_context: "RequestContext",
     ) -> dict[str, Any]:
         """List the distinct scopes across a bank's observations.
@@ -9679,8 +9681,15 @@ class MemoryEngine(MemoryEngineInterface):
         number of observations in it. The empty list ``[]`` is the "global" scope
         of untagged observations. Results are ordered most-populous first.
 
+        Args:
+            bank_id: Bank identifier
+            limit: Maximum number of scopes to return
+            offset: Offset for pagination
+            request_context: Request context for authentication.
+
         Returns:
-            Dict with ``scopes``: list of ``{"tags": list[str], "count": int}``.
+            Dict with ``scopes`` (list of ``{"tags": list[str], "count": int}``),
+            ``total`` (distinct scopes in the bank), ``limit`` and ``offset``.
         """
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
@@ -9694,8 +9703,9 @@ class MemoryEngine(MemoryEngineInterface):
         from .memories import get_memories
 
         async with acquire_with_retry(backend) as conn:
-            scopes = await get_memories().observation_scope_counts(conn=conn, fq_table=fq_table, bank_id=bank_id)
-        return {"scopes": scopes}
+            return await get_memories().observation_scope_counts(
+                conn=conn, fq_table=fq_table, bank_id=bank_id, limit=limit, offset=offset
+            )
 
     async def retry_failed_consolidation(
         self,
@@ -19048,9 +19058,16 @@ class MemoryEngine(MemoryEngineInterface):
         self,
         bank_id: str,
         *,
+        limit: int = 100,
+        offset: int = 0,
         request_context: "RequestContext",
-    ) -> list[dict[str, Any]]:
-        """List webhooks for a bank in the bank's resolved schema."""
+    ) -> dict[str, Any]:
+        """One page of a bank's webhooks, from the bank's resolved schema.
+
+        Returns ``{"items": [row], "total", "limit", "offset"}``, ordered by
+        created_at then id. ``total`` counts every webhook on the bank, not just
+        the page.
+        """
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
             from hindsight_api.extensions import BankReadContext, BankReadOperation
@@ -19062,12 +19079,24 @@ class MemoryEngine(MemoryEngineInterface):
 
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
-            rows = await backend.ops.list_webhooks_for_bank(
+            total = await backend.ops.count_webhooks_for_bank(
                 conn,
                 fq_table("webhooks"),
                 bank_id,
             )
-        return [dict(row) for row in rows]
+            rows = await backend.ops.list_webhooks_for_bank(
+                conn,
+                fq_table("webhooks"),
+                bank_id,
+                limit,
+                offset,
+            )
+        return {
+            "items": [dict(row) for row in rows],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
 
     async def update_webhook(
         self,

--- a/hindsight-api-slim/tests/test_graph_filtering.py
+++ b/hindsight-api-slim/tests/test_graph_filtering.py
@@ -316,6 +316,47 @@ async def test_observation_scopes_enumeration(memory, api_client, test_bank_id, 
 
 @pytest.mark.asyncio
 @pytest.mark.memory_backend_incompatible
+async def test_observation_scopes_pagination(memory, api_client, test_bank_id, request_context):
+    """The scopes endpoint pages: each page is capped, total counts every scope."""
+    await _seed_scoped_observations(memory, test_bank_id, request_context)
+
+    first = await api_client.get(
+        f"/v1/default/banks/{test_bank_id}/observations/scopes",
+        params={"limit": 2, "offset": 0},
+    )
+    assert first.status_code == 200
+    first_data = first.json()
+    assert first_data["total"] == 4
+    assert first_data["limit"] == 2
+    assert first_data["offset"] == 0
+    assert len(first_data["scopes"]) == 2
+
+    second = await api_client.get(
+        f"/v1/default/banks/{test_bank_id}/observations/scopes",
+        params={"limit": 2, "offset": 2},
+    )
+    assert second.status_code == 200
+    second_data = second.json()
+    assert second_data["total"] == 4
+    assert second_data["offset"] == 2
+    assert len(second_data["scopes"]) == 2
+
+    # The two pages are disjoint and together enumerate every scope, in one stable order.
+    paged = [tuple(scope["tags"]) for scope in first_data["scopes"] + second_data["scopes"]]
+    assert len(set(paged)) == 4
+
+    # Past the end: no scopes, but total still reports the whole histogram.
+    beyond = await api_client.get(
+        f"/v1/default/banks/{test_bank_id}/observations/scopes",
+        params={"limit": 2, "offset": 10},
+    )
+    assert beyond.status_code == 200
+    assert beyond.json()["scopes"] == []
+    assert beyond.json()["total"] == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
 async def test_graph_exact_scope_filter(memory, api_client, test_bank_id, request_context):
     """tags_match=exact filters observations to exactly one scope, not supersets."""
     await _seed_scoped_observations(memory, test_bank_id, request_context)

--- a/hindsight-api-slim/tests/test_memories_extension.py
+++ b/hindsight-api-slim/tests/test_memories_extension.py
@@ -659,9 +659,25 @@ class InMemoryMemories(MemoriesExtension):
         self.calls.append("memories_timeseries")
         return []
 
-    async def observation_scope_counts(self, *, conn, fq_table, bank_id):
+    async def observation_scope_counts(self, *, conn, fq_table, bank_id, limit=100, offset=0):
         self.calls.append("observation_scope_counts")
-        return []
+        # Same paged shape as list_tags above: the histogram is the store's to group,
+        # order and page, so the stub does it over its own rows rather than shipping
+        # every scope back for the engine to trim.
+        counts: dict[tuple[str, ...], int] = {}
+        for row in self.rows.values():
+            if row.fact_type != "observation":
+                continue
+            scope = tuple(sorted(row.tags or []))
+            counts[scope] = counts.get(scope, 0) + 1
+        scopes = [{"tags": list(scope), "count": count} for scope, count in counts.items()]
+        scopes.sort(key=lambda it: (-it["count"], it["tags"]))
+        return {
+            "scopes": scopes[offset : offset + limit],
+            "total": len(scopes),
+            "limit": limit,
+            "offset": offset,
+        }
 
     # -- the knowledge-page index -------------------------------------------
     #

--- a/hindsight-api-slim/tests/test_webhooks.py
+++ b/hindsight-api-slim/tests/test_webhooks.py
@@ -790,6 +790,49 @@ class TestWebhookHttpApi:
         await api_client.delete(f"/v1/default/banks/{bank_id}/webhooks/{webhook_id}")
 
     @pytest.mark.asyncio
+    async def test_http_list_webhooks_pagination(self, api_client: httpx.AsyncClient):
+        """GET /webhooks pages: each page is capped and total counts every webhook."""
+        bank_id = f"http-wh-{uuid.uuid4().hex[:8]}"
+
+        created = []
+        for i in range(3):
+            resp = await api_client.post(
+                f"/v1/default/banks/{bank_id}/webhooks",
+                json={"url": f"https://example.com/page-{i}", "event_types": ["consolidation.completed"]},
+            )
+            assert resp.status_code == 201
+            created.append(resp.json()["id"])
+
+        try:
+            first = await api_client.get(
+                f"/v1/default/banks/{bank_id}/webhooks",
+                params={"limit": 2, "offset": 0},
+            )
+            assert first.status_code == 200
+            first_data = first.json()
+            assert first_data["total"] == 3
+            assert first_data["limit"] == 2
+            assert first_data["offset"] == 0
+            assert len(first_data["items"]) == 2
+
+            second = await api_client.get(
+                f"/v1/default/banks/{bank_id}/webhooks",
+                params={"limit": 2, "offset": 2},
+            )
+            assert second.status_code == 200
+            second_data = second.json()
+            assert second_data["total"] == 3
+            assert second_data["offset"] == 2
+            assert len(second_data["items"]) == 1
+
+            # The pages are disjoint and together cover every webhook on the bank.
+            paged_ids = [item["id"] for item in first_data["items"] + second_data["items"]]
+            assert sorted(paged_ids) == sorted(created)
+        finally:
+            for webhook_id in created:
+                await api_client.delete(f"/v1/default/banks/{bank_id}/webhooks/{webhook_id}")
+
+    @pytest.mark.asyncio
     async def test_http_delete_webhook(self, api_client: httpx.AsyncClient):
         """DELETE /webhooks/{id} removes the webhook; subsequent list returns empty for that bank."""
         bank_id = f"http-wh-{uuid.uuid4().hex[:8]}"

--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -1193,7 +1193,7 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::WebhookListResponse> {
         self.runtime.block_on(async {
-            let response = self.client.list_webhooks(bank_id, None).await?;
+            let response = self.client.list_webhooks(bank_id, None, None, None).await?;
             Ok(response.into_inner())
         })
     }

--- a/hindsight-cli/src/commands/webhook.rs
+++ b/hindsight-cli/src/commands/webhook.rs
@@ -45,6 +45,15 @@ pub fn list(
                 }
                 println!();
             }
+            // The listing is paged server-side; say so rather than quietly
+            // showing the first page as if it were everything.
+            let shown = result.items.len() as i64;
+            if shown < result.total {
+                println!(
+                    "  {}",
+                    ui::dim(&format!("Showing {} of {} webhooks.", shown, result.total))
+                );
+            }
         }
     } else {
         output::print_output(&result, output_format)?;

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -3592,7 +3592,8 @@ paths:
         \ with. Returns every distinct scope (tag order normalized) with the number\
         \ of observations in it; the empty tag list is the global/untagged scope.\
         \ Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact)\
-        \ to filter observations to exactly that scope."
+        \ to filter observations to exactly that scope. Paged: `total` reports every\
+        \ distinct scope in the bank."
       operationId: list_observation_scopes
       parameters:
       - explode: false
@@ -3603,6 +3604,31 @@ paths:
           title: Bank Id
           type: string
         style: simple
+      - description: Maximum number of scopes to return
+        explode: true
+        in: query
+        name: limit
+        required: false
+        schema:
+          default: 100
+          description: Maximum number of scopes to return
+          maximum: 1000
+          minimum: 0
+          title: Limit
+          type: integer
+        style: form
+      - description: Offset for pagination
+        explode: true
+        in: query
+        name: offset
+        required: false
+        schema:
+          default: 0
+          description: Offset for pagination
+          minimum: 0
+          title: Offset
+          type: integer
+        style: form
       - explode: false
         in: header
         name: authorization
@@ -3881,7 +3907,8 @@ paths:
       - Banks
   /v1/default/banks/{bank_id}/webhooks:
     get:
-      description: List all webhooks registered for a bank.
+      description: "List the webhooks registered for a bank, oldest first. Paged:\
+        \ `total` reports every webhook on the bank."
       operationId: list_webhooks
       parameters:
       - explode: false
@@ -3892,6 +3919,31 @@ paths:
           title: Bank Id
           type: string
         style: simple
+      - description: Maximum number of webhooks to return
+        explode: true
+        in: query
+        name: limit
+        required: false
+        schema:
+          default: 100
+          description: Maximum number of webhooks to return
+          maximum: 1000
+          minimum: 0
+          title: Limit
+          type: integer
+        style: form
+      - description: Offset for pagination
+        explode: true
+        in: query
+        name: offset
+        required: false
+        schema:
+          default: 0
+          description: Offset for pagination
+          minimum: 0
+          title: Offset
+          type: integer
+        style: form
       - explode: false
         in: header
         name: authorization
@@ -9032,6 +9084,8 @@ components:
     ObservationScopesResponse:
       description: Response model for the observation scopes enumeration endpoint.
       example:
+        limit: 100
+        offset: 0
         scopes:
         - count: 12
           tags:
@@ -9042,14 +9096,30 @@ components:
           - project:apollo
         - count: 2
           tags: []
+        total: 3
       properties:
         scopes:
           description: "Distinct observation scopes, most populous first"
           items:
             $ref: '#/components/schemas/ObservationScope'
           type: array
+        total:
+          description: Total number of distinct scopes in the bank (ignores limit/offset)
+          title: Total
+          type: integer
+        limit:
+          description: Maximum number of scopes returned in this page
+          title: Limit
+          type: integer
+        offset:
+          description: Offset this page started at
+          title: Offset
+          type: integer
       required:
+      - limit
+      - offset
       - scopes
+      - total
       title: ObservationScopesResponse
     OperationProgress:
       description: |-
@@ -10626,6 +10696,9 @@ components:
     WebhookListResponse:
       description: Response model for listing webhooks.
       example:
+        total: 6
+        offset: 5
+        limit: 1
         items:
         - event_types:
           - event_types
@@ -10666,8 +10739,23 @@ components:
           items:
             $ref: '#/components/schemas/WebhookResponse'
           type: array
+        total:
+          description: Total number of webhooks on the bank (ignores limit/offset)
+          title: Total
+          type: integer
+        limit:
+          description: Maximum number of webhooks returned in this page
+          title: Limit
+          type: integer
+        offset:
+          description: Offset this page started at
+          title: Offset
+          type: integer
       required:
       - items
+      - limit
+      - offset
+      - total
       title: WebhookListResponse
     WebhookResponse:
       description: Response model for a webhook.

--- a/hindsight-clients/go/api_memory.go
+++ b/hindsight-clients/go/api_memory.go
@@ -1099,7 +1099,21 @@ type ApiListObservationScopesRequest struct {
 	ctx context.Context
 	ApiService *MemoryAPIService
 	bankId string
+	limit *int32
+	offset *int32
 	authorization *string
+}
+
+// Maximum number of scopes to return
+func (r ApiListObservationScopesRequest) Limit(limit int32) ApiListObservationScopesRequest {
+	r.limit = &limit
+	return r
+}
+
+// Offset for pagination
+func (r ApiListObservationScopesRequest) Offset(offset int32) ApiListObservationScopesRequest {
+	r.offset = &offset
+	return r
 }
 
 func (r ApiListObservationScopesRequest) Authorization(authorization string) ApiListObservationScopesRequest {
@@ -1114,7 +1128,7 @@ func (r ApiListObservationScopesRequest) Execute() (*ObservationScopesResponse, 
 /*
 ListObservationScopes List observation scopes
 
-Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope.
+Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope. Paged: `total` reports every distinct scope in the bank.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId
@@ -1150,6 +1164,18 @@ func (a *MemoryAPIService) ListObservationScopesExecute(r ApiListObservationScop
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.limit != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "limit", r.limit, "form", "")
+	} else {
+		var defaultValue int32 = 100
+		r.limit = &defaultValue
+	}
+	if r.offset != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "offset", r.offset, "form", "")
+	} else {
+		var defaultValue int32 = 0
+		r.offset = &defaultValue
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/hindsight-clients/go/api_webhooks.go
+++ b/hindsight-clients/go/api_webhooks.go
@@ -435,7 +435,21 @@ type ApiListWebhooksRequest struct {
 	ctx context.Context
 	ApiService *WebhooksAPIService
 	bankId string
+	limit *int32
+	offset *int32
 	authorization *string
+}
+
+// Maximum number of webhooks to return
+func (r ApiListWebhooksRequest) Limit(limit int32) ApiListWebhooksRequest {
+	r.limit = &limit
+	return r
+}
+
+// Offset for pagination
+func (r ApiListWebhooksRequest) Offset(offset int32) ApiListWebhooksRequest {
+	r.offset = &offset
+	return r
 }
 
 func (r ApiListWebhooksRequest) Authorization(authorization string) ApiListWebhooksRequest {
@@ -450,7 +464,7 @@ func (r ApiListWebhooksRequest) Execute() (*WebhookListResponse, *http.Response,
 /*
 ListWebhooks List webhooks
 
-List all webhooks registered for a bank.
+List the webhooks registered for a bank, oldest first. Paged: `total` reports every webhook on the bank.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId
@@ -486,6 +500,18 @@ func (a *WebhooksAPIService) ListWebhooksExecute(r ApiListWebhooksRequest) (*Web
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.limit != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "limit", r.limit, "form", "")
+	} else {
+		var defaultValue int32 = 100
+		r.limit = &defaultValue
+	}
+	if r.offset != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "offset", r.offset, "form", "")
+	} else {
+		var defaultValue int32 = 0
+		r.offset = &defaultValue
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/hindsight-clients/go/model_observation_scopes_response.go
+++ b/hindsight-clients/go/model_observation_scopes_response.go
@@ -23,6 +23,12 @@ var _ MappedNullable = &ObservationScopesResponse{}
 type ObservationScopesResponse struct {
 	// Distinct observation scopes, most populous first
 	Scopes []ObservationScope `json:"scopes"`
+	// Total number of distinct scopes in the bank (ignores limit/offset)
+	Total int32 `json:"total"`
+	// Maximum number of scopes returned in this page
+	Limit int32 `json:"limit"`
+	// Offset this page started at
+	Offset int32 `json:"offset"`
 }
 
 type _ObservationScopesResponse ObservationScopesResponse
@@ -31,9 +37,12 @@ type _ObservationScopesResponse ObservationScopesResponse
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewObservationScopesResponse(scopes []ObservationScope) *ObservationScopesResponse {
+func NewObservationScopesResponse(scopes []ObservationScope, total int32, limit int32, offset int32) *ObservationScopesResponse {
 	this := ObservationScopesResponse{}
 	this.Scopes = scopes
+	this.Total = total
+	this.Limit = limit
+	this.Offset = offset
 	return &this
 }
 
@@ -69,6 +78,78 @@ func (o *ObservationScopesResponse) SetScopes(v []ObservationScope) {
 	o.Scopes = v
 }
 
+// GetTotal returns the Total field value
+func (o *ObservationScopesResponse) GetTotal() int32 {
+	if o == nil {
+		var ret int32
+		return ret
+	}
+
+	return o.Total
+}
+
+// GetTotalOk returns a tuple with the Total field value
+// and a boolean to check if the value has been set.
+func (o *ObservationScopesResponse) GetTotalOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Total, true
+}
+
+// SetTotal sets field value
+func (o *ObservationScopesResponse) SetTotal(v int32) {
+	o.Total = v
+}
+
+// GetLimit returns the Limit field value
+func (o *ObservationScopesResponse) GetLimit() int32 {
+	if o == nil {
+		var ret int32
+		return ret
+	}
+
+	return o.Limit
+}
+
+// GetLimitOk returns a tuple with the Limit field value
+// and a boolean to check if the value has been set.
+func (o *ObservationScopesResponse) GetLimitOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Limit, true
+}
+
+// SetLimit sets field value
+func (o *ObservationScopesResponse) SetLimit(v int32) {
+	o.Limit = v
+}
+
+// GetOffset returns the Offset field value
+func (o *ObservationScopesResponse) GetOffset() int32 {
+	if o == nil {
+		var ret int32
+		return ret
+	}
+
+	return o.Offset
+}
+
+// GetOffsetOk returns a tuple with the Offset field value
+// and a boolean to check if the value has been set.
+func (o *ObservationScopesResponse) GetOffsetOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Offset, true
+}
+
+// SetOffset sets field value
+func (o *ObservationScopesResponse) SetOffset(v int32) {
+	o.Offset = v
+}
+
 func (o ObservationScopesResponse) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -80,6 +161,9 @@ func (o ObservationScopesResponse) MarshalJSON() ([]byte, error) {
 func (o ObservationScopesResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["scopes"] = o.Scopes
+	toSerialize["total"] = o.Total
+	toSerialize["limit"] = o.Limit
+	toSerialize["offset"] = o.Offset
 	return toSerialize, nil
 }
 
@@ -89,6 +173,9 @@ func (o *ObservationScopesResponse) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"scopes",
+		"total",
+		"limit",
+		"offset",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/hindsight-clients/go/model_webhook_list_response.go
+++ b/hindsight-clients/go/model_webhook_list_response.go
@@ -22,6 +22,12 @@ var _ MappedNullable = &WebhookListResponse{}
 // WebhookListResponse Response model for listing webhooks.
 type WebhookListResponse struct {
 	Items []WebhookResponse `json:"items"`
+	// Total number of webhooks on the bank (ignores limit/offset)
+	Total int32 `json:"total"`
+	// Maximum number of webhooks returned in this page
+	Limit int32 `json:"limit"`
+	// Offset this page started at
+	Offset int32 `json:"offset"`
 }
 
 type _WebhookListResponse WebhookListResponse
@@ -30,9 +36,12 @@ type _WebhookListResponse WebhookListResponse
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewWebhookListResponse(items []WebhookResponse) *WebhookListResponse {
+func NewWebhookListResponse(items []WebhookResponse, total int32, limit int32, offset int32) *WebhookListResponse {
 	this := WebhookListResponse{}
 	this.Items = items
+	this.Total = total
+	this.Limit = limit
+	this.Offset = offset
 	return &this
 }
 
@@ -68,6 +77,78 @@ func (o *WebhookListResponse) SetItems(v []WebhookResponse) {
 	o.Items = v
 }
 
+// GetTotal returns the Total field value
+func (o *WebhookListResponse) GetTotal() int32 {
+	if o == nil {
+		var ret int32
+		return ret
+	}
+
+	return o.Total
+}
+
+// GetTotalOk returns a tuple with the Total field value
+// and a boolean to check if the value has been set.
+func (o *WebhookListResponse) GetTotalOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Total, true
+}
+
+// SetTotal sets field value
+func (o *WebhookListResponse) SetTotal(v int32) {
+	o.Total = v
+}
+
+// GetLimit returns the Limit field value
+func (o *WebhookListResponse) GetLimit() int32 {
+	if o == nil {
+		var ret int32
+		return ret
+	}
+
+	return o.Limit
+}
+
+// GetLimitOk returns a tuple with the Limit field value
+// and a boolean to check if the value has been set.
+func (o *WebhookListResponse) GetLimitOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Limit, true
+}
+
+// SetLimit sets field value
+func (o *WebhookListResponse) SetLimit(v int32) {
+	o.Limit = v
+}
+
+// GetOffset returns the Offset field value
+func (o *WebhookListResponse) GetOffset() int32 {
+	if o == nil {
+		var ret int32
+		return ret
+	}
+
+	return o.Offset
+}
+
+// GetOffsetOk returns a tuple with the Offset field value
+// and a boolean to check if the value has been set.
+func (o *WebhookListResponse) GetOffsetOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Offset, true
+}
+
+// SetOffset sets field value
+func (o *WebhookListResponse) SetOffset(v int32) {
+	o.Offset = v
+}
+
 func (o WebhookListResponse) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -79,6 +160,9 @@ func (o WebhookListResponse) MarshalJSON() ([]byte, error) {
 func (o WebhookListResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["items"] = o.Items
+	toSerialize["total"] = o.Total
+	toSerialize["limit"] = o.Limit
+	toSerialize["offset"] = o.Offset
 	return toSerialize, nil
 }
 
@@ -88,6 +172,9 @@ func (o *WebhookListResponse) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"items",
+		"total",
+		"limit",
+		"offset",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/hindsight-clients/python/hindsight_client_api/api/memory_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/memory_api.py
@@ -2384,6 +2384,8 @@ class MemoryApi:
     async def list_observation_scopes(
         self,
         bank_id: StrictStr,
+        limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=0)]], Field(description="Maximum number of scopes to return")] = None,
+        offset: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Offset for pagination")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -2400,10 +2402,14 @@ class MemoryApi:
     ) -> ObservationScopesResponse:
         """List observation scopes
 
-        Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope.
+        Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope. Paged: `total` reports every distinct scope in the bank.
 
         :param bank_id: (required)
         :type bank_id: str
+        :param limit: Maximum number of scopes to return
+        :type limit: int
+        :param offset: Offset for pagination
+        :type offset: int
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2430,6 +2436,8 @@ class MemoryApi:
 
         _param = self._list_observation_scopes_serialize(
             bank_id=bank_id,
+            limit=limit,
+            offset=offset,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -2456,6 +2464,8 @@ class MemoryApi:
     async def list_observation_scopes_with_http_info(
         self,
         bank_id: StrictStr,
+        limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=0)]], Field(description="Maximum number of scopes to return")] = None,
+        offset: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Offset for pagination")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -2472,10 +2482,14 @@ class MemoryApi:
     ) -> ApiResponse[ObservationScopesResponse]:
         """List observation scopes
 
-        Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope.
+        Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope. Paged: `total` reports every distinct scope in the bank.
 
         :param bank_id: (required)
         :type bank_id: str
+        :param limit: Maximum number of scopes to return
+        :type limit: int
+        :param offset: Offset for pagination
+        :type offset: int
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2502,6 +2516,8 @@ class MemoryApi:
 
         _param = self._list_observation_scopes_serialize(
             bank_id=bank_id,
+            limit=limit,
+            offset=offset,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -2528,6 +2544,8 @@ class MemoryApi:
     async def list_observation_scopes_without_preload_content(
         self,
         bank_id: StrictStr,
+        limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=0)]], Field(description="Maximum number of scopes to return")] = None,
+        offset: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Offset for pagination")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -2544,10 +2562,14 @@ class MemoryApi:
     ) -> RESTResponseType:
         """List observation scopes
 
-        Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope.
+        Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope. Paged: `total` reports every distinct scope in the bank.
 
         :param bank_id: (required)
         :type bank_id: str
+        :param limit: Maximum number of scopes to return
+        :type limit: int
+        :param offset: Offset for pagination
+        :type offset: int
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2574,6 +2596,8 @@ class MemoryApi:
 
         _param = self._list_observation_scopes_serialize(
             bank_id=bank_id,
+            limit=limit,
+            offset=offset,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -2595,6 +2619,8 @@ class MemoryApi:
     def _list_observation_scopes_serialize(
         self,
         bank_id,
+        limit,
+        offset,
         authorization,
         _request_auth,
         _content_type,
@@ -2620,6 +2646,14 @@ class MemoryApi:
         if bank_id is not None:
             _path_params['bank_id'] = bank_id
         # process the query parameters
+        if limit is not None:
+            
+            _query_params.append(('limit', limit))
+            
+        if offset is not None:
+            
+            _query_params.append(('offset', offset))
+            
         # process the header parameters
         if authorization is not None:
             _header_params['authorization'] = authorization

--- a/hindsight-clients/python/hindsight_client_api/api/webhooks_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/webhooks_api.py
@@ -974,6 +974,8 @@ class WebhooksApi:
     async def list_webhooks(
         self,
         bank_id: StrictStr,
+        limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=0)]], Field(description="Maximum number of webhooks to return")] = None,
+        offset: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Offset for pagination")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -990,10 +992,14 @@ class WebhooksApi:
     ) -> WebhookListResponse:
         """List webhooks
 
-        List all webhooks registered for a bank.
+        List the webhooks registered for a bank, oldest first. Paged: `total` reports every webhook on the bank.
 
         :param bank_id: (required)
         :type bank_id: str
+        :param limit: Maximum number of webhooks to return
+        :type limit: int
+        :param offset: Offset for pagination
+        :type offset: int
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -1020,6 +1026,8 @@ class WebhooksApi:
 
         _param = self._list_webhooks_serialize(
             bank_id=bank_id,
+            limit=limit,
+            offset=offset,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -1046,6 +1054,8 @@ class WebhooksApi:
     async def list_webhooks_with_http_info(
         self,
         bank_id: StrictStr,
+        limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=0)]], Field(description="Maximum number of webhooks to return")] = None,
+        offset: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Offset for pagination")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -1062,10 +1072,14 @@ class WebhooksApi:
     ) -> ApiResponse[WebhookListResponse]:
         """List webhooks
 
-        List all webhooks registered for a bank.
+        List the webhooks registered for a bank, oldest first. Paged: `total` reports every webhook on the bank.
 
         :param bank_id: (required)
         :type bank_id: str
+        :param limit: Maximum number of webhooks to return
+        :type limit: int
+        :param offset: Offset for pagination
+        :type offset: int
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -1092,6 +1106,8 @@ class WebhooksApi:
 
         _param = self._list_webhooks_serialize(
             bank_id=bank_id,
+            limit=limit,
+            offset=offset,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -1118,6 +1134,8 @@ class WebhooksApi:
     async def list_webhooks_without_preload_content(
         self,
         bank_id: StrictStr,
+        limit: Annotated[Optional[Annotated[int, Field(le=1000, strict=True, ge=0)]], Field(description="Maximum number of webhooks to return")] = None,
+        offset: Annotated[Optional[Annotated[int, Field(strict=True, ge=0)]], Field(description="Offset for pagination")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
@@ -1134,10 +1152,14 @@ class WebhooksApi:
     ) -> RESTResponseType:
         """List webhooks
 
-        List all webhooks registered for a bank.
+        List the webhooks registered for a bank, oldest first. Paged: `total` reports every webhook on the bank.
 
         :param bank_id: (required)
         :type bank_id: str
+        :param limit: Maximum number of webhooks to return
+        :type limit: int
+        :param offset: Offset for pagination
+        :type offset: int
         :param authorization:
         :type authorization: str
         :param _request_timeout: timeout setting for this request. If one
@@ -1164,6 +1186,8 @@ class WebhooksApi:
 
         _param = self._list_webhooks_serialize(
             bank_id=bank_id,
+            limit=limit,
+            offset=offset,
             authorization=authorization,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -1185,6 +1209,8 @@ class WebhooksApi:
     def _list_webhooks_serialize(
         self,
         bank_id,
+        limit,
+        offset,
         authorization,
         _request_auth,
         _content_type,
@@ -1210,6 +1236,14 @@ class WebhooksApi:
         if bank_id is not None:
             _path_params['bank_id'] = bank_id
         # process the query parameters
+        if limit is not None:
+            
+            _query_params.append(('limit', limit))
+            
+        if offset is not None:
+            
+            _query_params.append(('offset', offset))
+            
         # process the header parameters
         if authorization is not None:
             _header_params['authorization'] = authorization

--- a/hindsight-clients/python/hindsight_client_api/models/observation_scopes_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/observation_scopes_response.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List
 from hindsight_client_api.models.observation_scope import ObservationScope
 from typing import Optional, Set
@@ -28,7 +28,10 @@ class ObservationScopesResponse(BaseModel):
     Response model for the observation scopes enumeration endpoint.
     """ # noqa: E501
     scopes: List[ObservationScope] = Field(description="Distinct observation scopes, most populous first")
-    __properties: ClassVar[List[str]] = ["scopes"]
+    total: StrictInt = Field(description="Total number of distinct scopes in the bank (ignores limit/offset)")
+    limit: StrictInt = Field(description="Maximum number of scopes returned in this page")
+    offset: StrictInt = Field(description="Offset this page started at")
+    __properties: ClassVar[List[str]] = ["scopes", "total", "limit", "offset"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -88,7 +91,10 @@ class ObservationScopesResponse(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "scopes": [ObservationScope.from_dict(_item) for _item in obj["scopes"]] if obj.get("scopes") is not None else None
+            "scopes": [ObservationScope.from_dict(_item) for _item in obj["scopes"]] if obj.get("scopes") is not None else None,
+            "total": obj.get("total"),
+            "limit": obj.get("limit"),
+            "offset": obj.get("offset")
         })
         return _obj
 

--- a/hindsight-clients/python/hindsight_client_api/models/webhook_list_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/webhook_list_response.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List
 from hindsight_client_api.models.webhook_response import WebhookResponse
 from typing import Optional, Set
@@ -28,7 +28,10 @@ class WebhookListResponse(BaseModel):
     Response model for listing webhooks.
     """ # noqa: E501
     items: List[WebhookResponse]
-    __properties: ClassVar[List[str]] = ["items"]
+    total: StrictInt = Field(description="Total number of webhooks on the bank (ignores limit/offset)")
+    limit: StrictInt = Field(description="Maximum number of webhooks returned in this page")
+    offset: StrictInt = Field(description="Offset this page started at")
+    __properties: ClassVar[List[str]] = ["items", "total", "limit", "offset"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -88,7 +91,10 @@ class WebhookListResponse(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "items": [WebhookResponse.from_dict(_item) for _item in obj["items"]] if obj.get("items") is not None else None
+            "items": [WebhookResponse.from_dict(_item) for _item in obj["items"]] if obj.get("items") is not None else None,
+            "total": obj.get("total"),
+            "limit": obj.get("limit"),
+            "offset": obj.get("offset")
         })
         return _obj
 

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -1367,7 +1367,7 @@ export const clearObservations = <ThrowOnError extends boolean = false>(
 /**
  * List observation scopes
  *
- * Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope.
+ * Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope. Paged: `total` reports every distinct scope in the bank.
  */
 export const listObservationScopes = <ThrowOnError extends boolean = false>(
   options: Options<ListObservationScopesData, ThrowOnError>
@@ -1475,7 +1475,7 @@ export const triggerConsolidation = <ThrowOnError extends boolean = false>(
 /**
  * List webhooks
  *
- * List all webhooks registered for a bank.
+ * List the webhooks registered for a bank, oldest first. Paged: `total` reports every webhook on the bank.
  */
 export const listWebhooks = <ThrowOnError extends boolean = false>(
   options: Options<ListWebhooksData, ThrowOnError>

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -3935,6 +3935,24 @@ export type ObservationScopesResponse = {
    * Distinct observation scopes, most populous first
    */
   scopes: Array<ObservationScope>;
+  /**
+   * Total
+   *
+   * Total number of distinct scopes in the bank (ignores limit/offset)
+   */
+  total: number;
+  /**
+   * Limit
+   *
+   * Maximum number of scopes returned in this page
+   */
+  limit: number;
+  /**
+   * Offset
+   *
+   * Offset this page started at
+   */
+  offset: number;
 };
 
 /**
@@ -5520,6 +5538,24 @@ export type WebhookListResponse = {
    * Items
    */
   items: Array<WebhookResponse>;
+  /**
+   * Total
+   *
+   * Total number of webhooks on the bank (ignores limit/offset)
+   */
+  total: number;
+  /**
+   * Limit
+   *
+   * Maximum number of webhooks returned in this page
+   */
+  limit: number;
+  /**
+   * Offset
+   *
+   * Offset this page started at
+   */
+  offset: number;
 };
 
 /**
@@ -8431,7 +8467,20 @@ export type ListObservationScopesData = {
      */
     bank_id: string;
   };
-  query?: never;
+  query?: {
+    /**
+     * Limit
+     *
+     * Maximum number of scopes to return
+     */
+    limit?: number;
+    /**
+     * Offset
+     *
+     * Offset for pagination
+     */
+    offset?: number;
+  };
   url: "/v1/default/banks/{bank_id}/observations/scopes";
 };
 
@@ -8698,7 +8747,20 @@ export type ListWebhooksData = {
      */
     bank_id: string;
   };
-  query?: never;
+  query?: {
+    /**
+     * Limit
+     *
+     * Maximum number of webhooks to return
+     */
+    limit?: number;
+    /**
+     * Offset
+     *
+     * Offset for pagination
+     */
+    offset?: number;
+  };
   url: "/v1/default/banks/{bank_id}/webhooks";
 };
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/observations/scopes/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/observations/scopes/route.ts
@@ -16,8 +16,15 @@ export async function GET(request: Request, { params }: { params: Promise<{ bank
       );
     }
 
+    const { searchParams } = new URL(request.url);
+    const queryParams = new URLSearchParams();
+    for (const key of ["limit", "offset"]) {
+      const value = searchParams.get(key);
+      if (value) queryParams.append(key, value);
+    }
+
     const response = await fetch(
-      `${DATAPLANE_URL}/v1/default/banks/${bankId}/observations/scopes`,
+      `${DATAPLANE_URL}/v1/default/banks/${bankId}/observations/scopes${queryParams.toString() ? `?${queryParams}` : ""}`,
       { headers: getDataplaneHeaders() }
     );
 

--- a/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/route.ts
+++ b/hindsight-control-plane/src/app/api/banks/[bankId]/webhooks/route.ts
@@ -4,7 +4,14 @@ import { localizeApiErrorPayload } from "@/lib/i18n/api-errors";
 
 export async function GET(request: Request, { params }: { params: Promise<{ bankId: string }> }) {
   const { bankId } = await params;
-  const res = await fetch(dataplaneBankUrl(bankId, "/webhooks"), {
+  const { searchParams } = new URL(request.url);
+  const queryParams = new URLSearchParams();
+  for (const key of ["limit", "offset"]) {
+    const value = searchParams.get(key);
+    if (value) queryParams.append(key, value);
+  }
+  const path = `/webhooks${queryParams.toString() ? `?${queryParams}` : ""}`;
+  const res = await fetch(dataplaneBankUrl(bankId, path), {
     headers: getDataplaneHeaders({ "Content-Type": "application/json" }),
   });
   const data = await res.json();

--- a/hindsight-control-plane/src/components/webhooks-view.tsx
+++ b/hindsight-control-plane/src/components/webhooks-view.tsx
@@ -44,6 +44,9 @@ import {
   X,
   ChevronDown,
   ChevronRight,
+  ChevronLeft,
+  ChevronsLeft,
+  ChevronsRight,
   Pencil,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
@@ -71,6 +74,8 @@ interface CreateWebhookForm {
     params: KeyValuePair[];
   };
 }
+
+const ITEMS_PER_PAGE = 50;
 
 const DEFAULT_FORM: CreateWebhookForm = {
   url: "",
@@ -306,6 +311,9 @@ export function WebhooksView() {
   const t = useTranslations("webhooksView");
   const { currentBank } = useBank();
   const [webhooks, setWebhooks] = useState<Webhook[]>([]);
+  // Pagination state — the listing endpoint pages (see loadWebhooks).
+  const [currentPage, setCurrentPage] = useState(1);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -331,24 +339,16 @@ export function WebhooksView() {
   const [deliveriesCursor, setDeliveriesCursor] = useState<string | null>(null);
   const [loadingMoreDeliveries, setLoadingMoreDeliveries] = useState(false);
 
-  const loadWebhooks = async () => {
+  const loadWebhooks = async (page: number = currentPage) => {
     if (!currentBank) return;
     setLoading(true);
     try {
-      // The endpoint pages (default 100). This view shows the bank's whole
-      // webhook list and its count, so walk every page rather than silently
-      // rendering the first one as if it were everything.
-      const pageSize = 100;
-      const all: Webhook[] = [];
-      let offset = 0;
-      let total = 0;
-      do {
-        const page = await client.listWebhooks(currentBank, { limit: pageSize, offset });
-        all.push(...(page.items || []));
-        total = page.total;
-        offset += pageSize;
-      } while (all.length < total && offset < total);
-      setWebhooks(all);
+      const data = await client.listWebhooks(currentBank, {
+        limit: ITEMS_PER_PAGE,
+        offset: (page - 1) * ITEMS_PER_PAGE,
+      });
+      setWebhooks(data.items || []);
+      setTotal(data.total || 0);
     } catch (error) {
       console.error("Error loading webhooks:", error);
     } finally {
@@ -356,9 +356,29 @@ export function WebhooksView() {
     }
   };
 
+  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
+  const offset = (currentPage - 1) * ITEMS_PER_PAGE;
+
+  const handlePageChange = async (newPage: number) => {
+    setCurrentPage(newPage);
+    await loadWebhooks(newPage);
+  };
+
+  // A delete can empty the last page; step back so the view never lands on a
+  // page that no longer exists.
+  const reloadAfterMutation = async () => {
+    const page = webhooks.length === 1 && currentPage > 1 ? currentPage - 1 : currentPage;
+    setCurrentPage(page);
+    await loadWebhooks(page);
+  };
+
   useEffect(() => {
     if (currentBank) {
-      loadWebhooks();
+      // Back to page 1 on a bank switch: the page number belongs to the bank we
+      // just left, and carrying it over lands on an offset the new bank may not
+      // reach (page 3 of a 120-webhook bank, then a bank with two).
+      setCurrentPage(1);
+      loadWebhooks(1);
     }
   }, [currentBank]);
 
@@ -376,7 +396,9 @@ export function WebhooksView() {
       setCreateDialogOpen(false);
       setForm(DEFAULT_FORM);
       setShowSecret(false);
-      await loadWebhooks();
+      // Rows are ordered oldest-first, so the new webhook is on the last page —
+      // reloading the current page would close the dialog and appear to do nothing.
+      await handlePageChange(Math.ceil((total + 1) / ITEMS_PER_PAGE));
     } catch (error) {
       // Error toast shown by API client interceptor
     } finally {
@@ -390,7 +412,7 @@ export function WebhooksView() {
     setDeleteConfirmWebhook(null);
     try {
       await client.deleteWebhook(currentBank, webhookId);
-      await loadWebhooks();
+      await reloadAfterMutation();
     } catch (error) {
       // Error toast shown by API client interceptor
     } finally {
@@ -503,9 +525,7 @@ export function WebhooksView() {
               />
             </button>
           </div>
-          <p className="text-sm text-muted-foreground">
-            {t("webhookCount", { count: webhooks.length })}
-          </p>
+          <p className="text-sm text-muted-foreground">{t("webhookCount", { count: total })}</p>
         </div>
         <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
           <Plus className="w-4 h-4 mr-2" />
@@ -612,6 +632,54 @@ export function WebhooksView() {
               ))}
             </TableBody>
           </Table>
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between mt-3 pt-3 border-t">
+              <div className="text-xs text-muted-foreground">
+                {offset + 1}-{Math.min(offset + ITEMS_PER_PAGE, total)} of {total}
+              </div>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePageChange(1)}
+                  disabled={currentPage === 1 || loading}
+                  className="h-7 w-7 p-0"
+                >
+                  <ChevronsLeft className="h-3 w-3" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePageChange(currentPage - 1)}
+                  disabled={currentPage === 1 || loading}
+                  className="h-7 w-7 p-0"
+                >
+                  <ChevronLeft className="h-3 w-3" />
+                </Button>
+                <span className="text-xs px-2">
+                  {currentPage} / {totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePageChange(currentPage + 1)}
+                  disabled={currentPage === totalPages || loading}
+                  className="h-7 w-7 p-0"
+                >
+                  <ChevronRight className="h-3 w-3" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePageChange(totalPages)}
+                  disabled={currentPage === totalPages || loading}
+                  className="h-7 w-7 p-0"
+                >
+                  <ChevronsRight className="h-3 w-3" />
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
       ) : (
         <p className="text-muted-foreground text-center py-8 text-sm">{t("emptyStateCanManage")}</p>

--- a/hindsight-control-plane/src/components/webhooks-view.tsx
+++ b/hindsight-control-plane/src/components/webhooks-view.tsx
@@ -335,8 +335,20 @@ export function WebhooksView() {
     if (!currentBank) return;
     setLoading(true);
     try {
-      const data = await client.listWebhooks(currentBank);
-      setWebhooks(data.items || []);
+      // The endpoint pages (default 100). This view shows the bank's whole
+      // webhook list and its count, so walk every page rather than silently
+      // rendering the first one as if it were everything.
+      const pageSize = 100;
+      const all: Webhook[] = [];
+      let offset = 0;
+      let total = 0;
+      do {
+        const page = await client.listWebhooks(currentBank, { limit: pageSize, offset });
+        all.push(...(page.items || []));
+        total = page.total;
+        offset += pageSize;
+      } while (all.length < total && offset < total);
+      setWebhooks(all);
     } catch (error) {
       console.error("Error loading webhooks:", error);
     } finally {

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -1442,10 +1442,16 @@ export class ControlPlaneClient {
    * consolidated with. Returns every distinct scope (tag order normalized) with
    * the number of observations in it; the empty tag list is the global scope.
    */
-  async listObservationScopes(bankId: string) {
+  async listObservationScopes(bankId: string, params?: { limit?: number; offset?: number }) {
+    const query = new URLSearchParams();
+    if (params?.limit !== undefined) query.append("limit", String(params.limit));
+    if (params?.offset !== undefined) query.append("offset", String(params.offset));
     return this.fetchApi<{
       scopes: Array<{ tags: string[]; count: number }>;
-    }>(bankApi(bankId, `/observations/scopes`));
+      total: number;
+      limit: number;
+      offset: number;
+    }>(bankApi(bankId, `/observations/scopes${query.toString() ? `?${query}` : ""}`));
   }
 
   // ============= TAGS =============
@@ -1958,8 +1964,16 @@ export class ControlPlaneClient {
   /**
    * List webhooks for a bank
    */
-  async listWebhooks(bankId: string): Promise<{ items: Webhook[] }> {
-    return this.fetchApi<{ items: Webhook[] }>(bankApi(bankId, "/webhooks"));
+  async listWebhooks(
+    bankId: string,
+    params?: { limit?: number; offset?: number }
+  ): Promise<{ items: Webhook[]; total: number; limit: number; offset: number }> {
+    const query = new URLSearchParams();
+    if (params?.limit !== undefined) query.append("limit", String(params.limit));
+    if (params?.offset !== undefined) query.append("offset", String(params.offset));
+    return this.fetchApi<{ items: Webhook[]; total: number; limit: number; offset: number }>(
+      bankApi(bankId, `/webhooks${query.toString() ? `?${query}` : ""}`)
+    );
   }
 
   /**

--- a/hindsight-docs/docs/developer/observations.mdx
+++ b/hindsight-docs/docs/developer/observations.mdx
@@ -177,7 +177,7 @@ By default, observations are scoped to all of a memory's tags combined. The `obs
 
 See [`observation_scopes` in the Retain API](./api/retain#observation_scopes) for the full explanation and options.
 
-To inspect the scopes that already exist in a bank, call `GET /v1/default/banks/{bank_id}/observations/scopes`. The response lists each exact tag set with its observation count; the empty tag list is the global scope. Use a returned scope as `tags` with `tags_match: "exact"` when you need to filter to that precise observation scope without also matching observations that carry extra tags. To recall **only** the global scope — the untagged observations written by `observation_scopes: "shared"` — pass an empty list with exact matching: `tags: []`, `tags_match: "exact"`.
+To inspect the scopes that already exist in a bank, call `GET /v1/default/banks/{bank_id}/observations/scopes`. The response lists each exact tag set with its observation count; the empty tag list is the global scope. The listing is paged (`limit`, default 100, and `offset`), with `total` reporting how many distinct scopes the bank holds. Use a returned scope as `tags` with `tags_match: "exact"` when you need to filter to that precise observation scope without also matching observations that carry extra tags. To recall **only** the global scope — the untagged observations written by `observation_scopes: "shared"` — pass an empty list with exact matching: `tags: []`, `tags_match: "exact"`.
 
 ---
 

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -5178,7 +5178,7 @@
           "Memory"
         ],
         "summary": "List observation scopes",
-        "description": "Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope.",
+        "description": "Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope. Paged: `total` reports every distinct scope in the bank.",
         "operationId": "list_observation_scopes",
         "parameters": [
           {
@@ -5189,6 +5189,33 @@
               "type": "string",
               "title": "Bank Id"
             }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 0,
+              "description": "Maximum number of scopes to return",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Maximum number of scopes to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Offset for pagination",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Offset for pagination"
           },
           {
             "name": "authorization",
@@ -5690,7 +5717,7 @@
           "Webhooks"
         ],
         "summary": "List webhooks",
-        "description": "List all webhooks registered for a bank.",
+        "description": "List the webhooks registered for a bank, oldest first. Paged: `total` reports every webhook on the bank.",
         "operationId": "list_webhooks",
         "parameters": [
           {
@@ -5701,6 +5728,33 @@
               "type": "string",
               "title": "Bank Id"
             }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 0,
+              "description": "Maximum number of webhooks to return",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Maximum number of webhooks to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Offset for pagination",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Offset for pagination"
           },
           {
             "name": "authorization",
@@ -13184,15 +13238,35 @@
             "type": "array",
             "title": "Scopes",
             "description": "Distinct observation scopes, most populous first"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total number of distinct scopes in the bank (ignores limit/offset)"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "description": "Maximum number of scopes returned in this page"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "description": "Offset this page started at"
           }
         },
         "type": "object",
         "required": [
-          "scopes"
+          "scopes",
+          "total",
+          "limit",
+          "offset"
         ],
         "title": "ObservationScopesResponse",
         "description": "Response model for the observation scopes enumeration endpoint.",
         "example": {
+          "limit": 100,
+          "offset": 0,
           "scopes": [
             {
               "count": 12,
@@ -13211,7 +13285,8 @@
               "count": 2,
               "tags": []
             }
-          ]
+          ],
+          "total": 3
         }
       },
       "OperationProgress": {
@@ -16113,11 +16188,29 @@
             },
             "type": "array",
             "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total number of webhooks on the bank (ignores limit/offset)"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "description": "Maximum number of webhooks returned in this page"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "description": "Offset this page started at"
           }
         },
         "type": "object",
         "required": [
-          "items"
+          "items",
+          "total",
+          "limit",
+          "offset"
         ],
         "title": "WebhookListResponse",
         "description": "Response model for listing webhooks."

--- a/skills/hindsight-docs/references/developer/observations.md
+++ b/skills/hindsight-docs/references/developer/observations.md
@@ -185,7 +185,7 @@ By default, observations are scoped to all of a memory's tags combined. The `obs
 
 See [`observation_scopes` in the Retain API](./api/retain#observation_scopes) for the full explanation and options.
 
-To inspect the scopes that already exist in a bank, call `GET /v1/default/banks/{bank_id}/observations/scopes`. The response lists each exact tag set with its observation count; the empty tag list is the global scope. Use a returned scope as `tags` with `tags_match: "exact"` when you need to filter to that precise observation scope without also matching observations that carry extra tags. To recall **only** the global scope — the untagged observations written by `observation_scopes: "shared"` — pass an empty list with exact matching: `tags: []`, `tags_match: "exact"`.
+To inspect the scopes that already exist in a bank, call `GET /v1/default/banks/{bank_id}/observations/scopes`. The response lists each exact tag set with its observation count; the empty tag list is the global scope. The listing is paged (`limit`, default 100, and `offset`), with `total` reporting how many distinct scopes the bank holds. Use a returned scope as `tags` with `tags_match: "exact"` when you need to filter to that precise observation scope without also matching observations that carry extra tags. To recall **only** the global scope — the untagged observations written by `observation_scopes: "shared"` — pass an empty list with exact matching: `tags: []`, `tags_match: "exact"`.
 
 ---
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -5178,7 +5178,7 @@
           "Memory"
         ],
         "summary": "List observation scopes",
-        "description": "Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope.",
+        "description": "Enumerate the distinct scopes across a bank's observations. Each observation lives under a scope: the exact set of tags it was consolidated with. Returns every distinct scope (tag order normalized) with the number of observations in it; the empty tag list is the global/untagged scope. Use a returned scope with the graph endpoint (tags=<scope> & tags_match=exact) to filter observations to exactly that scope. Paged: `total` reports every distinct scope in the bank.",
         "operationId": "list_observation_scopes",
         "parameters": [
           {
@@ -5189,6 +5189,33 @@
               "type": "string",
               "title": "Bank Id"
             }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 0,
+              "description": "Maximum number of scopes to return",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Maximum number of scopes to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Offset for pagination",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Offset for pagination"
           },
           {
             "name": "authorization",
@@ -5690,7 +5717,7 @@
           "Webhooks"
         ],
         "summary": "List webhooks",
-        "description": "List all webhooks registered for a bank.",
+        "description": "List the webhooks registered for a bank, oldest first. Paged: `total` reports every webhook on the bank.",
         "operationId": "list_webhooks",
         "parameters": [
           {
@@ -5701,6 +5728,33 @@
               "type": "string",
               "title": "Bank Id"
             }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 0,
+              "description": "Maximum number of webhooks to return",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Maximum number of webhooks to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Offset for pagination",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Offset for pagination"
           },
           {
             "name": "authorization",
@@ -13184,15 +13238,35 @@
             "type": "array",
             "title": "Scopes",
             "description": "Distinct observation scopes, most populous first"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total number of distinct scopes in the bank (ignores limit/offset)"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "description": "Maximum number of scopes returned in this page"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "description": "Offset this page started at"
           }
         },
         "type": "object",
         "required": [
-          "scopes"
+          "scopes",
+          "total",
+          "limit",
+          "offset"
         ],
         "title": "ObservationScopesResponse",
         "description": "Response model for the observation scopes enumeration endpoint.",
         "example": {
+          "limit": 100,
+          "offset": 0,
           "scopes": [
             {
               "count": 12,
@@ -13211,7 +13285,8 @@
               "count": 2,
               "tags": []
             }
-          ]
+          ],
+          "total": 3
         }
       },
       "OperationProgress": {
@@ -16113,11 +16188,29 @@
             },
             "type": "array",
             "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total number of webhooks on the bank (ignores limit/offset)"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "description": "Maximum number of webhooks returned in this page"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "description": "Offset this page started at"
           }
         },
         "type": "object",
         "required": [
-          "items"
+          "items",
+          "total",
+          "limit",
+          "offset"
         ],
         "title": "WebhookListResponse",
         "description": "Response model for listing webhooks."


### PR DESCRIPTION
## Problem

Two `GET` endpoints returned an unbounded collection:

- `GET /v1/default/banks/{bank_id}/observations/scopes` grouped every observation in the bank and returned one row per distinct tag set. A bank has as many scopes as it has distinct tag sets, so this grows with the data — a bank tagged per session produces one scope per session.
- `GET /v1/default/banks/{bank_id}/webhooks` selected every webhook row for the bank.

Neither is bounded by construction, so both were an unbounded payload plus unbounded per-row work.

## Change

Both endpoints now take `limit` (default 100, `ge=0`, `le=1000`) and `offset`, and return `total` / `limit` / `offset` next to the page — the shape `list_tags` and the other paged list endpoints already use.

The bound reaches the SQL, not just the response:

- **Scopes**: the histogram is grouped, ordered (`count DESC, scope ASC`) and paged in one query, with a separate `COUNT(*)` over the distinct scopes for `total`. The whole histogram never crosses the wire.
- **Webhooks**: `LIMIT/OFFSET` on the listing plus a count query. Ordering gains an `id` tiebreak (`ORDER BY created_at, id`) so a page boundary cannot fall inside a group of rows sharing a `created_at`.

Consumers page with them rather than silently rendering the first page as if it were everything:

- Control plane: the webhooks view walks every page (it shows the bank's full list and its count); both proxy routes forward `limit`/`offset`; `lib/api.ts` types updated.
- CLI: `hs webhook list` prints `Showing N of M webhooks.` when the page is short of the total.

## Tests

- `test_observation_scopes_pagination` — pages are capped and disjoint, together enumerate every scope, `total` is the whole histogram, and an offset past the end returns an empty page with the correct `total`.
- `test_http_list_webhooks_pagination` — same for webhooks, asserting the two pages together cover exactly the created set.

`tests/test_graph_filtering.py` + `tests/test_webhooks.py`: 85 passed locally.

## Generated files

OpenAPI spec, Python/TypeScript/Go/Rust clients and the docs skill regenerated. `check-openapi-compatibility` passes (warns only that the two responses gained required fields, as expected for an additive change); `cli-coverage-check` passes.

## Note

The two engine methods return `dict`, matching `list_tags` and the rest of this endpoint family rather than introducing a one-off typed page model here.