### PR TITLE
fix(temporal): "last weekend" asked on a weekend means the previous one

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/chinese_temporal_periods.py
+++ b/hindsight-api-slim/hindsight_api/engine/chinese_temporal_periods.py
@@ -1705,10 +1705,13 @@ def extract_chinese_period(query: str, reference_date: datetime) -> DateRange | 
         return constraint(sat, sat + timedelta(days=1))
 
     if chinese_search(rf"上{_CHINESE_OPTIONAL_PERIOD_MARKER}(周|星期|礼拜)末"):
-        days_since_sat = (reference_date.weekday() + 2) % 7
-        if days_since_sat == 0:
-            days_since_sat = 7
-        sat = reference_date - timedelta(days=days_since_sat)
+        # Anchor to last week's Monday like every sibling rule above, rather
+        # than stepping back to the most recent Saturday. Stepping back lands on
+        # the weekend in progress when asked on a Sunday, which makes 上周末
+        # return the same window as 这周末 and leaves the weekend the user meant
+        # unreachable -- 上上周末 is already a week further back.
+        start = reference_date - timedelta(days=reference_date.weekday() + 7)
+        sat = start + timedelta(days=5)
         return constraint(sat, sat + timedelta(days=1))
 
     if chinese_search(r"(?<!每)(?<!个)(?<!各)(?<!隔)周末"):

--- a/hindsight-api-slim/hindsight_api/engine/temporal_periods.py
+++ b/hindsight-api-slim/hindsight_api/engine/temporal_periods.py
@@ -152,9 +152,15 @@ def _extract_non_chinese_period(
         query,
         re.IGNORECASE,
     ):
+        # Step back to the Saturday that opened the previous weekend. On a
+        # weekend day the arithmetic lands on the weekend in progress -- 0 days
+        # back on Saturday, 1 on Sunday -- so both roll back a further week.
+        # "last weekend" asked on a Sunday means the one before this one, not
+        # the day before and today. Matches the "last week" rule above, which
+        # already steps a full week past the current one.
         days_since_sat = (reference_date.weekday() + 2) % 7
-        if days_since_sat == 0:
-            days_since_sat = 7
+        if days_since_sat <= 1:
+            days_since_sat += 7
         sat = reference_date - timedelta(days=days_since_sat)
         return _constraint(sat, sat + timedelta(days=1))
 

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -235,6 +235,26 @@ def test_query_analyzer_last_weekend(query_analyzer):
     assert analysis.temporal_constraint.end_date.day == 12  # Sunday
 
 
+def test_query_analyzer_last_weekend_on_a_weekend_day(query_analyzer):
+    """'last weekend' asked on Sat/Sun means the previous one, not this one.
+
+    Stepping back to the most recent Saturday lands on the weekend in progress
+    when the question is asked during it, so a Sunday query returned yesterday
+    and today.
+    """
+    # 2025-01-18 is a Saturday, 2025-01-19 the Sunday after it. Both should
+    # resolve to the weekend before: Saturday 11th to Sunday 12th.
+    for reference_date in (datetime(2025, 1, 18, 12, 0, 0), datetime(2025, 1, 19, 12, 0, 0)):
+        analysis = query_analyzer.analyze("what did I do last weekend?", reference_date)
+
+        assert analysis.temporal_constraint is not None, reference_date.strftime("%A")
+        assert analysis.temporal_constraint.start_date.day == 11, reference_date.strftime("%A")
+        assert analysis.temporal_constraint.end_date.day == 12, reference_date.strftime("%A")
+        assert analysis.temporal_constraint.end_date < reference_date, (
+            f"{reference_date:%A}: last weekend must end before the query is asked"
+        )
+
+
 def test_query_analyzer_couple_days_ago(query_analyzer):
     """Test extraction of 'a couple of days ago' colloquial expression."""
     reference_date = datetime(2025, 1, 15, 12, 0, 0)

--- a/hindsight-api-slim/tests/test_query_analyzer.py
+++ b/hindsight-api-slim/tests/test_query_analyzer.py
@@ -255,6 +255,26 @@ def test_query_analyzer_last_weekend_on_a_weekend_day(query_analyzer):
         )
 
 
+def test_query_analyzer_chinese_last_weekend_on_a_weekend_day(query_analyzer):
+    """上周末 asked on Sat/Sun means the previous weekend, as in English.
+
+    The Chinese extractor carried the same step-back-to-Saturday arithmetic, so
+    on a Sunday it returned the weekend in progress -- the same window as 这周末,
+    with the weekend the user meant reachable from neither it nor 上上周末.
+    """
+    # 2025-01-18 is a Saturday, 2025-01-19 the Sunday after it. Both should
+    # resolve to the weekend before: Saturday 11th to Sunday 12th.
+    for reference_date in (datetime(2025, 1, 18, 12, 0, 0), datetime(2025, 1, 19, 12, 0, 0)):
+        analysis = query_analyzer.analyze("上周末去了哪里", reference_date)
+
+        assert analysis.temporal_constraint is not None, reference_date.strftime("%A")
+        assert analysis.temporal_constraint.start_date.day == 11, reference_date.strftime("%A")
+        assert analysis.temporal_constraint.end_date.day == 12, reference_date.strftime("%A")
+        assert analysis.temporal_constraint.end_date < reference_date, (
+            f"{reference_date:%A}: 上周末 must end before the query is asked"
+        )
+
+
 def test_query_analyzer_couple_days_ago(query_analyzer):
     """Test extraction of 'a couple of days ago' colloquial expression."""
     reference_date = datetime(2025, 1, 15, 12, 0, 0)


### PR DESCRIPTION
## Problem

The `last weekend` rule steps back to the most recent Saturday:

```python
days_since_sat = (reference_date.weekday() + 2) % 7
if days_since_sat == 0:
    days_since_sat = 7
```

On a weekend day that lands on the weekend *in progress*. Saturday was special-cased (the `% 7` gives 0, corrected to 7), but Sunday gives 1 — so the window becomes yesterday and today:

| asked on | resolved window |
|---|---|
| Mon–Fri | Sat 29 – Sun 30 ✓ |
| Sat | Sat 29 – Sun 30 ✓ |
| **Sun** | **Sat 5 – Sun 6** ✗ (yesterday and today) |

So "what did I do last weekend?" asked on a Sunday searches the weekend the user is currently in, and returns nothing from the weekend they meant. It is a silent wrong answer — a constraint is produced, just the wrong one — and it only reproduces one day in seven, so it does not show up in a test with a fixed midweek reference date.

The sibling `last week` rule already handles this: `reference_date.weekday() + 7` steps a full week past the current one whatever day it is asked on.

The Chinese extractor carried the identical arithmetic for 上周末, so the same Sunday query was wrong there too. Worse, on that day 上周末 returns the same window as 这周末 while 上上周末 is already a week further back, leaving the weekend the user meant reachable from no phrase at all:

```
ref          day   上周末 (before)   corrected     这周末       上上周末
2025-01-18   Sat   2025-01-11       2025-01-11    2025-01-18   2025-01-04
2025-01-19   Sun   2025-01-18       2025-01-11    2025-01-18   2025-01-04
```

## Fix

Roll back a further week on both weekend days rather than only on Saturday, so every day resolves to the same Saturday–Sunday pair.

In the Chinese extractor the correction is expressed as `reference_date - timedelta(days=reference_date.weekday() + 7)` plus 5 days — the same result on all seven days, and the anchoring style already used by 这周末 (Monday plus 5) and 上上周末 (`weekday() + 14`, plus 5), so the four weekend rules now read as one family.

## Scope

One arithmetic branch in each of `temporal_periods.py` and `chinese_temporal_periods.py`. Monday–Saturday behaviour is byte-identical in both, so the existing `test_query_analyzer_last_weekend` (Wednesday reference) and the Wednesday-referenced Chinese cases (上周末 / 上一个周末 / 上星期末 / 上礼拜末 / 上週末 / 上上周末) still pass unchanged.

## Test plan

- Ran: `pytest tests/test_query_analyzer.py` → 485 passed.
- Two new tests, one per extractor, assert both weekend days resolve to the previous Saturday–Sunday and that the window ends before the query is asked.
- Checked: reverting only `temporal_periods.py` fails the English test; reverting only `chinese_temporal_periods.py` fails the Chinese one (`1 failed, 365 passed` on `-k chinese`).
- `ruff check` and `ruff format --check` clean on all touched files.