### PR TITLE
fix(llm): identify OpenAI-compatible requests

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_headers.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_headers.py
@@ -1,0 +1,17 @@
+"""Shared HTTP headers for Hindsight's OpenAI-compatible transports."""
+
+from hindsight_api import __version__
+
+OPENAI_COMPATIBLE_USER_AGENT = f"hindsight/openai-compatible/{__version__}"
+
+
+def with_openai_compatible_user_agent(default_headers: dict[str, str] | None) -> dict[str, str]:
+    """Return client headers with Hindsight's transport identity when unset.
+
+    Header names are case-insensitive, so inspect them accordingly before adding
+    the canonical spelling. An operator-supplied value remains authoritative.
+    """
+    headers = dict(default_headers or {})
+    if not any(name.lower() == "user-agent" for name in headers):
+        headers["User-Agent"] = OPENAI_COMPATIBLE_USER_AGENT
+    return headers

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -55,6 +55,7 @@ from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usag
 from hindsight_api.engine.llm_transport import build_sdk_timeout, describe_transport_error
 from hindsight_api.engine.llm_wrapper import parse_llm_json
 from hindsight_api.engine.providers.llm_debug import dump_request_on_4xx
+from hindsight_api.engine.providers.openai_compatible_headers import with_openai_compatible_user_agent
 from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.engine.structured_output import provider_json_schema, strict_json_schema
 from hindsight_api.metrics import get_metrics_collector
@@ -819,9 +820,11 @@ class OpenAICompatibleLLM(LLMInterface):
         )
 
         # Create OpenAI client — extract query params from base_url (e.g. Azure api-version)
-        client_kwargs: dict[str, Any] = {"api_key": self.api_key, "max_retries": 0}
-        if default_headers:
-            client_kwargs["default_headers"] = default_headers
+        client_kwargs: dict[str, Any] = {
+            "api_key": self.api_key,
+            "max_retries": 0,
+            "default_headers": with_openai_compatible_user_agent(default_headers),
+        }
         if self.base_url:
             parsed = urlparse(self.base_url)
             if parsed.query:

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_responses_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_responses_llm.py
@@ -54,6 +54,7 @@ from hindsight_api.engine.llm_interface import (
 from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
 from hindsight_api.engine.llm_transport import build_sdk_timeout, describe_transport_error
 from hindsight_api.engine.providers.llm_debug import dump_request_on_4xx
+from hindsight_api.engine.providers.openai_compatible_headers import with_openai_compatible_user_agent
 
 # Provider-agnostic pure helpers (text cleanup, quota-defer parsing, json-mode
 # hint). These are module-level utilities, not chat/completions behavior.
@@ -213,9 +214,11 @@ class OpenAIResponsesLLM(LLMInterface):
 
         # Manual retries (max_retries=0). Extract query params from base_url so an
         # Azure-style ``?api-version=`` is forwarded as a default query param.
-        client_kwargs: dict[str, Any] = {"api_key": self.api_key, "max_retries": 0}
-        if self.default_headers:
-            client_kwargs["default_headers"] = self.default_headers
+        client_kwargs: dict[str, Any] = {
+            "api_key": self.api_key,
+            "max_retries": 0,
+            "default_headers": with_openai_compatible_user_agent(self.default_headers),
+        }
         if self.base_url:
             parsed = urlparse(self.base_url)
             if parsed.query:

--- a/hindsight-api-slim/tests/test_cache_affinity.py
+++ b/hindsight-api-slim/tests/test_cache_affinity.py
@@ -33,6 +33,7 @@ from hindsight_api.engine.cache_affinity import (
 from hindsight_api.engine.llm_trace import LLMTraceContext, reset_trace_context, set_trace_context
 from hindsight_api.engine.llm_wrapper import LLMProvider, create_llm_provider
 from hindsight_api.engine.providers.nous_auth import NousAuthManager
+from hindsight_api.engine.providers.openai_compatible_headers import OPENAI_COMPATIBLE_USER_AGENT
 from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
 
 _HEX32 = re.compile(r"\A[0-9a-f]{32}\Z")
@@ -340,6 +341,17 @@ def test_default_headers_reach_the_openai_compatible_client():
         default_headers={"x-test": "1"},
     )
     assert llm._client.default_headers["x-test"] == "1"
+
+
+def test_openai_compatible_client_identifies_hindsight():
+    llm = _llm()
+    assert llm._client.default_headers["User-Agent"] == OPENAI_COMPATIBLE_USER_AGENT
+
+
+def test_configured_user_agent_wins_case_insensitively():
+    llm = _llm(default_headers={"user-agent": "operator-client/1.0"})
+    assert llm._client.default_headers["user-agent"] == "operator-client/1.0"
+    assert OPENAI_COMPATIBLE_USER_AGENT not in llm._client.default_headers.values()
 
 
 def test_default_headers_reach_the_fireworks_client():

--- a/hindsight-api-slim/tests/test_openai_responses_provider.py
+++ b/hindsight-api-slim/tests/test_openai_responses_provider.py
@@ -395,6 +395,18 @@ def test_default_headers_passed_to_client():
     assert llm._client.default_headers.get("X-Trace-Id") == "abc123"
 
 
+def test_default_user_agent_identifies_hindsight():
+    from hindsight_api.engine.providers.openai_compatible_headers import OPENAI_COMPATIBLE_USER_AGENT
+
+    llm = OpenAIResponsesLLM(
+        provider="openai-responses",
+        api_key="sk-test",
+        base_url="",
+        model="gpt-5.6",
+    )
+    assert llm._client.default_headers["User-Agent"] == OPENAI_COMPATIBLE_USER_AGENT
+
+
 def test_custom_base_url_targets_compatible_responses_endpoint():
     """A custom base_url routes the OpenAI SDK at an OpenAI-compatible /v1/responses endpoint."""
     llm = OpenAIResponsesLLM(


### PR DESCRIPTION
## Summary
- Send a versioned Hindsight User-Agent on OpenAI-compatible Chat Completions and Responses requests.
- Preserve explicitly configured User-Agent headers case-insensitively.

## Why
Adding a unique client identifier is a reasonable compatibility measure: some providers now expect or require an identifiable User-Agent and may reject or deprioritize generic SDK traffic.

## Validation
Focused transport tests, Ruff, and type checking pass.