### PR TITLE
memories: drop count_chunks from the extension seam

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -714,7 +714,7 @@ class MemoriesExtension(Extension, ABC):
     #:
     #: True is a store that keeps memories elsewhere. It owns a dedicated document store (bodies go
     #: through ``put_document`` / ``get_document_record`` / ``get_chunk_text`` / ``list_chunk_texts``
-    #: / ``count_chunks`` / ``document_content_hash``), resolves entity NAMES itself, and commits the
+    #: / ``document_content_hash``), resolves entity NAMES itself, and commits the
     #: entire retain — resolution, upserts and the document replace — as ONE atomic server-side call
     #: (``retain``). The orchestrator then needs no Postgres connection phase for it.
     #:
@@ -1195,10 +1195,6 @@ class MemoriesExtension(Extension, ABC):
 
     async def list_chunk_texts(self, *, bank_id: str, document_id: str) -> "list[str] | None":
         """Every chunk's text in order, or ``None`` if the document does not exist."""
-        raise NotImplementedError
-
-    async def count_chunks(self, *, bank_id: str, document_id: str) -> int:
-        """How many chunks a document has (0 if it does not exist)."""
         raise NotImplementedError
 
     async def set_document_tags(self, *, bank_id: str, document_id: str, tags: "list[str]") -> None:

--- a/hindsight-api-slim/tests/test_memories_extension.py
+++ b/hindsight-api-slim/tests/test_memories_extension.py
@@ -623,11 +623,6 @@ class InMemoryMemories(MemoriesExtension):
         doc = self.documents.get(str(document_id))
         return list(doc["chunk_texts"]) if doc else None
 
-    async def count_chunks(self, *, bank_id, document_id):
-        self.calls.append("count_chunks")
-        doc = self.documents.get(str(document_id))
-        return len(doc["chunk_texts"]) if doc else 0
-
     async def delete_document_record(self, *, bank_id, document_id):
         self.calls.append("delete_document_record")
         self.documents.pop(str(document_id), None)


### PR DESCRIPTION
Nothing calls it.

`count_chunks` is declared on `MemoriesExtension` and implemented by the in-memory stub, but no engine, API, worker or MCP path ever reaches for it. A `git grep ".count_chunks("` across the tree returns only the declaration itself and the stub's override.

A backend that owns its rows has to answer every method the seam declares, so an unreachable one is a cost paid by every implementer for nothing. The two things a caller would plausibly want it for already have cheaper answers: `list_chunk_texts` returns the chunks, and a document record carries its own chunk count.

Removing the declaration also drops it from the interface-driven parametrised checks (`test_stub_answers_every_interface_method`, `test_stub_signature_accepts_interface_params`), so the stub's override goes with it.

`tests/test_memories_extension.py` passes: 188 passed. (20 errors in that file are `pg0-embedded` not being installed locally, and are unrelated.)