### PR TITLE
fix(opencode-go): send x-opencode-session, one id per operation (#4071)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cache_affinity.py
+++ b/hindsight-api-slim/hindsight_api/engine/cache_affinity.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 # xAI's documented cache-pinning header, and OpenAI's cache-routing field.
 XAI_CONV_ID_HEADER = "x-grok-conv-id"
 OPENAI_PROMPT_CACHE_KEY_PARAM = "prompt_cache_key"
+# OpenCode Go's conversation-grouping header (#4071).
+OPENCODE_SESSION_HEADER = "x-opencode-session"
 
 # Hosts (exact or parent domain) whose backends implement the xAI header.
 _XAI_DOMAINS = ("x.ai", "grok.com")
@@ -155,6 +157,35 @@ def cache_affinity_id(messages: Any) -> str | None:
     if trace_ctx is not None and trace_ctx.trace_id:
         return hashlib.sha256(str(trace_ctx.trace_id).encode("utf-8")).hexdigest()[:32]
     return _first_message_fingerprint(messages)
+
+
+def apply_opencode_session(request: dict[str, Any], provider: str) -> None:
+    """Add OpenCode Go's conversation-grouping header to ``request`` in place.
+
+    OpenCode Go asks third-party clients to send ``x-opencode-session`` so
+    requests of one conversation are grouped, and has warned that requests
+    omitting it will be rejected (#4071). That makes it a protocol requirement
+    rather than a cache optimization, so it is applied whenever the provider is
+    ``opencode-go`` regardless of the configured ``cache_affinity`` mode — an
+    operator setting ``none`` to opt out of cache pinning must not lose a header
+    the backend requires.
+
+    The value is the operation-scoped id from :func:`cache_affinity_id`, so every
+    LLM call of one retain/reflect/consolidation run shares it — including the
+    provider's own retries, since this is applied to ``call_params`` once before
+    the retry loop — while separate runs get different ids.
+
+    User-wins, matching :func:`apply_cache_affinity`: a value the caller already
+    placed in ``extra_headers`` is kept. Never raises; when no id can be derived
+    the request goes out unchanged.
+    """
+    if provider.lower() != "opencode-go":
+        return
+    session_id = cache_affinity_id(request.get("messages"))
+    if session_id is None:
+        return
+    extra_headers = request.setdefault("extra_headers", {})
+    extra_headers.setdefault(OPENCODE_SESSION_HEADER, session_id)
 
 
 def apply_cache_affinity(request: dict[str, Any], mode: CacheAffinityMode) -> None:

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -40,6 +40,7 @@ from hindsight_api.engine.bank_attribution import apply_bank_attribution
 from hindsight_api.engine.cache_affinity import (
     CacheAffinityMode,
     apply_cache_affinity,
+    apply_opencode_session,
     parse_cache_affinity,
     resolve_cache_affinity,
 )
@@ -1147,6 +1148,7 @@ class OpenAICompatibleLLM(LLMInterface):
         # deterministic (the schema text is fixed per response_format), so the id
         # stays stable across the calls of one run.
         apply_cache_affinity(call_params, self._cache_affinity)
+        apply_opencode_session(call_params, self.provider)
 
         last_exception = None
 
@@ -1550,6 +1552,7 @@ class OpenAICompatibleLLM(LLMInterface):
 
         apply_bank_attribution(call_params)
         apply_cache_affinity(call_params, self._cache_affinity)
+        apply_opencode_session(call_params, self.provider)
 
         last_exception = None
 

--- a/hindsight-api-slim/tests/test_opencode_go_session_header.py
+++ b/hindsight-api-slim/tests/test_opencode_go_session_header.py
@@ -1,0 +1,228 @@
+"""OpenCode Go's required ``x-opencode-session`` conversation header (#4071).
+
+The header must carry ONE id per logical operation: every LLM call of a single
+retain/reflect run — including the provider's internal retries — sends the same
+value, while separate runs send different ones. The id comes from the operation's
+bound ``trace_id``, so these tests drive the real trace context rather than
+asserting on a freshly minted uuid.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from hindsight_api.engine.cache_affinity import (
+    OPENCODE_SESSION_HEADER,
+    apply_opencode_session,
+)
+from hindsight_api.engine.llm_trace import (
+    LLMTraceContext,
+    reset_trace_context,
+    set_trace_context,
+)
+from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
+
+
+class SimpleJsonResponse(BaseModel):
+    ok: bool
+
+
+def _llm(provider: str = "opencode-go") -> OpenAICompatibleLLM:
+    base_urls = {
+        "opencode-go": "https://opencode.ai/zen/go/v1",
+        "openai": "https://api.openai.com/v1",
+    }
+    return OpenAICompatibleLLM(
+        provider=provider,
+        api_key="test-key",
+        base_url=base_urls[provider],
+        model="deepseek-v4-flash" if provider == "opencode-go" else "gpt-4o",
+    )
+
+
+def _response(*, content: str | None = '{"ok": true}'):
+    choice = SimpleNamespace(
+        finish_reason="stop",
+        message=SimpleNamespace(content=content, tool_calls=None, refusal=None),
+    )
+    return SimpleNamespace(choices=[choice], usage=None, error=None)
+
+
+def _sent_session_ids(create: AsyncMock) -> list[str | None]:
+    """The session header sent on each attempt, in call order."""
+    return [(call.kwargs.get("extra_headers") or {}).get(OPENCODE_SESSION_HEADER) for call in create.call_args_list]
+
+
+@contextmanager
+def traced_operation(trace_id: str):
+    """Bind an operation trace context, as ConfiguredLLMProvider does per run.
+
+    Must be entered inside the test body: a ContextVar token can only be reset
+    in the context that created it, so binding from a sync fixture and resetting
+    after an async test raises "created in a different Context".
+    """
+    token = set_trace_context(LLMTraceContext(bank_id="b1", operation="reflect", trace_id=trace_id))
+    try:
+        yield
+    finally:
+        reset_trace_context(token)
+
+
+@pytest.mark.asyncio
+async def test_opencode_go_sends_session_header():
+    llm = _llm()
+    create = AsyncMock(return_value=_response())
+    llm._client.chat.completions.create = create
+
+    with (
+        traced_operation("trace-abc"),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        await llm.call(messages=[{"role": "user", "content": "Hi"}], max_retries=0)
+
+    (session_id,) = _sent_session_ids(create)
+    assert session_id, "opencode-go must send the session header"
+
+
+@pytest.mark.asyncio
+async def test_session_id_is_stable_across_provider_retries():
+    """A retried call is still ONE logical operation — the id must not change."""
+    llm = _llm()
+    # First attempt returns unparseable JSON, forcing the provider's own retry.
+    create = AsyncMock(side_effect=[_response(content="not json"), _response(content='{"ok": true}')])
+    llm._client.chat.completions.create = create
+
+    with (
+        traced_operation("trace-retry"),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.asyncio.sleep", new=AsyncMock()),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        result = await llm.call(
+            messages=[{"role": "user", "content": "Hi"}],
+            response_format=SimpleJsonResponse,
+            max_retries=1,
+            initial_backoff=0,
+        )
+
+    assert result.ok is True
+    first, second = _sent_session_ids(create)
+    assert first and second
+    assert first == second, "retries of one operation must reuse the session id"
+
+
+@pytest.mark.asyncio
+async def test_all_calls_of_one_operation_share_one_session_id():
+    """The reflect-session property: separate calls in one run share the id."""
+    llm = _llm()
+    create = AsyncMock(return_value=_response())
+    llm._client.chat.completions.create = create
+
+    with (
+        traced_operation("trace-one-run"),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        # An agent loop makes several LLM calls within a single operation, and
+        # the message list grows between them.
+        await llm.call(messages=[{"role": "user", "content": "Step 1"}], max_retries=0)
+        await llm.call(
+            messages=[
+                {"role": "user", "content": "Step 1"},
+                {"role": "assistant", "content": "ok"},
+                {"role": "user", "content": "Step 2"},
+            ],
+            max_retries=0,
+        )
+
+    first, second = _sent_session_ids(create)
+    assert first and second
+    assert first == second, "all calls of one reflect run must share the session id"
+
+
+@pytest.mark.asyncio
+async def test_separate_operations_get_separate_session_ids():
+    """Two runs are two conversations, so their ids must differ."""
+    llm = _llm()
+    create = AsyncMock(return_value=_response())
+    llm._client.chat.completions.create = create
+    messages = [{"role": "user", "content": "Same prompt both runs"}]
+
+    with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
+        for trace_id in ("trace-run-1", "trace-run-2"):
+            token = set_trace_context(LLMTraceContext(bank_id="b1", operation="reflect", trace_id=trace_id))
+            try:
+                await llm.call(messages=messages, max_retries=0)
+            finally:
+                reset_trace_context(token)
+
+    first, second = _sent_session_ids(create)
+    assert first and second
+    assert first != second, "separate operations must get separate session ids"
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_send_the_session_header():
+    llm = _llm()
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content="done", tool_calls=None),
+            )
+        ],
+        usage=None,
+        error=None,
+    )
+    create = AsyncMock(return_value=response)
+    llm._client.chat.completions.create = create
+
+    with (
+        traced_operation("trace-tools"),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        await llm.call_with_tools(messages=[{"role": "user", "content": "Hi"}], tools=[], max_retries=0)
+
+    (session_id,) = _sent_session_ids(create)
+    assert session_id, "call_with_tools must also send the session header"
+
+
+@pytest.mark.asyncio
+async def test_other_providers_do_not_send_the_header():
+    """The header is opencode-go's own protocol, not a generic addition."""
+    llm = _llm("openai")
+    create = AsyncMock(return_value=_response())
+    llm._client.chat.completions.create = create
+
+    with (
+        traced_operation("trace-openai"),
+        patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
+    ):
+        await llm.call(messages=[{"role": "user", "content": "Hi"}], max_retries=0)
+
+    assert _sent_session_ids(create) == [None]
+
+
+def test_caller_supplied_header_wins():
+    """An explicitly set header is preserved rather than overwritten."""
+    request = {
+        "messages": [{"role": "user", "content": "Hi"}],
+        "extra_headers": {OPENCODE_SESSION_HEADER: "operator-chosen-id"},
+    }
+    apply_opencode_session(request, "opencode-go")
+    assert request["extra_headers"][OPENCODE_SESSION_HEADER] == "operator-chosen-id"
+
+
+def test_untraced_call_still_sends_a_header():
+    """Outside a traced context the id falls back to a message fingerprint."""
+    request = {"messages": [{"role": "system", "content": "You are a helper."}]}
+    apply_opencode_session(request, "opencode-go")
+    assert request["extra_headers"][OPENCODE_SESSION_HEADER]
+
+
+def test_underivable_id_leaves_the_request_unchanged():
+    """Fail-open: a malformed message list must not add a header or raise."""
+    request: dict = {"messages": "not-a-list"}
+    apply_opencode_session(request, "opencode-go")
+    assert "extra_headers" not in request


### PR DESCRIPTION
Closes #4071.

OpenCode Go asks third-party clients to send `x-opencode-session` so requests of one conversation are grouped, and has warned that requests omitting it will be rejected. Hindsight forwarded it only when an operator hand-configured `default_headers` — which pins one static id across every unrelated conversation.

## One id per operation, not per call

The id comes from `cache_affinity_id()`, which resolves to the operation's bound `trace_id` — the same engine-identity source `x-grok-conv-id` already uses. So a single retain/reflect/consolidation run sends **one** id across:

- the agent loop's successive LLM calls (even as the message list grows mid-run), and
- the provider's own internal retries, since the header is applied to `call_params` once *before* the retry loop.

Separate runs get separate ids. Outside a traced context it falls back to the existing first-message fingerprint.

## Applied independently of `cache_affinity`

This is a protocol requirement, not a cache optimization, so it is applied whenever the provider is `opencode-go` regardless of the configured mode — an operator setting `cache_affinity=none` to opt out of cache pinning must not lose a header the backend requires. User-wins via `setdefault` (a caller-supplied header is kept), and fail-open (an underivable id leaves the request byte-identical).

## Tests

`tests/test_opencode_go_session_header.py` — 9 tests driving the real trace context rather than asserting on a freshly minted uuid:

- header is sent for `opencode-go`, on both `call()` and `call_with_tools()`
- **id is stable across the provider's retries** (first attempt returns unparseable JSON, forcing a retry)
- **all calls of one operation share one id**, including when the message list grows between them
- separate operations get separate ids (same prompt, different `trace_id`)
- other providers send nothing
- caller-supplied header wins; untraced calls still get an id; a malformed message list adds no header and does not raise

Verified these fail without the fix: disabling the provider check drops 6 of the 9. Full suite green — 85 cache-affinity/opencode tests, 100 provider + trace tests, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhvBKibMPS8KqukcXb9hXJ
