### PR TITLE
ci: run the core suite when the workspace lockfile or root manifest changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,14 @@ jobs:
             - 'scripts/**'
             - '.python-version'
             - '.env.example'
+            # The workspace lockfile and root manifest determine which versions
+            # the API actually runs against, so a change to either can break it
+            # without touching a line of source. Both are deliberately bare
+            # patterns: they match only the files at the repository root. A
+            # glob such as '**/uv.lock' would pull every integration lockfile
+            # into the core suite.
+            - 'uv.lock'
+            - 'pyproject.toml'
           clients-ts:
             - 'hindsight-clients/typescript/**'
             - 'package.json'


### PR DESCRIPTION
## The gap

`uv.lock` and `pyproject.toml` at the repository root determine which dependency versions the API is built and tested against. Neither appears in any path filter, so a pull request changing only one of them resolves `core` to false and every Python job is skipped.

The result is a green check set that proves nothing. A dependency bump touching only the workspace lockfile currently reports success having run three jobs — `detect-changes`, `verify-generated-files`, `build-docs` — with `test-api` and the rest of the suite skipped. Nothing observes whether the new versions actually work.

This is easy to miss on review, because "all checks passed" and "the change was tested" look identical in the UI.

## The tell

The workflow already treats the lockfile as environment-determining. It is part of the `test-api` venv cache key:

```yaml
key: ${{ runner.os }}-venv-test-api-${{ hashFiles('uv.lock', 'hindsight-api-slim/pyproject.toml', '.python-version') }}
```

So the cache is invalidated by a file that cannot trigger the job whose cache it keys. The workflow knows the lockfile matters; the filter just never said so.

## The change

Adds both root files to the `core` filter.

Both patterns are **bare**, matching only the files at the repository root. A glob such as `**/uv.lock` would match the ~52 integration lockfiles under `hindsight-integrations/` and run the full core suite for every sample-project bump. Verified with picomatch:

```
uv.lock                                  -> match
hindsight-integrations/crewai/uv.lock    -> no match
hindsight-integrations/llamaindex/uv.lock-> no match
hindsight-api-slim/uv.lock               -> no match
```

`**/uv.lock` matches all four, which is what we do not want.

## Cost

A root-lockfile-only change now runs the 30 jobs gated on `core`, where it previously ran three. That is the intended trade: these are exactly the changes no other filter covers, and they alter the runtime environment for everything.

Bumps confined to an integration's own lockfile are unaffected — they keep matching only their own integration filter.

## Verifying it works

This PR cannot demonstrate the fix on itself: it changes a workflow file, which is not in the `core` filter either. The check comes on the next pull request that touches the root lockfile — `test-api` should run rather than skip.