### PR TITLE
chore: update the tagline to "Agent Memory That Learns"

### DIFF
--- a/hindsight-all-slim/README.md
+++ b/hindsight-all-slim/README.md
@@ -1,6 +1,6 @@
 # hindsight-all
 
-All-in-one package for Hindsight - Agent Memory That Works Like Human Memory
+All-in-one package for Hindsight - Agent Memory That Learns
 
 ## Quick Start
 

--- a/hindsight-all-slim/pyproject.toml
+++ b/hindsight-all-slim/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "hindsight-all-slim"
 version = "0.9.2"
-description = "Hindsight: Agent Memory That Works Like Human Memory - Slim All-in-One Bundle"
+description = "Hindsight: Agent Memory That Learns - Slim All-in-One Bundle"
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/hindsight-all/README.md
+++ b/hindsight-all/README.md
@@ -1,6 +1,6 @@
 # hindsight-all
 
-All-in-one package for Hindsight - Agent Memory That Works Like Human Memory
+All-in-one package for Hindsight - Agent Memory That Learns
 
 ## Quick Start
 

--- a/hindsight-all/pyproject.toml
+++ b/hindsight-all/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "hindsight-all"
 version = "0.9.2"
-description = "Hindsight: Agent Memory That Works Like Human Memory - All-in-One Bundle"
+description = "Hindsight: Agent Memory That Learns - All-in-One Bundle"
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/hindsight-api-slim/hindsight_api/banner.py
+++ b/hindsight-api-slim/hindsight_api/banner.py
@@ -46,7 +46,7 @@ def gradient_text(text: str, start: tuple = GRADIENT_START, end: tuple = GRADIEN
 def print_banner():
     """Print the Hindsight startup banner."""
     print(LOGO)
-    tagline = gradient_text("Hindsight: Agent Memory That Works Like Human Memory")
+    tagline = gradient_text("Hindsight: Agent Memory That Learns")
     print(f"\n  {tagline}\n")
 
 

--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "hindsight-api-slim"
 version = "0.9.2"
-description = "Hindsight: Agent Memory That Works Like Human Memory"
+description = "Hindsight: Agent Memory That Learns"
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/hindsight-api-slim/tests/test_banner.py
+++ b/hindsight-api-slim/tests/test_banner.py
@@ -1,0 +1,56 @@
+"""Tests for the startup banner.
+
+The banner is the first thing a user sees, and the tagline in it is the
+project's public one-liner — it should not drift from the description on the
+repository by accident. The gradient wraps every character in an ANSI escape,
+so these strip the escapes and assert on the text that actually reads.
+"""
+
+import re
+
+from hindsight_api.banner import (
+    GRADIENT_END,
+    GRADIENT_START,
+    gradient_text,
+    print_banner,
+)
+
+TAGLINE = "Hindsight: Agent Memory That Learns"
+
+ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
+
+
+class TestGradientText:
+    def test_plain_text_survives_the_gradient(self):
+        assert strip_ansi(gradient_text(TAGLINE)) == TAGLINE
+
+    def test_spans_the_full_gradient(self):
+        rendered = gradient_text("abc")
+        r, g, b = GRADIENT_START
+        assert f"\033[38;2;{r};{g};{b}m" in rendered
+        r, g, b = GRADIENT_END
+        assert f"\033[38;2;{r};{g};{b}m" in rendered
+
+    def test_spaces_are_not_colored(self):
+        # Spaces are emitted bare, so a run of them costs no escape sequences.
+        assert "  " in gradient_text("a  b")
+
+    def test_empty_string_does_not_divide_by_zero(self):
+        assert strip_ansi(gradient_text("")) == ""
+
+
+class TestPrintBanner:
+    def test_prints_the_tagline(self, capsys):
+        print_banner()
+        assert TAGLINE in strip_ansi(capsys.readouterr().out)
+
+    def test_prints_the_logo_above_the_tagline(self, capsys):
+        print_banner()
+        out = strip_ansi(capsys.readouterr().out)
+        # The logo is drawn with half-block characters.
+        assert "▄" in out
+        assert out.index("▄") < out.index(TAGLINE)

--- a/hindsight-api/pyproject.toml
+++ b/hindsight-api/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "hindsight-api"
 version = "0.9.2"
-description = "Hindsight: Agent Memory That Works Like Human Memory"
+description = "Hindsight: Agent Memory That Learns"
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/hindsight-dev/hindsight_dev/generate_llms_full.py
+++ b/hindsight-dev/hindsight_dev/generate_llms_full.py
@@ -116,7 +116,7 @@ def main():
     timestamp = datetime.now(timezone.utc).isoformat()
     sections.append(f"""# Hindsight Documentation
 
-> Agent Memory that Works Like Human Memory
+> Agent Memory That Learns
 
 This file contains the complete Hindsight documentation for LLM consumption.
 Generated: {timestamp}

--- a/hindsight-docs/docusaurus.config.ts
+++ b/hindsight-docs/docusaurus.config.ts
@@ -11,7 +11,7 @@ const ANNOUNCEMENT_BAR = 'Hindsight is State-of-the-Art on Memory for AI Agents 
 
 const config: Config = {
   title: 'Hindsight',
-  tagline: 'Hindsight: Agent Memory That Works Like Human Memory',
+  tagline: 'Hindsight: Agent Memory That Learns',
   favicon: 'img/favicon.png',
 
   future: {

--- a/hindsight-docs/static/llms.txt
+++ b/hindsight-docs/static/llms.txt
@@ -1,6 +1,6 @@
 # Hindsight
 
-> Agent Memory that Works Like Human Memory
+> Agent Memory That Learns
 
 Hindsight is an agent memory system that gives AI agents persistent, structured memory across sessions. It extracts facts, entities, and relationships from conversations and enables temporal reasoning, opinion formation, and multi-strategy retrieval.
 


### PR DESCRIPTION
## What & why

The startup banner, the package descriptions, the docs-site tagline and `llms.txt` still carried the old tagline, **"Agent Memory That Works Like Human Memory"**. The project's one-liner is now **"Agent Memory That Learns"** — this aligns every published copy so they stop drifting apart.

The banner is the first thing anyone sees when the API starts:

```
  Hindsight: Agent Memory That Learns
```

## Changes

Every place the old tagline was published:

| Surface | File |
|---|---|
| API startup banner | `hindsight-api-slim/hindsight_api/banner.py` |
| PyPI package descriptions | `hindsight-api/`, `hindsight-api-slim/`, `hindsight-all/`, `hindsight-all-slim/` `pyproject.toml` |
| Bundle READMEs | `hindsight-all/README.md`, `hindsight-all-slim/README.md` |
| Docs site tagline | `hindsight-docs/docusaurus.config.ts` |
| `llms.txt` header | `hindsight-docs/static/llms.txt` |
| `llms-full.txt` header | `hindsight-dev/hindsight_dev/generate_llms_full.py` |

A `grep` for the old string now returns nothing. `llms-full.txt` itself is gitignored and regenerated at build, so it picks up the new header automatically.

## Tests

`banner.py` had no test coverage at all — the eight existing callers all patch `print_banner` out, so nothing asserted what it actually prints. Added `hindsight-api-slim/tests/test_banner.py` (6 tests):

- the tagline appears in the banner output, with the logo above it
- `gradient_text` round-trips its input text unchanged
- the rendered gradient spans both endpoint colours
- spaces stay uncoloured, and an empty string doesn't divide by zero

The gradient wraps every character in an ANSI escape, so the tests strip the escapes and assert on the text that actually reads. Verified they fail when the tagline regresses, rather than passing vacuously.

Also rendered the banner by hand to confirm the gradient still runs the full `#0074d9` → `#009296` sweep across the shorter string.

## Note

The repository description currently reads `Hindsight: Agent Memory That  Learns` — with a double space between "That" and "Learns". I used the single-space form here; worth fixing the description so the canonical source is clean.

https://claude.ai/code/session_011mnzArjiCdBxa8dh1H47Fa