### PR TITLE
security: pin the llama.cpp prompt cache to RAM

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/llamacpp_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/llamacpp_llm.py
@@ -179,6 +179,17 @@ class LlamaCppServer:
             # Prompt cache: reuse KV cache for repeated system prompts
             "--cache",
             "true",
+            # Keep the prompt cache in RAM. llama_cpp.server's other option,
+            # `disk`, is backed by diskcache, which pickles cache entries
+            # (CVE-2025-69872): anyone able to write to the cache directory
+            # gets code execution in this process when an entry is read back.
+            # diskcache has had no release since 5.6.3 in 2023 and no fixed
+            # version exists, so the exposure is permanent if the disk backend
+            # is ever selected. `ram` is already llama_cpp.server's default;
+            # stating it here means a future edit has to opt into the risk
+            # deliberately rather than inherit it by changing a default.
+            "--cache_type",
+            "ram",
         ]
         # Only pass chat_format if explicitly set (most GGUF models have it embedded)
         if self.chat_format:

--- a/hindsight-api-slim/tests/test_llamacpp_cache_type.py
+++ b/hindsight-api-slim/tests/test_llamacpp_cache_type.py
@@ -1,0 +1,67 @@
+"""The llama.cpp prompt cache must stay in RAM, never on disk.
+
+`llama_cpp.server` offers two prompt-cache backends. The `disk` one is backed
+by diskcache, which pickles its entries (CVE-2025-69872): anyone able to write
+to the cache directory gets code execution in the server process when an entry
+is read back. diskcache has had no release since 5.6.3 in 2023 and no fixed
+version exists, so choosing that backend is a permanent exposure rather than a
+version to bump.
+
+`ram` happens to be llama_cpp.server's own default, which is why this was never
+a live vulnerability. That is exactly the problem: the safety rested on a
+default in someone else's package, invisible at our call site. These tests
+assert we pass the flag ourselves, so switching to the disk backend has to be a
+deliberate edit rather than an inherited default that quietly changes.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from hindsight_api.engine.providers import llamacpp_llm
+from hindsight_api.engine.providers.llamacpp_llm import LlamaCppServer
+
+
+def _captured_cmd(monkeypatch, tmp_path, **kwargs) -> list[str]:
+    """Start a server with the subprocess stubbed, and return the argv.
+
+    `start()` writes a log file under MODELS_DIR before spawning, so point that
+    at tmp_path; otherwise it raises before Popen and captures nothing.
+    """
+    captured: dict[str, list[str]] = {}
+
+    def _fake_popen(cmd, *args, **popen_kwargs):
+        captured["cmd"] = cmd
+        proc = MagicMock()
+        proc.poll.return_value = None
+        return proc
+
+    monkeypatch.setattr(llamacpp_llm, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(llamacpp_llm.subprocess, "Popen", _fake_popen)
+    # _wait_for_ready polls a real socket for up to 120s. The argv is captured
+    # at Popen, well before that, so skip it.
+    monkeypatch.setattr(LlamaCppServer, "_wait_for_ready", AsyncMock())
+
+    server = LlamaCppServer(model_path=Path("/tmp/model.gguf"), port=18080, **kwargs)
+    asyncio.run(server.start())
+
+    assert captured.get("cmd"), "subprocess.Popen was never reached"
+    return captured["cmd"]
+
+
+def test_cache_type_is_passed_explicitly(monkeypatch, tmp_path):
+    """Guards CVE-2025-69872: the flag must be present, not left to a default."""
+    cmd = _captured_cmd(monkeypatch, tmp_path)
+    assert "--cache_type" in cmd, (
+        "llama.cpp server started without an explicit --cache_type. The prompt "
+        "cache backend would then follow llama_cpp.server's default, which can "
+        "change without notice; the `disk` backend pickles via diskcache "
+        "(CVE-2025-69872, no fixed version)."
+    )
+
+
+def test_cache_type_is_ram_not_disk(monkeypatch, tmp_path):
+    cmd = _captured_cmd(monkeypatch, tmp_path)
+    value = cmd[cmd.index("--cache_type") + 1]
+    assert value == "ram", f"prompt cache backend is {value!r}, must be 'ram'"
+    assert "disk" not in cmd, "the diskcache-backed prompt cache must never be selected"


### PR DESCRIPTION
## The exposure

`llama_cpp.server` offers two prompt-cache backends:

```python
# llama_cpp/server/model.py
if settings.cache_type == "disk":
    cache = llama_cpp.LlamaDiskCache(...)   # backed by diskcache
else:
    cache = llama_cpp.LlamaRAMCache(...)
```

The `disk` one uses **diskcache**, which pickles its entries — [CVE-2025-69872](https://github.com/advisories/GHSA-w8v5-vhqr-4h9v). Anyone able to write to the cache directory gets arbitrary code execution in the server process when an entry is read back.

**No fixed version exists.** diskcache's latest release is 5.6.3, published 2023-08-31, and the vulnerable range is `<= 5.6.3`. This is not something a bump resolves.

## Why this is worth a commit rather than nothing

`LlamaCppServer.start()` passes `--cache true` but has never set `--cache_type`, so it inherits the upstream default:

```python
cache_type: Literal["ram", "disk"] = Field(default="ram", ...)
```

That default is `ram`, so the vulnerable path has never been taken. But the safety rests entirely on a default in someone else's package — invisible at our call site, and free to change in any llama-cpp-python release without us noticing.

This passes `--cache_type ram` explicitly. **No behaviour change today.** The point is that reaching the vulnerable backend now requires a deliberate edit here, rather than an upstream default shifting underneath us.

## Reachability, for the record

diskcache reaches the tree through an opt-in chain:

```
hindsight-all[local-llm] → hindsight-api-slim[local-llm] → llama-cpp-python → diskcache
```

Not installed by a default `pip install`, and not in the standalone image, which syncs `--extra local-ml --extra embedded-db`. The `local-llm` docker-compose runs upstream `ghcr.io/ggml-org/llama.cpp:server` as its own container and does not use the Python package at all.

It is genuinely shipped for anyone installing the `local-llm` extra, though, which is why this is a code change rather than a note.

## Tests

Two, in `tests/test_llamacpp_cache_type.py`:

- `--cache_type` is present at all — guards against dropping back to an inherited default
- its value is `ram`, and `disk` appears nowhere in the argv

**Both fail with the change reverted** (verified by stashing it).

The harness stubs `subprocess.Popen` to capture the argv, points `MODELS_DIR` at `tmp_path` (`start()` opens a log file there before spawning), and stubs `_wait_for_ready`, which otherwise polls a real socket for 120 s — that last one is why these run in ~2.5 s rather than four minutes.

19 passed across the llamacpp and local-provider suites. Ruff clean.