### PR TITLE
fix(retain): keep per-fact tags when a delta retain only updates metadata

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -417,6 +417,31 @@ def _normalize_scopes(value: list | str | None) -> list | str | None:
     return value
 
 
+def _reconcile_unit_tags(
+    unit_tags: list[str] | None,
+    document_tags: list[str] | None,
+    previous_document_tags: list[str] | None,
+) -> list[str]:
+    """The tags a surviving unit should carry after a delta retain.
+
+    A unit's tags are the document's tags plus whatever extraction derived for that
+    fact alone (``_inject_label_tags`` appends a ``key:value`` tag per entity label
+    group configured with ``tag: true``). Only the first half is reproducible from
+    the document row, so replacing the list wholesale drops the second half.
+
+    ``previous_document_tags`` is the document's tag set before this retain, which is
+    what makes the two halves separable: anything the unit carries that the old
+    document tag set did not put there is fact-derived and is kept. ``None`` means the
+    caller could not read it, and the document's tags are applied as-is.
+    """
+    incoming = list(document_tags or [])
+    if previous_document_tags is None:
+        return incoming
+    previous = set(previous_document_tags)
+    already = set(incoming)
+    return incoming + [t for t in (unit_tags or []) if t not in previous and t not in already]
+
+
 async def update_memory_units_metadata_and_tags(
     conn,
     bank_id: str,
@@ -425,6 +450,7 @@ async def update_memory_units_metadata_and_tags(
     metadata: dict[str, Any],
     *,
     observation_scopes: list | str | None = None,
+    previous_document_tags: list[str] | None = None,
     ops=None,
 ) -> int:
     """Update document-level attributes on existing memory units.
@@ -432,6 +458,13 @@ async def update_memory_units_metadata_and_tags(
     Delta retain preserves unchanged chunks and their facts. Propagate the
     current document tags, metadata and observation scoping so its optimized
     result matches a full replace.
+
+    Matching a full replace is why ``previous_document_tags`` exists: a full
+    replace re-extracts, so it re-derives the per-fact label tags this path has
+    no way to recompute. Given the document's previous tag set, those tags are
+    the ones a survivor carries that the previous set did not contain, and they
+    are kept (see ``_reconcile_unit_tags``). Without it the units are relabelled
+    with the document's tags alone.
 
     ``metadata`` arrives as the raw retain_params bag (the document row keeps
     the caller's input verbatim), so null-valued keys are dropped here — the
@@ -480,10 +513,11 @@ async def update_memory_units_metadata_and_tags(
         #
         # Set unconditionally, mirroring `SET metadata = $4`: a document whose metadata was cleared
         # must clear on its survivors too, which an absent key would not do.
+        reconciled = {m.unit_id: _reconcile_unit_tags(m.tags, tags, previous_document_tags) for m in page.memories}
         patches = [
             MemoryPatch(
                 unit_id=m.unit_id,
-                tags=list(tags or []),
+                tags=reconciled[m.unit_id],
                 metadata={
                     META_METADATA_JSON: json.dumps(drop_null_values(metadata or {})),
                     META_OBSERVATION_SCOPES: json.dumps(observation_scopes),
@@ -498,7 +532,7 @@ async def update_memory_units_metadata_and_tags(
             for m in page.memories
             if m.fact_type in ("experience", "world")
             and (
-                set(m.tags or []) != set(tags or [])
+                set(m.tags or []) != set(reconciled[m.unit_id])
                 or _normalize_scopes(m.observation_scopes) != _normalize_scopes(observation_scopes)
             )
         ]
@@ -520,15 +554,24 @@ async def update_memory_units_metadata_and_tags(
         bank_id,
         document_id,
     )
+    reconciled_by_id = {row["id"]: _reconcile_unit_tags(row["tags"], tags, previous_document_tags) for row in prior}
     rescoped_ids = [
         row["id"]
         for row in prior
         if row["fact_type"] in ("experience", "world")
         and (
-            set(row["tags"] or []) != set(tags or [])
+            set(row["tags"] or []) != set(reconciled_by_id[row["id"]])
             or _normalize_scopes(row["observation_scopes"]) != _normalize_scopes(observation_scopes)
         )
     ]
+    # Rows that keep something extra, grouped so the follow-up below is one statement per
+    # distinct tag list rather than one per unit. Empty whenever no unit carries a
+    # fact-derived tag, which is every document without label tags.
+    keepers: dict[tuple[str, ...], list] = {}
+    for row in prior:
+        reconciled = reconciled_by_id[row["id"]]
+        if set(reconciled) != set(tags or []):
+            keepers.setdefault(tuple(reconciled), []).append(row["id"])
 
     result = await conn.execute(
         f"""
@@ -542,6 +585,14 @@ async def update_memory_units_metadata_and_tags(
         json.dumps(drop_null_values(metadata)),
         json.dumps(observation_scopes) if observation_scopes is not None else None,
     )
+
+    for reconciled, unit_ids in keepers.items():
+        await conn.execute(
+            f"UPDATE {fq_table('memory_units')} SET tags = $1 WHERE bank_id = $2 AND id = ANY($3::uuid[])",
+            list(reconciled),
+            bank_id,
+            unit_ids,
+        )
 
     if rescoped_ids:
         await delete_stale_observations_for_memories(conn, bank_id, rescoped_ids, ops=ops)

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -433,6 +433,12 @@ def _reconcile_unit_tags(
     what makes the two halves separable: anything the unit carries that the old
     document tag set did not put there is fact-derived and is kept. ``None`` means the
     caller could not read it, and the document's tags are applied as-is.
+
+    The separation is a set difference, so it cannot split a tag the document
+    supplied *and* extraction derived: that tag reads as document-derived in full
+    and is dropped when the document drops it, where a full replace would re-run
+    ``_inject_label_tags`` and keep it. Telling those apart needs the unit's
+    entities and the bank's label config, neither of which this layer has.
     """
     incoming = list(document_tags or [])
     if previous_document_tags is None:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -3819,11 +3819,16 @@ async def _try_delta_retain(
         # the chunk state we based our delta diff on is stale — abort.
         async with acquire_with_retry(pool) as conn:
             async with conn.transaction():
-                current_hash = await conn.fetchval(
-                    f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2 FOR UPDATE",
+                # Read the tags in the same locked row: once the document row is
+                # rewritten below, which half of a survivor's tags came from the
+                # document is no longer answerable.
+                prior_doc = await conn.fetchrow(
+                    f"SELECT content_hash, tags FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2 FOR UPDATE",
                     effective_doc_id,
                     bank_id,
                 )
+                current_hash = prior_doc["content_hash"] if prior_doc else None
+                previous_document_tags = list(prior_doc["tags"] or []) if prior_doc else None
                 # Verify the document hasn't been replaced since we loaded chunks.
                 # Compare the current hash against what we snapshotted at load time.
                 if current_hash is not None and doc_hash_at_load is not None and current_hash != doc_hash_at_load:
@@ -3897,6 +3902,7 @@ async def _try_delta_retain(
                     merged_tags,
                     retain_params.get("metadata", {}),
                     observation_scopes=retain_params.get("observation_scopes"),
+                    previous_document_tags=previous_document_tags,
                     ops=pool.ops,
                 )
                 log_buffer.append(
@@ -4024,6 +4030,12 @@ async def _delta_metadata_only(
         # facts alone" — would otherwise decide it HAD moved and fall back to a full retain, which
         # rebuilds the facts and orphans every observation standing on them.
         current_content_hash = await _meta_store.document_content_hash(bank_id=bank_id, document_id=document_id)
+        # `put_document` below replaces the record's tags, so read the ones it is
+        # about to replace. A store that does not report them leaves this None and
+        # the units are relabelled with the document's tags alone, as before.
+        _prior_record = await _meta_store.get_document_record(bank_id=bank_id, document_id=document_id)
+        _prior_tags = (_prior_record or {}).get("tags")
+        previous_document_tags = list(_prior_tags) if _prior_tags is not None else None
         if expected_content_hash is not None and current_content_hash != expected_content_hash:
             log_buffer.append(
                 f"[delta] Document {document_id} changed before metadata update — falling back to full retain"
@@ -4065,6 +4077,7 @@ async def _delta_metadata_only(
                     merged_tags,
                     retain_params.get("metadata", {}),
                     observation_scopes=retain_params.get("observation_scopes"),
+                    previous_document_tags=previous_document_tags,
                     ops=pool.ops,
                 )
         if outbox_callback is not None:
@@ -4079,11 +4092,16 @@ async def _delta_metadata_only(
     async with acquire_with_retry(pool) as conn:
         async with conn.transaction():
             # Lock the document row to serialize with concurrent retains
-            current_content_hash = await conn.fetchval(
-                f"SELECT content_hash FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2 FOR UPDATE",
+            # Tags come from the same locked read: `upsert_document_metadata` below
+            # overwrites them, and after that which half of a survivor's tags the
+            # document contributed is no longer answerable.
+            prior_doc = await conn.fetchrow(
+                f"SELECT content_hash, tags FROM {fq_table('documents')} WHERE id = $1 AND bank_id = $2 FOR UPDATE",
                 document_id,
                 bank_id,
             )
+            current_content_hash = prior_doc["content_hash"] if prior_doc else None
+            previous_document_tags = list(prior_doc["tags"] or []) if prior_doc else None
             if expected_content_hash is not None and current_content_hash != expected_content_hash:
                 log_buffer.append(
                     f"[delta] Document {document_id} changed before metadata update — falling back to full retain"
@@ -4112,6 +4130,7 @@ async def _delta_metadata_only(
                 merged_tags,
                 retain_params.get("metadata", {}),
                 observation_scopes=retain_params.get("observation_scopes"),
+                previous_document_tags=previous_document_tags,
                 ops=pool.ops,
             )
             if outbox_callback is not None:

--- a/hindsight-api-slim/tests/test_delta_retain.py
+++ b/hindsight-api-slim/tests/test_delta_retain.py
@@ -594,6 +594,153 @@ async def test_delta_retain_tags_propagated_to_existing_units(memory, request_co
         await memory.delete_bank(bank_id, request_context=request_context)
 
 
+_LABEL_TAG_CONTENT = "The team standardised on Postgres for the metadata store."
+
+
+def test_reconcile_unit_tags():
+    """The document-derived half is replaced; the rest of the unit's tags is kept."""
+    from hindsight_api.engine.retain.fact_storage import _reconcile_unit_tags
+
+    unit = ["team-a", "category:durable"]
+
+    # No previous tag set to compare against: nothing can be told apart, so the
+    # document's tags are applied as-is.
+    assert _reconcile_unit_tags(unit, ["team-b"], None) == ["team-b"]
+
+    # team-a came from the document and is gone from it; category:durable did not.
+    assert _reconcile_unit_tags(unit, ["team-b"], ["team-a"]) == ["team-b", "category:durable"]
+
+    # A document that carried no tags contributed none of the unit's.
+    assert _reconcile_unit_tags(unit, ["team-b"], []) == ["team-b", "team-a", "category:durable"]
+
+    # A kept tag that the document now also carries is not duplicated.
+    assert _reconcile_unit_tags(unit, ["category:durable"], []) == ["category:durable", "team-a"]
+
+    assert _reconcile_unit_tags([], ["team-b"], ["team-a"]) == ["team-b"]
+    assert _reconcile_unit_tags(unit, [], ["team-a"]) == ["category:durable"]
+
+
+async def _bank_with_label_tags(memory, request_context, bank_id):
+    """A bank whose `category` label group doubles as a tag, with a stub extractor."""
+    await memory._ensure_bank_exists(bank_id, request_context)
+    await memory._config_resolver.update_bank_config(
+        bank_id=bank_id,
+        updates={
+            "entity_labels": [
+                {
+                    "key": "category",
+                    "description": "Kind of decision",
+                    "type": "multi-values",
+                    "tag": True,
+                    "optional": True,
+                    "values": [{"value": "durable", "description": "A durable technical decision"}],
+                }
+            ],
+            "entities_allow_free_form": False,
+        },
+        context=request_context,
+    )
+
+    def _one_labelled_fact(messages, scope):
+        if scope != "retain_extract_facts":
+            return None
+        return {
+            "facts": [
+                {
+                    "what": _LABEL_TAG_CONTENT,
+                    "when": "N/A",
+                    "where": "N/A",
+                    "who": "N/A",
+                    "why": "N/A",
+                    "fact_kind": "conversation",
+                    "fact_type": "world",
+                    "entities": [],
+                    "labels": {"category": ["durable"]},
+                }
+            ]
+        }
+
+    memory._retain_llm_config.set_response_callback(_one_labelled_fact)
+
+
+async def _unit_tags(memory, request_context, bank_id, document_id):
+    listing = await memory.list_memory_units(
+        bank_id, document_id=document_id, limit=1000, request_context=request_context
+    )
+    return [sorted(row["tags"] or []) for row in listing["items"]]
+
+
+@pytest.mark.asyncio
+async def test_delta_retain_keeps_label_derived_tags_on_surviving_units(memory, request_context):
+    """
+    A tag `_inject_label_tags` derived for one fact lives only on that memory unit,
+    never on the document row, so the document's tag set cannot reproduce it. A
+    re-retain of unchanged content takes the metadata-only path, which must
+    reconcile the document-derived tags rather than replace the unit's whole list.
+    """
+    bank_id = f"test_delta_label_tags_{_ts()}"
+    document_id = "label-tags-doc"
+
+    try:
+        await _bank_with_label_tags(memory, request_context, bank_id)
+
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": _LABEL_TAG_CONTENT, "document_id": document_id, "tags": ["scope:test"]}],
+            request_context=request_context,
+        )
+        v1 = await _unit_tags(memory, request_context, bank_id, document_id)
+        assert v1 == [["category:durable", "scope:test"]], f"extraction should tag the unit, got {v1}"
+
+        # Byte-identical content, one document tag added: no chunk changes, so this
+        # is the metadata-only delta path.
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": _LABEL_TAG_CONTENT, "document_id": document_id, "tags": ["scope:test", "team-b"]}],
+            request_context=request_context,
+        )
+
+        v2 = await _unit_tags(memory, request_context, bank_id, document_id)
+        assert v2 == [["category:durable", "scope:test", "team-b"]], (
+            f"the label-derived tag should survive and the new document tag should propagate, got {v2}"
+        )
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+async def test_delta_retain_drops_a_removed_document_tag_from_surviving_units(memory, request_context):
+    """
+    Reconciling must not turn into "keep everything": a tag the document no longer
+    carries is still removed from its units, which is what the observation
+    invalidation cascade keys on.
+    """
+    bank_id = f"test_delta_tag_removal_{_ts()}"
+    document_id = "tag-removal-doc"
+
+    try:
+        await _bank_with_label_tags(memory, request_context, bank_id)
+
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": _LABEL_TAG_CONTENT, "document_id": document_id, "tags": ["scope:test", "team-a"]}],
+            request_context=request_context,
+        )
+        v1 = await _unit_tags(memory, request_context, bank_id, document_id)
+        assert v1 == [["category:durable", "scope:test", "team-a"]], f"unexpected v1 tags: {v1}"
+
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": _LABEL_TAG_CONTENT, "document_id": document_id, "tags": ["scope:test"]}],
+            request_context=request_context,
+        )
+
+        v2 = await _unit_tags(memory, request_context, bank_id, document_id)
+        assert v2 == [["category:durable", "scope:test"]], f"team-a should be gone, got {v2}"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
 # ============================================================
 # Chunk Management Tests
 # ============================================================

--- a/hindsight-api-slim/tests/test_delta_retain.py
+++ b/hindsight-api-slim/tests/test_delta_retain.py
@@ -619,6 +619,13 @@ def test_reconcile_unit_tags():
     assert _reconcile_unit_tags([], ["team-b"], ["team-a"]) == ["team-b"]
     assert _reconcile_unit_tags(unit, [], ["team-a"]) == ["category:durable"]
 
+    # The one case a set difference cannot separate, pinned so it is a known
+    # answer rather than a surprise: the document supplied `category:durable` and
+    # extraction also derived it for the fact. The tag reads as document-derived
+    # in full and goes when the document drops it, where a full replace would
+    # re-run `_inject_label_tags` and keep it.
+    assert _reconcile_unit_tags(["category:durable"], [], ["category:durable"]) == []
+
 
 async def _bank_with_label_tags(memory, request_context, bank_id):
     """A bank whose `category` label group doubles as a tag, with a stub extractor."""


### PR DESCRIPTION
Superseded by #4120, which merged this morning. That one splits the label tags by config key (`label_tag_keys` and `split_label_tags` in `entity_labels.py`) instead of inferring provenance from the document's previous tag set, so it also covers the overlap case listed as the third limit below, plus the delta-retain path and the tags PATCH that this PR left alone. Closing this one.

On current main the reprocess half is already fixed: `reprocess_document` sets `force_reextract`, the delta attempt is gated on `not force_reextract`, and running the label config from the issue through a reprocess re-extracts and keeps `category:durable`. So #3949 does cover that question.

The loss is still reachable the other way. A plain re-retain of the same content still lands on the metadata-only delta path, and that path does `SET tags = <document tags>` on every surviving unit. `_inject_label_tags` puts `category:durable` on the unit and never on the document row, so the document's tag set can't reproduce it and it's gone.

What separates the two halves is the document's previous tag set: a tag a unit carries that the old document set didn't contain is fact-derived, so it's kept. It's read in the locked SELECT that already fetches `content_hash`, before the row gets rewritten. A store that can't report it gets the old behaviour.

Removal still works, a tag dropped from the document is still dropped from its units, which is what the #4019 invalidation keys on. There's a test for that direction too.

Three limits. The store-owned branch of that function has no test in the repo, so only the SQL path is pinned here. A tag the document supplied and extraction also derived reads as document-derived to a set difference, so dropping it from the document drops it from the units, where a full replace would re-derive it; that case comes out the same as it does on main, and what changes here is the case where the document never carried the tag. And this doesn't repair units that already lost their tags.

Fixes #4068


