### PR TITLE
fix(search): clamp future dates before the exponential recency power

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/search/reranking.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/reranking.py
@@ -50,7 +50,10 @@ def compute_recency_decay(
     if function == "exponential":
         if halflife_days <= 0:
             return 0.5
-        return min(1.0, 0.5 ** (days_ago / halflife_days))
+        # Clamp ahead of the power: 0.5 ** a large negative exponent overflows.
+        if days_ago <= 0:
+            return 1.0
+        return 0.5 ** (days_ago / halflife_days)
     # "linear" (default): straight decay to a 0.1 floor over the window.
     window = linear_window_days if linear_window_days > 0 else _RECENCY_DECAY_LINEAR_WINDOW_DAYS
     return max(0.1, min(1.0, 1.0 - (days_ago / window)))

--- a/hindsight-api-slim/tests/test_combined_scoring.py
+++ b/hindsight-api-slim/tests/test_combined_scoring.py
@@ -242,6 +242,18 @@ class TestRecencyDecayFunction:
         assert compute_recency_decay(-100, "linear") == 1.0
         assert compute_recency_decay(-100, "exponential", halflife_days=90) == 1.0
 
+    def test_far_future_dates_clamp_without_overflowing(self):
+        """The clamp has to run before the power: 0.5 ** a large negative exponent
+        overflows float, so min() never gets to cap it."""
+        assert compute_recency_decay(-92_160, "exponential", halflife_days=90) == 1.0
+        assert compute_recency_decay(-200_000, "exponential", halflife_days=7) == 1.0
+
+    def test_far_future_unit_does_not_fail_scoring(self):
+        """One far-future memory must not take the whole recall down with it."""
+        sr = _make_result(ce_norm=0.5, occurred_start=NOW + timedelta(days=20_000))
+        apply_combined_scoring([sr], now=NOW, recency_decay_function="exponential", recency_decay_halflife_days=7.0)
+        assert sr.recency == 1.0
+
     def test_nonpositive_halflife_falls_back_to_neutral(self):
         """A misconfigured (<=0) half-life degrades to neutral rather than dividing by zero."""
         assert compute_recency_decay(30, "exponential", halflife_days=0) == 0.5


### PR DESCRIPTION
`compute_recency_decay` raises `OverflowError` on the exponential curve when a memory is dated far enough ahead. Nothing guards the scoring step, so one such row takes down the whole recall for that bank (`Failed to search memories (OverflowError)`).

`min(1.0, 0.5 ** (days_ago / halflife_days))` puts the clamp outside the power, and the power overflows once the exponent drops past -1024. The docstring says future dates clamp to full freshness and `test_future_dates_clamp_to_max` pins that, but only at -100 days, which is nowhere near the edge.

How far ahead you have to be depends on `HINDSIGHT_API_RECENCY_DECAY_HALFLIFE_DAYS`, which has no lower bound:

- 90 (the default): breaks past about 252 years ahead
- 30: about 84 years
- 7: about 19.6 years

At the default that needs a 9999-style sentinel date. At a week-long half-life it's just a fact about something that runs to 2050. #3413 showed nothing outside years 1 to 9999 can reach the date columns and that still holds, but 9999 is representable, and it's that end of the range that hurts here rather than the BC end.

Moved the clamp ahead of the power. Linear and "none" are untouched, and the positive side already underflows to 0.0 without raising.

Two tests next to the existing clamp one: the curve at the overflow point, and a far-future unit going through `apply_combined_scoring`. Both fail on main with OverflowError at reranking.py:53.
