### PR TITLE
fix: retry transient Gemini embedding requests

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -1943,6 +1943,14 @@ class LiteLLMSDKEmbeddings(Embeddings):
 # without a "google/" or "models/" prefix.
 _GEMINI_AGGREGATING_MODEL_MARKER = "gemini-embedding-2"
 
+# Keep provider-level retries short enough that the worker retains control of
+# the operation budget while absorbing ordinary quota and service blips. The
+# SDK's retry layer is request-scoped, unlike the worker's whole-task retry.
+_GEMINI_EMBEDDING_RETRY_ATTEMPTS = 5
+_GEMINI_EMBEDDING_RETRY_INITIAL_DELAY = 1.0
+_GEMINI_EMBEDDING_RETRY_MAX_DELAY = 10.0
+_GEMINI_EMBEDDING_RETRY_STATUS_CODES = [429, 500, 502, 503, 504]
+
 
 def _gemini_model_aggregates_inputs(model: str) -> bool:
     """Whether the model aggregates a multi-input request into one embedding."""
@@ -2037,7 +2045,14 @@ class GeminiEmbeddings(Embeddings):
         if not self.api_key:
             raise ValueError("Gemini embeddings provider requires an API key")
 
-        client_kwargs = {"api_key": self.api_key}
+        retry_options = genai_types.HttpRetryOptions(
+            attempts=_GEMINI_EMBEDDING_RETRY_ATTEMPTS,
+            initial_delay=_GEMINI_EMBEDDING_RETRY_INITIAL_DELAY,
+            max_delay=_GEMINI_EMBEDDING_RETRY_MAX_DELAY,
+            exp_base=2.0,
+            jitter=1.0,
+            http_status_codes=_GEMINI_EMBEDDING_RETRY_STATUS_CODES,
+        )
         if self.force_ipv4:
             import httpx
 
@@ -2045,12 +2060,15 @@ class GeminiEmbeddings(Embeddings):
                 timeout=10,
                 transport=httpx.HTTPTransport(local_address="0.0.0.0"),
             )
-            client_kwargs["http_options"] = genai_types.HttpOptions(
+            http_options = genai_types.HttpOptions(
+                retry_options=retry_options,
                 timeout=10000,
-                httpxClient=self._httpx_client,
+                httpx_client=self._httpx_client,
             )
+        else:
+            http_options = genai_types.HttpOptions(retry_options=retry_options)
 
-        self._client = genai.Client(**client_kwargs)
+        self._client = genai.Client(api_key=self.api_key, http_options=http_options)
         logger.info(f"Embeddings: initializing Gemini provider with model {self.model}")
 
     def _init_vertexai(self, genai) -> None:
@@ -2087,6 +2105,16 @@ class GeminiEmbeddings(Embeddings):
             "vertexai": True,
             "project": self.vertexai_project_id,
             "location": self.vertexai_region,
+            "http_options": genai.types.HttpOptions(
+                retry_options=genai.types.HttpRetryOptions(
+                    attempts=_GEMINI_EMBEDDING_RETRY_ATTEMPTS,
+                    initial_delay=_GEMINI_EMBEDDING_RETRY_INITIAL_DELAY,
+                    max_delay=_GEMINI_EMBEDDING_RETRY_MAX_DELAY,
+                    exp_base=2.0,
+                    jitter=1.0,
+                    http_status_codes=_GEMINI_EMBEDDING_RETRY_STATUS_CODES,
+                )
+            ),
         }
         if credentials is not None:
             client_kwargs["credentials"] = credentials

--- a/hindsight-api-slim/tests/test_gemini_embeddings.py
+++ b/hindsight-api-slim/tests/test_gemini_embeddings.py
@@ -55,6 +55,7 @@ def _make_mock_google_module(mock_genai: MagicMock) -> MagicMock:
     mod.genai = mock_genai
     mod.genai.types.EmbedContentConfig = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
     mod.genai.types.HttpOptions = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
+    mod.genai.types.HttpRetryOptions = MagicMock(side_effect=lambda **kw: MagicMock(**kw))
     return mod
 
 
@@ -104,11 +105,30 @@ class TestGeminiEmbeddings:
         assert emb.dimension == 768
         assert emb.provider_name == "google"
         assert emb._is_vertexai is True
-        mock_genai.Client.assert_called_once_with(
-            vertexai=True,
-            project="test-project",
-            location="us-central1",
+        client_kwargs = mock_genai.Client.call_args.kwargs
+        assert client_kwargs["vertexai"] is True
+        assert client_kwargs["project"] == "test-project"
+        assert client_kwargs["location"] == "us-central1"
+        assert client_kwargs["http_options"].retry_options is not None
+
+    async def test_initialization_configures_bounded_transient_retries(self):
+        """Retry only quota and transient service responses within a bounded budget."""
+        mock_genai = _make_mock_genai()
+        emb = GeminiEmbeddings(model="gemini-embedding-001", api_key="test-key")
+
+        with _patch_google_import(mock_genai):
+            await emb.initialize()
+
+        mock_genai.types.HttpRetryOptions.assert_called_once_with(
+            attempts=5,
+            initial_delay=1.0,
+            max_delay=10.0,
+            exp_base=2.0,
+            jitter=1.0,
+            http_status_codes=[429, 500, 502, 503, 504],
         )
+        retry_options = mock_genai.types.HttpOptions.call_args.kwargs["retry_options"]
+        assert retry_options is not None
 
     async def test_initialization_missing_api_key(self):
         """Test that missing API key raises ValueError when no vertexai_project_id."""
@@ -193,6 +213,10 @@ class TestGeminiEmbeddings:
         mock_http_client.assert_called_once_with(timeout=10, transport=mock_transport)
         assert emb._httpx_client is mock_httpx_client
         assert "http_options" in mock_genai.Client.call_args.kwargs
+        http_options_kwargs = mock_genai.types.HttpOptions.call_args.kwargs
+        assert http_options_kwargs["retry_options"] is not None
+        assert http_options_kwargs["timeout"] == 10000
+        assert http_options_kwargs["httpx_client"] is mock_httpx_client
 
     def test_auto_detect_vertexai(self):
         """Test that _is_vertexai is auto-detected from vertexai_project_id."""


### PR DESCRIPTION
## Problem

Native Gemini embedding requests currently fail immediately on quota and transient service responses. The worker can retry the whole task, but that coarse retry can dead-letter retain and consolidation operations during a short provider outage.

Closes #4103.

## Fix

Configure the Google GenAI client with a bounded request-level retry policy for 429 and transient 5xx responses. Apply the same policy to Gemini API and Vertex AI clients, and merge it into the existing `force_ipv4` HTTP options so the custom transport and timeout are preserved. Permanent 4xx responses remain fail-fast.

## Test

- `uv run --directory hindsight-api-slim pytest tests/test_gemini_embeddings.py -q` (36 passed, 1 skipped)
- Ruff check on the changed source and tests
- Ruff format check
- `git diff --check`

## Risk

Retries add bounded latency when Google is unavailable. The policy is capped at five total attempts and a 10-second maximum delay; exhausted requests still propagate to the worker, and the status-code allowlist excludes permanent client errors.