### PR TITLE
fix(tracing): attach bank ID to retain spans

### DIFF
--- a/hindsight-api-slim/hindsight_api/tracing.py
+++ b/hindsight-api-slim/hindsight_api/tracing.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import time
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Optional
 
 from opentelemetry import trace
@@ -301,6 +302,7 @@ def get_tracer() -> trace.Tracer | NoOpTracer:
     return _tracer
 
 
+@contextmanager
 def create_operation_span(operation: str, bank_id: str | None = None):
     """
     Create a parent span for a Hindsight operation (retain, reflect, consolidation, etc.).
@@ -317,21 +319,17 @@ def create_operation_span(operation: str, bank_id: str | None = None):
         Span context manager
     """
     if not _tracing_enabled or _tracer is None:
-        # Return a no-op context manager
-        from contextlib import nullcontext
-
-        return nullcontext()
+        yield None
+        return
 
     span_name = f"hindsight.{operation}"
-    span = _tracer.start_as_current_span(span_name)
-
-    # Add operation-specific attributes
-    if span and hasattr(span, "set_attribute"):
+    # OpenTelemetry returns a context manager here, not the span itself. Set
+    # attributes on the span yielded by that manager so exporters receive them.
+    with _tracer.start_as_current_span(span_name) as span:
         span.set_attribute("hindsight.operation", operation)
         if bank_id:
             span.set_attribute("hindsight.bank_id", bank_id)
-
-    return span
+        yield span
 
 
 def is_tracing_enabled() -> bool:

--- a/hindsight-api-slim/tests/test_tracing.py
+++ b/hindsight-api-slim/tests/test_tracing.py
@@ -287,10 +287,13 @@ def test_create_operation_span_enabled(mock_tracer):
     """Test that create_operation_span creates a span when tracing is enabled."""
     # Mock the tracer
     mock_span = MagicMock()
-    mock_tracer.start_as_current_span.return_value = mock_span
+    mock_context = MagicMock()
+    mock_context.__enter__.return_value = mock_span
+    mock_tracer.start_as_current_span.return_value = mock_context
 
     # Create operation span
-    span = create_operation_span("retain", "bank123")
+    with create_operation_span("retain", "bank123") as span:
+        assert span is mock_span
 
     # Verify span was created with correct name
     mock_tracer.start_as_current_span.assert_called_once_with("hindsight.retain")
@@ -305,10 +308,13 @@ def test_create_operation_span_enabled(mock_tracer):
 def test_create_operation_span_no_bank_id(mock_tracer):
     """Test that create_operation_span works without bank_id."""
     mock_span = MagicMock()
-    mock_tracer.start_as_current_span.return_value = mock_span
+    mock_context = MagicMock()
+    mock_context.__enter__.return_value = mock_span
+    mock_tracer.start_as_current_span.return_value = mock_context
 
     # Create operation span without bank_id
-    span = create_operation_span("consolidation")
+    with create_operation_span("consolidation"):
+        pass
 
     # Verify span was created
     mock_tracer.start_as_current_span.assert_called_once_with("hindsight.consolidation")
@@ -323,7 +329,9 @@ def test_create_operation_span_no_bank_id(mock_tracer):
 def test_create_operation_span_all_operations(mock_tracer):
     """Test that all 4 operations can create parent spans."""
     mock_span = MagicMock()
-    mock_tracer.start_as_current_span.return_value = mock_span
+    mock_context = MagicMock()
+    mock_context.__enter__.return_value = mock_span
+    mock_tracer.start_as_current_span.return_value = mock_context
 
     operations = ["retain", "consolidation", "reflect", "mental_model_refresh"]
 
@@ -331,7 +339,8 @@ def test_create_operation_span_all_operations(mock_tracer):
         mock_tracer.reset_mock()
         mock_span.reset_mock()
 
-        span = create_operation_span(operation, "test_bank")
+        with create_operation_span(operation, "test_bank"):
+            pass
 
         # Verify span was created with correct name
         mock_tracer.start_as_current_span.assert_called_once_with(f"hindsight.{operation}")


### PR DESCRIPTION
Fixes #4106.

`start_as_current_span()` returns a context manager, but `create_operation_span()` was attempting to set attributes on that manager rather than on the span it yields. As a result, the documented `hindsight.operation` and `hindsight.bank_id` attributes never reached retain, reflect, or consolidation operation spans.

This enters the OpenTelemetry context first, applies attributes to the yielded span, and preserves the existing operation context-manager API. The regression tests now keep the context manager and yielded span as distinct mocks so this failure mode is covered.

Tests:
- `uv run pytest tests/test_tracing.py -q` (28 passed)
- `./scripts/hooks/lint.sh`