### PR TITLE
fix(retain): report how many memories a synchronous retain created (#4065)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -921,6 +921,7 @@ class RetainResponse(BaseModel):
                 "bank_id": "user123",
                 "items_count": 2,
                 "async": False,
+                "memories_created": 5,
                 "usage": {"input_tokens": 500, "output_tokens": 100, "total_tokens": 600},
             }
         },
@@ -939,6 +940,17 @@ class RetainResponse(BaseModel):
     operation_ids: list[str] | None = Field(
         default=None,
         description="Operation IDs when items were submitted as multiple strategy groups (async=true with mixed per-item strategies). operation_id is set to the first entry for backward compatibility.",
+    )
+    memories_created: int | None = Field(
+        default=None,
+        description=(
+            "How many memory units this retain created (only present for synchronous operations). "
+            "Extraction can legitimately find nothing to remember in content that carries no facts, "
+            "and that outcome is a success, not an error: the document is stored but has no memory "
+            "units, so it cannot be reached through recall. Zero here is what tells the caller that "
+            "happened. A re-retain of a document whose text is unchanged also reports zero, because "
+            "the delta path keeps the units it already has."
+        ),
     )
     usage: TokenUsage | None = Field(
         default=None,
@@ -8124,6 +8136,12 @@ def _register_routes(app: FastAPI):
 
                 # Synchronous processing: one batch per strategy group, aggregate results
                 total_items_count = 0
+                # Reported back to the caller. A retain whose extraction finds no
+                # facts stores the document and returns 200 with nothing behind it;
+                # without this count the caller cannot tell that from a retain that
+                # produced memories, and only discovers it later when recall comes
+                # back empty (#4065).
+                total_memories_created = 0
                 total_usage = TokenUsage(input_tokens=0, output_tokens=0, total_tokens=0)
                 with metrics.record_operation("retain", bank_id=bank_id, source="api"):
                     for group_strategy, contents in strategy_groups.items():
@@ -8141,6 +8159,8 @@ def _register_routes(app: FastAPI):
                             ),
                         )
                         total_items_count += len(contents)
+                        # `result` is the per-content-item list of created unit ids.
+                        total_memories_created += sum(len(unit_ids) for unit_ids in result)
                         if usage:
                             total_usage = TokenUsage(
                                 input_tokens=total_usage.input_tokens + usage.input_tokens,
@@ -8154,6 +8174,7 @@ def _register_routes(app: FastAPI):
                         "bank_id": bank_id,
                         "items_count": total_items_count,
                         "async": False,
+                        "memories_created": total_memories_created,
                         "usage": total_usage,
                     }
                 )

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -340,12 +340,23 @@ async def _record_retain_document_outcome(pool: Any, bank_id: str, document_id: 
     ``units_created > 0`` already settles the outcome, so the count query only
     runs on the zero case — which is exactly the cheap path (nothing was written).
     Best-effort: telemetry must never fail a retain.
+
+    The zero case is also logged, not only counted. It was previously visible in
+    the metric alone, so an operator reading the logs of a retain that stored
+    nothing saw a completely ordinary, successful retain (#4065).
     """
     try:
         total = units_created
         if total == 0:
             async with acquire_with_retry(pool) as conn:
                 total = await fact_storage.count_document_memory_units(conn, bank_id, document_id)
+        if total == 0:
+            logger.warning(
+                f"[RETAIN] Document {document_id} (bank {bank_id}) has no memory units after this retain: "
+                f"extraction found nothing to remember in its content, so the document is stored but "
+                f"cannot be reached through recall. Content with no substance is dropped by design in "
+                f"'concise' extraction mode; set retain_extraction_mode='verbatim' to keep every item."
+            )
         get_metrics_collector().record_retain_document(bank_id=bank_id, memory_unit_count=total)
     except Exception:
         logger.debug("Failed to record retain document outcome metric", exc_info=True)

--- a/hindsight-api-slim/tests/test_retain_memories_created.py
+++ b/hindsight-api-slim/tests/test_retain_memories_created.py
@@ -1,0 +1,68 @@
+"""The synchronous retain response says how many memories it created (#4065).
+
+Extraction finding nothing to remember in a piece of content is a legitimate
+outcome — the document is stored, it just has no memory units, and recall can
+never reach it. The endpoint answered 200 either way and carried no count, so a
+caller could only discover the difference later, by recalling and finding
+nothing. Reported over enough content at once that looks like a storage engine
+silently dropping writes; it is not.
+"""
+
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _bank() -> str:
+    return f"memories_created_{uuid.uuid4().hex[:8]}"
+
+
+async def _retain(api_client, bank_id: str, content: str, document_id: str) -> dict:
+    response = await api_client.post(
+        f"/v1/default/banks/{bank_id}/memories",
+        json={"items": [{"content": content, "document_id": document_id}], "async": False},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+async def _document_unit_count(api_client, bank_id: str, document_id: str) -> int:
+    response = await api_client.get(f"/v1/default/banks/{bank_id}/documents/{document_id}")
+    assert response.status_code == 200, response.text
+    return response.json()["memory_unit_count"]
+
+
+async def test_sync_retain_reports_the_units_it_created(api_client):
+    """A retain that stores memories reports the same count the document owns."""
+    bank_id = _bank()
+    body = await _retain(
+        api_client,
+        bank_id,
+        "Alice is a machine learning researcher at Stanford.",
+        "doc-with-facts",
+    )
+
+    assert body["memories_created"] >= 1
+    assert body["memories_created"] == await _document_unit_count(api_client, bank_id, "doc-with-facts")
+
+    await api_client.delete(f"/v1/default/banks/{bank_id}")
+
+
+async def test_sync_retain_reports_zero_when_extraction_finds_nothing(api_client, monkeypatch):
+    """Nothing extracted is still a 200 — ``memories_created`` is what says so."""
+    from hindsight_api.engine.providers import mock_llm
+
+    monkeypatch.setattr(mock_llm.MockLLM, "_build_mock_facts", staticmethod(lambda messages: {"facts": []}))
+
+    bank_id = _bank()
+    body = await _retain(api_client, bank_id, "Independent concurrent marker CONCURRENT_INDEP_7.", "doc-no-facts")
+
+    assert body["success"] is True
+    assert body["memories_created"] == 0
+    # The document is stored regardless — that is the shape the issue observed
+    # from outside: a 200, a document, and nothing recallable behind it.
+    assert await _document_unit_count(api_client, bank_id, "doc-no-facts") == 0
+
+    await api_client.delete(f"/v1/default/banks/{bank_id}")

--- a/hindsight-api-slim/tests/test_retain_memories_created.py
+++ b/hindsight-api-slim/tests/test_retain_memories_created.py
@@ -5,7 +5,8 @@ outcome — the document is stored, it just has no memory units, and recall can
 never reach it. The endpoint answered 200 either way and carried no count, so a
 caller could only discover the difference later, by recalling and finding
 nothing. Reported over enough content at once that looks like a storage engine
-silently dropping writes; it is not.
+silently dropping writes; it is not — the default ``concise`` extraction mode
+drops content it judges not worth recalling, per item.
 """
 
 import uuid
@@ -64,5 +65,22 @@ async def test_sync_retain_reports_zero_when_extraction_finds_nothing(api_client
     # The document is stored regardless — that is the shape the issue observed
     # from outside: a 200, a document, and nothing recallable behind it.
     assert await _document_unit_count(api_client, bank_id, "doc-no-facts") == 0
+
+    await api_client.delete(f"/v1/default/banks/{bank_id}")
+
+
+async def test_zero_unit_document_is_logged(api_client, monkeypatch, caplog):
+    """The server says so too — the outcome used to reach a metric and nothing else."""
+    import logging
+
+    from hindsight_api.engine.providers import mock_llm
+
+    monkeypatch.setattr(mock_llm.MockLLM, "_build_mock_facts", staticmethod(lambda messages: {"facts": []}))
+
+    bank_id = _bank()
+    with caplog.at_level(logging.WARNING, logger="hindsight_api.engine.retain.orchestrator"):
+        await _retain(api_client, bank_id, "Independent concurrent marker CONCURRENT_INDEP_9.", "doc-logged")
+
+    assert any("has no memory units after this retain" in record.message for record in caplog.records)
 
     await api_client.delete(f"/v1/default/banks/{bank_id}")

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -9927,6 +9927,7 @@ components:
         async: false
         bank_id: user123
         items_count: 2
+        memories_created: 5
         success: true
         usage:
           input_tokens: 500
@@ -9954,6 +9955,9 @@ components:
             type: string
           nullable: true
           type: array
+        memories_created:
+          nullable: true
+          type: integer
         usage:
           $ref: '#/components/schemas/TokenUsage'
       required:

--- a/hindsight-clients/go/model_retain_response.go
+++ b/hindsight-clients/go/model_retain_response.go
@@ -28,6 +28,7 @@ type RetainResponse struct {
 	Async bool `json:"async"`
 	OperationId NullableString `json:"operation_id,omitempty"`
 	OperationIds []string `json:"operation_ids,omitempty"`
+	MemoriesCreated NullableInt32 `json:"memories_created,omitempty"`
 	Usage NullableTokenUsage `json:"usage,omitempty"`
 }
 
@@ -225,6 +226,48 @@ func (o *RetainResponse) SetOperationIds(v []string) {
 	o.OperationIds = v
 }
 
+// GetMemoriesCreated returns the MemoriesCreated field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *RetainResponse) GetMemoriesCreated() int32 {
+	if o == nil || IsNil(o.MemoriesCreated.Get()) {
+		var ret int32
+		return ret
+	}
+	return *o.MemoriesCreated.Get()
+}
+
+// GetMemoriesCreatedOk returns a tuple with the MemoriesCreated field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RetainResponse) GetMemoriesCreatedOk() (*int32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MemoriesCreated.Get(), o.MemoriesCreated.IsSet()
+}
+
+// HasMemoriesCreated returns a boolean if a field has been set.
+func (o *RetainResponse) HasMemoriesCreated() bool {
+	if o != nil && o.MemoriesCreated.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMemoriesCreated gets a reference to the given NullableInt32 and assigns it to the MemoriesCreated field.
+func (o *RetainResponse) SetMemoriesCreated(v int32) {
+	o.MemoriesCreated.Set(&v)
+}
+// SetMemoriesCreatedNil sets the value for MemoriesCreated to be an explicit nil
+func (o *RetainResponse) SetMemoriesCreatedNil() {
+	o.MemoriesCreated.Set(nil)
+}
+
+// UnsetMemoriesCreated ensures that no value is present for MemoriesCreated, not even an explicit nil
+func (o *RetainResponse) UnsetMemoriesCreated() {
+	o.MemoriesCreated.Unset()
+}
+
 // GetUsage returns the Usage field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *RetainResponse) GetUsage() TokenUsage {
 	if o == nil || IsNil(o.Usage.Get()) {
@@ -286,6 +329,9 @@ func (o RetainResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if o.OperationIds != nil {
 		toSerialize["operation_ids"] = o.OperationIds
+	}
+	if o.MemoriesCreated.IsSet() {
+		toSerialize["memories_created"] = o.MemoriesCreated.Get()
 	}
 	if o.Usage.IsSet() {
 		toSerialize["usage"] = o.Usage.Get()

--- a/hindsight-clients/python/hindsight_client_api/models/retain_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/retain_response.py
@@ -33,8 +33,9 @@ class RetainResponse(BaseModel):
     var_async: StrictBool = Field(description="Whether the operation was processed asynchronously", alias="async")
     operation_id: Optional[StrictStr] = None
     operation_ids: Optional[List[StrictStr]] = None
+    memories_created: Optional[StrictInt] = None
     usage: Optional[TokenUsage] = None
-    __properties: ClassVar[List[str]] = ["success", "bank_id", "items_count", "async", "operation_id", "operation_ids", "usage"]
+    __properties: ClassVar[List[str]] = ["success", "bank_id", "items_count", "async", "operation_id", "operation_ids", "memories_created", "usage"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -88,6 +89,11 @@ class RetainResponse(BaseModel):
         if self.operation_ids is None and "operation_ids" in self.model_fields_set:
             _dict['operation_ids'] = None
 
+        # set to None if memories_created (nullable) is None
+        # and model_fields_set contains the field
+        if self.memories_created is None and "memories_created" in self.model_fields_set:
+            _dict['memories_created'] = None
+
         # set to None if usage (nullable) is None
         # and model_fields_set contains the field
         if self.usage is None and "usage" in self.model_fields_set:
@@ -111,6 +117,7 @@ class RetainResponse(BaseModel):
             "async": obj.get("async"),
             "operation_id": obj.get("operation_id"),
             "operation_ids": obj.get("operation_ids"),
+            "memories_created": obj.get("memories_created"),
             "usage": TokenUsage.from_dict(obj["usage"]) if obj.get("usage") is not None else None
         })
         return _obj

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -4859,6 +4859,12 @@ export type RetainResponse = {
    */
   operation_ids?: Array<string> | null;
   /**
+   * Memories Created
+   *
+   * How many memory units this retain created (only present for synchronous operations). Extraction can legitimately find nothing to remember in content that carries no facts, and that outcome is a success, not an error: the document is stored but has no memory units, so it cannot be reached through recall. Zero here is what tells the caller that happened. A re-retain of a document whose text is unchanged also reports zero, because the delta path keeps the units it already has.
+   */
+  memories_created?: number | null;
+  /**
    * Token usage metrics for LLM calls during fact extraction (only present for synchronous operations)
    */
   usage?: TokenUsage | null;

--- a/hindsight-docs/docs/developer/api/retain.mdx
+++ b/hindsight-docs/docs/developer/api/retain.mdx
@@ -252,7 +252,20 @@ The synchronous retain response includes:
 - `bank_id` — the memory bank that received the content
 - `items_count` — number of items processed
 - `async` — whether processing ran asynchronously
+- `memories_created` — how many memory units the retain created, only present for synchronous operations
 - `usage` — token usage for the LLM calls (`input_tokens`, `output_tokens`, `total_tokens`), only present for synchronous operations
+
+:::note `memories_created` can legitimately be zero
+
+Extraction finds nothing to remember in content that carries no facts — a bare
+identifier, a greeting, boilerplate. The request still succeeds and the document
+is still stored; it just has no memory units, so recall cannot reach it. Check
+`memories_created` rather than the status code when you need to know that the
+content actually became memory. Re-retaining a document whose text has not
+changed also reports zero, because the unchanged content keeps the memories it
+already has.
+
+:::
 
 ---
 

--- a/hindsight-docs/docs/developer/api/retain.mdx
+++ b/hindsight-docs/docs/developer/api/retain.mdx
@@ -255,15 +255,33 @@ The synchronous retain response includes:
 - `memories_created` — how many memory units the retain created, only present for synchronous operations
 - `usage` — token usage for the LLM calls (`input_tokens`, `output_tokens`, `total_tokens`), only present for synchronous operations
 
-:::note `memories_created` can legitimately be zero
+:::warning `memories_created` can be zero — retain is not lossless by default
 
-Extraction finds nothing to remember in content that carries no facts — a bare
-identifier, a greeting, boilerplate. The request still succeeds and the document
-is still stored; it just has no memory units, so recall cannot reach it. Check
-`memories_created` rather than the status code when you need to know that the
-content actually became memory. Re-retaining a document whose text has not
-changed also reports zero, because the unchanged content keeps the memories it
-already has.
+The default extraction mode (`concise`) is deliberately selective: it drops
+greetings, filler, process chatter, and anything else it judges not worth
+recalling in six months. Content with no substance — a bare identifier, a
+tracking marker, boilerplate — therefore produces **no memory units at all**.
+The request still succeeds and the document is still stored; it just cannot be
+reached through recall, ever, because only memory units carry embeddings.
+
+Which items survive is decided per item by the model, so a batch of similar
+low-substance items comes back partially stored, and the surviving subset
+changes when the text changes. That is the extraction policy working, not writes
+being dropped.
+
+Two things follow:
+
+- **Check `memories_created`, not the status code**, when you need to know that
+  content actually became memory. The server also logs a warning for every
+  document left with zero memory units.
+- **If every item must be retrievable, change `retain_extraction_mode`.**
+  `verbatim` stores each chunk's original text as one memory and uses the model
+  only for metadata; `chunks` skips the LLM entirely and stores chunks as-is.
+  Neither can judge content away. `concise` trades completeness for recall
+  quality — these two make the opposite trade.
+
+Re-retaining a document whose text has not changed also reports zero, for an
+unrelated and harmless reason: the delta path keeps the memories it already has.
 
 :::
 

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -14983,6 +14983,18 @@
             "title": "Operation Ids",
             "description": "Operation IDs when items were submitted as multiple strategy groups (async=true with mixed per-item strategies). operation_id is set to the first entry for backward compatibility."
           },
+          "memories_created": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memories Created",
+            "description": "How many memory units this retain created (only present for synchronous operations). Extraction can legitimately find nothing to remember in content that carries no facts, and that outcome is a success, not an error: the document is stored but has no memory units, so it cannot be reached through recall. Zero here is what tells the caller that happened. A re-retain of a document whose text is unchanged also reports zero, because the delta path keeps the units it already has."
+          },
           "usage": {
             "anyOf": [
               {
@@ -15008,6 +15020,7 @@
           "async": false,
           "bank_id": "user123",
           "items_count": 2,
+          "memories_created": 5,
           "success": true,
           "usage": {
             "input_tokens": 500,

--- a/skills/hindsight-docs/references/developer/api/retain.md
+++ b/skills/hindsight-docs/references/developer/api/retain.md
@@ -320,16 +320,34 @@ The synchronous retain response includes:
 - `memories_created` — how many memory units the retain created, only present for synchronous operations
 - `usage` — token usage for the LLM calls (`input_tokens`, `output_tokens`, `total_tokens`), only present for synchronous operations
 
-> **📝 `memories_created` can legitimately be zero**
+> **⚠️ `memories_created` can be zero — retain is not lossless by default**
 >
 
-Extraction finds nothing to remember in content that carries no facts — a bare
-identifier, a greeting, boilerplate. The request still succeeds and the document
-is still stored; it just has no memory units, so recall cannot reach it. Check
-`memories_created` rather than the status code when you need to know that the
-content actually became memory. Re-retaining a document whose text has not
-changed also reports zero, because the unchanged content keeps the memories it
-already has.
+The default extraction mode (`concise`) is deliberately selective: it drops
+greetings, filler, process chatter, and anything else it judges not worth
+recalling in six months. Content with no substance — a bare identifier, a
+tracking marker, boilerplate — therefore produces **no memory units at all**.
+The request still succeeds and the document is still stored; it just cannot be
+reached through recall, ever, because only memory units carry embeddings.
+
+Which items survive is decided per item by the model, so a batch of similar
+low-substance items comes back partially stored, and the surviving subset
+changes when the text changes. That is the extraction policy working, not writes
+being dropped.
+
+Two things follow:
+
+- **Check `memories_created`, not the status code**, when you need to know that
+  content actually became memory. The server also logs a warning for every
+  document left with zero memory units.
+- **If every item must be retrievable, change `retain_extraction_mode`.**
+  `verbatim` stores each chunk's original text as one memory and uses the model
+  only for metadata; `chunks` skips the LLM entirely and stores chunks as-is.
+  Neither can judge content away. `concise` trades completeness for recall
+  quality — these two make the opposite trade.
+
+Re-retaining a document whose text has not changed also reports zero, for an
+unrelated and harmless reason: the delta path keeps the memories it already has.
 
 ---
 

--- a/skills/hindsight-docs/references/developer/api/retain.md
+++ b/skills/hindsight-docs/references/developer/api/retain.md
@@ -317,7 +317,19 @@ The synchronous retain response includes:
 - `bank_id` — the memory bank that received the content
 - `items_count` — number of items processed
 - `async` — whether processing ran asynchronously
+- `memories_created` — how many memory units the retain created, only present for synchronous operations
 - `usage` — token usage for the LLM calls (`input_tokens`, `output_tokens`, `total_tokens`), only present for synchronous operations
+
+> **📝 `memories_created` can legitimately be zero**
+>
+
+Extraction finds nothing to remember in content that carries no facts — a bare
+identifier, a greeting, boilerplate. The request still succeeds and the document
+is still stored; it just has no memory units, so recall cannot reach it. Check
+`memories_created` rather than the status code when you need to know that the
+content actually became memory. Re-retaining a document whose text has not
+changed also reports zero, because the unchanged content keeps the memories it
+already has.
 
 ---
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -14983,6 +14983,18 @@
             "title": "Operation Ids",
             "description": "Operation IDs when items were submitted as multiple strategy groups (async=true with mixed per-item strategies). operation_id is set to the first entry for backward compatibility."
           },
+          "memories_created": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memories Created",
+            "description": "How many memory units this retain created (only present for synchronous operations). Extraction can legitimately find nothing to remember in content that carries no facts, and that outcome is a success, not an error: the document is stored but has no memory units, so it cannot be reached through recall. Zero here is what tells the caller that happened. A re-retain of a document whose text is unchanged also reports zero, because the delta path keeps the units it already has."
+          },
           "usage": {
             "anyOf": [
               {
@@ -15008,6 +15020,7 @@
           "async": false,
           "bank_id": "user123",
           "items_count": 2,
+          "memories_created": 5,
           "success": true,
           "usage": {
             "input_tokens": 500,


### PR DESCRIPTION
Fixes #4065.

## What #4065 actually is

The concurrency is a red herring, and so is the write path. I reproduced the reported pattern by calling `extract_facts_from_text` directly on the issue's own marker strings — **no database, no document write, no HTTP layer**, and one call at a time:

```
concise mode, 8 markers, sequential:  [0,0,0,0,1,1,1,0]  -> 5 produced no facts
```

Then I re-ran each marker five times:

```
marker 0: [0,0,0,0,0]     marker 2: [1,1,1,1,1]
marker 1: [0,0,0,0,0]     marker 3: [1,1,1,1,1]
```

So it is not even nondeterministic per call — it is deterministic per text. `Independent concurrent marker CONCURRENT_INDEP_<ts>_<i>.` is a bare tracking marker, and the default `concise` extraction prompt is explicitly selective: *"Ask: would this be useful to recall in 6 months? If no, skip it."* For some of these strings the model answers no, for others yes, and it answers the same way every time for the same string. Nothing is racing and nothing is being dropped by the storage engine — consistent with @ebarkhordar's two negative reproductions.

The zero-fact writers still burn tokens (~1991 vs ~2148 for one that extracted), which is why the non-zero `usage` looked like proof the write had been lost. It isn't: extraction ran and legitimately returned `"facts": []`.

Downstream that is by design and already covered by `test_document_persisted_with_zero_facts`: the document is stored, has zero memory units, and recall cannot reach it.

## Why this was reported as data loss

Nothing said so, on either side of the wire.

- The **synchronous response** carries `success`, `items_count`, `async` and `usage` and no count of what was stored, so a caller cannot tell "your content became memory" from "there was nothing in it to remember" except by recalling later and finding nothing.
- The **server** counted the outcome in a metric (`_record_retain_document_outcome`, #3040) and logged nothing, so the logs of a retain that stored nothing look like an ordinary successful retain.

Over a batch, that is indistinguishable from writes being silently dropped.

## Changes

1. **`memories_created` on the synchronous retain response** — how many memory units this retain created. Zero is the signal that was missing.
2. **A warning log for every document left with zero memory units**, naming the cause and the fix.
3. **Docs** (`docs/developer/api/retain.mdx`): retain is not lossless by default, and if every item must be retrievable, `retain_extraction_mode` has two modes that cannot judge content away — `verbatim` (stores each chunk's text, model used only for metadata) and `chunks` (no LLM at all). Verified: `verbatim` keeps all eight of the issue's markers where `concise` keeps three.

Deliberately **not** done: falling back to storing raw content when extraction returns nothing. That was decided against previously — it introduces a hybrid storage mode and breaks the separation between extracted facts and raw text. Retrying was also ruled out by the measurement above: the answer is stable per text, so a retry recovers none of them.

## Tests

`hindsight-api-slim/tests/test_retain_memories_created.py` — the count matches the document's `memory_unit_count` on a normal retain; it is `0` with a 200 when extraction returns nothing; and the zero-unit document is logged.

OpenAPI, the generated Python/TS/Go clients, and the docs skill are regenerated. Both wrapper SDKs return the generated `RetainResponse`, so they pick the field up with no change.
