### PR TITLE
fix(cli): print the server's response body on API errors (#4049)

### DIFF
--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -62,6 +62,28 @@ where
     }
 }
 
+/// Await a generated-client call as `call(..).humanized().await?` rather than
+/// `call(..).await?`: this carries the HTTP response body into the error so the
+/// CLI can print what the server actually said, instead of progenitor's
+/// body-less "Unexpected Response: Response { .. }" (see issue #4049).
+#[allow(async_fn_in_trait)]
+trait Humanized<T> {
+    async fn humanized(self) -> anyhow::Result<T>;
+}
+
+impl<F, T, E> Humanized<T> for F
+where
+    F: std::future::Future<Output = std::result::Result<T, ClientError<E>>>,
+    E: serde::Serialize + std::fmt::Debug + Send + Sync + 'static,
+{
+    async fn humanized(self) -> anyhow::Result<T> {
+        match self.await {
+            Ok(value) => Ok(value),
+            Err(err) => Err(humanize_client_error(err).await),
+        }
+    }
+}
+
 // Types not defined in OpenAPI spec (TODO: add to openapi.json)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AgentStats {
@@ -154,6 +176,7 @@ impl ApiClient {
                 let page = self
                     .client
                     .list_banks(Some(PAGE_SIZE), Some(banks.len() as u64), None, None)
+                    .humanized()
                     .await?
                     .into_inner();
                 let fetched = page.banks.len();
@@ -173,7 +196,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::BankProfileResponse> {
         self.runtime.block_on(async {
-            let response = self.client.get_bank_profile(agent_id, None).await?;
+            let response = self
+                .client
+                .get_bank_profile(agent_id, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -182,7 +209,11 @@ impl ApiClient {
         self.runtime.block_on(async {
             // Third arg is the `refresh` query param (force fresh stats); the CLI
             // always reads the cached value, so pass None.
-            let response = self.client.get_agent_stats(agent_id, None, None).await?;
+            let response = self
+                .client
+                .get_agent_stats(agent_id, None, None)
+                .humanized()
+                .await?;
             let value = response.into_inner();
             // Convert to JSON Value first, then parse into our type
             let json_value = serde_json::to_value(&value)?;
@@ -208,6 +239,7 @@ impl ApiClient {
             let response = self
                 .client
                 .create_or_update_bank(agent_id, None, &request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -228,6 +260,7 @@ impl ApiClient {
             let response = self
                 .client
                 .add_bank_background(agent_id, None, &request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -246,10 +279,11 @@ impl ApiClient {
             );
         }
         self.runtime.block_on(async {
-            let response = match self.client.recall_memories(agent_id, None, request).await {
-                Ok(r) => r,
-                Err(e) => return Err(humanize_client_error(e).await),
-            };
+            let response = self
+                .client
+                .recall_memories(agent_id, None, request)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -261,10 +295,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::ReflectResponse> {
         self.runtime.block_on(async {
-            let response = match self.client.reflect(agent_id, None, request).await {
-                Ok(r) => r,
-                Err(e) => return Err(humanize_client_error(e).await),
-            };
+            let response = self
+                .client
+                .reflect(agent_id, None, request)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -277,10 +312,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<MemoryPutResult> {
         self.runtime.block_on(async {
-            let response = match self.client.retain_memories(agent_id, None, request).await {
-                Ok(r) => r,
-                Err(e) => return Err(humanize_client_error(e).await),
-            };
+            let response = self
+                .client
+                .retain_memories(agent_id, None, request)
+                .humanized()
+                .await?;
             let result = response.into_inner();
             Ok(MemoryPutResult {
                 success: result.success,
@@ -373,6 +409,7 @@ impl ApiClient {
                 let response = self
                     .client
                     .list_operations(agent_id, None, None, None, None, None, None)
+                    .humanized()
                     .await?;
                 let ops = response.into_inner();
 
@@ -437,6 +474,7 @@ impl ApiClient {
             let response = self
                 .client
                 .clear_bank_memories(agent_id, None, Some(fact_type))
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -462,6 +500,7 @@ impl ApiClient {
                     None,
                     None,
                 )
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -477,6 +516,7 @@ impl ApiClient {
             let response = self
                 .client
                 .get_document(agent_id, document_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -492,6 +532,7 @@ impl ApiClient {
             let response = self
                 .client
                 .delete_document(agent_id, document_id, None)
+                .humanized()
                 .await?;
             let value = response.into_inner();
             // Convert typed response to DeleteResponse
@@ -508,6 +549,7 @@ impl ApiClient {
             let response = self
                 .client
                 .list_operations(agent_id, None, None, None, None, None, None)
+                .humanized()
                 .await?;
             let value = response.into_inner();
             // Convert to JSON Value first, then parse into our type
@@ -527,6 +569,7 @@ impl ApiClient {
             let response = self
                 .client
                 .cancel_operation(agent_id, operation_id, None)
+                .humanized()
                 .await?;
             let value = response.into_inner();
             // Convert typed response to DeleteResponse
@@ -564,6 +607,7 @@ impl ApiClient {
                     type_filter,
                     None, // authorization
                 )
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -585,6 +629,7 @@ impl ApiClient {
                     offset.map(|o| o as u64),
                     None,
                 )
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -597,7 +642,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::EntityDetailResponse> {
         self.runtime.block_on(async {
-            let response = self.client.get_entity(bank_id, entity_id, None).await?;
+            let response = self
+                .client
+                .get_entity(bank_id, entity_id, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -612,6 +661,7 @@ impl ApiClient {
             let response = self
                 .client
                 .regenerate_entity_observations(bank_id, entity_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -619,7 +669,7 @@ impl ApiClient {
 
     pub fn delete_bank(&self, bank_id: &str, _verbose: bool) -> Result<types::DeleteResponse> {
         self.runtime.block_on(async {
-            let response = self.client.delete_bank(bank_id, None).await?;
+            let response = self.client.delete_bank(bank_id, None).humanized().await?;
             Ok(response.into_inner())
         })
     }
@@ -639,7 +689,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<serde_json::Value> {
         self.runtime.block_on(async {
-            let response = self.client.get_memory(bank_id, memory_id, None).await?;
+            let response = self
+                .client
+                .get_memory(bank_id, memory_id, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -656,6 +710,7 @@ impl ApiClient {
             let response = self
                 .client
                 .create_or_update_bank(bank_id, None, request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -668,7 +723,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::BankProfileResponse> {
         self.runtime.block_on(async {
-            let response = self.client.update_bank(bank_id, None, request).await?;
+            let response = self
+                .client
+                .update_bank(bank_id, None, request)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -687,7 +746,11 @@ impl ApiClient {
                 disposition: None,
                 ..Default::default()
             };
-            let response = self.client.update_bank(bank_id, None, &request).await?;
+            let response = self
+                .client
+                .update_bank(bank_id, None, &request)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -713,6 +776,7 @@ impl ApiClient {
                     type_filter,
                     None,
                 )
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -724,7 +788,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::BankConfigResponse> {
         self.runtime.block_on(async {
-            let response = self.client.get_bank_config(bank_id, None).await?;
+            let response = self
+                .client
+                .get_bank_config(bank_id, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -745,6 +813,7 @@ impl ApiClient {
             let response = self
                 .client
                 .update_bank_config(bank_id, None, &request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -756,7 +825,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::BankConfigResponse> {
         self.runtime.block_on(async {
-            let response = self.client.reset_bank_config(bank_id, None).await?;
+            let response = self
+                .client
+                .reset_bank_config(bank_id, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -782,6 +855,7 @@ impl ApiClient {
                     None,
                     None,
                 )
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -791,7 +865,7 @@ impl ApiClient {
 
     pub fn get_chunk(&self, chunk_id: &str, _verbose: bool) -> Result<types::ChunkResponse> {
         self.runtime.block_on(async {
-            let response = self.client.get_chunk(chunk_id, None).await?;
+            let response = self.client.get_chunk(chunk_id, None).humanized().await?;
             Ok(response.into_inner())
         })
     }
@@ -808,6 +882,7 @@ impl ApiClient {
             let response = self
                 .client
                 .get_operation_status(bank_id, operation_id, None, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -817,14 +892,18 @@ impl ApiClient {
 
     pub fn health(&self, _verbose: bool) -> Result<serde_json::Value> {
         self.runtime.block_on(async {
-            let response = self.client.health_endpoint_health_get().await?;
+            let response = self.client.health_endpoint_health_get().humanized().await?;
             Ok(response.into_inner())
         })
     }
 
     pub fn metrics(&self, _verbose: bool) -> Result<serde_json::Value> {
         self.runtime.block_on(async {
-            let response = self.client.metrics_endpoint_metrics_get().await?;
+            let response = self
+                .client
+                .metrics_endpoint_metrics_get()
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -840,6 +919,7 @@ impl ApiClient {
             let response = self
                 .client
                 .list_mental_models(bank_id, None, None, None, None, None, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -855,6 +935,7 @@ impl ApiClient {
             let response = self
                 .client
                 .get_mental_model(bank_id, mental_model_id, None, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -870,6 +951,7 @@ impl ApiClient {
             let response = self
                 .client
                 .create_mental_model(bank_id, None, request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -886,6 +968,7 @@ impl ApiClient {
             let response = self
                 .client
                 .update_mental_model(bank_id, mental_model_id, None, request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -901,6 +984,7 @@ impl ApiClient {
             let response = self
                 .client
                 .delete_mental_model(bank_id, mental_model_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -916,6 +1000,7 @@ impl ApiClient {
             let response = self
                 .client
                 .refresh_mental_model(bank_id, mental_model_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -931,6 +1016,7 @@ impl ApiClient {
             let response = self
                 .client
                 .dry_run_refresh_mental_model(bank_id, mental_model_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -946,6 +1032,7 @@ impl ApiClient {
             let response = self
                 .client
                 .get_mental_model_history(bank_id, mental_model_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -959,7 +1046,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::KnowledgeTreeResponse> {
         self.runtime.block_on(async {
-            let response = self.client.get_knowledge_base_tree(bank_id, None).await?;
+            let response = self
+                .client
+                .get_knowledge_base_tree(bank_id, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -974,6 +1065,7 @@ impl ApiClient {
             let response = self
                 .client
                 .create_knowledge_folder(bank_id, None, request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -989,6 +1081,7 @@ impl ApiClient {
             let response = self
                 .client
                 .create_knowledge_page(bank_id, None, request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1004,6 +1097,7 @@ impl ApiClient {
             let response = self
                 .client
                 .get_knowledge_page(bank_id, page_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1020,6 +1114,7 @@ impl ApiClient {
             let response = self
                 .client
                 .search_knowledge_base(bank_id, limit, query, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1036,6 +1131,7 @@ impl ApiClient {
             let response = self
                 .client
                 .update_knowledge_node(bank_id, node_id, None, request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1051,6 +1147,7 @@ impl ApiClient {
             let response = self
                 .client
                 .delete_knowledge_node(bank_id, node_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1062,7 +1159,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::KnowledgePageBundleResponse> {
         self.runtime.block_on(async {
-            let response = self.client.export_knowledge_base(bank_id, None).await?;
+            let response = self
+                .client
+                .export_knowledge_base(bank_id, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -1078,6 +1179,7 @@ impl ApiClient {
             let response = self
                 .client
                 .list_directives(bank_id, None, None, None, None, None, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1093,6 +1195,7 @@ impl ApiClient {
             let response = self
                 .client
                 .get_directive(bank_id, directive_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1105,7 +1208,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::DirectiveResponse> {
         self.runtime.block_on(async {
-            let response = self.client.create_directive(bank_id, None, request).await?;
+            let response = self
+                .client
+                .create_directive(bank_id, None, request)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -1121,6 +1228,7 @@ impl ApiClient {
             let response = self
                 .client
                 .update_directive(bank_id, directive_id, None, request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1136,6 +1244,7 @@ impl ApiClient {
             let response = self
                 .client
                 .delete_directive(bank_id, directive_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1153,6 +1262,7 @@ impl ApiClient {
             let response = self
                 .client
                 .trigger_consolidation(bank_id, None, &body)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1164,7 +1274,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::DeleteResponse> {
         self.runtime.block_on(async {
-            let response = self.client.clear_observations(bank_id, None).await?;
+            let response = self
+                .client
+                .clear_observations(bank_id, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -1173,7 +1287,7 @@ impl ApiClient {
 
     pub fn get_version(&self, _verbose: bool) -> Result<types::VersionResponse> {
         self.runtime.block_on(async {
-            let response = self.client.get_version().await?;
+            let response = self.client.get_version().humanized().await?;
             Ok(response.into_inner())
         })
     }
@@ -1193,7 +1307,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::WebhookListResponse> {
         self.runtime.block_on(async {
-            let response = self.client.list_webhooks(bank_id, None, None, None).await?;
+            let response = self
+                .client
+                .list_webhooks(bank_id, None, None, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -1205,7 +1323,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::WebhookResponse> {
         self.runtime.block_on(async {
-            let response = self.client.create_webhook(bank_id, None, request).await?;
+            let response = self
+                .client
+                .create_webhook(bank_id, None, request)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -1221,6 +1343,7 @@ impl ApiClient {
             let response = self
                 .client
                 .update_webhook(bank_id, webhook_id, None, request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1236,6 +1359,7 @@ impl ApiClient {
             let response = self
                 .client
                 .delete_webhook(bank_id, webhook_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1253,6 +1377,7 @@ impl ApiClient {
             let response = self
                 .client
                 .list_webhook_deliveries(bank_id, webhook_id, cursor, limit, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1278,6 +1403,7 @@ impl ApiClient {
                 .list_audit_logs(
                     bank_id, action, end_date, limit_nz, offset, start_date, transport, None,
                 )
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1294,6 +1420,7 @@ impl ApiClient {
             let response = self
                 .client
                 .audit_log_stats(bank_id, action, period, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1303,7 +1430,7 @@ impl ApiClient {
 
     pub fn get_bank_template_schema(&self, _verbose: bool) -> Result<serde_json::Value> {
         self.runtime.block_on(async {
-            let response = self.client.get_bank_template_schema().await?;
+            let response = self.client.get_bank_template_schema().humanized().await?;
             Ok(response.into_inner())
         })
     }
@@ -1314,7 +1441,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::BankTemplateManifest> {
         self.runtime.block_on(async {
-            let response = self.client.export_bank_template(bank_id, None).await?;
+            let response = self
+                .client
+                .export_bank_template(bank_id, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -1362,6 +1493,7 @@ impl ApiClient {
             let response = self
                 .client
                 .update_document(bank_id, document_id, None, &request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1379,6 +1511,7 @@ impl ApiClient {
             let response = self
                 .client
                 .get_observation_history(bank_id, memory_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1394,6 +1527,7 @@ impl ApiClient {
             let response = self
                 .client
                 .clear_memory_observations(bank_id, memory_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1411,6 +1545,7 @@ impl ApiClient {
             let response = self
                 .client
                 .retry_operation(bank_id, operation_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1426,6 +1561,7 @@ impl ApiClient {
             let response = self
                 .client
                 .delete_operation(bank_id, operation_id, None)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })
@@ -1439,7 +1575,11 @@ impl ApiClient {
         _verbose: bool,
     ) -> Result<types::RecoverConsolidationResponse> {
         self.runtime.block_on(async {
-            let response = self.client.recover_consolidation(bank_id, None).await?;
+            let response = self
+                .client
+                .recover_consolidation(bank_id, None)
+                .humanized()
+                .await?;
             Ok(response.into_inner())
         })
     }
@@ -1469,6 +1609,7 @@ impl ApiClient {
             let response = self
                 .client
                 .update_bank_disposition(bank_id, None, &request)
+                .humanized()
                 .await?;
             Ok(response.into_inner())
         })

--- a/hindsight-cli/src/errors.rs
+++ b/hindsight-cli/src/errors.rs
@@ -5,6 +5,48 @@ pub fn handle_api_error(err: anyhow::Error, api_url: &str) -> ! {
     std::process::exit(1);
 }
 
+/// Extract the server's own explanation from an error string produced by
+/// `humanize_client_error` ("API request failed (404 Not Found): {body}").
+///
+/// Returns the JSON `detail` field when the body carries one, the raw body
+/// otherwise, and `None` when there is no body at all. Every HTTP branch below
+/// surfaces this instead of discarding it: a self-explanatory server response
+/// beats generic guidance (see issues #2912, #4049).
+fn server_detail(err_str: &str) -> Option<String> {
+    // Errors carrying a body are shaped "<what> failed (<status>): <body>" —
+    // `humanize_client_error` and the hand-rolled reqwest paths both use it.
+    let (head, body) = err_str.split_once("): ")?;
+    let status = head.rsplit_once('(')?.1;
+    if !status.starts_with(|c: char| c.is_ascii_digit()) {
+        return None;
+    }
+    let body = body.trim();
+    if body.is_empty() {
+        return None;
+    }
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
+        return Some(body.to_string());
+    };
+    match json.get("detail") {
+        Some(serde_json::Value::String(detail)) => Some(detail.clone()),
+        Some(detail) => Some(detail.to_string()),
+        None => Some(body.to_string()),
+    }
+}
+
+/// A "Server response:" block for the detail, or nothing when the server sent
+/// no body.
+fn server_response_section(err_str: &str) -> String {
+    match server_detail(err_str) {
+        Some(detail) => format!(
+            "\n\n{}\n  {}",
+            "Server response:".bright_yellow(),
+            detail.bright_white()
+        ),
+        None => String::new(),
+    }
+}
+
 fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
     let err_str = err.to_string();
 
@@ -43,7 +85,9 @@ fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
             "API URL:".bright_yellow(),
             api_url.bright_white(),
             "Server response:".bright_yellow(),
-            err_str.bright_white()
+            server_detail(&err_str)
+                .unwrap_or_else(|| err_str.clone())
+                .bright_white()
         );
     }
 
@@ -97,6 +141,19 @@ fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
             );
         }
 
+        // A 404 that explains itself ("Document not found") is about the
+        // resource, not the route: print the server's words rather than
+        // sending the operator after an API path/version mismatch.
+        if let Some(detail) = server_detail(&err_str) {
+            return format!(
+                "{} {}\n\n{}\n  {}",
+                "✗".bright_red().bold(),
+                format!("Not found (404): {}", detail).bright_red().bold(),
+                "API URL:".bright_yellow(),
+                api_url.bright_white()
+            );
+        }
+
         return format!(
             "{} {}\n\n{}\n  {}\n\n{}\n  • {}\n  • {}\n\n{}\n  {}",
             "✗".bright_red().bold(),
@@ -114,7 +171,7 @@ fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
     // 401 Authentication failed
     if err_str.contains("401") {
         return format!(
-            "{} {}\n\n{}\n  {}\n\n{}\n  • {}\n  • {}\n\n{}\n  {}",
+            "{} {}\n\n{}\n  {}\n\n{}\n  • {}\n  • {}\n\n{}\n  {}{}",
             "✗".bright_red().bold(),
             "Authentication failed".bright_red().bold(),
             "API URL:".bright_yellow(),
@@ -123,14 +180,15 @@ fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
             "API requires authentication".bright_white(),
             "Invalid or missing credentials".bright_white(),
             "Try:".bright_green(),
-            "Check if the API requires an API key or token".bright_white()
+            "Check if the API requires an API key or token".bright_white(),
+            server_response_section(&err_str)
         );
     }
 
     // 403 Forbidden
     if err_str.contains("403") {
         return format!(
-            "{} {}\n\n{}\n  {}\n\n{}\n  • {}\n  • {}\n\n{}\n  {}",
+            "{} {}\n\n{}\n  {}\n\n{}\n  • {}\n  • {}\n\n{}\n  {}{}",
             "✗".bright_red().bold(),
             "Permission denied (403)".bright_red().bold(),
             "API URL:".bright_yellow(),
@@ -139,14 +197,15 @@ fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
             "This operation is not allowed".bright_white(),
             "The feature may be disabled on the server".bright_white(),
             "Try:".bright_green(),
-            "Check server configuration or contact your administrator".bright_white()
+            "Check server configuration or contact your administrator".bright_white(),
+            server_response_section(&err_str)
         );
     }
 
     // 500 Server Error
     if err_str.contains("500") || err_str.contains("502") || err_str.contains("503") {
         return format!(
-            "{} {}\n\n{}\n  {}\n\n{}\n  • {}\n  • {}\n\n{}\n  • {}\n  • {}",
+            "{} {}\n\n{}\n  {}\n\n{}\n  • {}\n  • {}\n\n{}\n  • {}\n  • {}{}",
             "✗".bright_red().bold(),
             "API server error".bright_red().bold(),
             "API URL:".bright_yellow(),
@@ -156,7 +215,8 @@ fn format_error_message(err: &anyhow::Error, api_url: &str) -> String {
             "Service temporarily unavailable".bright_white(),
             "Try:".bright_green(),
             "Check the API server logs for details".bright_white(),
-            "Try again in a few moments".bright_white()
+            "Try again in a few moments".bright_white(),
+            server_response_section(&err_str)
         );
     }
 
@@ -259,5 +319,90 @@ mod tests {
 
         assert!(message.contains("Batch operations will timeout in synchronous mode"));
         assert!(!message.contains("Request timed out"));
+    }
+
+    #[test]
+    fn http_404_with_a_detail_reports_the_server_message() {
+        let error = anyhow::anyhow!(
+            "API request failed (404 Not Found): {{\"detail\":\"Document not found\"}}"
+        );
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("Not found (404): Document not found"));
+        assert!(!message.contains("API endpoint not found"));
+        assert!(!message.contains("incompatible API version"));
+    }
+
+    #[test]
+    fn http_404_without_a_body_keeps_the_unknown_route_guidance() {
+        let error = anyhow::anyhow!("API request failed (404 Not Found)");
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("API endpoint not found (404)"));
+        assert!(message.contains("incompatible API version"));
+    }
+
+    #[test]
+    fn http_404_for_the_disabled_bank_config_api_keeps_its_dedicated_help() {
+        let error = anyhow::anyhow!(
+            "API request failed (404 Not Found): \
+             {{\"detail\":\"Bank configuration API is disabled\"}}"
+        );
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("HINDSIGHT_API_ENABLE_BANK_CONFIG_API=true"));
+    }
+
+    #[test]
+    fn http_403_surfaces_the_server_response() {
+        let error = anyhow::anyhow!(
+            "API request failed (403 Forbidden): {{\"detail\":\"Bank is read-only\"}}"
+        );
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("Permission denied (403)"));
+        assert!(message.contains("Bank is read-only"));
+    }
+
+    #[test]
+    fn http_500_surfaces_the_server_response() {
+        let error = anyhow::anyhow!(
+            "API request failed (500 Internal Server Error): {{\"detail\":\"embedding backend unreachable\"}}"
+        );
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("embedding backend unreachable"));
+    }
+
+    #[test]
+    fn a_body_from_the_hand_rolled_reqwest_paths_is_surfaced_too() {
+        let error = anyhow::anyhow!("Import failed (404 Not Found): bank does not exist");
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("Not found (404): bank does not exist"));
+    }
+
+    #[test]
+    fn a_parenthetical_that_is_not_a_status_is_not_read_as_a_body() {
+        let error = anyhow::anyhow!("some failure (not a status): 404 somewhere in the text");
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("API endpoint not found (404)"));
+    }
+
+    #[test]
+    fn a_non_json_body_is_shown_verbatim() {
+        let error = anyhow::anyhow!("API request failed (404 Not Found): <html>nginx 404</html>");
+
+        let message = format_error_message(&error, "http://localhost:8888");
+
+        assert!(message.contains("<html>nginx 404</html>"));
     }
 }

--- a/hindsight-cli/tests/api_error_surface.rs
+++ b/hindsight-cli/tests/api_error_surface.rs
@@ -1,0 +1,74 @@
+//! Structural guard: every generated-client call must surface the HTTP
+//! response body.
+//!
+//! A bare `self.client.foo(..).await?` converts progenitor's `Error` into
+//! `anyhow::Error` through its `Display`, which for the common
+//! `UnexpectedResponse` case is "Unexpected Response: Response { .. }" — the
+//! body is never read, so the CLI cannot print what the server actually said
+//! and falls back to generic guidance ("API endpoint not found (404)" for a
+//! plain "Document not found"; see issue #4049). `.humanized()` reads the body
+//! into the error instead.
+//!
+//! Nothing in the type system stops the next call site from writing the bare
+//! form — it compiles and only misbehaves against a real error response, which
+//! no unit test exercises. So the family is checked here, over the whole file,
+//! rather than one call at a time.
+
+/// Statement boundary for the crude scan below: `api.rs` writes one client call
+/// per statement, so everything since the last `;`/`{`/`}` is the call
+/// expression.
+fn statement_before(source: &str, offset: usize) -> &str {
+    let start = [';', '{', '}']
+        .iter()
+        .filter_map(|delimiter| source[..offset].rfind(*delimiter))
+        .max()
+        .unwrap_or(0);
+    &source[start..offset]
+}
+
+#[test]
+fn every_generated_client_call_surfaces_the_response_body() {
+    let source = include_str!("../src/api.rs");
+
+    let mut bare_calls = Vec::new();
+    for (offset, _) in source.match_indices(".await?") {
+        let statement = statement_before(source, offset);
+        let compact: String = statement.chars().filter(|c| !c.is_whitespace()).collect();
+
+        // `http_client` is the hand-rolled reqwest path (multipart upload,
+        // template import); it reads the body itself and formats its own error.
+        if !compact.contains("self.client") || compact.contains("http_client") {
+            continue;
+        }
+        if !compact.contains(".humanized()") {
+            let line = source[..offset].lines().count();
+            let call = statement
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ")
+                .trim_start_matches(['{', '}', ';'])
+                .trim()
+                .to_string();
+            bare_calls.push(format!("  src/api.rs:{}: {}", line, call));
+        }
+    }
+
+    assert!(
+        bare_calls.is_empty(),
+        "generated-client calls that swallow the server's response body — \
+         end them with `.humanized().await?` instead of `.await?`:\n{}",
+        bare_calls.join("\n")
+    );
+}
+
+#[test]
+fn the_guard_notices_a_bare_call() {
+    // Guards the guard: a scan that silently matches nothing would pass the
+    // test above forever.
+    let bare = "let response = self\n.client\n.get_document(bank_id, document_id, None)\n.await?;";
+    let statement = statement_before(bare, bare.find(".await?").unwrap());
+    let compact: String = statement.chars().filter(|c| !c.is_whitespace()).collect();
+
+    assert!(compact.contains("self.client"));
+    assert!(!compact.contains(".humanized()"));
+}


### PR DESCRIPTION
Fixes #4049.

`hindsight document get <bank> <missing-id>` printed:

```
✗ API endpoint not found (404)

Possible causes:
  • The API endpoint path has changed
  • You're using an incompatible API version
```

while the server had answered `404 {"detail":"Document not found"}`. Now:

```
✗ Not found (404): Document not found

API URL:
  http://localhost:8888
```

## Two things were dropping the body

The issue points at the 404 branch in `errors.rs`, which is half of it. The
other half is that the body was never in the error string to begin with:
`api.rs` ran only 3 of ~70 generated-client calls through
`humanize_client_error`, and the rest used a bare `.await?`. That converts
progenitor's error via its `Display`, which for the usual `UnexpectedResponse`
case is a body-less `Unexpected Response: Response { .. }` — the body is left
unread on the wire. Formatting alone could not have fixed the reported repro; I
confirmed that against a live API.

- **`api.rs`** — a `Humanized` extension trait on the call future. Every
  generated-client call is now `call(..).humanized().await?`, which reads the
  status and body into the error. The three hand-written
  `match … humanize_client_error` blocks collapse onto it.
- **`errors.rs`** — `server_detail()` extracts the JSON `detail` (or the raw
  body) from `"<what> failed (<status>): <body>"`, and every HTTP branch
  surfaces it: 404 with a detail reports it and drops the misleading
  path/version guidance, a bodyless 404 (a genuine unknown route) keeps that
  guidance, the bank-config-disabled 404 keeps its dedicated help, and
  401/403/5xx gained a `Server response:` block. The 400 branch prints just the
  detail rather than the whole raw error string.

## Keeping it fixed

Nothing in the type system stops the next call site from writing the bare form:
it compiles and only misbehaves against a real error response, which no unit
test exercises — which is exactly how this regressed past #2912. So
`tests/api_error_surface.rs` checks the whole family rather than one call at a
time: every statement in `api.rs` that awaits a generated-client call must end
in `.humanized()`. A second test guards the scanner itself against silently
matching nothing. `cargo test` already runs in the `test-cli` CI job.

## Testing

- 6 new unit tests in `errors.rs` (404 with/without a detail, the bank-config
  404, 403, 500, a non-JSON body) plus the 2 guard tests.
- `cargo test --bins` 111 passed; fmt clean, no new clippy warnings.
- Verified end to end against a local API: `document get` on a missing document
  now prints `✗ Not found (404): Document not found`, and `memory get` with a
  malformed id prints the server's `Invalid memory_id: … is not a valid UUID`.
