### PR TITLE
fix(reflect): run split synthesis's map calls at temperature 0

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -65,6 +65,22 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_ITERATIONS = 10
 
+#: Temperature for split synthesis's map calls. They copy claims and ids out of one
+#: chunk — the mechanical half of the job, like consolidation's extraction passes,
+#: which also run at 0. The reflect temperature (0.9 by default) belongs to the calls
+#: that reason and write; at that setting a map call sometimes answered a plainly
+#: relevant chunk with the six-token "(no relevant evidence)" sentinel and
+#: finish_reason=stop, dropping that chunk's evidence from the reduce (#4054).
+#:
+#: Applied only when a reflect temperature is configured at all: ``none`` resolves the
+#: whole chain to None so the parameter is omitted, which is how reasoning models that
+#: reject any temperature are run. Hardcoding 0 here would put it back for them.
+_MAP_TEMPERATURE = 0.0
+
+
+def _map_temperature() -> float | None:
+    return None if get_config().llm_temperature_reflect is None else _MAP_TEMPERATURE
+
 
 class ReflectNoAnswerError(RuntimeError):
     """The agent finished without producing an answer.
@@ -710,8 +726,18 @@ async def _run_reflect_agent_inner(
             f"total={elapsed_ms}ms"
         )
 
-    async def _tracked_llm_call(prompt: str, trace_scope: str, system_prompt: str, completion_cap: int | None) -> str:
-        """One tool-less LLM call with usage/trace accounting folded in."""
+    async def _tracked_llm_call(
+        prompt: str,
+        trace_scope: str,
+        system_prompt: str,
+        completion_cap: int | None,
+        temperature: float | None = None,
+    ) -> str:
+        """One tool-less LLM call with usage/trace accounting folded in.
+
+        ``temperature`` defaults to the reflect temperature, which is tuned for
+        writing an answer; callers that extract rather than write override it.
+        """
         nonlocal total_input_tokens, total_output_tokens, total_cached_tokens, total_thoughts_tokens
         llm_start = time.time()
         response, usage = await llm_config.call(
@@ -720,7 +746,7 @@ async def _run_reflect_agent_inner(
                 {"role": "user", "content": prompt},
             ],
             scope="reflect",
-            temperature=get_config().llm_temperature_reflect,
+            temperature=get_config().llm_temperature_reflect if temperature is None else temperature,
             max_completion_tokens=completion_cap,
             return_usage=True,
         )
@@ -783,6 +809,7 @@ async def _run_reflect_agent_inner(
                         f"final_map_{i}",
                         CLAIMS_SYSTEM_PROMPT,
                         synthesis_max_completion_tokens,
+                        temperature=_map_temperature(),
                     )
                     for i, chunk in enumerate(chunks, 1)
                 )

--- a/hindsight-api-slim/tests/test_reflect_split_synthesis.py
+++ b/hindsight-api-slim/tests/test_reflect_split_synthesis.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from hindsight_api.config import get_config
 from hindsight_api.engine.reflect.agent import run_reflect_agent
 from hindsight_api.engine.reflect.prompts import (
     _MIN_SPLIT_CHUNK_TOKENS,
@@ -225,6 +226,77 @@ class TestSplitSynthesisAgentFlow:
         )
         reduce_prompt = llm.call.await_args_list[-1].kwargs["messages"][1]["content"]
         assert "approximately 64 tokens" in reduce_prompt, "length target must reach the reduce prompt"
+
+    @pytest.mark.asyncio
+    async def test_map_calls_run_at_temperature_zero(self):
+        """The map calls copy claims and ids out of a chunk; they don't reason or
+        write, so they must not inherit reflect's 0.9 writing temperature. At 0.9 a
+        map call sometimes answered a plainly relevant chunk with the six-token
+        "(no relevant evidence)" sentinel, silently dropping that chunk's evidence
+        from the reduce (#4054). The reduce itself still writes, so it keeps the
+        reflect temperature."""
+        big = {"memories": [{"id": f"mem-{i}", "text": "fact " + "z" * 600} for i in range(60)]}
+        llm = self._mock_llm()
+        llm.call_with_tools.return_value = LLMToolCallResult(
+            tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "q"})],
+            finish_reason="tool_calls",
+        )
+
+        await run_reflect_agent(
+            llm_config=llm,
+            bank_id="b",
+            query="q?",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            max_context_tokens=int(_MIN_SPLIT_CHUNK_TOKENS / 0.8) + 10,
+            **self._functions(big),
+        )
+
+        map_calls = [c for c in llm.call.await_args_list if "extract evidence" in c.kwargs["messages"][0]["content"]]
+        assert len(map_calls) >= 2, "split synthesis did not engage"
+        assert all(c.kwargs["temperature"] == 0.0 for c in map_calls), (
+            f"map calls ran at {[c.kwargs['temperature'] for c in map_calls]}"
+        )
+        reduce_call = llm.call.await_args_list[-1]
+        assert reduce_call.kwargs["temperature"] == get_config().llm_temperature_reflect
+
+    @pytest.mark.asyncio
+    async def test_map_calls_omit_temperature_when_reflect_omits_it(self, monkeypatch):
+        """HINDSIGHT_API_LLM_TEMPERATURE=none drops the parameter from the request —
+        that is how models rejecting any temperature are run. The map pass must keep
+        omitting it rather than pinning its own 0."""
+        import hindsight_api.engine.reflect.agent as agent_module
+
+        # get_config() returns a proxy, not a dataclass, so the omit sentinel is
+        # simulated by shadowing just that attribute.
+        real_config = get_config()
+
+        class _NoTemperature:
+            llm_temperature_reflect = None
+
+            def __getattr__(self, name):
+                return getattr(real_config, name)
+
+        monkeypatch.setattr(agent_module, "get_config", _NoTemperature)
+
+        big = {"memories": [{"id": f"mem-{i}", "text": "fact " + "z" * 600} for i in range(60)]}
+        llm = self._mock_llm()
+        llm.call_with_tools.return_value = LLMToolCallResult(
+            tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "q"})],
+            finish_reason="tool_calls",
+        )
+
+        await run_reflect_agent(
+            llm_config=llm,
+            bank_id="b",
+            query="q?",
+            bank_profile={"name": "Test", "mission": "Testing"},
+            max_context_tokens=int(_MIN_SPLIT_CHUNK_TOKENS / 0.8) + 10,
+            **self._functions(big),
+        )
+
+        assert all(c.kwargs["temperature"] is None for c in llm.call.await_args_list), (
+            f"temperature was reintroduced: {[c.kwargs['temperature'] for c in llm.call.await_args_list]}"
+        )
 
     @pytest.mark.asyncio
     async def test_fitting_history_stays_single_call(self):


### PR DESCRIPTION
Fixes #4054.

## The bug

Forced split synthesis compresses each over-budget chunk into dated, cited claims (`final_map_N`), then reduces over the lot. Every one of those calls goes through `_tracked_llm_call`, which passes `HINDSIGHT_API_LLM_TEMPERATURE_REFLECT` — **0.9** by default.

That temperature belongs to the calls that reason and write. The map calls do neither: they copy claims and ids out of one chunk and are explicitly told not to answer the question. It's the same mechanical extraction that consolidation runs at `llm_temperature_consolidation = 0.0`.

At 0.9, a map call sometimes answered a chunk that plainly was relevant with the six-token `(no relevant evidence)` sentinel and `finish_reason=stop` — the issue reports it at 17k, 22k, 58k, 69k, 77k and 85k input tokens, with successes at 9k–52k and 78k, so it is not size-bound. The map call is the only thing that ever sees that chunk's raw memories, so its evidence never reached the reduce, which then wrote a fluent, cited answer from what was left. On one bank the missing chunk was the one that contradicted the verdict the document ended up stating.

## The fix

Give the map pass its own temperature (0.0). The reduce keeps the reflect temperature — it still writes the answer.

A configured `none` still omits the parameter for the map calls: that sentinel resolves the whole chain to `None` and is how models rejecting any temperature are run, so pinning 0 would have put it back for them and 400'd every map call.

Nothing inspects or second-guesses the model's output: if a map call says a chunk holds nothing, that is taken at face value. The map requests are in the LLM request log (`GET .../llm-requests`, scope `reflect`) and in `trace.llm_calls` as `final_map_N`, so a bad one is visible after the fact.

## Tests

- `test_map_calls_run_at_temperature_zero` — every map call goes out at 0.0 while the reduce keeps `llm_temperature_reflect`.
- `test_map_calls_omit_temperature_when_reflect_omits_it` — with the reflect temperature unset, no call carries the parameter at all.

## Not in this PR

The issue's other asks: `REFLECT_MAP_CHUNK_TOKENS`, keeping first-iteration `search_mental_models` results out of the context-budget check, and a no-credentials rule in the reduce prompt. `HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS` is already documented in the REFLECT table of `hindsight-docs/docs/developer/configuration.md`.
