### PR TITLE
fix(api): run tenant provisioning migrations through the isolation boundary

### DIFF
--- a/hindsight-api-slim/hindsight_api/extensions/context.py
+++ b/hindsight-api-slim/hindsight_api/extensions/context.py
@@ -106,12 +106,7 @@ class DefaultExtensionContext(ExtensionContext):
         import asyncio
 
         from hindsight_api.config import get_config
-        from hindsight_api.migrations import (
-            ensure_embedding_dimension,
-            ensure_text_search_extension,
-            ensure_vector_extension,
-            run_migrations,
-        )
+        from hindsight_api.migrations import run_migrations_for_schemas
 
         # Prefer getting URL from memory engine (handles pg0 case where URL is set after init)
         db_url = self._database_url
@@ -120,44 +115,32 @@ class DefaultExtensionContext(ExtensionContext):
             if engine_url:
                 db_url = engine_url
 
-        # Run synchronous migration functions in a thread so the asyncio event loop
-        # remains free. This is critical for single-machine deployments where the
-        # worker runs in-process: if run_migrations() blocks the event loop, any
-        # in-flight asyncpg transactions cannot flush their COMMIT, and
-        # CREATE INDEX CONCURRENTLY inside the migration waits for those transactions
-        # forever — a deadlock.
-        config = get_config()
-        await asyncio.to_thread(
-            run_migrations, db_url, schema=schema, migration_database_url=config.migration_database_url
-        )
-
-        # Ensure embedding column dimension matches the model's dimension
-        # This is needed because migrations create columns with default dimension
+        # Ensure the embedding column dimension matches the model's dimension: migrations
+        # create the columns with a default dimension.
+        embedding_dimension: int | None = None
         if self._memory_engine is not None:
             embeddings = getattr(self._memory_engine, "embeddings", None)
             if embeddings is not None:
-                dimension = getattr(embeddings, "dimension", None)
-                if dimension is not None:
-                    await asyncio.to_thread(
-                        ensure_embedding_dimension,
-                        db_url,
-                        dimension,
-                        schema=schema,
-                        vector_extension=config.vector_extension,
-                    )
+                embedding_dimension = getattr(embeddings, "dimension", None)
 
-        # Ensure vector indexes match the configured extension
+        # One call, not four: run_migrations_for_schemas is the migration-isolation
+        # boundary. Calling run_migrations() and then the ensure_* helpers separately
+        # would run each of them here -- and every one opens SQLAlchemy's sync engine,
+        # i.e. psycopg2, which has no free-threaded build. On a python3.14t interpreter
+        # that import re-enables the GIL for the life of the server (and, with the
+        # strict free-threading guard on, fails the request outright). Startup already
+        # goes through this entrypoint; runtime tenant provisioning must too, or
+        # provisioning a new bank on a free-threaded API 500s.
+        config = get_config()
         await asyncio.to_thread(
-            ensure_vector_extension, db_url, vector_extension=config.vector_extension, schema=schema
-        )
-
-        # Ensure text search columns/indexes match the configured extension
-        await asyncio.to_thread(
-            ensure_text_search_extension,
+            run_migrations_for_schemas,
             db_url,
+            [schema],
+            migration_database_url=config.migration_database_url,
+            embedding_dimension=embedding_dimension,
+            vector_extension=config.vector_extension,
             text_search_extension=config.text_search_extension,
             pg_search_tokenizer=config.text_search_extension_pg_search_tokenizer,
-            schema=schema,
         )
 
         # Provision any extension-owned bank-scoped tables for this schema,

--- a/hindsight-api-slim/tests/test_migration_isolation.py
+++ b/hindsight-api-slim/tests/test_migration_isolation.py
@@ -113,3 +113,34 @@ def test_main_rejects_an_unknown_target(monkeypatch):
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"target": "drop_everything", "kwargs": {}})))
     with pytest.raises(SystemExit, match="drop_everything"):
         migrations._main()
+
+
+async def test_extension_context_run_migration_goes_through_the_isolation_boundary():
+    """Runtime tenant provisioning must not open a sync engine in the server process.
+
+    ``ExtensionContext.run_migration`` is the seam cloud tenant provisioning uses to
+    create a schema for a new bank. It used to call ``run_migrations`` and then the
+    ``ensure_*`` helpers one by one -- and only the first of those isolates, so the
+    other three imported psycopg2 into a free-threaded API process and the request
+    500'd. ``run_migrations_for_schemas`` is the entrypoint that covers all four
+    behind one isolation check.
+    """
+    from hindsight_api.extensions.context import DefaultExtensionContext
+
+    ctx = DefaultExtensionContext(database_url="postgresql://user:pass@host/db")
+    with (
+        patch.object(migrations, "run_migrations_for_schemas") as sweep,
+        patch.object(migrations, "run_migrations") as run_one,
+        patch.object(migrations, "ensure_embedding_dimension") as dim,
+        patch.object(migrations, "ensure_vector_extension") as vec,
+        patch.object(migrations, "ensure_text_search_extension") as text_search,
+    ):
+        await ctx.run_migration("tenant_acme")
+
+    for unisolated in (run_one, dim, vec, text_search):
+        unisolated.assert_not_called()
+    (url, schemas), kwargs = sweep.call_args
+    assert url == "postgresql://user:pass@host/db"
+    assert schemas == ["tenant_acme"]
+    # The post-migration extension steps must still happen -- inside the child.
+    assert kwargs["vector_extension"] and kwargs["text_search_extension"]


### PR DESCRIPTION
## Problem

`ExtensionContext.run_migration` is the seam runtime tenant provisioning uses to create a schema for a new bank. It called `run_migrations()` and then the three `ensure_*` helpers one at a time — but only `run_migrations()` checks `HINDSIGHT_API_MIGRATION_ISOLATION`, so the other three opened SQLAlchemy's sync engine (psycopg2) directly in the API process.

On a free-threaded interpreter that import re-enables the GIL for the life of the server, and with the strict free-threading guard it fails the request outright:

```
PUT /banks/hsbench -> 500: The global interpreter lock (GIL) has been enabled to load
module 'psycopg2._psycopg', which has not declared that it can run safely without the GIL
```

Reproducible every time, so provisioning *any* new bank fails on a `-py3.14t` API.

Startup was already covered, because it goes through `run_migrations_for_schemas`, which isolates once and folds the `ensure_*` steps into the same child.

## Fix

Route the extension seam through the same entrypoint with a single schema. Same four steps, same order, one isolation check. Behaviour on 3.11 (and with isolation off) is unchanged: `run_migrations_for_schemas` runs a single schema inline.

## Test

`test_extension_context_run_migration_goes_through_the_isolation_boundary` asserts `run_migration` calls `run_migrations_for_schemas` and none of the four unisolated entrypoints.