### PR TITLE
fix(embed): forward every HINDSIGHT_* var to the daemon instead of a whitelist

### DIFF
--- a/hindsight-embed/hindsight_embed/cli.py
+++ b/hindsight-embed/hindsight_embed/cli.py
@@ -115,26 +115,36 @@ def load_config_file():
                         os.environ[key] = value
 
 
-def get_config():
-    """Get configuration from environment variables.
+ENV_LLM_PROVIDER = "HINDSIGHT_API_LLM_PROVIDER"
+ENV_LLM_API_KEY = "HINDSIGHT_API_LLM_API_KEY"
 
-    `llm_model` is left unset (None) when the env var is missing — the daemon's
-    hindsight-api process owns `PROVIDER_DEFAULT_MODELS` and resolves the
-    provider-keyed default itself. Duplicating that table here would silently
-    desync, and importing it from `hindsight_api.config` fails in standalone
-    venvs (e.g. `uvx hindsight-embed`) where `hindsight-api` isn't installed.
+
+def get_config() -> dict[str, str]:
+    """This invocation's daemon overrides, as ``HINDSIGHT_*`` environment variables.
+
+    Every ``HINDSIGHT_*`` variable in the process environment is forwarded
+    verbatim; there is no whitelist of known settings. A whitelist is exactly
+    how ``HINDSIGHT_API_LLM_BASE_URL`` came to be dropped while KEY/MODEL
+    applied (issue #4094) — ``hindsight-api``, not this wrapper, owns the list
+    of settings that exist, and it grows every release.
+
+    No provider or model default is injected: ``hindsight-api`` resolves both
+    (its ``DEFAULT_LLM_PROVIDER`` is this same ``"openai"``, and
+    ``PROVIDER_DEFAULT_MODELS`` is provider-keyed). Duplicating those tables
+    here would silently desync — and importing them fails in standalone venvs
+    (``uvx hindsight-embed``) where ``hindsight-api`` isn't installed anyway.
     """
     load_config_file()
-    provider = os.environ.get("HINDSIGHT_API_LLM_PROVIDER", "openai")
-    return {
-        "llm_api_key": (
-            None
-            if provider in NO_API_KEY_PROVIDERS
-            else os.environ.get("HINDSIGHT_API_LLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
-        ),
-        "llm_provider": provider,
-        "llm_model": os.environ.get("HINDSIGHT_API_LLM_MODEL"),
-    }
+    config = {key: value for key, value in os.environ.items() if key.startswith("HINDSIGHT_")}
+
+    # OPENAI_API_KEY is the one non-HINDSIGHT_ name honoured here, and only for
+    # providers that authenticate with an LLM API key at all.
+    provider = config.get(ENV_LLM_PROVIDER) or "openai"
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    if openai_key and ENV_LLM_API_KEY not in config and provider not in NO_API_KEY_PROVIDERS:
+        config[ENV_LLM_API_KEY] = openai_key
+
+    return config
 
 
 # Provider -> API-key env var (None = no key needed)
@@ -246,11 +256,20 @@ def _do_configure_from_env():
     # Save configuration
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
-    config_values = {"HINDSIGHT_API_LLM_PROVIDER": provider}
-    if model:
-        config_values["HINDSIGHT_API_LLM_MODEL"] = model
+    # Persist every HINDSIGHT_API_* variable the caller set, not a hand-listed
+    # subset: the subset is why HINDSIGHT_API_LLM_BASE_URL never reached the
+    # written profile (issue #4094). HINDSIGHT_EMBED_* is deliberately excluded
+    # — those configure this wrapper for one invocation (API URL, component
+    # versions), and baking them into the profile is not what a user setting
+    # them for a single `configure` run asked for.
+    config_values = {key: value for key, value in os.environ.items() if key.startswith("HINDSIGHT_API_") and value}
+    config_values[ENV_LLM_PROVIDER] = provider
     if api_key:
-        config_values["HINDSIGHT_API_LLM_API_KEY"] = api_key
+        config_values[ENV_LLM_API_KEY] = api_key
+    else:
+        # Providers in NO_API_KEY_PROVIDERS authenticate locally; don't persist
+        # a stale key that the resolved provider will never use.
+        config_values.pop(ENV_LLM_API_KEY, None)
 
     from .env_template import render_config
 
@@ -453,12 +472,7 @@ def _do_configure_interactive(profile_name: str | None = None, port: int | None 
         daemon_client.stop_daemon(daemon_profile)
 
     # Start daemon with new config
-    new_config = {
-        "llm_api_key": api_key,
-        "llm_provider": provider,
-        "llm_model": model,
-    }
-    if daemon_client.ensure_daemon_running(new_config, daemon_profile):
+    if daemon_client.ensure_daemon_running(dict(config_dict), daemon_profile):
         print("  \033[32m✓ Daemon started\033[0m")
     else:
         print("  \033[33m⚠ Failed to start daemon (will start on first command)\033[0m")

--- a/hindsight-embed/hindsight_embed/control_center/service.py
+++ b/hindsight-embed/hindsight_embed/control_center/service.py
@@ -13,20 +13,6 @@ import httpx
 from .. import daemon_client
 from ..profile_manager import ENV_API_PORT, ENV_CP_PORT, ProfileManager
 
-# The "simple alias" keys that ProfileManager.load_profile_config injects for
-# backward compatibility. They must never be written back into a profile's
-# .env, or they'd pollute it with lowercase duplicates.
-_ALIAS_KEYS = frozenset(
-    {
-        "llm_api_key",
-        "llm_provider",
-        "llm_model",
-        "llm_base_url",
-        "log_level",
-        "idle_timeout",
-    }
-)
-
 # Env var names the wizard owns. Writing config replaces these; everything else
 # in the profile (idle timeout, bank id, custom keys) is preserved untouched.
 _ENV_PROVIDER = "HINDSIGHT_API_LLM_PROVIDER"
@@ -188,10 +174,7 @@ def _read_raw_env(name: str) -> dict[str, str]:
         if "=" not in line:
             continue
         key, value = line.split("=", 1)
-        key = key.strip()
-        if key in _ALIAS_KEYS:
-            continue
-        env[key] = value.strip()
+        env[key.strip()] = value.strip()
     return env
 
 
@@ -224,9 +207,9 @@ def list_profiles() -> list[ProfileSummary]:
                 port=info.port,
                 is_active=info.is_active,
                 daemon_running=info.daemon_running,
-                provider=config.get("llm_provider"),
-                model=config.get("llm_model"),
-                has_api_key=bool(config.get("llm_api_key")),
+                provider=config.get(_ENV_PROVIDER),
+                model=config.get(_ENV_MODEL),
+                has_api_key=bool(config.get(_ENV_API_KEY)),
             )
         )
     return summaries
@@ -237,15 +220,15 @@ def get_profile_config(name: str) -> ProfileConfigView:
     name = normalize_profile(name)
     pm = ProfileManager()
     config = pm.load_profile_config(name)
-    api_key = config.get("llm_api_key")
+    api_key = config.get(_ENV_API_KEY)
     paths = pm.resolve_profile_paths(name)
     raw = _read_raw_env(name)
     return ProfileConfigView(
         name=name,
         display_name=_display_name(name),
-        provider=config.get("llm_provider"),
-        model=config.get("llm_model"),
-        base_url=config.get("llm_base_url"),
+        provider=config.get(_ENV_PROVIDER),
+        model=config.get(_ENV_MODEL),
+        base_url=config.get(_ENV_BASE_URL),
         api_key_masked=_mask_key(api_key),
         has_api_key=bool(api_key),
         api_port=paths.port,

--- a/hindsight-embed/hindsight_embed/daemon_client.py
+++ b/hindsight-embed/hindsight_embed/daemon_client.py
@@ -44,8 +44,10 @@ def ensure_daemon_running(config: dict, profile: str | None = None, extra_args: 
     Ensure daemon is running, starting it if needed.
 
     Args:
-        config: Configuration dict with LLM settings (accepts both simple keys
-                like "llm_api_key" and env var format like "HINDSIGHT_API_LLM_API_KEY").
+        config: Overrides for the daemon, keyed by environment variable name
+                ("HINDSIGHT_API_LLM_API_KEY", ...). Every HINDSIGHT_* key is
+                forwarded to the daemon process; the profile's own .env is
+                merged underneath it.
         profile: Profile name (None = resolve from priority).
         extra_args: Extra CLI arguments to pass to hindsight-api (e.g. ["--offline"]).
 

--- a/hindsight-embed/hindsight_embed/daemon_embed_manager.py
+++ b/hindsight-embed/hindsight_embed/daemon_embed_manager.py
@@ -720,31 +720,21 @@ class DaemonEmbedManager(EmbedManager):
         merged_config = {**profile_config, **config}
         config = merged_config
 
-        # Build environment with LLM config
-        # Support both formats: simple keys ("llm_api_key") and env var format ("HINDSIGHT_API_LLM_API_KEY")
+        # Build the daemon environment: every HINDSIGHT_* key in the merged
+        # profile/explicit config, forwarded verbatim under its own name.
+        #
+        # There is deliberately no whitelist of known settings. There used to be
+        # one — LLM/log/idle_timeout, keyed by lowercase aliases — and a setting
+        # missing from it (HINDSIGHT_API_LLM_BASE_URL, issue #4094) was reported
+        # as silently ignored while KEY/MODEL applied. hindsight-api owns the
+        # set of settings that exist and adds to it every release; mirroring
+        # that set here can only ever drift behind it.
+        #
+        # An explicit "" is forwarded, not skipped: that is how a caller clears
+        # an inherited setting — e.g. blanking the API key for a local LLM
+        # service that has no authentication (issue #3253). Only None means
+        # "not specified".
         env = os.environ.copy()
-
-        # Map of simple key -> env var key
-        key_mapping = {
-            "llm_api_key": "HINDSIGHT_API_LLM_API_KEY",
-            "llm_provider": "HINDSIGHT_API_LLM_PROVIDER",
-            "llm_model": "HINDSIGHT_API_LLM_MODEL",
-            "llm_base_url": "HINDSIGHT_API_LLM_BASE_URL",
-            "log_level": "HINDSIGHT_API_LOG_LEVEL",
-            "idle_timeout": "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT",
-        }
-
-        for simple_key, env_key in key_mapping.items():
-            # Check both simple format and env var format
-            value = config.get(simple_key) or config.get(env_key)
-            if value:
-                env[env_key] = str(value)
-
-        # Propagate any other HINDSIGHT_* keys from the merged profile/explicit
-        # config into the daemon env. Without this, arbitrary settings in the
-        # profile's .env file (e.g. HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU,
-        # HINDSIGHT_API_EMBEDDINGS_PROVIDER) are silently dropped because the
-        # whitelist above only covers LLM/log/idle_timeout keys.
         for key, value in config.items():
             if key.startswith("HINDSIGHT_") and value is not None:
                 env[key] = str(value)
@@ -948,12 +938,17 @@ class DaemonEmbedManager(EmbedManager):
             api_config = {k: v for k, v in config.items() if k.startswith("HINDSIGHT_API_")}
             if not api_config:
                 return
-            # Merge onto the existing .env so persisted keys (UI port, idle
-            # timeout, etc.) survive — create_profile overwrites the file, so we
-            # must carry the existing non-alias keys forward.
+            # Additive: seed keys the profile doesn't have yet, never overwrite
+            # ones it does. create_profile rewrites the whole file, so the
+            # existing keys have to be carried forward regardless (UI port, idle
+            # timeout, ...), and `config` here is the merged profile + this
+            # invocation's ambient HINDSIGHT_* environment — letting it win would
+            # make a one-off `HINDSIGHT_API_LLM_MODEL=... hindsight-embed recall`
+            # permanently rewrite the user's profile. The profile file is owned
+            # by `configure` and the control center; a daemon start only fills
+            # in what is missing.
             existing = self._profile_manager.load_profile_config(profile)
-            merged = {k: v for k, v in existing.items() if not k.islower()}
-            merged.update(api_config)
+            merged = {**api_config, **existing}
             self._profile_manager.create_profile(profile, port, merged)
         except Exception as e:
             logger.debug(f"Failed to register profile '{profile}' in metadata: {e}")
@@ -1203,7 +1198,7 @@ class DaemonEmbedManager(EmbedManager):
         Ensure daemon is running, starting it if needed.
 
         Args:
-            config: Environment configuration dict (HINDSIGHT_API_* vars)
+            config: Environment configuration dict (HINDSIGHT_* vars)
             profile: Profile name for isolation
             extra_args: Extra CLI arguments to pass to hindsight-api (e.g. ["--offline"])
 

--- a/hindsight-embed/hindsight_embed/embed_manager.py
+++ b/hindsight-embed/hindsight_embed/embed_manager.py
@@ -18,7 +18,7 @@ class EmbedManager(ABC):
         Ensure daemon is running for the given profile with config.
 
         Args:
-            config: Environment configuration dict (HINDSIGHT_API_* vars)
+            config: Environment configuration dict (HINDSIGHT_* vars)
             profile: Profile name for isolation
 
         Returns:

--- a/hindsight-embed/hindsight_embed/profile_manager.py
+++ b/hindsight-embed/hindsight_embed/profile_manager.py
@@ -591,8 +591,15 @@ class ProfileManager:
             name: Profile name (empty string for default).
 
         Returns:
-            Dictionary of environment variable key-value pairs from the profile's .env file.
-            Also includes simple key aliases (e.g., 'idle_timeout' for 'HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT').
+            Dictionary of environment variable key-value pairs from the profile's
+            .env file, under their own names.
+
+            This used to also inject lowercase aliases ('llm_base_url' for
+            'HINDSIGHT_API_LLM_BASE_URL', and five others). Every consumer then
+            had to strip them back out before writing a profile, and the alias
+            table was a second place a setting had to be listed to be seen at
+            all — which is how HINDSIGHT_API_LLM_BASE_URL went missing (issue
+            #4094). Callers now read the environment variable names directly.
         """
         paths = self.resolve_profile_paths(name)
         config = {}
@@ -614,21 +621,6 @@ class ProfileManager:
                 if "=" in line:
                     key, value = line.split("=", 1)
                     config[key.strip()] = value.strip()
-
-        # Add simple key aliases for backward compatibility
-        # Some code checks config.get("idle_timeout") instead of the full env var name
-        key_aliases = {
-            "HINDSIGHT_API_LLM_API_KEY": "llm_api_key",
-            "HINDSIGHT_API_LLM_PROVIDER": "llm_provider",
-            "HINDSIGHT_API_LLM_MODEL": "llm_model",
-            "HINDSIGHT_API_LLM_BASE_URL": "llm_base_url",
-            "HINDSIGHT_API_LOG_LEVEL": "log_level",
-            "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT": "idle_timeout",
-        }
-
-        for env_key, simple_key in key_aliases.items():
-            if env_key in config and simple_key not in config:
-                config[simple_key] = config[env_key]
 
         return config
 

--- a/hindsight-embed/tests/test_embed_manager.py
+++ b/hindsight-embed/tests/test_embed_manager.py
@@ -62,20 +62,47 @@ def test_manager_singleton():
 
 def test_register_profile_skips_when_no_api_keys():
     """
-    When config contains only short keys (no HINDSIGHT_API_* prefix),
-    _register_profile should not call create_profile, preserving any
-    existing profile .env file.
+    When config carries no HINDSIGHT_API_* keys there is nothing to persist, so
+    _register_profile must not call create_profile — which would rewrite the
+    profile .env from an empty config.
 
     Regression test for https://github.com/vectorize-io/hindsight/issues/894
     """
     manager = DaemonEmbedManager()
     manager._profile_manager = MagicMock()
 
-    # Config with short keys (as passed from cli.py's get_config())
-    config = {"llm_api_key": "sk-123", "llm_provider": "openai", "llm_model": "gpt-4o"}
-    manager._register_profile("myprofile", 8100, config)
+    manager._register_profile("myprofile", 8100, {"HINDSIGHT_EMBED_API_URL": "http://elsewhere"})
 
     manager._profile_manager.create_profile.assert_not_called()
+
+
+def test_register_profile_does_not_overwrite_configured_values(tmp_path, monkeypatch):
+    """A daemon start seeds missing keys but never rewrites configured ones.
+
+    `config` reaching _register_profile is the profile merged with this
+    invocation's ambient HINDSIGHT_* environment. Letting it win would make a
+    one-off `HINDSIGHT_API_LLM_MODEL=... hindsight-embed recall` permanently
+    rewrite the user's profile; the file is owned by `configure` and the
+    control center.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    manager = DaemonEmbedManager()
+    manager._profile_manager.create_profile(
+        "p", {"HINDSIGHT_API_LLM_PROVIDER": "anthropic", "HINDSIGHT_API_LLM_MODEL": "claude-sonnet-4-20250514"}
+    )
+
+    manager._register_profile(
+        "p",
+        9100,
+        {"HINDSIGHT_API_LLM_MODEL": "gpt-4o", "HINDSIGHT_API_LLM_BASE_URL": "https://example.com/v1"},
+    )
+
+    env = (tmp_path / ".hindsight" / "profiles" / "p.env").read_text(encoding="utf-8")
+    assert "HINDSIGHT_API_LLM_MODEL=claude-sonnet-4-20250514" in env  # configured value kept
+    assert "HINDSIGHT_API_LLM_MODEL=gpt-4o" not in env
+    assert "HINDSIGHT_API_LLM_BASE_URL=https://example.com/v1" in env  # missing key seeded
 
 
 def test_register_profile_calls_create_when_api_keys_present():

--- a/hindsight-embed/tests/test_profile_daemon_config.py
+++ b/hindsight-embed/tests/test_profile_daemon_config.py
@@ -86,9 +86,12 @@ def test_profile_config_is_loaded_for_daemon(temp_home):
     assert profile_config["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"
     assert profile_config["HINDSIGHT_API_LOG_LEVEL"] == "debug"
 
-    # Verify that idle_timeout simple key is also available for backward compat
-    # (some code checks config.get("idle_timeout"))
-    assert profile_config.get("idle_timeout") == "0"
+    # Keys are returned under their environment-variable names only. The
+    # lowercase aliases this used to also inject ("idle_timeout", "llm_base_url",
+    # ...) are gone: they were a second, hand-maintained list a setting had to
+    # appear in to be seen, which is how HINDSIGHT_API_LLM_BASE_URL went missing
+    # (issue #4094).
+    assert not [key for key in profile_config if key.islower()]
 
 
 def test_load_config_file_uses_correct_profile(temp_home, monkeypatch):
@@ -252,9 +255,9 @@ def test_get_config_respects_profile(temp_home, monkeypatch):
     config = get_config()
 
     # Should have loaded from production profile, NOT default
-    assert config["llm_provider"] == "anthropic", "Should use profile's provider"
-    assert config["llm_model"] == "claude-sonnet-4-20250514", "Should use profile's model"
-    assert config["llm_api_key"] == "sk-ant-production", "Should use profile's API key"
+    assert config["HINDSIGHT_API_LLM_PROVIDER"] == "anthropic", "Should use profile's provider"
+    assert config["HINDSIGHT_API_LLM_MODEL"] == "claude-sonnet-4-20250514", "Should use profile's model"
+    assert config["HINDSIGHT_API_LLM_API_KEY"] == "sk-ant-production", "Should use profile's API key"
 
 
 def test_profile_env_propagates_arbitrary_hindsight_keys_to_daemon(temp_home, monkeypatch):
@@ -579,10 +582,10 @@ def test_get_config_does_not_default_llm_model(temp_home, monkeypatch):
 
     config = get_config()
 
-    assert config["llm_provider"] == "gemini"
-    assert config["llm_model"] is None, (
-        "llm_model must be None when env var is unset so the daemon resolves "
-        "the provider default; got a hardcoded fallback instead"
+    assert config["HINDSIGHT_API_LLM_PROVIDER"] == "gemini"
+    assert "HINDSIGHT_API_LLM_MODEL" not in config, (
+        "the model must stay unset when the env var is unset so the daemon "
+        "resolves the provider default; got a hardcoded fallback instead"
     )
 
 
@@ -761,3 +764,122 @@ def test_posix_daemon_uses_console_entrypoint(temp_home, tmp_path, monkeypatch):
 
     cmd = manager._find_api_command("0.0.0")
     assert cmd == [str(console_bin)]
+
+
+def _capture_daemon_env(manager, profile: str, config: dict) -> dict[str, str]:
+    """Run `_start_daemon` with Popen stubbed and return the child's environment."""
+    from unittest.mock import MagicMock, patch
+
+    captured: dict[str, dict[str, str]] = {}
+    popen_called = [False]
+
+    def fake_popen(cmd, env, **kwargs):
+        captured["env"] = env
+        popen_called[0] = True
+        proc = MagicMock()
+        proc.pid = 12345
+        return proc
+
+    def fake_is_running(profile=""):
+        return popen_called[0]
+
+    with (
+        patch("hindsight_embed.daemon_embed_manager.subprocess.Popen", side_effect=fake_popen),
+        patch("hindsight_embed.daemon_embed_manager.time.sleep"),
+        patch.object(manager, "_clear_port", return_value=True),
+        patch.object(manager, "_find_api_command", return_value=["hindsight-api"]),
+        patch.object(manager, "is_running", side_effect=fake_is_running),
+    ):
+        manager._start_daemon(config=config, profile=profile)
+
+    return captured["env"]
+
+
+def _write_profile(temp_home: Path, name: str, body: str, port: int = 9878) -> None:
+    profile_dir = temp_home / ".hindsight" / "profiles"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / f"{name}.env").write_text(body, encoding="utf-8")
+    (profile_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "profiles": {
+                    name: {
+                        "port": port,
+                        "created_at": "2024-01-01T00:00:00+00:00",
+                        "last_used": "2024-01-01T00:00:00+00:00",
+                    }
+                },
+            }
+        )
+    )
+
+
+def test_profile_base_url_reaches_daemon_env(temp_home, monkeypatch):
+    """Regression test for issue #4094.
+
+    A profile that sets HINDSIGHT_API_LLM_BASE_URL alongside KEY/MODEL was
+    reported as having everything applied *except* the base URL, so LLM calls
+    went to api.openai.com and failed with OpenAI's own 401. This walks the
+    real path — `get_config()` -> `_start_daemon` -> the child's environment —
+    rather than testing either half in isolation.
+    """
+    from hindsight_embed.cli import get_config, set_cli_profile_override
+    from hindsight_embed.daemon_embed_manager import DaemonEmbedManager
+
+    base_url = "https://maas-api.example.com/openapi/compatible-mode/v1"
+    _write_profile(
+        temp_home,
+        "hermes",
+        "HINDSIGHT_API_LLM_API_KEY=sk-7c7e0\n"
+        "HINDSIGHT_API_LLM_MODEL=qwen3.8-27b\n"
+        f"HINDSIGHT_API_LLM_BASE_URL={base_url}\n",
+    )
+
+    for key in ("HINDSIGHT_API_LLM_API_KEY", "HINDSIGHT_API_LLM_MODEL", "HINDSIGHT_API_LLM_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    set_cli_profile_override("hermes")
+    try:
+        config = get_config()
+        assert config["HINDSIGHT_API_LLM_BASE_URL"] == base_url
+        env = _capture_daemon_env(DaemonEmbedManager(), "hermes", config)
+    finally:
+        set_cli_profile_override(None)
+
+    assert env.get("HINDSIGHT_API_LLM_BASE_URL") == base_url
+    assert env.get("HINDSIGHT_API_LLM_MODEL") == "qwen3.8-27b"
+    assert env.get("HINDSIGHT_API_LLM_API_KEY") == "sk-7c7e0"
+
+
+def test_configure_from_env_persists_every_api_var(temp_home, monkeypatch):
+    """Regression test for issue #4094.
+
+    `_do_configure_from_env` wrote a hand-listed subset (provider, model, key),
+    so a base URL — or any other HINDSIGHT_API_* setting — the user exported
+    never reached the profile it generated. HINDSIGHT_EMBED_* is deliberately
+    not persisted: those configure this wrapper for one invocation.
+    """
+    from hindsight_embed import cli
+
+    config_dir = temp_home / ".hindsight"
+    monkeypatch.setattr(cli, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(cli, "CONFIG_FILE", config_dir / "embed")
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "openai")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "sk-x")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_BASE_URL", "https://maas-api.example.com/v1")
+    monkeypatch.setenv("HINDSIGHT_API_EMBEDDINGS_PROVIDER", "tei")
+    monkeypatch.setenv("HINDSIGHT_EMBED_API_URL", "http://elsewhere:9999")
+
+    assert cli._do_configure_from_env() == 0
+
+    active = [
+        line.strip()
+        for line in (config_dir / "embed").read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    assert "HINDSIGHT_API_LLM_BASE_URL=https://maas-api.example.com/v1" in active
+    assert "HINDSIGHT_API_EMBEDDINGS_PROVIDER=tei" in active
+    assert not any(line.startswith("HINDSIGHT_EMBED_API_URL=") for line in active)


### PR DESCRIPTION
## Summary

Fixes #4094.

A `hindsight-embed` profile `.env` that sets `HINDSIGHT_API_LLM_BASE_URL` alongside KEY/MODEL was reported as having everything applied **except** the base URL — LLM calls went to `api.openai.com` and failed with OpenAI's own `401 invalid_api_key`.

**This is not a 0.8.6 → 0.9.2 regression.** The profile → daemon → API propagation path is byte-identical between the two tags, and a profile `.env` carrying the base URL does reach the daemon child on both. What is real is the surrounding design: the same six settings were hardcoded in **four** separate lists, and a setting had to appear in all of them to survive.

| Place | What it did |
|---|---|
| `profile_manager.load_profile_config` | injected lowercase aliases (`llm_base_url`, …) next to the real env keys |
| `daemon_embed_manager._start_daemon_locked` | mapped them back to `HINDSIGHT_API_*` — then a generic `HINDSIGHT_*` loop ran anyway |
| `control_center/service.py` `_ALIAS_KEYS` | stripped the injected aliases back out before writing a `.env` |
| `daemon_embed_manager._register_profile` | same strip, done a second way (`if not k.islower()`) |

`get_config()` carried three of the six, which is the actual user-visible hole: an exported `HINDSIGHT_API_LLM_BASE_URL` never reached a profile written by `hindsight-embed configure`, and the same omission exists verbatim in 0.8.6.

## What changed

Every layer now uses the name the setting already has, and forwards everything:

- `load_profile_config` returns environment-variable names only — the alias table is gone
- the daemon forwards **every** `HINDSIGHT_*` key in the merged config verbatim, no whitelist
- `get_config()` and `_do_configure_from_env` carry every `HINDSIGHT_API_*` variable the caller set
- the control center reads the env names directly

`hindsight-api` owns the set of settings that exist and adds to it every release; mirroring that set in the wrapper can only ever drift behind it.

## Preserved on purpose

- **An explicit `""` is still forwarded**, so blanking an inherited API key for an unauthenticated local LLM keeps working (#3253). Only `None` means "not specified".
- **`_register_profile` is now additive** — it seeds keys a profile lacks and never rewrites ones it has. Necessary now that the config it sees carries the ambient environment: otherwise a one-off `HINDSIGHT_API_LLM_MODEL=... hindsight-embed recall` would permanently rewrite the user's profile. This also generalises #894 ("a daemon start must not clobber the profile"), which previously held only by accident of key casing.
- No provider/model default is injected at this layer. `hindsight-api`'s `DEFAULT_LLM_PROVIDER` is the same `"openai"`, and injecting one here would *override* a profile's provider rather than fill in for it.

## Behaviour change worth calling out

An exported `HINDSIGHT_API_*` variable now wins over the profile's `.env` for the daemon. Previously the profile won (the generic passthrough ran after the whitelist), which is why the reporter's "export it at launch" workaround only took effect once the daemon was restarted.

## Test plan

- [x] `hindsight-embed`: 195 passed
- [x] `hindsight-all/tests/test_embedded_config.py`: 8 passed
- [x] `./scripts/hooks/lint.sh`, `./scripts/hooks/check-unused.sh` clean
- [x] Three new tests verified to **fail** against the pre-change source and pass after:
  - `test_profile_base_url_reaches_daemon_env` — the #4094 scenario end to end, `get_config()` → `_start_daemon` → the child's environment
  - `test_configure_from_env_persists_every_api_var` — base URL and an arbitrary `HINDSIGHT_API_*` var land in the written profile; `HINDSIGHT_EMBED_*` does not
  - `test_register_profile_does_not_overwrite_configured_values` — a daemon start seeds a missing key but leaves configured ones alone

## Note on #4108

#4108 targets the same issue with a narrower fix. Its premise — that the profile `.env` value is dropped — does not reproduce; the `get_config()` omission it also fixes is genuine and is subsumed here.