### PR TITLE
fix(retain): keep per-memory entity-label tags when a re-retain rewrites document tags (#4068)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -8749,6 +8749,7 @@ class MemoryEngine(MemoryEngineInterface):
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
                 from .memories import MemoryPatch, get_memories
+                from .retain.entity_labels import label_tag_keys, split_label_tags
 
                 _store = get_memories()
 
@@ -8792,6 +8793,25 @@ class MemoryEngine(MemoryEngineInterface):
                 retag = (
                     tags if (tags is not None and (current_tags is None or set(current_tags) != set(tags))) else None
                 )
+
+                # A retag replaces the DOCUMENT's tags on every unit, but the column also
+                # holds the projection of the `entity_labels` groups flagged `tag: true` —
+                # derived per memory from that memory's own entities at extraction, not
+                # from the document. This PATCH re-processes nothing, so it has no business
+                # rewriting them: each unit keeps the ones it carries (issue #4068).
+                _label_keys: set[str] = set()
+                if retag is not None:
+                    _retag_config = await self._config_resolver.resolve_full_config(bank_id, request_context)
+                    _label_keys = label_tag_keys(getattr(_retag_config, "entity_labels", None))
+
+                def _retagged(existing: list[str] | None) -> list[str]:
+                    merged = list(retag or [])
+                    seen = set(merged)
+                    for t in split_label_tags(existing, _label_keys):
+                        if t not in seen:
+                            seen.add(t)
+                            merged.append(t)
+                    return merged
 
                 set_parts: list[str] = ["updated_at = now()"]
                 params: list[Any] = []
@@ -8838,7 +8858,7 @@ class MemoryEngine(MemoryEngineInterface):
                     _doc_units = _doc_page.memories
                     if _doc_units:
                         await _store.update_memories(
-                            bank_id, [MemoryPatch(unit_id=m.unit_id, tags=list(retag)) for m in _doc_units]
+                            bank_id, [MemoryPatch(unit_id=m.unit_id, tags=_retagged(m.tags)) for m in _doc_units]
                         )
                     _src_ids = [m.unit_id for m in _doc_units if m.fact_type in ("experience", "world")]
                     if _src_ids:
@@ -8849,12 +8869,15 @@ class MemoryEngine(MemoryEngineInterface):
                             conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=_src_ids, when=None
                         )
                 elif retag is not None:
+                    # `tags` as well as `id`: the projection each unit must keep is read
+                    # here, before the blanket write below overwrites it.
                     unit_rows = await conn.fetch(
-                        f"SELECT id FROM {fq_table('memory_units')} WHERE document_id = $1 AND bank_id = $2 AND fact_type IN ('experience', 'world')",
+                        f"SELECT id, tags, fact_type FROM {fq_table('memory_units')} "
+                        f"WHERE document_id = $1 AND bank_id = $2",
                         document_id,
                         bank_id,
                     )
-                    unit_ids = [str(row["id"]) for row in unit_rows]
+                    unit_ids = [str(row["id"]) for row in unit_rows if row["fact_type"] in ("experience", "world")]
 
                     await conn.execute(
                         f"UPDATE {fq_table('memory_units')} SET tags = $1, updated_at = now() "
@@ -8863,6 +8886,30 @@ class MemoryEngine(MemoryEngineInterface):
                         document_id,
                         bank_id,
                     )
+
+                    # Restore each unit's own label projection over that blanket write.
+                    # A follow-up rather than one combined statement so a unit created
+                    # concurrently still lands on the document tags exactly as before;
+                    # a bank with no `tag: true` group issues nothing here at all.
+                    # Grouped by the FINAL array `_retagged` computed, not by the
+                    # projection alone: a unit whose label tag is also a document tag
+                    # would otherwise be written `[..., 'category:durable',
+                    # 'category:durable']`, since the two would be concatenated here
+                    # after `_retagged` had already deduped them.
+                    _by_final: dict[tuple[str, ...], list] = {}
+                    for _row in unit_rows:
+                        _final = _retagged(_row["tags"])
+                        if _final != list(retag):
+                            _by_final.setdefault(tuple(_final), []).append(_row["id"])
+                    for _final, _ids in _by_final.items():
+                        await conn.execute(
+                            f"UPDATE {fq_table('memory_units')} SET tags = $1, updated_at = now() "
+                            f"WHERE document_id = $2 AND bank_id = $3 AND id = ANY($4::uuid[])",
+                            list(_final),
+                            document_id,
+                            bank_id,
+                            _ids,
+                        )
 
                     if unit_ids:
                         import uuid as uuid_module

--- a/hindsight-api-slim/hindsight_api/engine/retain/entity_labels.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/entity_labels.py
@@ -303,3 +303,31 @@ def build_labels_lookup(labels_cfg: EntityLabelsConfig | list | None) -> set[str
             if group.key and v.value:
                 valid.add(f"{group.key}:{v.value}".lower())
     return valid
+
+
+def label_tag_keys(labels_cfg: "EntityLabelsConfig | dict | list | None") -> set[str]:
+    """The label group keys (lowercase) whose values are projected into a fact's tags.
+
+    A group flagged ``tag: true`` is mirrored out of the fact's entities and into its
+    ``tags`` array by ``_inject_label_tags``, so a ``key:value`` tag whose key is in this
+    set is *derived* from the unit's entities rather than supplied by the caller. Both
+    the projection itself and the re-retain path that must leave it alone read the set
+    from here, so a group's ``tag`` flag is honoured identically by the two.
+
+    Accepts EntityLabelsConfig or the raw config value.
+    """
+    if labels_cfg is None:
+        return set()
+    if not isinstance(labels_cfg, EntityLabelsConfig):
+        parsed = parse_entity_labels(labels_cfg)
+        if parsed is None:
+            return set()
+        labels_cfg = parsed
+    return {g.key.lower() for g in labels_cfg.attributes if g.tag and g.key}
+
+
+def split_label_tags(tags: "list[str] | None", keys: "set[str] | None") -> list[str]:
+    """The label-derived subset of ``tags`` — the entries ``label_tag_keys`` claims."""
+    if not tags or not keys:
+        return []
+    return [t for t in tags if ":" in t and t.split(":", 1)[0].lower() in keys]

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -26,7 +26,9 @@ from .entity_labels import (
     build_labels_lookup,
     build_labels_model,
     is_label_entity,
+    label_tag_keys,
     parse_entity_labels,
+    split_label_tags,
 )
 
 
@@ -3099,11 +3101,11 @@ def _inject_label_tags(facts: list[ExtractedFactType], config) -> None:
     labels_cfg = parse_entity_labels(config.entity_labels)
     if not labels_cfg:
         return
-    tag_group_keys = {g.key.lower() for g in labels_cfg.attributes if g.tag}
+    tag_group_keys = label_tag_keys(labels_cfg)
     if not tag_group_keys:
         return
     for fact in facts:
-        label_tags = [e for e in fact.entities if ":" in e and e.split(":", 1)[0].lower() in tag_group_keys]
+        label_tags = split_label_tags(fact.entities, tag_group_keys)
         if label_tags:
             existing = set(fact.tags)
             fact.tags = fact.tags + [t for t in label_tags if t not in existing]

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_storage.py
@@ -425,6 +425,7 @@ async def update_memory_units_metadata_and_tags(
     metadata: dict[str, Any],
     *,
     observation_scopes: list | str | None = None,
+    label_tag_keys: set[str] | None = None,
     ops=None,
 ) -> int:
     """Update document-level attributes on existing memory units.
@@ -432,6 +433,22 @@ async def update_memory_units_metadata_and_tags(
     Delta retain preserves unchanged chunks and their facts. Propagate the
     current document tags, metadata and observation scoping so its optimized
     result matches a full replace.
+
+    ``tags`` is the DOCUMENT's tag set and replaces what a survivor carries of it
+    outright — the caller owns those, so a re-retain that drops one drops it here too.
+    But the column also holds *label tags*: the projection of the ``entity_labels``
+    groups flagged ``tag: true``, mirrored out of each unit's own entities at extraction
+    (``_inject_label_tags``). Those are derived per fact, not per document, and a unit
+    only acquires them by being extracted — so a survivor, which by definition was not
+    re-extracted, keeps the ones it has. ``label_tag_keys`` names the group keys that
+    projection claims; a ``key:value`` tag under one of them is carried forward rather
+    than overwritten (issue #4068).
+
+    Without that carry-forward the same document ended a delta retain holding units
+    labelled ``category:durable`` beside units that were not, differing only in whether
+    their chunk happened to change — and a tags filter returned an arbitrary slice of it.
+    Passing no ``label_tag_keys`` (or a bank with no such group) keeps the plain
+    overwrite, which is what a document with no label projection wants.
 
     ``metadata`` arrives as the raw retain_params bag (the document row keeps
     the caller's input verbatim), so null-valued keys are dropped here — the
@@ -457,6 +474,17 @@ async def update_memory_units_metadata_and_tags(
     """
     from ..memories import MemoryPatch, get_memories
     from ..memories.base import META_METADATA_JSON, META_OBSERVATION_SCOPES
+    from .entity_labels import split_label_tags
+
+    def _tags_for(existing: list[str] | None) -> list[str]:
+        """The document tags, plus the label projection this unit already carries."""
+        merged = list(tags or [])
+        seen = set(merged)
+        for t in split_label_tags(existing, label_tag_keys):
+            if t not in seen:
+                seen.add(t)
+                merged.append(t)
+        return merged
 
     store = get_memories()
     if store.store_owned_for(bank_id):
@@ -480,10 +508,11 @@ async def update_memory_units_metadata_and_tags(
         #
         # Set unconditionally, mirroring `SET metadata = $4`: a document whose metadata was cleared
         # must clear on its survivors too, which an absent key would not do.
+        new_tags_by_unit = {m.unit_id: _tags_for(m.tags) for m in page.memories}
         patches = [
             MemoryPatch(
                 unit_id=m.unit_id,
-                tags=list(tags or []),
+                tags=new_tags_by_unit[m.unit_id],
                 metadata={
                     META_METADATA_JSON: json.dumps(drop_null_values(metadata or {})),
                     META_OBSERVATION_SCOPES: json.dumps(observation_scopes),
@@ -493,12 +522,16 @@ async def update_memory_units_metadata_and_tags(
         ]
         if patches:
             await store.update_memories(bank_id, patches)
+        # Against the tags the unit will actually END with, not the document's: a survivor
+        # keeping its label projection has not been rescoped, and comparing it to the bare
+        # document tags reported every such unit as moved on every retain — an observation
+        # sweep and a full re-consolidation of the document for no change at all.
         rescoped = [
             m.unit_id
             for m in page.memories
             if m.fact_type in ("experience", "world")
             and (
-                set(m.tags or []) != set(tags or [])
+                set(m.tags or []) != set(new_tags_by_unit[m.unit_id])
                 or _normalize_scopes(m.observation_scopes) != _normalize_scopes(observation_scopes)
             )
         ]
@@ -520,12 +553,14 @@ async def update_memory_units_metadata_and_tags(
         bank_id,
         document_id,
     )
+    new_tags_by_id = {row["id"]: _tags_for(row["tags"]) for row in prior}
+    # See the store-owned branch: the comparison is against what the unit ends with.
     rescoped_ids = [
         row["id"]
         for row in prior
         if row["fact_type"] in ("experience", "world")
         and (
-            set(row["tags"] or []) != set(tags or [])
+            set(row["tags"] or []) != set(new_tags_by_id[row["id"]])
             or _normalize_scopes(row["observation_scopes"]) != _normalize_scopes(observation_scopes)
         )
     ]
@@ -542,6 +577,31 @@ async def update_memory_units_metadata_and_tags(
         json.dumps(drop_null_values(metadata)),
         json.dumps(observation_scopes) if observation_scopes is not None else None,
     )
+
+    # Restore each survivor's label projection over the blanket write above. Done as a
+    # follow-up rather than folded into that statement so a row inserted concurrently
+    # still gets the document tags and metadata exactly as before — this pass only
+    # touches ids that were read, and a document carrying no label tags issues nothing.
+    # Grouped by the FINAL array `_tags_for` computed rather than by the projection
+    # alone, so the value written here is the one it already deduped — a unit whose
+    # label tag is also a document tag must not come back carrying it twice.
+    by_final: dict[tuple[str, ...], list] = {}
+    for row in prior:
+        final = new_tags_by_id[row["id"]]
+        if final != list(tags or []):
+            by_final.setdefault(tuple(final), []).append(row["id"])
+    for final, ids in by_final.items():
+        await conn.execute(
+            f"""
+            UPDATE {fq_table("memory_units")}
+            SET tags = $3, updated_at = NOW()
+            WHERE bank_id = $1 AND document_id = $2 AND id = ANY($4::uuid[])
+            """,
+            bank_id,
+            document_id,
+            list(final),
+            ids,
+        )
 
     if rescoped_ids:
         await delete_stale_observations_for_memories(conn, bank_id, rescoped_ids, ops=ops)

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -270,6 +270,7 @@ from . import (
 )
 from . import timing as _timing
 from .embedding_coalescer import CoalescingEmbedder
+from .entity_labels import label_tag_keys
 from .memory_budget import RetainMemoryBudget, estimate_chunk_bytes
 from .types import (
     CausalRelation,
@@ -3897,6 +3898,7 @@ async def _try_delta_retain(
                     merged_tags,
                     retain_params.get("metadata", {}),
                     observation_scopes=retain_params.get("observation_scopes"),
+                    label_tag_keys=label_tag_keys(getattr(config, "entity_labels", None)),
                     ops=pool.ops,
                 )
                 log_buffer.append(
@@ -4065,6 +4067,7 @@ async def _delta_metadata_only(
                     merged_tags,
                     retain_params.get("metadata", {}),
                     observation_scopes=retain_params.get("observation_scopes"),
+                    label_tag_keys=label_tag_keys(getattr(config, "entity_labels", None)),
                     ops=pool.ops,
                 )
         if outbox_callback is not None:
@@ -4112,6 +4115,7 @@ async def _delta_metadata_only(
                 merged_tags,
                 retain_params.get("metadata", {}),
                 observation_scopes=retain_params.get("observation_scopes"),
+                label_tag_keys=label_tag_keys(getattr(config, "entity_labels", None)),
                 ops=pool.ops,
             )
             if outbox_callback is not None:

--- a/hindsight-api-slim/tests/test_retain_label_tag_projection.py
+++ b/hindsight-api-slim/tests/test_retain_label_tag_projection.py
@@ -1,0 +1,262 @@
+"""#4068: what a re-retain may and may not rewrite on a surviving memory unit.
+
+``memory_units.tags`` carries two different things:
+
+* **Document tags** — what the caller hands to retain. Caller-owned, so a re-retain
+  replaces them outright: the new array is exactly what this submission said, with no
+  merge against the previous one. Same for the document metadata bag.
+* **Label tags** — the projection of ``entity_labels`` groups flagged ``tag: true``.
+  These are *derived* from the unit's own entities by ``_inject_label_tags``; the
+  entities are the ground truth and the tag is a mirror kept so the tags API can filter
+  on a label. A unit only acquires them by being extracted, so only a unit the LLM
+  actually re-extracted may see them change — and then exactly, to whatever the fresh
+  extraction produced. A survivor was not re-extracted, so its projection must stand.
+
+Today ``update_memory_units_metadata_and_tags`` overwrites the whole array with the
+document tags alone, which drops a survivor's label tags while the units extracted
+beside it in the same retain keep theirs.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api.engine.providers.mock_llm import MockLLM
+
+
+@pytest.fixture(scope="session")
+def db_url():
+    """Isolated pg0 instance so this module never touches the dev database."""
+    return "pg0://hs4068:55468"
+
+
+def _labels(*values):
+    return [
+        {
+            "key": "category",
+            "type": "multi-values",
+            "tag": True,
+            "optional": True,
+            "values": [{"value": v, "description": f"the {v} category"} for v in values],
+        }
+    ]
+
+
+class _Label:
+    """The label value the mock LLM attaches to every fact it extracts."""
+
+    value = "durable"
+
+
+@pytest.fixture(autouse=True)
+def labelled_extraction(monkeypatch):
+    def _facts(messages):
+        user_text = ""
+        for m in messages:
+            if m.get("role") == "user":
+                user_text = m.get("content", "")
+                break
+        return {
+            "facts": [
+                {
+                    "what": f"Fact about {user_text[-40:]}",
+                    "when": "N/A",
+                    "where": "N/A",
+                    "who": "N/A",
+                    "why": "N/A",
+                    "fact_kind": "conversation",
+                    "fact_type": "world",
+                    "entities": [f"category:{_Label.value}"],
+                }
+            ]
+        }
+
+    _Label.value = "durable"
+    monkeypatch.setattr(MockLLM, "_build_mock_facts", staticmethod(_facts))
+
+
+async def _units(memory, bank_id, document_id, request_context):
+    res = await memory.list_memory_units(bank_id, document_id=document_id, limit=200, request_context=request_context)
+    return {u["id"]: {"tags": set(u.get("tags") or []), "metadata": u.get("metadata")} for u in res["items"]}
+
+
+async def _retain(memory, bank_id, doc, content, tags, metadata, request_context):
+    await memory.retain_batch_async(
+        bank_id=bank_id,
+        contents=[{"content": content, "document_id": doc, "tags": tags, "metadata": metadata}],
+        request_context=request_context,
+    )
+
+
+# Two chunks under a 60-char chunk size, so a re-retain that rewrites only the second
+# leaves the first one's units in place as survivors.
+_A = "Alpha " * 20
+_B = "Bravo " * 20
+_C = "Charlie " * 20
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_document_tags_override_exactly_and_label_tags_survive(memory, request_context):
+    """One re-retain that changes the document tags, the metadata and one chunk."""
+    bank_id = f"test_4068_delta_{datetime.now(timezone.utc).timestamp()}"
+    doc = "doc-delta"
+    try:
+        await memory._ensure_bank_exists(bank_id, request_context)
+        await memory._config_resolver.update_bank_config(
+            bank_id, {"entity_labels": _labels("durable"), "retain_chunk_size": 60}
+        )
+
+        await _retain(memory, bank_id, doc, _A + "\n\n" + _B, ["t1"], {"src": "v1"}, request_context)
+        before = await _units(memory, bank_id, doc, request_context)
+        assert before and all(u["tags"] == {"t1", "category:durable"} for u in before.values()), before
+
+        await _retain(memory, bank_id, doc, _A + "\n\n" + _C, ["t2"], {"src": "v2"}, request_context)
+        after = await _units(memory, bank_id, doc, request_context)
+
+        survivors = {uid: u for uid, u in after.items() if uid in before}
+        fresh = {uid: u for uid, u in after.items() if uid not in before}
+        assert survivors, "the first chunk was re-extracted — no survivors to assert on"
+        assert fresh, "the second chunk was not re-extracted"
+
+        # Document tags: replaced outright, on every unit. 't1' is gone because this
+        # submission did not carry it, not merged forward.
+        # Label tags: 'category:durable' stands on the survivors (not re-extracted) and is
+        # re-derived on the fresh units.
+        for uid, u in after.items():
+            assert u["tags"] == {"t2", "category:durable"}, f"{uid}: {u['tags']}"
+            assert u["metadata"] == {"src": "v2"}, f"{uid}: {u['metadata']}"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_label_tags_are_exact_per_unit_not_merged(memory, request_context):
+    """A re-extracted unit takes the FRESH label exactly; a survivor keeps its own.
+
+    The two must not bleed into each other: no unit ends up carrying both labels.
+    """
+    bank_id = f"test_4068_exact_{datetime.now(timezone.utc).timestamp()}"
+    doc = "doc-exact"
+    try:
+        await memory._ensure_bank_exists(bank_id, request_context)
+        await memory._config_resolver.update_bank_config(
+            bank_id, {"entity_labels": _labels("durable", "provisional"), "retain_chunk_size": 60}
+        )
+
+        await _retain(memory, bank_id, doc, _A + "\n\n" + _B, ["t1"], {}, request_context)
+        before = await _units(memory, bank_id, doc, request_context)
+        assert before and all(u["tags"] == {"t1", "category:durable"} for u in before.values()), before
+
+        # The second retain's extraction yields a different label.
+        _Label.value = "provisional"
+        await _retain(memory, bank_id, doc, _A + "\n\n" + _C, ["t1"], {}, request_context)
+        after = await _units(memory, bank_id, doc, request_context)
+
+        survivors = {uid: u for uid, u in after.items() if uid in before}
+        fresh = {uid: u for uid, u in after.items() if uid not in before}
+        assert survivors and fresh, (survivors, fresh)
+
+        for uid, u in survivors.items():
+            assert u["tags"] == {"t1", "category:durable"}, f"survivor {uid} was relabelled: {u['tags']}"
+        for uid, u in fresh.items():
+            assert u["tags"] == {"t1", "category:provisional"}, f"fresh unit {uid} kept a stale label: {u['tags']}"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_unchanged_content_re_retain_keeps_label_tags(memory, request_context):
+    """The metadata-only path: nothing is re-extracted, so every label tag stands."""
+    bank_id = f"test_4068_same_{datetime.now(timezone.utc).timestamp()}"
+    doc = "doc-same"
+    try:
+        await memory._ensure_bank_exists(bank_id, request_context)
+        await memory._config_resolver.update_bank_config(bank_id, {"entity_labels": _labels("durable")})
+
+        content = "Alice works at Google."
+        await _retain(memory, bank_id, doc, content, ["t1"], {"src": "v1"}, request_context)
+        before = await _units(memory, bank_id, doc, request_context)
+        assert before
+
+        # Same bytes, new document tags and metadata: a pure relabelling.
+        await _retain(memory, bank_id, doc, content, ["t2"], {"src": "v2"}, request_context)
+        after = await _units(memory, bank_id, doc, request_context)
+
+        assert set(after) == set(before), "unchanged content must not replace any unit"
+        for uid, u in after.items():
+            assert u["tags"] == {"t2", "category:durable"}, f"{uid}: {u['tags']}"
+            assert u["metadata"] == {"src": "v2"}, f"{uid}: {u['metadata']}"
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_document_tags_patch_keeps_label_tags(memory, request_context):
+    """The tags PATCH re-processes nothing, so it may not touch the label projection."""
+    bank_id = f"test_4068_patch_{datetime.now(timezone.utc).timestamp()}"
+    doc = "doc-patch"
+    try:
+        await memory._ensure_bank_exists(bank_id, request_context)
+        await memory._config_resolver.update_bank_config(bank_id, {"entity_labels": _labels("durable")})
+
+        await _retain(memory, bank_id, doc, "Alice works at Google.", ["t1"], {}, request_context)
+        before = await _units(memory, bank_id, doc, request_context)
+        assert before and all(u["tags"] == {"t1", "category:durable"} for u in before.values()), before
+
+        assert await memory.update_document(doc, bank_id, tags=["t2"], request_context=request_context)
+        after = await _units(memory, bank_id, doc, request_context)
+
+        assert set(after) == set(before), "a retag must not replace any unit"
+        for uid, u in after.items():
+            assert u["tags"] == {"t2", "category:durable"}, f"{uid}: {u['tags']}"
+
+        # And the document's own tags are the document tags alone — the projection is a
+        # per-memory thing and must not be promoted onto the document row.
+        document = await memory.get_document(doc, bank_id, request_context=request_context)
+        assert set(document["tags"]) == {"t2"}, document["tags"]
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_label_tag_also_supplied_as_a_document_tag_is_not_duplicated(memory, request_context):
+    """A document tag that collides with the label projection must appear once.
+
+    The two halves of the array are computed separately, so a caller that happens to
+    send ``category:durable`` as a document tag is where they would be concatenated
+    into a unit carrying it twice.
+    """
+    bank_id = f"test_4068_dupe_{datetime.now(timezone.utc).timestamp()}"
+    doc = "doc-dupe"
+    try:
+        await memory._ensure_bank_exists(bank_id, request_context)
+        await memory._config_resolver.update_bank_config(
+            bank_id, {"entity_labels": _labels("durable"), "retain_chunk_size": 60}
+        )
+
+        # Every unit's projection is 'category:durable', and it is a document tag too.
+        await _retain(memory, bank_id, doc, _A + "\n\n" + _B, ["category:durable", "t1"], {}, request_context)
+        await _retain(memory, bank_id, doc, _A + "\n\n" + _C, ["category:durable", "t1"], {}, request_context)
+
+        res = await memory.list_memory_units(bank_id, document_id=doc, limit=200, request_context=request_context)
+        for unit in res["items"]:
+            raw = list(unit.get("tags") or [])
+            assert raw.count("category:durable") == 1, f"{unit['id']} carries a duplicated tag: {raw}"
+            assert set(raw) == {"category:durable", "t1"}, raw
+
+        # Same through the retag path.
+        assert await memory.update_document(
+            doc, bank_id, tags=["category:durable", "t2"], request_context=request_context
+        )
+        res = await memory.list_memory_units(bank_id, document_id=doc, limit=200, request_context=request_context)
+        for unit in res["items"]:
+            raw = list(unit.get("tags") or [])
+            assert raw.count("category:durable") == 1, f"{unit['id']} carries a duplicated tag: {raw}"
+            assert set(raw) == {"category:durable", "t2"}, raw
+    finally:
+        await memory.delete_bank(bank_id, request_context=request_context)


### PR DESCRIPTION
Fixes #4068.

## The two things in `memory_units.tags`

`memory_units.tags` carries two different things:

- **Document tags** — what the caller hands to retain. Caller-owned, so a re-retain replaces them outright: the new array is exactly what this submission said, with no merge against the previous one.
- **Label tags** — the projection of the `entity_labels` groups flagged `tag: true`. `_inject_label_tags` mirrors these out of each fact's **own entities** at extraction. The entities are the ground truth; the tag is a mirror kept so the tags API can filter on a label.

Every path that propagated document tags onto existing units overwrote the whole array with the document tags alone, destroying the projection on any unit that was not re-extracted:

- delta retain with changes — the surviving chunks' units;
- the unchanged-content metadata-only path;
- the document tags PATCH, which re-processes nothing at all.

So a document ended a delta retain holding units labelled `category:durable` beside units that were not, differing only in whether their chunk happened to change, and a tags filter returned an arbitrary slice of it. Measured on `main` — one re-retain changing document tags `t1`→`t2` and one of two chunks:

```
V1   : all 4 units   ['category:durable', 't1']
SURV : 2 units       ['t2']                      <- projection gone
NEW  : 3 units       ['category:durable', 't2']
```

Nothing was ever actually lost: the entities were untouched throughout, so this was a stale projection rather than missing data.

## The rule now

Document tags keep replacing outright — a submission that drops one drops it everywhere. Label tags change only on a unit the LLM actually re-extracted, and then exactly to what that extraction produced. A survivor keeps the projection it has.

`label_tag_keys()` / `split_label_tags()` in `entity_labels.py` give the rule one definition. `_inject_label_tags` reads it too, so extraction and re-retain cannot drift on what counts as a label tag.

In SQL it stays the blanket UPDATE plus one follow-up per distinct projection — typically one extra statement, and none at all for a bank with no `tag: true` group — so a row inserted concurrently still gets the document tags and metadata exactly as before.

## A second defect this exposed

`rescoped_ids` compared each unit's tags against the **document** tags to decide whether to invalidate its observations. A unit carrying a label tag never matched, so every re-retain treated the whole document as rescoped: an observation sweep plus a full re-consolidation, on every push, for no actual change. It now compares against the tags the unit will actually end with.

## Relationship to #3949

#3949 (`force_reextract` on reprocess) already prevents the exact symptom the issue reports — I verified reprocess re-extracts and re-derives the tags on current `main`, and that it restores tags already stripped on an affected bank. It did not fix the underlying defect, which this PR does.

## Tests

`hindsight-api-slim/tests/test_retain_label_tag_projection.py` — 4 tests, all failing before the change and passing after:

- document tags override exactly while the label projection survives a delta re-retain;
- label tags are exact per unit and never merged — a survivor stays `category:durable` in the same retain where its neighbour becomes `category:provisional`;
- the unchanged-content path keeps the projection;
- the tags PATCH keeps it too, and the document row's own tags stay the document tags alone.

The second is the one that pins the spec down: any fix that re-derives from bank config alone, or merges old and new labels, fails it.

1614 tests across the retain / tag / label / document / observation / consolidation suites pass. (`test_migration_observation_search_vector_backfill.py` errors with `No such revision 'c8f3a5d71e04'` — reproduced on a clean tree, unrelated to this change.)
