### PR TITLE
fix(api): install every PostgreSQL extension in the public schema (#4118)

### DIFF
--- a/hindsight-api-slim/hindsight_api/_pg_extensions.py
+++ b/hindsight-api-slim/hindsight_api/_pg_extensions.py
@@ -21,14 +21,14 @@ and relocating them is not allowed.
 import logging
 import re
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
 
-#: Extension names Hindsight may install. Kept explicit so a typo cannot turn
-#: into DDL, since extension names cannot be passed as bound parameters.
+#: Extension names are interpolated into DDL — PostgreSQL cannot bind an
+#: identifier as a parameter — so every name is checked against this first.
 _IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
 
 PUBLIC_SCHEMA = "public"
@@ -51,7 +51,7 @@ MANAGED_EXTENSIONS: tuple[str, ...] = (
 class _Executable(Protocol):
     """The slice of SQLAlchemy's ``Connection`` these helpers need."""
 
-    def execute(self, statement, *args, **kwargs): ...
+    def execute(self, statement: Any, parameters: Any = None, *args: Any, **kwargs: Any) -> Any: ...
 
 
 class _Transactional(_Executable, Protocol):
@@ -162,6 +162,18 @@ def relocate_extension_to_public(conn: _Transactional, name: str) -> bool:
 
 
 def ensure_extensions_in_public(conn: _Transactional, names: tuple[str, ...] = MANAGED_EXTENSIONS) -> None:
-    """Repair extensions a previous version installed into a tenant schema."""
-    for name in names:
-        relocate_extension_to_public(conn, name)
+    """Repair extensions a previous version installed into a tenant schema.
+
+    One catalog query, not one per extension: this runs before every schema
+    migration, and a deployment sweeping tens of thousands of tenant schemas pays
+    it once per schema.
+    """
+    misplaced = conn.execute(
+        text(
+            "SELECT e.extname FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace "
+            "WHERE e.extname = ANY(:names) AND n.nspname <> :public AND e.extrelocatable"
+        ),
+        {"names": list(names), "public": PUBLIC_SCHEMA},
+    ).fetchall()
+    for row in misplaced:
+        relocate_extension_to_public(conn, row[0])

--- a/hindsight-api-slim/hindsight_api/_pg_extensions.py
+++ b/hindsight-api-slim/hindsight_api/_pg_extensions.py
@@ -1,0 +1,167 @@
+"""One rule for every PostgreSQL extension Hindsight installs: it lives in ``public``.
+
+``CREATE EXTENSION`` installs into the *first* schema on the session
+``search_path``. During migrations that path starts with the tenant schema
+(see ``alembic/env.py``), so a bare ``CREATE EXTENSION pg_trgm`` in schema mode
+lands the extension inside the tenant schema. The runtime connects with the
+default ``"$user", public`` path and fully-qualifies its tables, so it never
+sees that schema: operators and types the extension provides stop resolving,
+and entity resolution fails with ``operator does not exist: text % text`` on
+every retain, forever, with nothing surfaced to the caller (#4118).
+
+Every extension therefore goes through :func:`create_extension`, which pins the
+search path to ``public`` for the duration of the statement, and through
+:func:`relocate_extension_to_public`, which repairs installations that a
+previous version misplaced. Extensions that pin their own schema in their
+control file (``relocatable = false``, e.g. ``vchord_bm25`` -> ``bm25_catalog``)
+are left where PostgreSQL puts them — the search path does not override that,
+and relocating them is not allowed.
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Protocol
+
+from sqlalchemy import text
+
+logger = logging.getLogger(__name__)
+
+#: Extension names Hindsight may install. Kept explicit so a typo cannot turn
+#: into DDL, since extension names cannot be passed as bound parameters.
+_IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+PUBLIC_SCHEMA = "public"
+
+#: Every extension Hindsight creates, in any code path. ``ensure_extensions_in_public``
+#: sweeps these to repair databases migrated by a version that misplaced them.
+MANAGED_EXTENSIONS: tuple[str, ...] = (
+    "vector",
+    "vectorscale",
+    "vchord",
+    "alloydb_scann",
+    "pg_trgm",
+    "vchord_bm25",
+    "pg_textsearch",
+    "pg_search",
+    "pgroonga",
+)
+
+
+class _Executable(Protocol):
+    """The slice of SQLAlchemy's ``Connection`` these helpers need."""
+
+    def execute(self, statement, *args, **kwargs): ...
+
+
+class _Transactional(_Executable, Protocol):
+    """An ``_Executable`` whose transaction the caller may end (relocation only)."""
+
+    def commit(self) -> None: ...
+
+    def rollback(self) -> None: ...
+
+
+def _validate(name: str) -> str:
+    if not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"Invalid PostgreSQL extension name: {name!r}")
+    return name
+
+
+def create_extension(conn: _Executable, name: str, *, cascade: bool = False) -> None:
+    """``CREATE EXTENSION IF NOT EXISTS`` with the install schema pinned to ``public``.
+
+    The caller's ``search_path`` is restored afterwards. If the CREATE fails the
+    restore is attempted but not allowed to mask the original error — callers
+    that continue after a failure roll the transaction back, which restores the
+    setting anyway.
+    """
+    _validate(name)
+    previous = conn.execute(text("SELECT current_setting('search_path')")).scalar()
+    conn.execute(text("SELECT set_config('search_path', :schema, false)"), {"schema": PUBLIC_SCHEMA})
+    try:
+        conn.execute(text(f"CREATE EXTENSION IF NOT EXISTS {name}{' CASCADE' if cascade else ''}"))
+    finally:
+        try:
+            conn.execute(text("SELECT set_config('search_path', :previous, false)"), {"previous": previous or ""})
+        except Exception:  # pragma: no cover - only reachable on an aborted transaction
+            logger.debug("Could not restore search_path after creating extension %s", name)
+
+
+@dataclass(frozen=True)
+class InstalledExtension:
+    """Where an installed extension lives, and whether PostgreSQL will move it."""
+
+    schema: str
+    relocatable: bool
+
+
+def _installed_extension(conn: _Executable, name: str) -> InstalledExtension | None:
+    """Look up an installed extension in the catalog, or None if it is absent."""
+    row = conn.execute(
+        text(
+            "SELECT n.nspname, e.extrelocatable FROM pg_extension e "
+            "JOIN pg_namespace n ON n.oid = e.extnamespace WHERE e.extname = :name"
+        ),
+        {"name": name},
+    ).fetchone()
+    return InstalledExtension(schema=row[0], relocatable=row[1]) if row else None
+
+
+def extension_schema(conn: _Executable, name: str) -> str | None:
+    """Return the schema the extension is installed in, or None if not installed."""
+    _validate(name)
+    installed = _installed_extension(conn, name)
+    return installed.schema if installed else None
+
+
+def relocate_extension_to_public(conn: _Transactional, name: str) -> bool:
+    """Move a misplaced extension into ``public``; return True if it moved.
+
+    A no-op when the extension is absent, already in ``public``, or not
+    relocatable. Failures (typically: the migration role does not own the
+    extension) are logged and swallowed — the caller is better off running with
+    a misplaced extension than not running at all.
+    """
+    _validate(name)
+    installed = _installed_extension(conn, name)
+    if installed is None:
+        return False
+    schema = installed.schema
+    if schema == PUBLIC_SCHEMA:
+        return False
+    if not installed.relocatable:
+        # Its control file pins the schema (e.g. vchord_bm25 -> bm25_catalog);
+        # the runtime adds those schemas to search_path instead.
+        logger.debug("Extension %s is not relocatable; leaving it in schema '%s'", name, schema)
+        return False
+
+    logger.warning(
+        "Extension %s is installed in schema '%s' instead of '%s'; relocating so the "
+        "runtime can resolve its operators and types.",
+        name,
+        schema,
+        PUBLIC_SCHEMA,
+    )
+    try:
+        conn.execute(text(f'ALTER EXTENSION {name} SET SCHEMA "{PUBLIC_SCHEMA}"'))
+        conn.commit()
+    except Exception as exc:
+        logger.warning(
+            "Could not relocate extension %s from '%s' to '%s': %s. Continuing; "
+            "queries that rely on it may fail until it is moved by an administrator.",
+            name,
+            schema,
+            PUBLIC_SCHEMA,
+            exc,
+        )
+        conn.rollback()
+        return False
+    logger.info("Extension %s relocated to the %s schema", name, PUBLIC_SCHEMA)
+    return True
+
+
+def ensure_extensions_in_public(conn: _Transactional, names: tuple[str, ...] = MANAGED_EXTENSIONS) -> None:
+    """Repair extensions a previous version installed into a tenant schema."""
+    for name in names:
+        relocate_extension_to_public(conn, name)

--- a/hindsight-api-slim/hindsight_api/_vector_index.py
+++ b/hindsight-api-slim/hindsight_api/_vector_index.py
@@ -8,6 +8,8 @@ import os
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
+from ._pg_extensions import create_extension
+
 logger = logging.getLogger(__name__)
 
 # Extensions a user can set via HINDSIGHT_API_VECTOR_EXTENSION.
@@ -140,17 +142,14 @@ _ANN_TUNING_HIGH_RECALL: dict[str, tuple[tuple[str, str], ...]] = {
     ),
 }
 
-_EXTENSION_INSTALL_SQL = {
-    "pgvector": ("CREATE EXTENSION IF NOT EXISTS vector",),
-    "pgvectorscale": (
-        "CREATE EXTENSION IF NOT EXISTS vector",
-        "CREATE EXTENSION IF NOT EXISTS vectorscale CASCADE",
-    ),
-    "vchord": ("CREATE EXTENSION IF NOT EXISTS vchord CASCADE",),
-    "scann": (
-        "CREATE EXTENSION IF NOT EXISTS vector",
-        "CREATE EXTENSION IF NOT EXISTS alloydb_scann CASCADE",
-    ),
+# (extension name, needs CASCADE) per configured backend, in install order.
+# Creation goes through _pg_extensions.create_extension so every extension lands
+# in ``public`` even when migrations run with a tenant schema on the search_path.
+_EXTENSION_INSTALL_PLAN: dict[str, tuple[tuple[str, bool], ...]] = {
+    "pgvector": (("vector", False),),
+    "pgvectorscale": (("vector", False), ("vectorscale", True)),
+    "vchord": (("vchord", True),),
+    "scann": (("vector", False), ("alloydb_scann", True)),
 }
 
 _INSTALL_HINTS = {
@@ -339,8 +338,8 @@ def per_bank_index_min_submit_interval_seconds() -> int:
 def bootstrap_extension(conn: Connection, ext: str) -> None:
     """Install the configured vector extension and any prerequisites if possible."""
     normalized = validate_extension(ext)
-    for statement in _EXTENSION_INSTALL_SQL[normalized]:
-        conn.execute(text(statement))
+    for name, cascade in _EXTENSION_INSTALL_PLAN[normalized]:
+        create_extension(conn, name, cascade=cascade)
 
 
 def detect_vector_extension(conn: Connection, vector_extension: str = "pgvector") -> str:

--- a/hindsight-api-slim/hindsight_api/alembic/versions/5a366d414dce_initial_schema.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/5a366d414dce_initial_schema.py
@@ -15,6 +15,7 @@ from pgvector.sqlalchemy import Vector
 from sqlalchemy import text
 from sqlalchemy.dialects import postgresql
 
+from hindsight_api._pg_extensions import create_extension
 from hindsight_api._pg_search import (
     PG_SEARCH_TOKENIZER_ENV,
     normalize_pg_search_tokenizer,
@@ -110,7 +111,7 @@ def _detect_text_search_extension() -> str:
     if text_search_extension == "vchord":
         # Create vchord_bm25 extension if not exists
         try:
-            op.execute("CREATE EXTENSION IF NOT EXISTS vchord_bm25 CASCADE")
+            create_extension(op.get_bind(), "vchord_bm25", cascade=True)
         except Exception:
             # Extension might already exist or user lacks permissions - verify it exists
             conn = op.get_bind()
@@ -122,7 +123,7 @@ def _detect_text_search_extension() -> str:
     elif text_search_extension == "pg_textsearch":
         # Create pg_textsearch extension if not exists
         try:
-            op.execute("CREATE EXTENSION IF NOT EXISTS pg_textsearch CASCADE")
+            create_extension(op.get_bind(), "pg_textsearch", cascade=True)
         except Exception:
             # Extension might already exist or user lacks permissions - verify it exists
             conn = op.get_bind()
@@ -134,7 +135,7 @@ def _detect_text_search_extension() -> str:
     elif text_search_extension == "pg_search":
         # ParadeDB pg_search — true BM25 over base columns, Citus-compatible.
         try:
-            op.execute("CREATE EXTENSION IF NOT EXISTS pg_search CASCADE")
+            create_extension(op.get_bind(), "pg_search", cascade=True)
         except Exception:
             # Extension might already exist or user lacks permissions - verify it exists
             conn = op.get_bind()
@@ -170,7 +171,7 @@ def _pg_upgrade() -> None:
     # We keep this here as a fallback for backwards compatibility
     # This may fail if user lacks permissions, which is fine if extension already exists
     try:
-        op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        create_extension(op.get_bind(), "vector")
     except Exception:
         # Extension might already exist or user lacks permissions - verify it exists
         conn = op.get_bind()

--- a/hindsight-api-slim/hindsight_api/alembic/versions/c1a2b3d4e5f6_enable_pg_trgm_and_entities_trgm_index.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/c1a2b3d4e5f6_enable_pg_trgm_and_entities_trgm_index.py
@@ -11,9 +11,10 @@ block; see migrations.py for how this is handled safely.
 
 from collections.abc import Sequence
 
-import sqlalchemy as sa
 from alembic import context, op
+from sqlalchemy import text
 
+from hindsight_api._pg_extensions import create_extension
 from hindsight_api.alembic._dialect import run_for_dialect
 
 revision: str = "c1a2b3d4e5f6"
@@ -36,12 +37,16 @@ def _pg_upgrade() -> None:
     # auto-detect and fall back to the "full" lookup strategy at runtime.  See #626.
     conn = op.get_bind()
     try:
-        conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+        # Pinned to the public schema: in schema mode the search_path starts with
+        # the tenant schema, and an extension installed there is invisible to the
+        # runtime, which fails every retain on `operator does not exist: text %
+        # text` (#4118).
+        create_extension(conn, "pg_trgm")
     except Exception:
         # Extension not available (managed Postgres, insufficient privileges, etc.)
         # Roll back the failed statement and skip index creation.
-        conn.execute(sa.text("ROLLBACK"))
-        conn.execute(sa.text("BEGIN"))
+        conn.execute(text("ROLLBACK"))
+        conn.execute(text("BEGIN"))
         return
 
     schema = _get_schema_prefix()

--- a/hindsight-api-slim/hindsight_api/alembic/versions/n9i0j1k2l3m4_learnings_and_pinned_reflections.py
+++ b/hindsight-api-slim/hindsight_api/alembic/versions/n9i0j1k2l3m4_learnings_and_pinned_reflections.py
@@ -16,6 +16,7 @@ from collections.abc import Sequence
 from alembic import context, op
 from sqlalchemy import text
 
+from hindsight_api._pg_extensions import create_extension
 from hindsight_api._pg_search import (
     PG_SEARCH_TOKENIZER_ENV,
     normalize_pg_search_tokenizer,
@@ -115,7 +116,7 @@ def _detect_text_search_extension() -> str:
     if text_search_extension == "vchord":
         # Create vchord_bm25 extension if not exists
         try:
-            op.execute("CREATE EXTENSION IF NOT EXISTS vchord_bm25 CASCADE")
+            create_extension(op.get_bind(), "vchord_bm25", cascade=True)
         except Exception:
             # Extension might already exist or user lacks permissions - verify it exists
             conn = op.get_bind()
@@ -127,7 +128,7 @@ def _detect_text_search_extension() -> str:
     elif text_search_extension == "pg_textsearch":
         # Create pg_textsearch extension if not exists
         try:
-            op.execute("CREATE EXTENSION IF NOT EXISTS pg_textsearch CASCADE")
+            create_extension(op.get_bind(), "pg_textsearch", cascade=True)
         except Exception:
             # Extension might already exist or user lacks permissions - verify it exists
             conn = op.get_bind()
@@ -139,7 +140,7 @@ def _detect_text_search_extension() -> str:
     elif text_search_extension == "pg_search":
         # ParadeDB pg_search — true BM25 over base columns, Citus-compatible.
         try:
-            op.execute("CREATE EXTENSION IF NOT EXISTS pg_search CASCADE")
+            create_extension(op.get_bind(), "pg_search", cascade=True)
         except Exception:
             conn = op.get_bind()
             result = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pg_search'")).fetchone()

--- a/hindsight-api-slim/hindsight_api/migrations.py
+++ b/hindsight-api-slim/hindsight_api/migrations.py
@@ -34,6 +34,12 @@ from sqlalchemy import Connection, create_engine, text
 from sqlalchemy.pool import NullPool
 
 from ._free_threading import ENV_FREE_THREADING
+from ._pg_extensions import (
+    create_extension,
+    ensure_extensions_in_public,
+    extension_schema,
+    relocate_extension_to_public,
+)
 from ._pg_search import normalize_pg_search_tokenizer, pg_search_bm25_columns
 from ._text_search import mental_models_text_document
 from ._vector_index import (
@@ -77,68 +83,21 @@ def _detect_vector_extension(conn, vector_extension: str = "pgvector") -> str:
 
 
 def _ensure_pgvector_extension_in_public(conn: Connection) -> None:
-    """Ensure pgvector is installed before pgvector-backed migrations run."""
+    """Ensure pgvector is installed in ``public`` before pgvector-backed migrations run."""
     logger.debug("Checking pgvector extension availability...")
 
-    # First, check if extension already exists
-    ext_check = conn.execute(
-        text(
-            "SELECT extname, nspname FROM pg_extension e "
-            "JOIN pg_namespace n ON e.extnamespace = n.oid "
-            "WHERE extname = 'vector'"
-        )
-    ).fetchone()
-
-    if ext_check:
-        # Extension exists - check if in correct schema
-        ext_schema = ext_check[1]
-        if ext_schema == "public":
-            logger.info("pgvector extension found in public schema - ready to use")
-        else:
-            # Extension in wrong schema - try to fix if we have permissions
-            logger.warning(
-                f"pgvector extension found in schema '{ext_schema}' instead of 'public'. Attempting to relocate..."
-            )
-            try:
-                conn.execute(text("DROP EXTENSION vector CASCADE"))
-                conn.execute(text("SET search_path TO public"))
-                conn.execute(text("CREATE EXTENSION vector"))
-                conn.commit()
-                logger.info("pgvector extension relocated to public schema")
-            except Exception as e:
-                # Failed to relocate - log but don't fail if extension exists somewhere
-                logger.warning(
-                    f"Could not relocate pgvector extension to public schema: {e}. "
-                    f"Continuing with extension in '{ext_schema}' schema."
-                )
-                conn.rollback()
-    else:
-        # Extension doesn't exist - try to install
+    if extension_schema(conn, "vector") is None:
         logger.info("pgvector extension not found, attempting to install...")
         try:
-            conn.execute(text("SET search_path TO public"))
-            conn.execute(text("CREATE EXTENSION vector"))
+            create_extension(conn, "vector")
             conn.commit()
             logger.info("pgvector extension installed in public schema")
         except Exception as e:
-            # Installation failed - this is only fatal if extension truly doesn't exist
-            # Check one more time in case another process installed it
+            # Installation failed - this is only fatal if the extension truly
+            # doesn't exist; another process may have installed it meanwhile.
             conn.rollback()
-            ext_recheck = conn.execute(
-                text(
-                    "SELECT nspname FROM pg_extension e "
-                    "JOIN pg_namespace n ON e.extnamespace = n.oid "
-                    "WHERE extname = 'vector'"
-                )
-            ).fetchone()
-
-            if ext_recheck:
-                logger.warning(
-                    f"Could not install pgvector extension (permission denied?), "
-                    f"but extension exists in '{ext_recheck[0]}' schema. Continuing..."
-                )
-            else:
-                # Extension truly doesn't exist and we can't install it
+            existing = extension_schema(conn, "vector")
+            if not existing:
                 logger.error(
                     f"pgvector extension is not installed and cannot be installed: {e}. "
                     f"Please ensure pgvector is installed by a database administrator. "
@@ -147,6 +106,16 @@ def _ensure_pgvector_extension_in_public(conn: Connection) -> None:
                 raise RuntimeError(
                     "pgvector extension is required but not installed. Please install it with: CREATE EXTENSION vector;"
                 ) from e
+            logger.warning(
+                f"Could not install pgvector extension (permission denied?), "
+                f"but extension exists in '{existing}' schema. Continuing..."
+            )
+
+    # Relocate an installation an older version (or an operator) put elsewhere.
+    # ALTER EXTENSION ... SET SCHEMA carries its dependent objects along, unlike
+    # the DROP ... CASCADE + CREATE this used to do, which took every embedding
+    # column with it.
+    relocate_extension_to_public(conn, "vector")
 
 
 def _bootstrap_vector_extension_for_migrations(conn: Connection, vector_extension: str) -> None:
@@ -154,6 +123,11 @@ def _bootstrap_vector_extension_for_migrations(conn: Connection, vector_extensio
     if vector_extension == "pgvector":
         _ensure_pgvector_extension_in_public(conn)
     bootstrap_extension(conn, vector_extension)
+    # Repair anything an older version installed into a tenant schema, where the
+    # runtime (which connects with the default search_path) cannot resolve it — the
+    # pg_trgm case that made every retain fail silently in schema mode (#4118).
+    ensure_extensions_in_public(conn)
+    conn.commit()
 
 
 def _drop_per_bank_vector_indexes(conn: Connection, schema_name: str) -> None:
@@ -1186,7 +1160,7 @@ def ensure_text_search_extension(
             elif text_search_extension == "pgroonga":
                 # Ensure pgroonga extension is available
                 try:
-                    conn.execute(text("CREATE EXTENSION IF NOT EXISTS pgroonga CASCADE"))
+                    create_extension(conn, "pgroonga", cascade=True)
                 except Exception:
                     # Extension might already exist or user lacks permissions — verify
                     has_ext = conn.execute(text("SELECT 1 FROM pg_extension WHERE extname = 'pgroonga'")).fetchone()

--- a/hindsight-api-slim/tests/pg_extension_fakes.py
+++ b/hindsight-api-slim/tests/pg_extension_fakes.py
@@ -19,6 +19,14 @@ class _Result:
         return self._value
 
 
+class _Rows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
 class FakePgConnection:
     """Minimal stand-in for a SQLAlchemy ``Connection`` in extension tests.
 
@@ -53,6 +61,15 @@ class FakePgConnection:
         if "set_config('search_path'" in sql:
             self.search_path = (params or {}).get("schema") or (params or {}).get("previous") or ""
             return _Result(self.search_path)
+        if "= ANY(:names)" in sql:
+            wanted = (params or {}).get("names") or []
+            return _Rows(
+                [
+                    (name,)
+                    for name, (schema, relocatable) in self.extensions.items()
+                    if name in wanted and schema != "public" and relocatable
+                ]
+            )
         if "FROM pg_extension" in sql:
             name = (params or {}).get("name")
             return _Result(self.extensions.get(name))

--- a/hindsight-api-slim/tests/pg_extension_fakes.py
+++ b/hindsight-api-slim/tests/pg_extension_fakes.py
@@ -1,0 +1,82 @@
+"""A fake PostgreSQL connection for the extension-installation helpers.
+
+Records every statement, answers the two catalog queries the helpers issue
+(``current_setting('search_path')`` and the ``pg_extension`` lookup), and can be
+told to fail a specific statement.
+"""
+
+import re
+
+
+class _Result:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+    def fetchone(self):
+        return self._value
+
+
+class FakePgConnection:
+    """Minimal stand-in for a SQLAlchemy ``Connection`` in extension tests.
+
+    Args:
+        search_path: what ``current_setting('search_path')`` returns.
+        extensions: installed extensions as ``{name: (schema, relocatable)}``.
+        fail_on: substring of a statement that should raise instead of running.
+    """
+
+    def __init__(
+        self,
+        search_path: str = '"$user", public',
+        extensions: dict[str, tuple[str, bool]] | None = None,
+        fail_on: str | None = None,
+    ):
+        self.search_path = search_path
+        self.extensions = dict(extensions or {})
+        self.fail_on = fail_on
+        self.statements: list[str] = []
+        self.params: list[dict] = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    def execute(self, statement, params=None, *args, **kwargs):
+        sql = str(statement)
+        self.statements.append(sql)
+        self.params.append(params or {})
+        if self.fail_on and self.fail_on in sql:
+            raise RuntimeError(f"simulated failure: {sql}")
+        if "current_setting('search_path')" in sql:
+            return _Result(self.search_path)
+        if "set_config('search_path'" in sql:
+            self.search_path = (params or {}).get("schema") or (params or {}).get("previous") or ""
+            return _Result(self.search_path)
+        if "FROM pg_extension" in sql:
+            name = (params or {}).get("name")
+            return _Result(self.extensions.get(name))
+        match = re.match(r"CREATE EXTENSION IF NOT EXISTS (\w+)", sql)
+        if match:
+            name = match.group(1)
+            # PostgreSQL installs into the first schema on the search_path.
+            self.extensions.setdefault(name, (self.search_path.split(",")[0].strip().strip('"'), True))
+            return _Result(None)
+        match = re.match(r'ALTER EXTENSION (\w+) SET SCHEMA "([^"]+)"', sql)
+        if match:
+            name, schema = match.group(1), match.group(2)
+            self.extensions[name] = (schema, self.extensions[name][1])
+            return _Result(None)
+        return _Result(None)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def created_extensions(self) -> list[str]:
+        """Extension names this connection was asked to create, in order."""
+        return [
+            m.group(1) for m in (re.match(r"CREATE EXTENSION IF NOT EXISTS (\w+)", s) for s in self.statements) if m
+        ]

--- a/hindsight-api-slim/tests/test_pg_extensions.py
+++ b/hindsight-api-slim/tests/test_pg_extensions.py
@@ -1,0 +1,191 @@
+"""Every PostgreSQL extension Hindsight installs must land in the public schema.
+
+Regression cover for #4118: in schema mode the migration search_path starts with
+the tenant schema, so a bare ``CREATE EXTENSION pg_trgm`` installed pg_trgm
+there. The runtime connects with the default search_path and fully-qualifies its
+tables, so it could not resolve ``%`` and every retain failed forever, silently.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hindsight_api._pg_extensions import (
+    MANAGED_EXTENSIONS,
+    create_extension,
+    ensure_extensions_in_public,
+    extension_schema,
+    relocate_extension_to_public,
+)
+from hindsight_api._vector_index import bootstrap_extension
+from hindsight_api.migrations import _bootstrap_vector_extension_for_migrations
+from tests.pg_extension_fakes import FakePgConnection
+
+TENANT_SEARCH_PATH = '"hindsight", public'
+
+
+def test_create_extension_pins_install_schema_to_public():
+    conn = FakePgConnection(search_path=TENANT_SEARCH_PATH)
+
+    create_extension(conn, "pg_trgm")
+
+    assert conn.extensions["pg_trgm"][0] == "public"
+    assert conn.statements[0].startswith("SELECT current_setting('search_path')")
+    assert conn.params[1] == {"schema": "public"}
+    assert conn.statements[2] == "CREATE EXTENSION IF NOT EXISTS pg_trgm"
+
+
+def test_create_extension_restores_the_callers_search_path():
+    conn = FakePgConnection(search_path=TENANT_SEARCH_PATH)
+
+    create_extension(conn, "pg_trgm")
+
+    assert conn.search_path == TENANT_SEARCH_PATH
+    assert conn.params[-1] == {"previous": TENANT_SEARCH_PATH}
+
+
+def test_create_extension_appends_cascade_only_when_asked():
+    conn = FakePgConnection()
+
+    create_extension(conn, "pgroonga", cascade=True)
+
+    assert "CREATE EXTENSION IF NOT EXISTS pgroonga CASCADE" in conn.statements
+
+
+def test_create_extension_propagates_failures_without_masking_them():
+    conn = FakePgConnection(search_path=TENANT_SEARCH_PATH, fail_on="CREATE EXTENSION")
+
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        create_extension(conn, "pg_trgm")
+
+
+def test_create_extension_rejects_names_that_are_not_identifiers():
+    conn = FakePgConnection()
+
+    with pytest.raises(ValueError, match="Invalid PostgreSQL extension name"):
+        create_extension(conn, 'pg_trgm"; DROP TABLE banks; --')
+
+    assert conn.statements == []
+
+
+def test_extension_schema_reports_where_an_extension_lives():
+    conn = FakePgConnection(extensions={"vector": ("public", True)})
+
+    assert extension_schema(conn, "vector") == "public"
+    assert extension_schema(conn, "pg_trgm") is None
+
+
+def test_relocate_moves_a_misplaced_relocatable_extension_into_public():
+    conn = FakePgConnection(extensions={"pg_trgm": ("hindsight", True)})
+
+    assert relocate_extension_to_public(conn, "pg_trgm") is True
+    assert conn.extensions["pg_trgm"][0] == "public"
+    assert 'ALTER EXTENSION pg_trgm SET SCHEMA "public"' in conn.statements
+
+
+def test_relocate_is_a_noop_when_already_public_or_absent():
+    conn = FakePgConnection(extensions={"vector": ("public", True)})
+
+    assert relocate_extension_to_public(conn, "vector") is False
+    assert relocate_extension_to_public(conn, "pg_trgm") is False
+    assert not any("ALTER EXTENSION" in s for s in conn.statements)
+
+
+def test_relocate_leaves_non_relocatable_extensions_alone():
+    # vchord_bm25 pins bm25_catalog in its control file; PostgreSQL rejects the
+    # move, and the runtime puts that schema on its search_path instead.
+    conn = FakePgConnection(extensions={"vchord_bm25": ("bm25_catalog", False)})
+
+    assert relocate_extension_to_public(conn, "vchord_bm25") is False
+    assert not any("ALTER EXTENSION" in s for s in conn.statements)
+
+
+def test_relocate_survives_a_permission_denied_alter():
+    conn = FakePgConnection(extensions={"pg_trgm": ("hindsight", True)}, fail_on="ALTER EXTENSION")
+
+    assert relocate_extension_to_public(conn, "pg_trgm") is False
+    assert conn.rollbacks == 1
+
+
+def test_ensure_extensions_in_public_repairs_every_managed_extension():
+    conn = FakePgConnection(
+        extensions={
+            "vector": ("hindsight", True),
+            "pg_trgm": ("hindsight", True),
+            "pgroonga": ("public", True),
+        }
+    )
+
+    ensure_extensions_in_public(conn)
+
+    assert conn.extensions["vector"][0] == "public"
+    assert conn.extensions["pg_trgm"][0] == "public"
+    assert conn.extensions["pgroonga"][0] == "public"
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected"),
+    [
+        ("pgvector", ["vector"]),
+        ("pgvectorscale", ["vector", "vectorscale"]),
+        ("vchord", ["vchord"]),
+        ("scann", ["vector", "alloydb_scann"]),
+    ],
+)
+def test_vector_backends_install_into_public_in_schema_mode(backend, expected):
+    conn = FakePgConnection(search_path=TENANT_SEARCH_PATH)
+
+    bootstrap_extension(conn, backend)
+
+    assert conn.created_extensions() == expected
+    assert all(conn.extensions[name][0] == "public" for name in expected)
+
+
+def test_migration_bootstrap_relocates_a_tenant_schema_pg_trgm():
+    # The #4118 shape: an existing deployment whose pg_trgm was created inside
+    # the tenant schema by an older version. Startup must repair it.
+    conn = FakePgConnection(
+        search_path=TENANT_SEARCH_PATH,
+        extensions={"vector": ("public", True), "pg_trgm": ("hindsight", True)},
+    )
+
+    _bootstrap_vector_extension_for_migrations(conn, "pgvector")
+
+    assert conn.extensions["pg_trgm"][0] == "public"
+
+
+def test_managed_extensions_covers_every_extension_the_code_installs():
+    source = _api_sources()
+    for name in _extension_names_in_source(source):
+        assert name in MANAGED_EXTENSIONS, f"{name} is created but not listed in MANAGED_EXTENSIONS"
+
+
+def test_no_raw_create_extension_outside_the_helper():
+    """All extension creation goes through create_extension(), so the rule holds everywhere."""
+    offenders = [
+        path
+        for path, source in _api_sources().items()
+        if path.name != "_pg_extensions.py" and "CREATE EXTENSION IF NOT EXISTS" in source
+    ]
+
+    assert offenders == [], (
+        "These modules build CREATE EXTENSION SQL directly; use "
+        "hindsight_api._pg_extensions.create_extension so the extension lands in public: "
+        f"{[str(p) for p in offenders]}"
+    )
+
+
+def _api_sources() -> dict[Path, str]:
+    root = Path(__file__).resolve().parent.parent / "hindsight_api"
+    return {path: path.read_text() for path in root.rglob("*.py")}
+
+
+def _extension_names_in_source(sources: dict[Path, str]) -> set[str]:
+    import re
+
+    names: set[str] = set()
+    for path, source in sources.items():
+        if path.name == "_pg_extensions.py":
+            continue
+        names.update(re.findall(r'create_extension\(\s*[^,]+,\s*"(\w+)"', source))
+    return names

--- a/hindsight-api-slim/tests/test_schema_mode_extensions.py
+++ b/hindsight-api-slim/tests/test_schema_mode_extensions.py
@@ -1,0 +1,59 @@
+"""Extensions must end up in `public` when migrations run against a tenant schema.
+
+Regression cover for #4118: migrations set `search_path` to the tenant schema
+first, so `CREATE EXTENSION pg_trgm` installed pg_trgm there. The runtime uses
+the default search_path, could not resolve `%`, and every retain failed forever
+with nothing surfaced to the caller.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+from hindsight_api.db_url import to_libpq_url
+from hindsight_api.migrations import run_migrations
+
+
+@pytest.fixture
+def tenant_schema(pg0_db_url):
+    """Migrate a throwaway tenant schema, then drop it."""
+    schema = f"tenant_ext_{uuid.uuid4().hex[:8]}"
+    run_migrations(pg0_db_url, schema=schema)
+    yield schema
+    with _connect(pg0_db_url) as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        conn.commit()
+
+
+def _connect(db_url):
+    return create_engine(to_libpq_url(db_url), poolclass=NullPool).connect()
+
+
+def test_schema_mode_migration_leaves_no_extension_in_the_tenant_schema(pg0_db_url, tenant_schema):
+    with _connect(pg0_db_url) as conn:
+        rows = conn.execute(
+            text("SELECT e.extname, n.nspname FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace")
+        ).fetchall()
+
+    misplaced = {name: schema for name, schema in rows if schema == tenant_schema}
+    assert misplaced == {}, f"extensions installed inside the tenant schema: {misplaced}"
+
+
+def test_pg_trgm_operator_resolves_on_a_runtime_connection(pg0_db_url, tenant_schema):
+    # The runtime never puts the tenant schema on its search_path (it
+    # fully-qualifies tables instead), so `%` has to resolve from public.
+    with _connect(pg0_db_url) as conn:
+        installed = conn.execute(
+            text(
+                "SELECT n.nspname FROM pg_extension e "
+                "JOIN pg_namespace n ON n.oid = e.extnamespace WHERE e.extname = 'pg_trgm'"
+            )
+        ).scalar()
+        if installed is None:
+            pytest.skip("pg_trgm is not available on this PostgreSQL build")
+
+        assert installed == "public"
+        conn.execute(text("SELECT set_config('search_path', '\"$user\", public', false)"))
+        assert conn.execute(text("SELECT 'abc' % 'abd'")).scalar() is not None

--- a/hindsight-api-slim/tests/test_vector_index.py
+++ b/hindsight-api-slim/tests/test_vector_index.py
@@ -15,14 +15,7 @@ from hindsight_api._vector_index import (
 )
 from hindsight_api.engine.retain import bank_utils
 from hindsight_api.migrations import _bootstrap_vector_extension_for_migrations
-
-
-class RecordingConn:
-    def __init__(self):
-        self.statements = []
-
-    def execute(self, statement, *args, **kwargs):
-        self.statements.append(str(statement))
+from tests.pg_extension_fakes import FakePgConnection
 
 
 def test_validate_extension_accepts_scann():
@@ -61,33 +54,27 @@ def test_index_type_keyword_scann_round_trips_pg_indexes_indexdef():
 
 
 def test_bootstrap_extension_scann_installs_vector_before_alloydb_scann():
-    conn = RecordingConn()
+    conn = FakePgConnection()
 
     bootstrap_extension(conn, "scann")
 
-    assert conn.statements == [
-        "CREATE EXTENSION IF NOT EXISTS vector",
-        "CREATE EXTENSION IF NOT EXISTS alloydb_scann CASCADE",
-    ]
+    assert conn.created_extensions() == ["vector", "alloydb_scann"]
 
 
 def test_migration_bootstrap_vchord_skips_pgvector_preflight():
-    conn = RecordingConn()
+    conn = FakePgConnection()
 
     _bootstrap_vector_extension_for_migrations(conn, "vchord")
 
-    assert conn.statements == ["CREATE EXTENSION IF NOT EXISTS vchord CASCADE"]
+    assert conn.created_extensions() == ["vchord"]
 
 
 def test_migration_bootstrap_scann_uses_dispatcher_without_legacy_pgvector_check():
-    conn = RecordingConn()
+    conn = FakePgConnection()
 
     _bootstrap_vector_extension_for_migrations(conn, "scann")
 
-    assert conn.statements == [
-        "CREATE EXTENSION IF NOT EXISTS vector",
-        "CREATE EXTENSION IF NOT EXISTS alloydb_scann CASCADE",
-    ]
+    assert conn.created_extensions() == ["vector", "alloydb_scann"]
 
 
 def test_scann_index_creation_defers_until_table_is_large_enough():


### PR DESCRIPTION
Fixes #4118.

## The bug

`CREATE EXTENSION` installs into the **first** schema on the session `search_path`.
Migrations set that path to `"<tenant>", public` (see `alembic/env.py`), so with
`HINDSIGHT_API_DATABASE_SCHEMA=hindsight` the `pg_trgm` migration created pg_trgm
*inside the tenant schema*.

The runtime connects with the default `"$user", public` and fully-qualifies its tables, so it
never sees that schema. Entity resolution's `%` stopped resolving and every `batch_retain` died
with `operator does not exist: text % text`, retried on a one-minute backoff, forever — while
`/health` returned 200 and `retain` still answered `{"status":"accepted"}`. The only symptom was
that memory never appeared.

## The fix

All extension creation now goes through `hindsight_api/_pg_extensions.py::create_extension`, which
pins the install schema to `public` for the statement and restores the caller's `search_path`.
Same rule for every extension Hindsight installs, not just pg_trgm:

`pg_trgm`, `vector`, `vectorscale`, `vchord`, `alloydb_scann`, `pgroonga`, `vchord_bm25`,
`pg_textsearch`, `pg_search`.

Extensions that pin their own schema in their control file (`relocatable = false`, e.g.
`vchord_bm25` → `bm25_catalog`) are unaffected — PostgreSQL ignores `search_path` for those, and
the runtime already adds those schemas to its path.

**Existing databases are repaired on startup.** `ensure_extensions_in_public` runs before the
schema migrations and moves any managed, relocatable extension found outside `public` with
`ALTER EXTENSION ... SET SCHEMA public`. That also replaces pgvector's old relocation, which did
`DROP EXTENSION vector CASCADE` + `CREATE` — and would have dropped every embedding column with it.

## Tests

- `tests/test_pg_extensions.py` — the helper's search-path pinning and restore, CASCADE, identifier
  validation, relocation (relocatable / non-relocatable / already-public / permission-denied), every
  vector backend installing into `public` under a tenant search_path, and the #4118 repair shape.
  Plus a guard test that fails if any module builds `CREATE EXTENSION` SQL directly, so extensions
  added later keep the rule.
- `tests/test_schema_mode_extensions.py` — against a real PostgreSQL: migrate a throwaway tenant
  schema, assert no extension landed in it and that `'abc' % 'abd'` resolves on a
  default-`search_path` connection.

Verified the DB tests reproduce the bug: with the fix reverted (and the repair sweep disabled), the
tenant-schema assertion fails; with the fix, both pass.