### PR TITLE
refactor(api-slim): return a named result from LLMInterface.call

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -348,15 +348,14 @@ async def _dedup_adjudicate(
     if best_id is None:
         return _DedupOutcome(best_id=None, merged_text="", should_merge=False)
 
-    decision = _dedup_decision_from_response(
-        await dedup_llm_config.call(
-            messages=[{"role": "user", "content": _DEDUP_PROMPT.format(new=anchor_text, existing=best_text)}],
-            response_format=_DedupDecision,
-            temperature=config.llm_temperature_consolidation,
-            scope="consolidation_dedup",
-            strict_schema=get_config().llm_strict_schema_consolidation,
-        )
+    dedup_call = await dedup_llm_config.call(
+        messages=[{"role": "user", "content": _DEDUP_PROMPT.format(new=anchor_text, existing=best_text)}],
+        response_format=_DedupDecision,
+        temperature=config.llm_temperature_consolidation,
+        scope="consolidation_dedup",
+        strict_schema=get_config().llm_strict_schema_consolidation,
     )
+    decision = _dedup_decision_from_response(dedup_call.content)
     if decision.action != "merge":
         return _DedupOutcome(best_id=best_id, merged_text="", should_merge=False, best_text=best_text)
     merged_text = (sanitize_llm_output(decision.text) or "").strip() or best_text
@@ -3194,7 +3193,8 @@ async def _consolidate_batch_with_llm(
                 call_kwargs["max_retries"] = inner_max_retries
             if cached_prefix_name is not None:
                 call_kwargs["cached_prefix"] = cached_prefix_name
-            response: _ConsolidationBatchResponse = await llm_config.call(**call_kwargs)
+            batch_call = await llm_config.call(**call_kwargs)
+            response: _ConsolidationBatchResponse = batch_call.content
             # Defensive truncation: some LLM providers may not enforce JSON schema max_length
             creates = response.creates
             if remaining_observation_slots is not None and remaining_observation_slots >= 0:

--- a/hindsight-api-slim/hindsight_api/engine/llm_interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_interface.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any, Callable, Self
 
-from .response_models import LLMToolCallResult
+from .response_models import LLMCallResult, LLMToolCallResult
 
 logger = logging.getLogger(__name__)
 
@@ -148,10 +148,9 @@ class LLMInterface(ABC):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         cached_prefix: str | None = None,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """
         Make an LLM API call with retry logic.
 
@@ -168,7 +167,6 @@ class LLMInterface(ABC):
             strict_schema: Grammar-enforce structured output via json_schema strict
                 (OpenAI-compatible, LiteLLM) instead of the soft json_object path. Gemini
                 enforces its response_schema natively; providers without a strict mode ignore it.
-            return_usage: If True, return tuple (result, TokenUsage) instead of just result.
             cached_prefix: Opaque handle from ``get_or_create_cached_prefix`` for the
                 cacheable system prefix, or None. Providers without explicit prompt
                 caching ignore it (and the wrapper only forwards it when set).
@@ -179,8 +177,6 @@ class LLMInterface(ABC):
                 occupies a permit.
 
         Returns:
-            If return_usage=False: Parsed response if response_format is provided, otherwise text content.
-            If return_usage=True: Tuple of (result, TokenUsage) with token counts.
 
         Raises:
             OutputTooLongError: If output exceeds token limits.

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -15,6 +15,7 @@ from json_repair import repair_json
 from pydantic import BaseModel
 
 from .._cross_loop import CrossLoopSemaphore
+from .response_models import LLMCallResult
 
 # Vertex AI imports (conditional - for LLMProvider to pass credentials to GeminiLLM)
 try:
@@ -227,8 +228,8 @@ def sanitize_llm_value(value: Any) -> Any:
 
     ``sanitize_text`` guards a single field. This guards a whole response — the
     text a provider returned, the dict a structured call parsed, the pydantic
-    model it validated into, the ``(result, usage)`` tuple ``return_usage=True``
-    hands back — so that *every* LLM call is covered at one boundary instead of
+    model it validated into, the ``LLMCallResult`` ``call`` hands back — so that
+    *every* LLM call is covered at one boundary instead of
     each consumer remembering to scrub its own fields (see issue #3729).
 
     It matters beyond embeddings. A lone surrogate is legal in a Python ``str``
@@ -273,7 +274,8 @@ def sanitize_llm_value(value: Any) -> Any:
             cleaned_dict[cleaned_key] = cleaned_item
         return cleaned_dict if changed else value
 
-    # ``tuple`` is here for the ``return_usage=True`` shape, ``(result, TokenUsage)``.
+    # ``call`` returns an ``LLMCallResult`` now, handled by the BaseModel branch
+    # above; ``tuple`` stays because a parsed JSON payload can nest either.
     if isinstance(value, (list, tuple)):
         cleaned_items = [sanitize_llm_value(item) for item in value]
         if all(cleaned is original for cleaned, original in zip(cleaned_items, value)):
@@ -1187,9 +1189,8 @@ class LLMProvider:
         max_backoff: float | None = None,
         skip_validation: bool = False,
         strict_schema: bool | None = None,
-        return_usage: bool = False,
         cached_prefix: str | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """
         Make an LLM API call with retry logic.
 
@@ -1211,11 +1212,8 @@ class LLMProvider:
                 inherits the server-level HINDSIGHT_API_LLM_STRICT_SCHEMA flag; an explicit
                 True or False wins over it, so a caller can force strict output on -- or off --
                 for its own scope. Providers without a strict mode ignore it.
-            return_usage: If True, return tuple (result, TokenUsage) instead of just result.
 
         Returns:
-            If return_usage=False: Parsed response if response_format is provided, otherwise text content.
-            If return_usage=True: Tuple of (result, TokenUsage) with token counts from the LLM call.
 
         Raises:
             OutputTooLongError: If output exceeds token limits.
@@ -1322,7 +1320,6 @@ class LLMProvider:
                         max_backoff=max_backoff,
                         skip_validation=skip_validation,
                         strict_schema=strict_schema,
-                        return_usage=return_usage,
                         **cache_kwarg,
                         **attempt_kwarg,
                     )
@@ -1796,7 +1793,7 @@ class ConfiguredLLMProvider:
 
     # ── overridden call methods ────────────────────────────────────────────────
 
-    async def call(self, messages: list[dict[str, Any]], **kwargs: Any) -> Any:
+    async def call(self, messages: list[dict[str, Any]], **kwargs: Any) -> LLMCallResult:
         from .providers.gemini_llm import _safety_settings_ctx
 
         token = _safety_settings_ctx.set(object.__getattribute__(self, "_gemini_safety_settings"))

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -16156,7 +16156,7 @@ class MemoryEngine(MemoryEngineInterface):
                             max_output_tokens=max(2048, int(doc_max_tokens * 1.5)),
                         )
                         unsay_llm = await _op_llm()
-                        raw_unsay = await unsay_llm.call(
+                        unsay_call = await unsay_llm.call(
                             messages=[
                                 {"role": "system", "content": STRUCTURED_RETRACTION_SYSTEM_PROMPT},
                                 {"role": "user", "content": unsay_prompt},
@@ -16165,6 +16165,7 @@ class MemoryEngine(MemoryEngineInterface):
                             temperature=get_config().llm_temperature_consolidation,
                             scope="mental_model_retraction_ops",
                         )
+                        raw_unsay = unsay_call.content
                         unsay_ops = parse_delta_operation_list(raw_unsay)
                         unsay_outcome = apply_operations(current_doc, unsay_ops.operations)
                         retraction_operations = MentalModelDeltaOperations(
@@ -16288,7 +16289,7 @@ class MemoryEngine(MemoryEngineInterface):
                     # same decoupling reflect's synthesis got in #3365/#3389 — the
                     # document-length budget lives in the prompt (``max_output_tokens``
                     # above), never in the transport cap.
-                    raw = await delta_llm.call(
+                    delta_call = await delta_llm.call(
                         messages=[
                             {"role": "system", "content": STRUCTURED_DELTA_SYSTEM_PROMPT},
                             {"role": "user", "content": user_prompt},
@@ -16300,6 +16301,7 @@ class MemoryEngine(MemoryEngineInterface):
                         temperature=get_config().llm_temperature_consolidation,
                         scope="mental_model_delta_ops",
                     )
+                    raw = delta_call.content
                     op_list = parse_delta_operation_list(raw)
                     apply_outcome = apply_operations(current_doc, op_list.operations)
                     delta_operations = MentalModelDeltaOperations(

--- a/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/anthropic_llm.py
@@ -25,6 +25,8 @@ from hindsight_api.engine.structured_output import provider_json_schema
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
+from ..response_models import LLMCallResult
+
 logger = logging.getLogger(__name__)
 
 
@@ -243,9 +245,8 @@ class AnthropicLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """
         Make an LLM API call with retry logic.
 
@@ -262,11 +263,8 @@ class AnthropicLLM(LLMInterface):
             strict_schema: Route structured output through a forced tool_use tool for
                 native constrained decoding (issue #1002). When False, falls back to
                 schema-in-prompt + JSON parse.
-            return_usage: If True, return tuple (result, TokenUsage) instead of just result.
 
         Returns:
-            If return_usage=False: Parsed response if response_format is provided, otherwise text content.
-            If return_usage=True: Tuple of (result, TokenUsage) with token counts.
 
         Raises:
             OutputTooLongError: If output exceeds token limits.
@@ -433,15 +431,13 @@ class AnthropicLLM(LLMInterface):
                         f"time={duration:.3f}s"
                     )
 
-                if return_usage:
-                    token_usage = TokenUsage(
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        total_tokens=total_tokens,
-                        cached_tokens=cached_tokens,
-                    )
-                    return result, token_usage
-                return result
+                token_usage = TokenUsage(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=total_tokens,
+                    cached_tokens=cached_tokens,
+                )
+                return LLMCallResult(content=result, usage=token_usage)
 
             except json.JSONDecodeError as e:
                 last_exception = e

--- a/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/claude_code_llm.py
@@ -29,6 +29,8 @@ from hindsight_api.engine.structured_output import provider_json_schema
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
+from ..response_models import LLMCallResult
+
 logger = logging.getLogger(__name__)
 
 
@@ -192,9 +194,8 @@ class ClaudeCodeLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """
         Make an LLM API call with retry logic.
 
@@ -209,11 +210,8 @@ class ClaudeCodeLLM(LLMInterface):
             max_backoff: Maximum backoff time in seconds.
             skip_validation: Return raw JSON without Pydantic validation.
             strict_schema: Use strict JSON schema enforcement (not supported).
-            return_usage: If True, return tuple (result, TokenUsage) instead of just result.
 
         Returns:
-            If return_usage=False: Parsed response if response_format is provided, otherwise text content.
-            If return_usage=True: Tuple of (result, TokenUsage) with estimated token counts.
 
         Raises:
             OutputTooLongError: If output exceeds token limits (not supported by Claude Agent SDK).
@@ -384,15 +382,12 @@ class ClaudeCodeLLM(LLMInterface):
                         f"slow llm call: scope={scope}, model={self.provider}/{self.model}, time={duration:.3f}s"
                     )
 
-                if return_usage:
-                    token_usage = TokenUsage(
-                        input_tokens=estimated_input,
-                        output_tokens=estimated_output,
-                        total_tokens=estimated_input + estimated_output,
-                    )
-                    return result, token_usage
-
-                return result
+                token_usage = TokenUsage(
+                    input_tokens=estimated_input,
+                    output_tokens=estimated_output,
+                    total_tokens=estimated_input + estimated_output,
+                )
+                return LLMCallResult(content=result, usage=token_usage)
 
             except ValidationError:
                 # Pydantic schema validation failure — retrying with the same

--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -36,6 +36,7 @@ from hindsight_api.engine.structured_output import provider_json_schema, strict_
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
+from ..response_models import LLMCallResult
 from .codex_auth import (
     _CODEX_CLIENT_ID,
     _CODEX_REFRESH_TOKEN_URL,
@@ -448,9 +449,8 @@ class CodexLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """Make API call to Codex backend with SSE streaming.
 
         Args:
@@ -673,18 +673,14 @@ class CodexLLM(LLMInterface):
                     # bugs that would otherwise silently erase spans (#3025).
                     logger.debug("Codex span recording failed: %s", span_error, exc_info=True)
 
-                if return_usage:
-                    # Codex doesn't provide token counts, estimate based on content
-                    estimated_input = sum(len(m.get("content", "")) for m in messages) // 4
-                    estimated_output = len(content) // 4
-                    token_usage = TokenUsage(
-                        input_tokens=estimated_input,
-                        output_tokens=estimated_output,
-                        total_tokens=estimated_input + estimated_output,
-                    )
-                    return result, token_usage
-
-                return result
+                estimated_input = sum(len(m.get("content", "")) for m in messages) // 4
+                estimated_output = len(content) // 4
+                token_usage = TokenUsage(
+                    input_tokens=estimated_input,
+                    output_tokens=estimated_output,
+                    total_tokens=estimated_input + estimated_output,
+                )
+                return LLMCallResult(content=result, usage=token_usage)
 
             except httpx.HTTPStatusError as e:
                 status_code = e.response.status_code

--- a/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/gemini_llm.py
@@ -31,6 +31,8 @@ from hindsight_api.engine.structured_output import has_tagged_union, provider_js
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
+from ..response_models import LLMCallResult
+
 logger = logging.getLogger(__name__)
 
 # Per-request Gemini safety settings override.
@@ -412,10 +414,9 @@ class GeminiLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         cached_prefix: str | None = None,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """
         Make a Gemini/VertexAI API call with retry logic.
 
@@ -431,7 +432,6 @@ class GeminiLLM(LLMInterface):
             skip_validation: Return raw JSON without Pydantic validation.
             strict_schema: Ignored — Gemini always grammar-enforces structured output via its
                 native response_schema, so it is strict regardless of this flag.
-            return_usage: If True, return tuple (result, TokenUsage).
             cached_prefix: Optional CachedContent resource name (from
                 ``GeminiCacheManager.get_or_create``). When set, the
                 system_instruction is assumed to live in the cache; this call
@@ -442,8 +442,6 @@ class GeminiLLM(LLMInterface):
                 normal uncached path.
 
         Returns:
-            If return_usage=False: Parsed response if response_format provided, else text.
-            If return_usage=True: Tuple of (result, TokenUsage).
         """
         start_time = time.time()
 
@@ -663,16 +661,14 @@ class GeminiLLM(LLMInterface):
                         f"time={duration:.3f}s"
                     )
 
-                if return_usage:
-                    token_usage = TokenUsage(
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        total_tokens=input_tokens + output_tokens,
-                        cached_tokens=cached_tokens,
-                        thoughts_tokens=thoughts_tokens,
-                    )
-                    return result, token_usage
-                return result
+                token_usage = TokenUsage(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=input_tokens + output_tokens,
+                    cached_tokens=cached_tokens,
+                    thoughts_tokens=thoughts_tokens,
+                )
+                return LLMCallResult(content=result, usage=token_usage)
 
             except json.JSONDecodeError as e:
                 last_exception = e

--- a/hindsight-api-slim/hindsight_api/engine/providers/github_copilot_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/github_copilot_llm.py
@@ -31,6 +31,8 @@ from hindsight_api.engine.structured_output import provider_json_schema
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
+from ..response_models import LLMCallResult
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -593,9 +595,8 @@ class GitHubCopilotLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         start_time = time.time()
 
         for attempt in range(max_retries + 1):
@@ -661,9 +662,7 @@ class GitHubCopilotLLM(LLMInterface):
                     scope=scope,
                     duration=duration,
                 )
-                if return_usage:
-                    return result, invocation.usage
-                return result
+                return LLMCallResult(content=result, usage=invocation.usage)
             except ValidationError:
                 raise
             except Exception as error:

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -37,6 +37,8 @@ from hindsight_api.engine.structured_output import provider_json_schema, strict_
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
+from ..response_models import LLMCallResult
+
 
 @lru_cache(maxsize=1)
 def _litellm_timeout_exc() -> type[BaseException]:
@@ -296,9 +298,8 @@ class LiteLLMLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         start_time = time.time()
 
         call_kwargs = self._build_common_kwargs(messages, max_completion_tokens, temperature)
@@ -442,14 +443,12 @@ class LiteLLMLLM(LLMInterface):
                         f"time={duration:.3f}s"
                     )
 
-                if return_usage:
-                    token_usage = TokenUsage(
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        total_tokens=total_tokens,
-                    )
-                    return result, token_usage
-                return result
+                token_usage = TokenUsage(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=total_tokens,
+                )
+                return LLMCallResult(content=result, usage=token_usage)
 
             except OutputTooLongError:
                 raise

--- a/hindsight-api-slim/hindsight_api/engine/providers/llamacpp_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/llamacpp_llm.py
@@ -28,6 +28,8 @@ from hindsight_api._cross_loop import CrossLoopLock
 from hindsight_api.engine.llm_interface import LLM_TOOL_CHOICE_AUTO, LLMInterface, LLMToolChoice
 from hindsight_api.engine.response_models import LLMToolCallResult
 
+from ..response_models import LLMCallResult
+
 logger = logging.getLogger(__name__)
 
 # Default GGUF model for offline mode
@@ -428,9 +430,8 @@ class LlamaCppLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """Delegate call to the OpenAI-compatible API."""
         await self._ensure_initialized()
         return await self._delegate.call(
@@ -444,7 +445,6 @@ class LlamaCppLLM(LLMInterface):
             max_backoff=max_backoff,
             skip_validation=skip_validation,
             strict_schema=strict_schema,
-            return_usage=return_usage,
             attempt_context=attempt_context,
         )
 

--- a/hindsight-api-slim/hindsight_api/engine/providers/mock_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/mock_llm.py
@@ -11,7 +11,7 @@ from contextlib import AbstractAsyncContextManager
 from typing import Any
 
 from ..llm_interface import LLM_TOOL_CHOICE_AUTO, LLMInterface, LLMToolChoice, LLMToolChoiceMode
-from ..response_models import LLMToolCall, LLMToolCallResult, TokenUsage
+from ..response_models import LLMCallResult, LLMToolCall, LLMToolCallResult, TokenUsage
 
 logger = logging.getLogger(__name__)
 
@@ -44,10 +44,11 @@ class MockLLM(LLMInterface):
         mock_llm.set_mock_response({"answer": "test"})
 
         # Make calls
-        result = await mock_llm.call(
+        call_result = await mock_llm.call(
             messages=[{"role": "user", "content": "test"}],
             response_format=MyResponseModel
         )
+        result = call_result.content
 
         # Verify calls
         calls = mock_llm.get_mock_calls()
@@ -112,9 +113,8 @@ class MockLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """
         Make a mock LLM API call.
 
@@ -131,11 +131,8 @@ class MockLLM(LLMInterface):
             max_backoff: Not used in mock.
             skip_validation: Return raw JSON without Pydantic validation.
             strict_schema: Not used in mock.
-            return_usage: If True, return tuple (result, TokenUsage) instead of just result.
 
         Returns:
-            If return_usage=False: Parsed response if response_format is provided, otherwise text content.
-            If return_usage=True: Tuple of (result, TokenUsage) with mock token counts.
         """
         # Record the call for test verification
         call_record = {
@@ -208,10 +205,8 @@ class MockLLM(LLMInterface):
         else:
             result = "mock response"
 
-        if return_usage:
-            token_usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
-            return result, token_usage
-        return result
+        token_usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        return LLMCallResult(content=result, usage=token_usage)
 
     async def call_with_tools(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/providers/none_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/none_llm.py
@@ -12,7 +12,7 @@ from contextlib import AbstractAsyncContextManager
 from typing import Any, Callable
 
 from ..llm_interface import LLM_TOOL_CHOICE_AUTO, LLMInterface, LLMToolChoice
-from ..response_models import LLMToolCallResult
+from ..response_models import LLMCallResult, LLMToolCallResult
 
 logger = logging.getLogger(__name__)
 
@@ -52,9 +52,8 @@ class NoneLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """Raise LLMNotAvailableError — no LLM is configured."""
         raise LLMNotAvailableError(
             "LLM provider is set to 'none'. This operation requires an LLM. "

--- a/hindsight-api-slim/hindsight_api/engine/providers/nous_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/nous_llm.py
@@ -34,6 +34,8 @@ from hindsight_api.engine.providers.nous_auth import (
 )
 from hindsight_api.engine.providers.openai_compatible_llm import OpenAICompatibleLLM
 
+from ..response_models import LLMCallResult
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["NousLLM", "NousAuthManager", "NousNotLoggedInError", "NousRefreshExpiredError"]
@@ -154,7 +156,7 @@ class NousLLM(OpenAICompatibleLLM):
         await self._ensure_fresh_token()
         return await super().verify_connection()
 
-    async def call(self, *args: Any, **kwargs: Any) -> Any:
+    async def call(self, *args: Any, **kwargs: Any) -> LLMCallResult:
         return await self._with_auth_retry(super().call, "call", *args, **kwargs)
 
     async def call_with_tools(self, *args: Any, **kwargs: Any) -> Any:

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -60,6 +60,8 @@ from hindsight_api.engine.structured_output import provider_json_schema, strict_
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
+from ..response_models import LLMCallResult
+
 logger = logging.getLogger(__name__)
 
 # Seed applied to every Groq request for deterministic behavior
@@ -1024,9 +1026,8 @@ class OpenAICompatibleLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """
         Make an LLM API call with retry logic.
 
@@ -1043,11 +1044,8 @@ class OpenAICompatibleLLM(LLMInterface):
             strict_schema: Use strict json_schema (grammar-enforced) response_format instead of
                 the soft json_object path. Supported by OpenAI and schema-capable self-hosted
                 backends (llama.cpp, vLLM). Server-wide via HINDSIGHT_API_LLM_STRICT_SCHEMA.
-            return_usage: If True, return tuple (result, TokenUsage) instead of just result.
 
         Returns:
-            If return_usage=False: Parsed response if response_format is provided, otherwise text content.
-            If return_usage=True: Tuple of (result, TokenUsage) with token counts.
 
         Raises:
             OutputTooLongError: If output exceeds token limits.
@@ -1075,7 +1073,6 @@ class OpenAICompatibleLLM(LLMInterface):
                 max_backoff=max_backoff,
                 skip_validation=skip_validation,
                 scope=scope,
-                return_usage=return_usage,
                 attempt_context=attempt_context,
             )
 
@@ -1340,9 +1337,7 @@ class OpenAICompatibleLLM(LLMInterface):
                         f"time={duration:.3f}s, ratio out/in={ratio:.2f}"
                     )
 
-                if return_usage:
-                    return result, token_counts
-                return result
+                return LLMCallResult(content=result, usage=token_counts)
 
             except LengthFinishReasonError as e:
                 logger.warning(f"LLM output exceeded token limits: {str(e)}")
@@ -1411,9 +1406,10 @@ class OpenAICompatibleLLM(LLMInterface):
                                         output_tokens=0,
                                         success=True,
                                     )
-                                    if return_usage:
-                                        return result, TokenUsage(input_tokens=0, output_tokens=0, total_tokens=0)
-                                    return result
+                                    return LLMCallResult(
+                                        content=result,
+                                        usage=TokenUsage(input_tokens=0, output_tokens=0, total_tokens=0),
+                                    )
                     except (json.JSONDecodeError, KeyError, TypeError):
                         pass  # Failed to parse tool_use_failed, continue with normal retry
 
@@ -1732,7 +1728,6 @@ class OpenAICompatibleLLM(LLMInterface):
         max_backoff: float,
         skip_validation: bool,
         scope: str = "memory",
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
     ) -> Any:
         """
@@ -1956,14 +1951,12 @@ class OpenAICompatibleLLM(LLMInterface):
                         error=None,
                     )
 
-                    if return_usage:
-                        token_usage = TokenUsage(
-                            input_tokens=input_tokens,
-                            output_tokens=output_tokens,
-                            total_tokens=total_tokens,
-                        )
-                        return validated_result, token_usage
-                    return validated_result
+                    token_usage = TokenUsage(
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        total_tokens=total_tokens,
+                    )
+                    return LLMCallResult(content=validated_result, usage=token_usage)
 
                 except ProviderResponseError as e:
                     last_exception = e

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_responses_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_responses_llm.py
@@ -68,6 +68,8 @@ from hindsight_api.engine.structured_output import provider_json_schema, strict_
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
+from ..response_models import LLMCallResult
+
 logger = logging.getLogger(__name__)
 
 
@@ -442,9 +444,8 @@ class OpenAIResponsesLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """Make a Responses API call with retry logic (see ``LLMInterface.call``)."""
         start_time = time.time()
         is_reasoning_model = self._supports_reasoning_model()
@@ -513,7 +514,7 @@ class OpenAIResponsesLLM(LLMInterface):
                     f"slow llm call: scope={scope}, model={self.provider}/{self.model}, "
                     f"input_tokens={usage.input_tokens}, output_tokens={usage.output_tokens}, time={duration:.3f}s"
                 )
-            return (result, usage) if return_usage else result
+            return LLMCallResult(content=result, usage=usage)
 
         return await self._run_with_retries(
             params,

--- a/hindsight-api-slim/hindsight_api/engine/providers/xai_oauth_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/xai_oauth_llm.py
@@ -69,6 +69,8 @@ from hindsight_api.engine.structured_output import provider_json_schema, strict_
 from hindsight_api.metrics import get_metrics_collector
 from hindsight_api.worker.stage import set_stage
 
+from ..response_models import LLMCallResult
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -704,9 +706,8 @@ class XaiOAuthLLM(LLMInterface):
         max_backoff: float = 60.0,
         skip_validation: bool = False,
         strict_schema: bool = False,
-        return_usage: bool = False,
         attempt_context: Callable[[], AbstractAsyncContextManager[None]] | None = None,
-    ) -> Any:
+    ) -> LLMCallResult:
         """Make a non-streaming completion call with retry logic.
 
         Non-streaming is deliberate for the first implementation: the engine
@@ -788,15 +789,16 @@ class XaiOAuthLLM(LLMInterface):
                     finish_reason=completion_content.finish_reason,
                 )
 
-                if return_usage:
-                    return result, TokenUsage(
+                return LLMCallResult(
+                    content=result,
+                    usage=TokenUsage(
                         input_tokens=counts.input_tokens,
                         output_tokens=counts.output_tokens,
                         total_tokens=counts.total_tokens,
                         cached_tokens=counts.cached_tokens,
                         thoughts_tokens=counts.thoughts_tokens,
-                    )
-                return result
+                    ),
+                )
 
             # XaiOAuthRefreshError is retried alongside the transport errors: a
             # credential-side blip (a network error reaching auth.x.ai, a 5xx

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -260,7 +260,7 @@ INSTRUCTIONS:
 
 OUTPUT:"""
 
-        structured_result, usage = await llm_config.call(
+        call_result = await llm_config.call(
             messages=[
                 {
                     "role": "system",
@@ -279,8 +279,9 @@ OUTPUT:"""
             initial_backoff=0.25,
             max_backoff=1.0,
             skip_validation=True,  # We'll handle the dict ourselves
-            return_usage=True,
         )
+        structured_result = call_result.content
+        usage = call_result.usage
 
         # Convert to dict
         if hasattr(structured_result, "model_dump"):
@@ -714,7 +715,7 @@ async def _run_reflect_agent_inner(
         """One tool-less LLM call with usage/trace accounting folded in."""
         nonlocal total_input_tokens, total_output_tokens, total_cached_tokens, total_thoughts_tokens
         llm_start = time.time()
-        response, usage = await llm_config.call(
+        call_result = await llm_config.call(
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": prompt},
@@ -722,8 +723,9 @@ async def _run_reflect_agent_inner(
             scope="reflect",
             temperature=get_config().llm_temperature_reflect,
             max_completion_tokens=completion_cap,
-            return_usage=True,
         )
+        response = call_result.content
+        usage = call_result.usage
         llm_duration = int((time.time() - llm_start) * 1000)
         total_input_tokens += usage.input_tokens
         total_output_tokens += usage.output_tokens
@@ -1387,7 +1389,7 @@ async def _process_done_tool(
             )
             rewrite_user = f"Target budget: {max_tokens} tokens.\n\nText to rewrite:\n{answer}"
 
-        rewritten, rewrite_usage = await llm_config.call(
+        call_result = await llm_config.call(
             messages=[
                 {"role": "system", "content": rewrite_system},
                 {"role": "user", "content": rewrite_user},
@@ -1395,8 +1397,9 @@ async def _process_done_tool(
             scope="reflect",
             temperature=get_config().llm_temperature_reflect,
             max_completion_tokens=get_config().reflect_max_completion_tokens,
-            return_usage=True,
         )
+        rewritten = call_result.content
+        rewrite_usage = call_result.usage
         if document is not None:
             trimmed = _document_from_rewrite(rewritten, answer)
             document, answer = trimmed.structure, trimmed.markdown

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -130,6 +130,35 @@ class TokenUsage(BaseModel):
         )
 
 
+class LLMCallResult(BaseModel):
+    """What one ``LLMInterface.call`` produced: the response, and what it cost.
+
+    ``call`` used to return either the bare response or a ``(response, usage)``
+    tuple depending on a ``return_usage: bool`` argument — a boolean that changed
+    the return type, which is why all fourteen implementations were annotated
+    ``-> Any`` and neither shape was ever checked. Callers that wanted the cost
+    unpacked two names; callers that did not got the response directly, and
+    nothing could tell you at the call site which you were looking at.
+
+    Returning this unconditionally mirrors ``call_with_tools``, which has always
+    returned a named ``LLMToolCallResult``. Usage is always available, so a caller
+    that wants to record cost no longer has to change the call's return type to
+    get it.
+    """
+
+    content: Any = Field(
+        default=None,
+        description=(
+            "The parsed response when a response_format was given, otherwise the text content. "
+            "Typed Any because the parsed shape is the caller's own response_format model."
+        ),
+    )
+    usage: TokenUsage = Field(
+        default_factory=TokenUsage,
+        description="Tokens this call consumed. Zero-valued when the provider reports none.",
+    )
+
+
 class ExtractedFact(BaseModel):
     """A single candidate fact produced by dry-run extraction (no resolution/links/persistence).
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/bank_utils.py
@@ -510,9 +510,10 @@ Merged mission:"""
     try:
         messages = [{"role": "user", "content": prompt}]
 
-        content = await llm_config.call(
+        call_result = await llm_config.call(
             messages=messages, scope="bank_mission", temperature=0.3, max_completion_tokens=8192
         )
+        content = call_result.content
 
         logger.info(f"LLM response for mission merge (first 500 chars): {content[:500]}")
 

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1902,12 +1902,13 @@ async def _extract_facts_from_chunk(
                 initial_backoff=initial_backoff,
                 max_backoff=max_backoff,
                 skip_validation=True,  # Get raw JSON, we'll validate leniently
-                return_usage=True,
             )
             if cached_prefix_name is not None:
                 call_kwargs["cached_prefix"] = cached_prefix_name
 
-            extraction_response_json, call_usage = await llm_config.call(**call_kwargs)
+            extraction_call = await llm_config.call(**call_kwargs)
+            extraction_response_json = extraction_call.content
+            call_usage = extraction_call.usage
             usage = usage + call_usage  # Aggregate usage across retries
 
             # Lenient parsing of facts from raw JSON

--- a/hindsight-api-slim/hindsight_api/engine/search/think_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/think_utils.py
@@ -224,11 +224,12 @@ async def reflect(
     system_message = get_system_message(disposition)
 
     # Call LLM
-    answer_text = await llm_config.call(
+    call_result = await llm_config.call(
         messages=[{"role": "system", "content": system_message}, {"role": "user", "content": prompt}],
         scope="memory_think",
         temperature=get_config().llm_temperature_reflect,
         max_completion_tokens=1000,
     )
+    answer_text = call_result.content
 
     return answer_text.strip()

--- a/hindsight-api-slim/tests/llm_judge.py
+++ b/hindsight-api-slim/tests/llm_judge.py
@@ -133,13 +133,15 @@ async def _judge_once(
     last_error: Exception | None = None
     for attempt in range(max(1, _JUDGE_CALL_ATTEMPTS)):
         try:
-            result = await judge.call(
-                messages=messages,
-                response_format=JudgeVerdict,
-                max_completion_tokens=256,
-                temperature=temperature,
-                scope="test_judge",
-            )
+            result = (
+                await judge.call(
+                    messages=messages,
+                    response_format=JudgeVerdict,
+                    max_completion_tokens=256,
+                    temperature=temperature,
+                    scope="test_judge",
+                )
+            ).content
             if isinstance(result, JudgeVerdict):
                 return result
             if isinstance(result, dict):

--- a/hindsight-api-slim/tests/test_anthropic_structured_tool_use.py
+++ b/hindsight-api-slim/tests/test_anthropic_structured_tool_use.py
@@ -50,13 +50,15 @@ async def test_strict_schema_uses_forced_tool_choice():
     provider = _make_anthropic_provider()
     provider._client.messages.create = AsyncMock(return_value=_tool_use_response({"action": "skip", "reason": "dup"}))
     with patch("hindsight_api.engine.providers.anthropic_llm.get_metrics_collector"):
-        result = await provider.call(
-            messages=[{"role": "user", "content": "decide"}],
-            response_format=_Decision,
-            strict_schema=True,
-            scope="test",
-            max_retries=0,
-        )
+        result = (
+            await provider.call(
+                messages=[{"role": "user", "content": "decide"}],
+                response_format=_Decision,
+                strict_schema=True,
+                scope="test",
+                max_retries=0,
+            )
+        ).content
     kwargs = provider._client.messages.create.call_args.kwargs
     # forced tool_use requested
     assert "tools" in kwargs and len(kwargs["tools"]) == 1
@@ -98,13 +100,15 @@ async def test_non_strict_keeps_text_injection_fallback():
     resp.stop_reason = "end_turn"
     provider._client.messages.create = AsyncMock(return_value=resp)
     with patch("hindsight_api.engine.providers.anthropic_llm.get_metrics_collector"):
-        result = await provider.call(
-            messages=[{"role": "user", "content": "decide"}],
-            response_format=_Decision,
-            strict_schema=False,
-            scope="test",
-            max_retries=0,
-        )
+        result = (
+            await provider.call(
+                messages=[{"role": "user", "content": "decide"}],
+                response_format=_Decision,
+                strict_schema=False,
+                scope="test",
+                max_retries=0,
+            )
+        ).content
     kwargs = provider._client.messages.create.call_args.kwargs
     assert "tools" not in kwargs  # no forced tool when not strict
     # system is a cache_control-marked block list; the schema text-injection

--- a/hindsight-api-slim/tests/test_claude_code_llm_error_result.py
+++ b/hindsight-api-slim/tests/test_claude_code_llm_error_result.py
@@ -137,11 +137,13 @@ async def test_call_ignores_non_error_result_message(monkeypatch):
     monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
 
     provider = _instantiate_provider()
-    result = await provider.call(
-        messages=[{"role": "user", "content": "hi"}],
-        max_retries=0,
-        scope="test",
-    )
+    result = (
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_retries=0,
+            scope="test",
+        )
+    ).content
 
     assert result == "ok"
 
@@ -165,13 +167,15 @@ async def test_call_records_span_for_unvalidated_dict(monkeypatch):
     monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
     monkeypatch.setattr(tracing, "get_span_recorder", lambda: span_recorder)
 
-    result = await _instantiate_provider().call(
-        messages=[{"role": "user", "content": "extract facts"}],
-        response_format=_StructuredResponse,
-        skip_validation=True,
-        max_retries=0,
-        scope="retain_extract_facts",
-    )
+    result = (
+        await _instantiate_provider().call(
+            messages=[{"role": "user", "content": "extract facts"}],
+            response_format=_StructuredResponse,
+            skip_validation=True,
+            max_retries=0,
+            scope="retain_extract_facts",
+        )
+    ).content
 
     assert result == {"fact": "x"}
     assert span_recorder.record_llm_call.call_args.kwargs["response_content"] == '{"fact": "x"}'
@@ -197,11 +201,13 @@ async def test_call_survives_span_recorder_failure(monkeypatch):
     monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
     monkeypatch.setattr(tracing, "get_span_recorder", lambda: span_recorder)
 
-    result = await _instantiate_provider().call(
-        messages=[{"role": "user", "content": "hi"}],
-        max_retries=0,
-        scope="test",
-    )
+    result = (
+        await _instantiate_provider().call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_retries=0,
+            scope="test",
+        )
+    ).content
 
     assert result == "ok"
     span_recorder.record_llm_call.assert_called_once()

--- a/hindsight-api-slim/tests/test_claude_code_llm_isolation.py
+++ b/hindsight-api-slim/tests/test_claude_code_llm_isolation.py
@@ -82,11 +82,13 @@ async def test_call_passes_isolation_env_to_sdk_options(monkeypatch):
     monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
 
     provider = _instantiate_provider()
-    result = await provider.call(
-        messages=[{"role": "user", "content": "hi"}],
-        max_retries=0,
-        scope="test",
-    )
+    result = (
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_retries=0,
+            scope="test",
+        )
+    ).content
 
     assert result == "ok"
     assert "options" in captured, "fake query was not called"

--- a/hindsight-api-slim/tests/test_claude_code_llm_tool_round.py
+++ b/hindsight-api-slim/tests/test_claude_code_llm_tool_round.py
@@ -300,11 +300,13 @@ async def test_call_pins_configured_model(monkeypatch):
     monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
 
     provider = _instantiate_provider()
-    result = await provider.call(
-        messages=[{"role": "user", "content": "hi"}],
-        max_retries=0,
-        scope="test",
-    )
+    result = (
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            max_retries=0,
+            scope="test",
+        )
+    ).content
 
     assert result == "ok"
     assert captured["opts"].model == "claude-haiku-4-5"

--- a/hindsight-api-slim/tests/test_codex_oauth_refresh.py
+++ b/hindsight-api-slim/tests/test_codex_oauth_refresh.py
@@ -686,12 +686,14 @@ async def test_call_reactively_refreshes_on_401_and_retries(tmp_path: Path):
         stub_codex_stream_with(llm, fake_backend_stream),
         patch.object(llm, "_parse_sse_stream", new_callable=AsyncMock, return_value="ok"),
     ):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "ping"}],
-            max_retries=0,
-            initial_backoff=0.0,
-            max_backoff=0.0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "ping"}],
+                max_retries=0,
+                initial_backoff=0.0,
+                max_backoff=0.0,
+            )
+        ).content
 
     assert result == "ok"
     assert call_count["refresh"] == 1

--- a/hindsight-api-slim/tests/test_codex_stream_deadline.py
+++ b/hindsight-api-slim/tests/test_codex_stream_deadline.py
@@ -141,7 +141,7 @@ async def test_normal_response_still_parses():
     server, base_url = await _sse_server(chunks_per_second=1, body=body, finite=True)
     llm = _build_llm(base_url, timeout=30.0)
     try:
-        assert await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0) == "hello world"
+        assert (await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)).content == "hello world"
     finally:
         await llm.cleanup()
         server.close()

--- a/hindsight-api-slim/tests/test_codex_strict_schema.py
+++ b/hindsight-api-slim/tests/test_codex_strict_schema.py
@@ -93,12 +93,14 @@ async def test_strict_schema_uses_forced_function_tool():
     with stub_codex_stream(llm, response) as mock_stream:
         with patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock) as mock_parse:
             mock_parse.return_value = (None, [tool_call])
-            result = await llm.call(
-                messages=[{"role": "user", "content": "The sky is blue"}],
-                response_format=_Fact,
-                strict_schema=True,
-                max_retries=0,
-            )
+            result = (
+                await llm.call(
+                    messages=[{"role": "user", "content": "The sky is blue"}],
+                    response_format=_Fact,
+                    strict_schema=True,
+                    max_retries=0,
+                )
+            ).content
         sent_payload = mock_stream.call_args.kwargs["json"]
         sent_headers = mock_stream.call_args.kwargs["headers"]
 
@@ -128,13 +130,15 @@ async def test_strict_schema_skip_validation_returns_dict():
         with stub_codex_stream(llm, response) as mock_stream:
             with patch.object(llm, "_parse_sse_tool_stream", new_callable=AsyncMock) as mock_parse:
                 mock_parse.return_value = (None, [tool_call])
-                result = await llm.call(
-                    messages=[{"role": "user", "content": "hi"}],
-                    response_format=_Fact,
-                    strict_schema=True,
-                    skip_validation=True,
-                    max_retries=0,
-                )
+                result = (
+                    await llm.call(
+                        messages=[{"role": "user", "content": "hi"}],
+                        response_format=_Fact,
+                        strict_schema=True,
+                        skip_validation=True,
+                        max_retries=0,
+                    )
+                ).content
 
     assert result == {"fact": "x"}
     assert span_recorder.record_llm_call.call_args.kwargs["response_content"] == '{"fact": "x"}'
@@ -175,12 +179,14 @@ async def test_non_strict_repairs_invalid_escapes_without_retrying():
     with stub_codex_stream(llm, response) as mock_stream:
         with patch.object(llm, "_parse_sse_stream", new_callable=AsyncMock) as mock_parse:
             mock_parse.return_value = escape_heavy
-            result = await llm.call(
-                messages=[{"role": "user", "content": "coding transcript"}],
-                response_format=_Fact,
-                strict_schema=False,
-                max_retries=3,
-            )
+            result = (
+                await llm.call(
+                    messages=[{"role": "user", "content": "coding transcript"}],
+                    response_format=_Fact,
+                    strict_schema=False,
+                    max_retries=3,
+                )
+            ).content
 
     # Parsed on the first attempt (no retry storm): the SSE stream was read once.
     assert mock_stream.call_count == 1

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -4,6 +4,7 @@ These tests exercise the real consolidation implementation with actual database 
 Note: Consolidation runs automatically after retain via SyncTaskBackend in tests.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -2428,7 +2429,9 @@ class TestBuildResponseModel:
         creates = [_CreateAction(text=f"observation {index}", source_fact_ids=[f"fact-{index}"]) for index in range(3)]
         llm_config = SimpleNamespace(
             _provider_impl=None,
-            call=AsyncMock(return_value=_ConsolidationBatchResponse(creates=creates)),
+            call=AsyncMock(
+                return_value=LLMCallResult(content=_ConsolidationBatchResponse(creates=creates), usage=TokenUsage())
+            ),
         )
         config = SimpleNamespace(
             llm_output_language=None,

--- a/hindsight-api-slim/tests/test_consolidation_dedup.py
+++ b/hindsight-api-slim/tests/test_consolidation_dedup.py
@@ -5,6 +5,7 @@ guard the fix in CI — unlike the real-LLM integration test, which only trigger
 the path stochastically.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import logging
 import types
 import uuid
@@ -279,7 +280,10 @@ async def test_dedup_no_twin_above_threshold_returns_none() -> None:
 
 async def test_dedup_llm_keep_does_not_merge() -> None:
     kwargs, conn, llm = _ctx()
-    llm.call.return_value = '{"action": "keep", "text": "", "reason": "different language"}'
+    llm.call.return_value = LLMCallResult(
+        content='{"action": "keep", "text": "", "reason": "different language"}',
+        usage=TokenUsage(),
+    )
     with _patch_embed(), _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
         result = await _dedup_reconcile_create(**kwargs)
     assert result is None
@@ -290,7 +294,10 @@ async def test_dedup_llm_keep_does_not_merge() -> None:
 
 async def test_dedup_llm_missing_action_defaults_to_keep() -> None:
     kwargs, conn, llm = _ctx()
-    llm.call.return_value = _DedupDecision(reason="underfilled structured response")
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(reason="underfilled structured response"),
+        usage=TokenUsage(),
+    )
     with _patch_embed(), _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
         result = await _dedup_reconcile_create(**kwargs)
     assert result is None
@@ -383,8 +390,9 @@ def test_dedup_prompt_contract_requests_json_not_key_value() -> None:
 async def test_dedup_llm_merge_folds_into_twin() -> None:
     kwargs, conn, llm = _ctx()
     kwargs["create_source_ids"] = [uuid.uuid4(), uuid.uuid4()]
-    llm.call.return_value = (
-        '{"action": "merge", "text": "Uzbek content on YouTube is very rich.", "reason": "same fact"}'
+    llm.call.return_value = LLMCallResult(
+        content=('{"action": "merge", "text": "Uzbek content on YouTube is very rich.", "reason": "same fact"}'),
+        usage=TokenUsage(),
     )
     with _patch_embed(), _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]):
         result = await _dedup_reconcile_create(**kwargs)
@@ -414,8 +422,9 @@ async def test_dedup_llm_merge_sanitizes_text_before_write() -> None:
     # A raw NUL reaching the driver breaks the Postgres UTF-8 encode.
     kwargs, conn, llm = _ctx()
     kwargs["create_source_ids"] = [uuid.uuid4(), uuid.uuid4()]
-    llm.call.return_value = _DedupDecision(
-        action="merge", text="Uzbek content\x00 on YouTube is very rich.", reason="same fact"
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(action="merge", text="Uzbek content\x00 on YouTube is very rich.", reason="same fact"),
+        usage=TokenUsage(),
     )
     with _patch_embed(), _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]):
         result = await _dedup_reconcile_create(**kwargs)
@@ -429,7 +438,10 @@ async def test_dedup_llm_merge_sanitizes_text_before_write() -> None:
 async def test_dedup_picks_highest_above_threshold_skips_below() -> None:
     # Only the >=threshold candidate is considered; a 0.95 result is ignored at threshold 0.97.
     kwargs, conn, llm = _ctx(threshold=0.97)
-    llm.call.return_value = _DedupDecision(action="keep")
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(action="keep"),
+        usage=TokenUsage(),
+    )
     with _patch_embed(), _patch_probe([_obs("near but distinct", 0.95), _obs("the real twin", 0.98)]):
         await _dedup_reconcile_create(**kwargs)
     # the twin passed to the LLM is the >=0.97 one, not the 0.95
@@ -476,7 +488,10 @@ def _update_ctx(threshold: float = 0.97):
 @pytest.mark.memory_backend_incompatible
 async def test_dedup_update_merge_folds_into_twin_and_deletes_updated() -> None:
     kwargs, conn, llm = _update_ctx()
-    llm.call.return_value = _DedupDecision(action="merge", text="Uzbek YouTube content is very rich and growing.")
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(action="merge", text="Uzbek YouTube content is very rich and growing."),
+        usage=TokenUsage(),
+    )
     with _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
         await _dedup_reconcile_update(**kwargs)
     llm.call.assert_awaited_once()
@@ -499,7 +514,10 @@ async def test_dedup_update_merge_folds_into_twin_and_deletes_updated() -> None:
 
 async def test_dedup_update_keep_does_not_merge() -> None:
     kwargs, conn, llm = _update_ctx()
-    llm.call.return_value = _DedupDecision(action="keep", reason="different growth claim")
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(action="keep", reason="different growth claim"),
+        usage=TokenUsage(),
+    )
     with _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
         await _dedup_reconcile_update(**kwargs)
     llm.call.assert_awaited_once()
@@ -579,7 +597,10 @@ async def test_dedup_create_twin_vanished_returns_none_so_caller_creates() -> No
     # no row (fetchval -> None); the helper must return None so the caller still CREATEs.
     kwargs, conn, llm = _ctx()
     conn.fetchval_result = None
-    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(action="merge", text="merged text"),
+        usage=TokenUsage(),
+    )
     with (
         _patch_embed(),
         _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]),
@@ -598,7 +619,10 @@ async def test_dedup_create_fold_uses_only_live_new_sources() -> None:
     deleted_source_id = uuid.uuid4()
     kwargs["create_source_ids"] = [deleted_source_id, live_source_id]
     conn.live_rows = [{"id": live_source_id}]
-    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(action="merge", text="merged text"),
+        usage=TokenUsage(),
+    )
     with (
         _patch_embed(),
         _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]),
@@ -613,7 +637,10 @@ async def test_dedup_create_all_new_sources_deleted_returns_none() -> None:
     kwargs, conn, llm = _ctx()
     kwargs["create_source_ids"] = [uuid.uuid4(), uuid.uuid4()]
     conn.live_rows = []
-    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(action="merge", text="merged text"),
+        usage=TokenUsage(),
+    )
     with (
         _patch_embed(),
         _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.99)]),
@@ -630,7 +657,10 @@ async def test_dedup_update_twin_vanished_does_not_delete_updated() -> None:
     # If the fold matches no row (twin vanished mid-window), the updated row must NOT be deleted.
     kwargs, conn, llm = _update_ctx()
     conn.fetchval_result = None
-    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(action="merge", text="merged text"),
+        usage=TokenUsage(),
+    )
     with _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
         await _dedup_reconcile_update(**kwargs)
     conn.fetchval.assert_awaited_once()  # fold attempted
@@ -646,7 +676,10 @@ async def test_dedup_update_fold_uses_only_live_updated_sources() -> None:
     deleted_source_id = uuid.uuid4()
     conn.fetchrow_result = {"source_memory_ids": [deleted_source_id, live_source_id]}
     conn.live_rows = [{"id": live_source_id}]
-    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(action="merge", text="merged text"),
+        usage=TokenUsage(),
+    )
     with _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
         await _dedup_reconcile_update(**kwargs)
     conn.fetchval.assert_awaited_once()
@@ -658,7 +691,10 @@ async def test_dedup_update_all_updated_sources_deleted_skips_fold_and_delete() 
     kwargs, conn, llm = _update_ctx()
     conn.fetchrow_result = {"source_memory_ids": [uuid.uuid4(), uuid.uuid4()]}
     conn.live_rows = []
-    llm.call.return_value = _DedupDecision(action="merge", text="merged text")
+    llm.call.return_value = LLMCallResult(
+        content=_DedupDecision(action="merge", text="merged text"),
+        usage=TokenUsage(),
+    )
     with _patch_probe([_obs("Uzbek content on YouTube is described as very rich.", 0.98)]):
         await _dedup_reconcile_update(**kwargs)
     conn.fetchval.assert_not_called()

--- a/hindsight-api-slim/tests/test_consolidation_retry_budget.py
+++ b/hindsight-api-slim/tests/test_consolidation_retry_budget.py
@@ -1,6 +1,7 @@
 """Tests for consolidation retry budget configurability (issue #1042) and
 failure classification (issue #3684)."""
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,7 +21,10 @@ def mock_llm_config():
     response.creates = []
     response.updates = []
     response.deletes = []
-    llm.call.return_value = response
+    llm.call.return_value = LLMCallResult(
+        content=response,
+        usage=TokenUsage(),
+    )
     return llm
 
 

--- a/hindsight-api-slim/tests/test_content_policy_refusal_permanent.py
+++ b/hindsight-api-slim/tests/test_content_policy_refusal_permanent.py
@@ -19,6 +19,8 @@ These tests pin the permanence at all three layers:
 
 from __future__ import annotations
 
+from hindsight_api.engine.response_models import TokenUsage
+
 import json
 import uuid
 from dataclasses import dataclass, field

--- a/hindsight-api-slim/tests/test_document_tracking.py
+++ b/hindsight-api-slim/tests/test_document_tracking.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from hindsight_api import RequestContext
-from hindsight_api.engine.response_models import TokenUsage
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 
 
 @pytest.mark.asyncio
@@ -513,9 +513,7 @@ async def test_document_stored_without_chunks_when_zero_facts(memory_no_llm_veri
 
     async def mock_llm_zero_facts(*args, **kwargs):
         response = {"facts": []}
-        if kwargs.get("return_usage", False):
-            return response, TokenUsage(input_tokens=10, output_tokens=2)
-        return response
+        return LLMCallResult(content=response, usage=TokenUsage(input_tokens=10, output_tokens=2))
 
     try:
         with patch("hindsight_api.engine.llm_wrapper.LLMProvider.call", new=mock_llm_zero_facts):

--- a/hindsight-api-slim/tests/test_fact_extraction_retry.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_retry.py
@@ -9,6 +9,7 @@ BaseException'), which happened when last_error was only set in the
 BadRequestError handler and not for non-dict JSON responses.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import dataclasses
 import json
 from datetime import datetime, timezone
@@ -163,9 +164,7 @@ def _make_llm_config(mock_response):
     # Set explicitly: ``model`` is an instance attribute, so ``spec=LLMProvider``
     # does not provide it, and the extraction error paths name the model.
     llm.model = "mock-model"
-    token_usage = MagicMock()
-    token_usage.__add__ = lambda self, other: self
-    llm.call = AsyncMock(return_value=(mock_response, token_usage))
+    llm.call = AsyncMock(return_value=LLMCallResult(content=mock_response, usage=TokenUsage()))
     return llm
 
 
@@ -731,7 +730,7 @@ def _make_recording_llm(mock_response):
 
     llm = MagicMock(spec=LLMProvider)
     llm.provider = "mock"
-    llm.call = AsyncMock(return_value=(mock_response, TokenUsage()))
+    llm.call = AsyncMock(return_value=LLMCallResult(content=mock_response, usage=TokenUsage()))
     return llm
 
 

--- a/hindsight-api-slim/tests/test_gemini_cache.py
+++ b/hindsight-api-slim/tests/test_gemini_cache.py
@@ -339,12 +339,14 @@ async def test_call_falls_back_to_uncached_when_cache_400s():
     llm._client.aio.models = MagicMock()
     llm._client.aio.models.generate_content = AsyncMock(side_effect=_gen)
 
-    result = await llm.call(
-        messages=[{"role": "system", "content": "SYSTEM PREFIX"}, {"role": "user", "content": "doc"}],
-        cached_prefix="cachedContents/stale",
-        max_retries=2,
-        temperature=0.1,
-    )
+    result = (
+        await llm.call(
+            messages=[{"role": "system", "content": "SYSTEM PREFIX"}, {"role": "user", "content": "doc"}],
+            cached_prefix="cachedContents/stale",
+            max_retries=2,
+            temperature=0.1,
+        )
+    ).content
 
     # The request succeeded via the uncached retry.
     assert result == "extracted"

--- a/hindsight-api-slim/tests/test_gemini_deadline_retry.py
+++ b/hindsight-api-slim/tests/test_gemini_deadline_retry.py
@@ -95,7 +95,9 @@ async def test_call_retries_once_after_the_deadline():
     generate = _generate_content(_never_answers, lambda: _answers(_text_response("recovered")))
     provider._client.aio.models.generate_content = generate
 
-    result = await provider.call(messages=[{"role": "user", "content": "hi"}], scope="reflect", initial_backoff=0.0)
+    result = (
+        await provider.call(messages=[{"role": "user", "content": "hi"}], scope="reflect", initial_backoff=0.0)
+    ).content
 
     assert result == "recovered", "the retry's answer must be returned, not the stall"
     assert generate.call_count == 2

--- a/hindsight-api-slim/tests/test_github_copilot_llm.py
+++ b/hindsight-api-slim/tests/test_github_copilot_llm.py
@@ -201,14 +201,15 @@ def test_invalid_reasoning_effort_does_not_acquire_runtime(monkeypatch):
 async def test_plain_call_isolates_session_and_reports_usage(monkeypatch):
     provider, client = _provider(monkeypatch, [_assistant_event("ok"), _usage_event()])
 
-    result, usage = await provider.call(
+    call_result = await provider.call(
         messages=[
             {"role": "system", "content": "Reply concisely."},
             {"role": "user", "content": "Say ok."},
         ],
-        return_usage=True,
         max_retries=0,
     )
+    result = call_result.content
+    usage = call_result.usage
 
     assert result == "ok"
     assert usage.input_tokens == 120
@@ -245,11 +246,13 @@ async def test_structured_call_uses_terminal_schema_tool(monkeypatch):
         [_assistant_event("", [request]), _usage_event()],
     )
 
-    result = await provider.call(
-        messages=[{"role": "user", "content": "Return an answer."}],
-        response_format=_StructuredAnswer,
-        max_retries=0,
-    )
+    result = (
+        await provider.call(
+            messages=[{"role": "user", "content": "Return an answer."}],
+            response_format=_StructuredAnswer,
+            max_retries=0,
+        )
+    ).content
 
     assert result == _StructuredAnswer(answer="captured")
     tool = client.create_kwargs["tools"][0]
@@ -448,8 +451,7 @@ async def test_session_cleanup_timeout_invalidates_runtime(monkeypatch):
             messages=[{"role": "user", "content": "say ok"}],
             max_retries=0,
         )
-        == "ok"
-    )
+    ).content == "ok"
 
     assert time.monotonic() - started < 0.2
     assert runtime.invalidations == ["transient session cleanup timed out or failed"]

--- a/hindsight-api-slim/tests/test_input_robustness.py
+++ b/hindsight-api-slim/tests/test_input_robustness.py
@@ -21,7 +21,7 @@ from hindsight_api.engine.llm_wrapper import (
     sanitize_text,
 )
 from hindsight_api.engine.reflect.tokenization import count_prompt_tokens
-from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
+from hindsight_api.engine.response_models import LLMCallResult, LLMToolCall, LLMToolCallResult, TokenUsage
 from hindsight_api.engine.retain.fact_extraction import Fact
 from hindsight_api.engine.token_encoding import count_tokens, truncate_to_tokens
 
@@ -102,8 +102,8 @@ async def test_fact_extraction_sanitizes_surrogates_generated_by_llm():
     llm = MagicMock(spec=LLMProvider)
     llm.provider = "mock"
     llm.call = AsyncMock(
-        return_value=(
-            {
+        return_value=LLMCallResult(
+            content={
                 "facts": [
                     {
                         "what": "Alex laughed 😂",
@@ -116,7 +116,7 @@ async def test_fact_extraction_sanitizes_surrogates_generated_by_llm():
                     }
                 ]
             },
-            TokenUsage(),
+            usage=TokenUsage(),
         )
     )
 
@@ -178,8 +178,12 @@ def test_sanitize_llm_value_scrubs_pydantic_models():
     assert cleaned.output_tokens == 42
 
 
-def test_sanitize_llm_value_preserves_return_usage_tuple_shape():
-    """``return_usage=True`` hands back ``(result, TokenUsage)`` — both must survive."""
+def test_sanitize_llm_value_preserves_tuple_shape():
+    """A tuple reaching the scrubber keeps its shape — both members must survive.
+
+    ``call`` returns an ``LLMCallResult`` now (handled by the BaseModel branch), but
+    parsed JSON payloads still nest tuples, so the tuple branch has to stay correct.
+    """
     usage = TokenUsage()
     cleaned = sanitize_llm_value(({"text": f"x{HIGH_SURROGATE}"}, usage))
     assert isinstance(cleaned, tuple) and len(cleaned) == 2
@@ -221,8 +225,8 @@ async def test_llm_provider_call_sanitizes_response():
 
     result = await llm.call(messages=[{"role": "user", "content": "hi"}], skip_validation=True)
 
-    assert result["facts"][0]["what"] == "Alex laughed 😂"
-    assert result["facts"][0]["what"].encode("utf-8")
+    assert result.content["facts"][0]["what"] == "Alex laughed 😂"
+    assert result.content["facts"][0]["what"].encode("utf-8")
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_litellm_forced_tool_structured_output.py
+++ b/hindsight-api-slim/tests/test_litellm_forced_tool_structured_output.py
@@ -69,7 +69,7 @@ async def _call_capturing_request(llm: LiteLLMLLM, response: _Response) -> dict[
     """Run ``call`` against a stubbed completion and return the request kwargs."""
     completion = AsyncMock(return_value=response)
     llm._acompletion = completion  # type: ignore[method-assign]
-    result = await llm.call(messages=_MESSAGES, response_format=_Facts, max_retries=0)
+    result = (await llm.call(messages=_MESSAGES, response_format=_Facts, max_retries=0)).content
     return {"kwargs": completion.await_args.kwargs, "result": result}
 
 
@@ -151,7 +151,7 @@ async def test_plain_calls_are_untouched_by_the_flag():
     completion = AsyncMock(return_value=_Response(_Message("hello"), finish_reason="stop"))
     llm._acompletion = completion  # type: ignore[method-assign]
 
-    result = await llm.call(messages=_MESSAGES, max_retries=0)
+    result = (await llm.call(messages=_MESSAGES, max_retries=0)).content
 
     assert result == "hello"
     assert "tools" not in completion.await_args.kwargs
@@ -188,11 +188,13 @@ async def test_skip_validation_returns_the_raw_tool_arguments():
     response = _Response(_Message(None, [_ToolCall("structured_response", '{"facts": ["raw"]}')]))
     llm._acompletion = AsyncMock(return_value=response)  # type: ignore[method-assign]
 
-    result = await llm.call(
-        messages=_MESSAGES,
-        response_format=_Facts,
-        skip_validation=True,
-        max_retries=0,
-    )
+    result = (
+        await llm.call(
+            messages=_MESSAGES,
+            response_format=_Facts,
+            skip_validation=True,
+            max_retries=0,
+        )
+    ).content
 
     assert result == {"facts": ["raw"]}

--- a/hindsight-api-slim/tests/test_litellm_json_repair.py
+++ b/hindsight-api-slim/tests/test_litellm_json_repair.py
@@ -52,14 +52,16 @@ async def test_malformed_json_repaired_after_retries_exhausted(monkeypatch):
 
     monkeypatch.setattr(provider, "_acompletion", _fake)
 
-    result = await provider.call(
-        messages=[{"role": "user", "content": "hi"}],
-        response_format=_Facts,
-        skip_validation=True,
-        max_retries=1,
-        initial_backoff=0.01,
-        max_backoff=0.01,
-    )
+    result = (
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            response_format=_Facts,
+            skip_validation=True,
+            max_retries=1,
+            initial_backoff=0.01,
+            max_backoff=0.01,
+        )
+    ).content
 
     # A clean re-roll is preferred first: attempt 0 raises, attempt 1 repairs.
     assert calls == 2
@@ -76,14 +78,16 @@ async def test_clean_reroll_preferred_over_repair(monkeypatch):
 
     monkeypatch.setattr(provider, "_acompletion", _fake)
 
-    result = await provider.call(
-        messages=[{"role": "user", "content": "hi"}],
-        response_format=_Facts,
-        skip_validation=True,
-        max_retries=1,
-        initial_backoff=0.01,
-        max_backoff=0.01,
-    )
+    result = (
+        await provider.call(
+            messages=[{"role": "user", "content": "hi"}],
+            response_format=_Facts,
+            skip_validation=True,
+            max_retries=1,
+            initial_backoff=0.01,
+            max_backoff=0.01,
+        )
+    ).content
 
     assert result == {"a": 2}  # the clean re-roll, not a repair of the first
 

--- a/hindsight-api-slim/tests/test_llm_extra_body.py
+++ b/hindsight-api-slim/tests/test_llm_extra_body.py
@@ -219,14 +219,16 @@ async def test_gemini_structured_call_uses_native_schema_without_prompt_duplicat
     response.text = '{"answer": "ok"}'
     provider._client.aio.models.generate_content = AsyncMock(return_value=response)
 
-    result = await provider.call(
-        messages=[
-            {"role": "system", "content": "Return concise JSON."},
-            {"role": "user", "content": "hello"},
-        ],
-        response_format=StructuredAnswer,
-        scope="test",
-    )
+    result = (
+        await provider.call(
+            messages=[
+                {"role": "system", "content": "Return concise JSON."},
+                {"role": "user", "content": "hello"},
+            ],
+            response_format=StructuredAnswer,
+            scope="test",
+        )
+    ).content
 
     config_arg = provider._client.aio.models.generate_content.call_args.kwargs.get("config")
     assert result.answer == "ok"
@@ -249,15 +251,17 @@ async def test_gemini_cached_structured_call_keeps_native_schema():
     response.text = '{"answer": "ok"}'
     provider._client.aio.models.generate_content = AsyncMock(return_value=response)
 
-    result = await provider.call(
-        messages=[
-            {"role": "system", "content": "Return concise JSON."},
-            {"role": "user", "content": "hello"},
-        ],
-        response_format=StructuredAnswer,
-        cached_prefix="cachedContents/test",
-        scope="test",
-    )
+    result = (
+        await provider.call(
+            messages=[
+                {"role": "system", "content": "Return concise JSON."},
+                {"role": "user", "content": "hello"},
+            ],
+            response_format=StructuredAnswer,
+            cached_prefix="cachedContents/test",
+            scope="test",
+        )
+    ).content
 
     config_arg = provider._client.aio.models.generate_content.call_args.kwargs.get("config")
     assert result.answer == "ok"
@@ -282,17 +286,19 @@ async def test_gemini_structured_parse_failure_falls_back_to_prompt_schema():
     valid.text = '{"answer": "ok"}'
     provider._client.aio.models.generate_content = AsyncMock(side_effect=[invalid, valid])
 
-    result = await provider.call(
-        messages=[
-            {"role": "system", "content": "Return concise JSON."},
-            {"role": "user", "content": "hello"},
-        ],
-        response_format=StructuredAnswer,
-        scope="test",
-        max_retries=1,
-        initial_backoff=0,
-        max_backoff=0,
-    )
+    result = (
+        await provider.call(
+            messages=[
+                {"role": "system", "content": "Return concise JSON."},
+                {"role": "user", "content": "hello"},
+            ],
+            response_format=StructuredAnswer,
+            scope="test",
+            max_retries=1,
+            initial_backoff=0,
+            max_backoff=0,
+        )
+    ).content
 
     first_config = provider._client.aio.models.generate_content.call_args_list[0].kwargs["config"]
     fallback_config = provider._client.aio.models.generate_content.call_args_list[1].kwargs["config"]
@@ -322,18 +328,20 @@ async def test_gemini_cached_parse_retry_keeps_cached_native_schema():
     valid.text = '{"answer": "ok"}'
     provider._client.aio.models.generate_content = AsyncMock(side_effect=[invalid, valid])
 
-    result = await provider.call(
-        messages=[
-            {"role": "system", "content": "Return concise JSON."},
-            {"role": "user", "content": "hello"},
-        ],
-        response_format=StructuredAnswer,
-        cached_prefix="cachedContents/test",
-        scope="test",
-        max_retries=1,
-        initial_backoff=0,
-        max_backoff=0,
-    )
+    result = (
+        await provider.call(
+            messages=[
+                {"role": "system", "content": "Return concise JSON."},
+                {"role": "user", "content": "hello"},
+            ],
+            response_format=StructuredAnswer,
+            cached_prefix="cachedContents/test",
+            scope="test",
+            max_retries=1,
+            initial_backoff=0,
+            max_backoff=0,
+        )
+    ).content
 
     first_config = provider._client.aio.models.generate_content.call_args_list[0].kwargs["config"]
     retry_config = provider._client.aio.models.generate_content.call_args_list[1].kwargs["config"]

--- a/hindsight-api-slim/tests/test_llm_per_op_concurrency.py
+++ b/hindsight-api-slim/tests/test_llm_per_op_concurrency.py
@@ -297,7 +297,7 @@ class TestSemaphoreEnforcement:
                 provider.call(messages=[{"role": "user", "content": "unrelated"}], scope="retain"),
                 timeout=0.5,
             )
-            assert await asyncio.wait_for(retrying, timeout=3) == "ok"
+            assert (await asyncio.wait_for(retrying, timeout=3)).content == "ok"
 
         assert events == ["retrying-attempt-1", "unrelated", "retrying"]
 
@@ -381,7 +381,7 @@ class TestSemaphoreEnforcement:
             assert holder.stage == "llm.openai.retain.attempt=1/2.backoff", (
                 "backoff sleep must be visible in the stage while no permit is held"
             )
-            assert await asyncio.wait_for(task, timeout=3) == "ok"
+            assert (await asyncio.wait_for(task, timeout=3)).content == "ok"
 
     @pytest.mark.asyncio
     async def test_per_op_composes_with_global(self):

--- a/hindsight-api-slim/tests/test_llm_provider.py
+++ b/hindsight-api-slim/tests/test_llm_provider.py
@@ -83,13 +83,15 @@ async def test_llm_api_methods():
     await llm.verify_connection()
 
     # Test 2: call() with plain text
-    response = await llm.call(
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "What is 2+2? Answer in one word."},
-        ],
-        max_completion_tokens=50,
-    )
+    response = (
+        await llm.call(
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "What is 2+2? Answer in one word."},
+            ],
+            max_completion_tokens=50,
+        )
+    ).content
     assert response is not None, "call() returned None"
     assert len(response) > 0, "call() returned empty string"
 
@@ -100,14 +102,16 @@ async def test_llm_api_methods():
         answer: str
         confidence: str
 
-    structured = await llm.call(
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "What is the capital of France?"},
-        ],
-        response_format=TestResponse,
-        max_completion_tokens=100,
-    )
+    structured = (
+        await llm.call(
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "What is the capital of France?"},
+            ],
+            response_format=TestResponse,
+            max_completion_tokens=100,
+        )
+    ).content
     assert isinstance(structured, TestResponse), f"Expected TestResponse, got {type(structured)}"
     assert structured.answer, "Structured output missing 'answer'"
     assert structured.confidence, "Structured output missing 'confidence'"

--- a/hindsight-api-slim/tests/test_llm_router_provider.py
+++ b/hindsight-api-slim/tests/test_llm_router_provider.py
@@ -210,11 +210,13 @@ class TestRouterCall:
         mock_router.acompletion = AsyncMock(return_value=mock_router_response)
         provider = _make_router_provider(two_step_config, mock_router)
 
-        result = await provider.call(
-            messages=[{"role": "user", "content": "hi"}],
-            max_completion_tokens=50,
-            max_retries=0,
-        )
+        result = (
+            await provider.call(
+                messages=[{"role": "user", "content": "hi"}],
+                max_completion_tokens=50,
+                max_retries=0,
+            )
+        ).content
         assert result == "ok"
         # Hindsight always issues against model_name="default"; Router handles fallback,
         # load-balancing, and routing strategy from there.
@@ -240,11 +242,13 @@ class TestRouterCall:
         mock_router.acompletion = AsyncMock(return_value=response)
         provider = _make_router_provider(two_step_config, mock_router)
 
-        result = await provider.call(
-            messages=[{"role": "user", "content": "q"}],
-            response_format=MySchema,
-            max_retries=0,
-        )
+        result = (
+            await provider.call(
+                messages=[{"role": "user", "content": "q"}],
+                response_format=MySchema,
+                max_retries=0,
+            )
+        ).content
         assert isinstance(result, MySchema)
         assert result.answer == "42"
 
@@ -255,12 +259,14 @@ class TestRouterCall:
         mock_router.acompletion = AsyncMock(side_effect=[Exception("503 Service Unavailable"), mock_router_response])
         provider = _make_router_provider(two_step_config, mock_router)
 
-        result = await provider.call(
-            messages=[{"role": "user", "content": "hi"}],
-            max_retries=2,
-            initial_backoff=0.0,
-            max_backoff=0.0,
-        )
+        result = (
+            await provider.call(
+                messages=[{"role": "user", "content": "hi"}],
+                max_retries=2,
+                initial_backoff=0.0,
+                max_backoff=0.0,
+            )
+        ).content
         assert result == "ok"
         assert mock_router.acompletion.await_count == 2
 

--- a/hindsight-api-slim/tests/test_llm_stage_breadcrumbs.py
+++ b/hindsight-api-slim/tests/test_llm_stage_breadcrumbs.py
@@ -7,6 +7,7 @@ An operator debugging a wedged worker spent hours on Bedrock for tasks that had
 never reached Bedrock.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import asyncio
 
 import pytest
@@ -52,7 +53,7 @@ async def test_stage_drops_queued_once_the_call_is_in_flight(monkeypatch):
 
     async def fake_call(**_kwargs):
         seen.append(holder.stage)
-        return "ok"
+        return LLMCallResult(content="ok", usage=TokenUsage())
 
     monkeypatch.setattr(llm._provider_impl, "call", fake_call)
 

--- a/hindsight-api-slim/tests/test_llm_strict_schema.py
+++ b/hindsight-api-slim/tests/test_llm_strict_schema.py
@@ -23,6 +23,7 @@ reads the same retain-scoped field rather than the global flag, keeping the batc
 and streaming paths in agreement.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import dataclasses
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -331,9 +332,8 @@ async def test_retain_chunk_extraction_threads_retain_flag(strict):
     llm_config = MagicMock(spec=LLMProvider)
     llm_config.provider = "mock"
     llm_config._provider_impl = SimpleNamespace(supports_prompt_caching=lambda: False)
-    token_usage = MagicMock()
-    token_usage.__add__ = lambda self, other: self
-    llm_config.call = AsyncMock(return_value=({"facts": []}, token_usage))
+    token_usage = TokenUsage()
+    llm_config.call = AsyncMock(return_value=LLMCallResult(content={"facts": []}, usage=token_usage))
 
     await _extract_facts_from_chunk(
         chunk="some text",
@@ -355,7 +355,7 @@ async def test_reflect_structured_output_threads_reflect_flag(strict):
 
     llm_config = MagicMock(spec=LLMProvider)
     llm_config.provider = "mock"
-    llm_config.call = AsyncMock(return_value=({"answer": "x"}, MagicMock()))
+    llm_config.call = AsyncMock(return_value=LLMCallResult(content={"answer": "x"}, usage=TokenUsage()))
 
     with patch(
         "hindsight_api.engine.reflect.agent.get_config",

--- a/hindsight-api-slim/tests/test_llm_timeout_propagation.py
+++ b/hindsight-api-slim/tests/test_llm_timeout_propagation.py
@@ -13,6 +13,7 @@ were resolved into ``HindsightConfig`` but never reached the provider, so a conf
 (``LiteLLM call exceeded timeout=120.0s``) and the per-op retry knobs were inert.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import pytest
 
 from hindsight_api.config import (
@@ -35,7 +36,7 @@ def _spy_provider_call(monkeypatch, llm: LLMConfig) -> dict:
 
     async def fake_call(**kwargs):
         captured.update(kwargs)
-        return "ok"
+        return LLMCallResult(content="ok", usage=TokenUsage())
 
     monkeypatch.setattr(llm._provider_impl, "call", fake_call)
     return captured

--- a/hindsight-api-slim/tests/test_llm_token_metrics.py
+++ b/hindsight-api-slim/tests/test_llm_token_metrics.py
@@ -43,14 +43,16 @@ async def test_llm_metrics_recorded_for_groq():
         )
 
         # Make an LLM call with clear instruction
-        response = await llm.call(
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant. Always respond."},
-                {"role": "user", "content": "What is 2+2? Reply with just the number."},
-            ],
-            max_completion_tokens=50,
-            scope="test_metrics",
-        )
+        response = (
+            await llm.call(
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant. Always respond."},
+                    {"role": "user", "content": "What is 2+2? Reply with just the number."},
+                ],
+                max_completion_tokens=50,
+                scope="test_metrics",
+            )
+        ).content
 
         # Verify record_llm_call was called - this is the main test
         assert mock_collector.record_llm_call.called, "record_llm_call should have been called"
@@ -106,12 +108,14 @@ async def test_llm_metrics_recorded_for_structured_output():
         )
 
         # Make a structured output call
-        response = await llm.call(
-            messages=[{"role": "user", "content": "Say hello in French. Return greeting and language."}],
-            response_format=SimpleResponse,
-            max_completion_tokens=100,
-            scope="structured_output_test",
-        )
+        response = (
+            await llm.call(
+                messages=[{"role": "user", "content": "Say hello in French. Return greeting and language."}],
+                response_format=SimpleResponse,
+                max_completion_tokens=100,
+                scope="structured_output_test",
+            )
+        ).content
 
         # Verify structured response
         assert isinstance(response, SimpleResponse)
@@ -154,19 +158,21 @@ async def test_noop_collector_when_metrics_disabled():
         model="openai/gpt-oss-20b",
     )
 
-    response = await llm.call(
-        messages=[{"role": "user", "content": "Say 'test' in one word."}],
-        max_completion_tokens=50,
-    )
+    response = (
+        await llm.call(
+            messages=[{"role": "user", "content": "Say 'test' in one word."}],
+            max_completion_tokens=50,
+        )
+    ).content
 
     assert response is not None
     print(f"\nLLM call succeeded with NoOpMetricsCollector: {response}")
 
 
 @pytest.mark.asyncio
-async def test_return_usage_returns_tuple():
+async def test_call_reports_token_usage():
     """
-    Test that return_usage=True returns (result, TokenUsage) tuple.
+    Test that call() returns an LLMCallResult carrying token usage.
     """
     from hindsight_api.engine.response_models import TokenUsage
 
@@ -181,15 +187,16 @@ async def test_return_usage_returns_tuple():
         model="openai/gpt-oss-20b",
     )
 
-    # Call with return_usage=True
-    result, usage = await llm.call(
+    # Call and read the usage off the result
+    call_result = await llm.call(
         messages=[
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "What is 2+2? Reply with just the number."},
         ],
         max_completion_tokens=50,
-        return_usage=True,
     )
+    result = call_result.content
+    usage = call_result.usage
 
     # Verify result is the response text
     assert result is not None
@@ -201,15 +208,15 @@ async def test_return_usage_returns_tuple():
     assert usage.output_tokens >= 0, f"Expected output_tokens >= 0, got {usage.output_tokens}"
     assert usage.total_tokens == usage.input_tokens + usage.output_tokens
 
-    print(f"\nreturn_usage=True test:")
+    print("\ncall() usage test:")
     print(f"  result: {result}")
     print(f"  usage: {usage}")
 
 
 @pytest.mark.asyncio
-async def test_return_usage_with_structured_output():
+async def test_call_reports_token_usage_for_structured_output():
     """
-    Test that return_usage=True works with structured output (JSON).
+    Test that usage is reported for structured output (JSON) too.
     """
     from pydantic import BaseModel
     from hindsight_api.engine.response_models import TokenUsage
@@ -229,13 +236,14 @@ async def test_return_usage_with_structured_output():
         model="openai/gpt-oss-20b",
     )
 
-    # Call with return_usage=True and structured output
-    result, usage = await llm.call(
+    # Call and read the usage off the result and structured output
+    call_result = await llm.call(
         messages=[{"role": "user", "content": "What is 5+3? Return the answer and a brief explanation."}],
         response_format=MathAnswer,
         max_completion_tokens=100,
-        return_usage=True,
     )
+    result = call_result.content
+    usage = call_result.usage
 
     # Verify result is the parsed response
     assert isinstance(result, MathAnswer)
@@ -247,6 +255,6 @@ async def test_return_usage_with_structured_output():
     assert usage.input_tokens > 0
     assert usage.output_tokens > 0
 
-    print(f"\nStructured output with return_usage=True:")
+    print("\nStructured output usage:")
     print(f"  result: {result}")
     print(f"  usage: {usage}")

--- a/hindsight-api-slim/tests/test_llm_trace.py
+++ b/hindsight-api-slim/tests/test_llm_trace.py
@@ -198,7 +198,7 @@ def registered_recorder():
 @pytest.mark.asyncio
 async def test_wrapper_success_recorded_by_provider(registered_recorder):
     llm = LLMProvider(provider="mock", api_key="", base_url="", model="mock")
-    result = await llm.call(messages=[{"role": "user", "content": "hello"}], scope="memory")
+    result = (await llm.call(messages=[{"role": "user", "content": "hello"}], scope="memory")).content
 
     assert result == "mock response"
     assert len(registered_recorder.records) == 1
@@ -390,12 +390,14 @@ async def test_retain_extract_success_records_usage_once(registered_recorder):
         return_value=_openai_response_with_usage('{"fact": "the sky is blue"}')
     )
 
-    result = await llm.call(
-        messages=[{"role": "user", "content": "extract facts"}],
-        response_format=_Extracted,
-        scope="retain_extract_facts",
-        max_retries=0,
-    )
+    result = (
+        await llm.call(
+            messages=[{"role": "user", "content": "extract facts"}],
+            response_format=_Extracted,
+            scope="retain_extract_facts",
+            max_retries=0,
+        )
+    ).content
 
     assert isinstance(result, _Extracted)
     assert len(registered_recorder.records) == 1

--- a/hindsight-api-slim/tests/test_llm_transport_diagnostics.py
+++ b/hindsight-api-slim/tests/test_llm_transport_diagnostics.py
@@ -12,6 +12,7 @@ cover the three pieces that make that distinction visible:
   the request was actually in flight.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import asyncio
 import logging
 from unittest.mock import patch
@@ -279,7 +280,7 @@ async def test_permit_wait_is_reported_separately_from_request_time(monkeypatch)
         llm = llm_wrapper.LLMConfig(provider="mock", api_key="", base_url="", model="m")
 
         async def fake_call(**kwargs):
-            return "ok"
+            return LLMCallResult(content="ok", usage=TokenUsage())
 
         monkeypatch.setattr(llm._provider_impl, "call", fake_call)
 
@@ -287,7 +288,7 @@ async def test_permit_wait_is_reported_separately_from_request_time(monkeypatch)
         await asyncio.sleep(_PERMIT_HOLD_SECONDS)
         assert not call.done(), "call should be queued behind the permit"
         saturated.release()
-        assert await call == "ok"
+        assert (await call).content == "ok"
     finally:
         reset_queue_wait_sink(token)
 

--- a/hindsight-api-slim/tests/test_load_large_batch.py
+++ b/hindsight-api-slim/tests/test_load_large_batch.py
@@ -21,7 +21,7 @@ from hindsight_api.engine.cross_encoder import LocalSTCrossEncoder
 from hindsight_api.engine.query_analyzer import DateparserQueryAnalyzer
 from hindsight_api.engine.task_backend import SyncTaskBackend
 from hindsight_api.engine.retain.fact_extraction import FactExtractionResponse, ExtractedFact
-from hindsight_api.engine.response_models import TokenUsage
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 
 logger = logging.getLogger(__name__)
 
@@ -170,10 +170,9 @@ class TestLargeBatchRetain:
             # Consolidation calls expect a _ConsolidationBatchResponse (not a raw dict),
             # because consolidation does NOT use skip_validation=True.
             if kwargs.get("scope") == "consolidation":
-                return_usage = kwargs.get("return_usage", False)
-                if return_usage:
-                    return _ConsolidationBatchResponse(), TokenUsage(input_tokens=0, output_tokens=0)
-                return _ConsolidationBatchResponse()
+                return LLMCallResult(
+                    content=_ConsolidationBatchResponse(), usage=TokenUsage(input_tokens=0, output_tokens=0)
+                )
 
             call_tracker["count"] += 1
 
@@ -186,14 +185,11 @@ class TestLargeBatchRetain:
             # Return a dict (parsed JSON) — fact extraction uses skip_validation=True
             response_dict = {"facts": mock_facts}
 
-            return_usage = kwargs.get("return_usage", False)
-            if return_usage:
-                usage = TokenUsage(
-                    input_tokens=len(user_msg) // 4,
-                    output_tokens=len(json.dumps(response_dict)) // 4,
-                )
-                return response_dict, usage
-            return response_dict
+            usage = TokenUsage(
+                input_tokens=len(user_msg) // 4,
+                output_tokens=len(json.dumps(response_dict)) // 4,
+            )
+            return LLMCallResult(content=response_dict, usage=usage)
 
         # Patch LLMProvider.call at the class level
         with patch("hindsight_api.engine.llm_wrapper.LLMProvider.call", new=mock_llm_call):
@@ -267,20 +263,16 @@ class TestLargeBatchRetain:
             from hindsight_api.engine.consolidation.consolidator import _ConsolidationBatchResponse
 
             if kwargs.get("scope") == "consolidation":
-                return_usage = kwargs.get("return_usage", False)
-                if return_usage:
-                    return _ConsolidationBatchResponse(), TokenUsage(input_tokens=0, output_tokens=0)
-                return _ConsolidationBatchResponse()
+                return LLMCallResult(
+                    content=_ConsolidationBatchResponse(), usage=TokenUsage(input_tokens=0, output_tokens=0)
+                )
 
             messages = kwargs.get("messages", args[0] if args else [])
             user_msg = messages[-1]["content"] if messages else ""
             mock_facts = create_mock_facts_from_content(user_msg, ratio=1.0)
             response_dict = {"facts": mock_facts}
 
-            return_usage = kwargs.get("return_usage", False)
-            if return_usage:
-                return response_dict, TokenUsage(input_tokens=100, output_tokens=50)
-            return response_dict
+            return LLMCallResult(content=response_dict, usage=TokenUsage(input_tokens=100, output_tokens=50))
 
         with patch("hindsight_api.engine.llm_wrapper.LLMProvider.call", new=mock_llm_call):
             start_time = time.time()
@@ -326,10 +318,7 @@ class TestLargeBatchRetain:
             ]
             response_dict = {"facts": mock_facts}
 
-            return_usage = kwargs.get("return_usage", False)
-            if return_usage:
-                return response_dict, TokenUsage(input_tokens=10, output_tokens=10)
-            return response_dict
+            return LLMCallResult(content=response_dict, usage=TokenUsage(input_tokens=10, output_tokens=10))
 
         with patch("hindsight_api.engine.llm_wrapper.LLMProvider.call", new=mock_llm_call):
             # Run 10 concurrent retain operations

--- a/hindsight-api-slim/tests/test_mental_model_delta.py
+++ b/hindsight-api-slim/tests/test_mental_model_delta.py
@@ -30,7 +30,7 @@ import pytest
 from hindsight_api import MemoryEngine, RequestContext
 from hindsight_api.engine.llm_wrapper import LLMConfig
 from hindsight_api.engine.maintenance import MaintenanceLoop
-from hindsight_api.engine.response_models import ReflectResult
+from hindsight_api.engine.response_models import LLMCallResult, ReflectResult, TokenUsage
 from hindsight_api.engine.retain import embedding_utils
 from tests.conftest import stub_refresh_has_sources
 
@@ -114,7 +114,7 @@ def patch_llm_call(monkeypatch):
 
         async def fake_call(*, messages, **kwargs):
             calls.append({"messages": messages, **kwargs})
-            return canned
+            return LLMCallResult(content=canned, usage=TokenUsage())
 
         monkeypatch.setattr(memory._reflect_llm_config, "call", fake_call)
         return calls
@@ -1062,7 +1062,7 @@ class TestDeltaRefreshPlumbing:
             captured["trace_operation"] = ctx.operation if ctx else None
             captured["trace_bank_id"] = ctx.bank_id if ctx else None
             captured["trace_metadata"] = dict(ctx.metadata) if ctx else None
-            return DeltaOperationList()
+            return LLMCallResult(content=DeltaOperationList(), usage=TokenUsage())
 
         # First (seeding) refresh — value captured here is overwritten by the second.
         monkeypatch.setattr(memory._reflect_llm_config, "call", capturing_call)
@@ -1268,7 +1268,7 @@ class TestDeltaRefreshPlumbing:
         async def ok_call(*, messages, **kwargs):
             from hindsight_api.engine.reflect.delta_ops import DeltaOperationList
 
-            return DeltaOperationList()
+            return LLMCallResult(content=DeltaOperationList(), usage=TokenUsage())
 
         monkeypatch.setattr(memory._reflect_llm_config, "call", ok_call)
         seeded = await memory.refresh_mental_model(

--- a/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
+++ b/hindsight-api-slim/tests/test_mental_model_dry_run_refresh.py
@@ -15,6 +15,7 @@ so what is under test is the refresh's own branching and reporting, not model
 behaviour.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import uuid
 from typing import Any
 
@@ -98,7 +99,8 @@ def patch_delta_llm(monkeypatch):
             calls.append({"messages": messages, **kwargs})
             if isinstance(returns, Exception):
                 raise returns
-            return returns
+            # `call` returns the envelope; `returns` is the payload the test canned.
+            return LLMCallResult(content=returns, usage=TokenUsage())
 
         monkeypatch.setattr(memory._reflect_llm_config, "call", fake_call)
         return calls

--- a/hindsight-api-slim/tests/test_mental_model_retractions.py
+++ b/hindsight-api-slim/tests/test_mental_model_retractions.py
@@ -7,6 +7,7 @@ the retraction prompt is not tested here: the pass is driven through a stub that
 returns a fixed operation list, so these cover the pipeline, not the model.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import json
 import os
 import uuid
@@ -490,7 +491,7 @@ def _patch_op_calls(monkeypatch, memory: MemoryEngine, *, retraction_ops, delta_
         is_retraction = system == STRUCTURED_RETRACTION_SYSTEM_PROMPT
         calls.append({"kind": "retraction" if is_retraction else "delta", "messages": messages, **kwargs})
         ops = _resolve_block_markers(retraction_ops if is_retraction else delta_ops, messages[1]["content"])
-        return DeltaOperationList.model_validate({"operations": ops})
+        return LLMCallResult(content=DeltaOperationList.model_validate({"operations": ops}), usage=TokenUsage())
 
     monkeypatch.setattr(memory._reflect_llm_config, "call", fake_call)
     return calls
@@ -909,15 +910,17 @@ async def test_real_model_removes_only_the_retracted_claim(retraction_llm):
         max_output_tokens=2048,
     )
 
-    raw = await retraction_llm.call(
-        messages=[
-            {"role": "system", "content": STRUCTURED_RETRACTION_SYSTEM_PROMPT},
-            {"role": "user", "content": prompt},
-        ],
-        max_completion_tokens=4096,
-        temperature=0.0,
-        scope="mental_model_retraction_ops",
-    )
+    raw = (
+        await retraction_llm.call(
+            messages=[
+                {"role": "system", "content": STRUCTURED_RETRACTION_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            max_completion_tokens=4096,
+            temperature=0.0,
+            scope="mental_model_retraction_ops",
+        )
+    ).content
     outcome = apply_operations(document, parse_delta_operation_list(raw).operations)
     result = render_document(outcome.document)
 

--- a/hindsight-api-slim/tests/test_mental_model_structured_output.py
+++ b/hindsight-api-slim/tests/test_mental_model_structured_output.py
@@ -18,7 +18,7 @@ from hindsight_api import MemoryEngine, RequestContext
 from hindsight_api.engine.memory_engine import MentalModelRefreshError
 from hindsight_api.engine.reflect import agent as reflect_agent
 from hindsight_api.engine.reflect.delta_ops import DeltaOperationList
-from hindsight_api.engine.response_models import ReflectResult
+from hindsight_api.engine.response_models import LLMCallResult, ReflectResult, TokenUsage
 from tests.conftest import stub_refresh_has_sources
 
 _SCHEMA = {
@@ -157,7 +157,7 @@ class TestMentalModelStructuredOutput:
         # Delta-ops call returns no operations → the document is preserved and
         # re-rendered, so final_content is the merged doc (here: the original).
         async def fake_delta_call(**kwargs):
-            return DeltaOperationList(operations=[])
+            return LLMCallResult(content=DeltaOperationList(operations=[]), usage=TokenUsage())
 
         monkeypatch.setattr(memory._reflect_llm_config, "call", fake_delta_call)
         so_calls = _patch_structured_output(monkeypatch, {"summary": "whole document"})

--- a/hindsight-api-slim/tests/test_multi_llm_provider.py
+++ b/hindsight-api-slim/tests/test_multi_llm_provider.py
@@ -15,6 +15,7 @@ from hindsight_api.engine.multi_llm import (
     _should_failover,
     _WeightedRoundRobin,
 )
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 
 
 class FakeMember:
@@ -35,7 +36,8 @@ class FakeMember:
 
     async def call(self, **kwargs):
         self.calls += 1
-        return self._resolve()
+        # `call` returns the envelope; `_resolve` yields the payload (or raises).
+        return LLMCallResult(content=self._resolve(), usage=TokenUsage())
 
     async def call_with_tools(self, **kwargs):
         self.calls += 1
@@ -73,7 +75,7 @@ def _round_robin(*members, weights=None):
 
 async def test_failover_uses_primary_on_success():
     a, b = FakeMember("a", "RA"), FakeMember("b", "RB")
-    result = await _failover(a, b).call(messages=[])
+    result = (await _failover(a, b).call(messages=[])).content
     assert result == "RA"
     assert (a.calls, b.calls) == (1, 0)  # secondary untouched
 
@@ -81,7 +83,7 @@ async def test_failover_uses_primary_on_success():
 async def test_failover_advances_only_after_member_raises():
     a = FakeMember("a", RuntimeError("primary down"))
     b = FakeMember("b", "RB")
-    result = await _failover(a, b).call(messages=[])
+    result = (await _failover(a, b).call(messages=[])).content
     assert result == "RB"
     assert (a.calls, b.calls) == (1, 1)
 
@@ -136,7 +138,7 @@ def test_should_failover_classification():
 async def test_round_robin_rotates_start_member():
     a, b, c = FakeMember("a", "RA"), FakeMember("b", "RB"), FakeMember("c", "RC")
     rr = _round_robin(a, b, c)
-    results = [await rr.call(messages=[]) for _ in range(3)]
+    results = [(await rr.call(messages=[])).content for _ in range(3)]
     # Smooth WRR with uniform weights visits every member once per cycle.
     assert sorted(results) == ["RA", "RB", "RC"]
     assert (a.calls, b.calls, c.calls) == (1, 1, 1)
@@ -148,7 +150,7 @@ async def test_round_robin_falls_over_when_selected_member_fails():
     # Two members, uniform weights: whichever is selected first, a failure must
     # still produce a successful result via the other member.
     rr = _round_robin(a, b)
-    result = await rr.call(messages=[])
+    result = (await rr.call(messages=[])).content
     assert result == "RB"
 
 

--- a/hindsight-api-slim/tests/test_named_result_stubs.py
+++ b/hindsight-api-slim/tests/test_named_result_stubs.py
@@ -45,23 +45,59 @@ NAMED_RESULTS = {
     "_build_group_clause": "TagClause",
     "_parse_tags_match": "TagMatchSemantics",
     "retrieve": "GraphRetrieval",
+    "call": "LLMCallResult",
     "_fit_structured_delta_prompt_parts": "FittedDeltaPrompt",
     "_validate_operations_list": "ValidatedOperations",
 }
 
 
+#: Shapes a double may legitimately return besides constructing the named type:
+#: awaiting the real thing, or handing back a value the test already built.
+def _is_named_result(node: ast.AST) -> bool:
+    """Whether ``node`` plausibly evaluates to the named result type.
+
+    Deliberately shallow — it accepts a constructor call, an await (delegating to
+    the real implementation), or a conditional over those. Anything else, notably
+    a bare literal or a raw payload variable, is what this guard exists to catch:
+    the recurring bug was a double handing back the *payload* where production
+    expects the *envelope*.
+    """
+    if isinstance(node, ast.Await):
+        return True
+    if isinstance(node, ast.IfExp):
+        return _is_named_result(node.body) and _is_named_result(node.orelse)
+    if isinstance(node, ast.Call):
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+        return name in set(NAMED_RESULTS.values()) or name in {"AsyncMock", "MagicMock", "Mock"}
+    return False
+
+
 def _test_modules():
-    return sorted(p for p in TESTS_DIR.glob("test_*.py"))
+    """Every module in tests/, not just ``test_*.py``.
+
+    The helpers are the dangerous ones: ``llm_judge.py`` calls ``judge.call()``
+    and is imported by every LLM-behaviour test, so one stale read there fails a
+    whole CI job class at once — which is exactly what happened, and why this
+    glob is ``*.py``."""
+    return sorted(p for p in TESTS_DIR.glob("*.py") if p.name != "__init__.py")
 
 
 def _returns_bare_tuple(fn: ast.AST) -> list[int]:
-    """Line numbers where ``fn`` itself returns a tuple literal (nested defs excluded)."""
+    """Line numbers where ``fn`` yields a bare tuple.
+
+    Accepts either a function (its own ``return`` statements, nested defs
+    excluded) or an assignment whose value is the stubbed result directly.
+    """
+    if isinstance(fn, ast.Assign):
+        return [] if _is_named_result(fn.value) else [fn.lineno]
     nested = [n for n in ast.walk(fn) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n is not fn]
     return [
         r.lineno
         for r in ast.walk(fn)
         if isinstance(r, ast.Return)
-        and isinstance(r.value, ast.Tuple)
+        and r.value is not None
+        and not _is_named_result(r.value)
         and not any(i.lineno <= r.lineno <= i.end_lineno for i in nested)
     ]
 
@@ -85,11 +121,54 @@ def _doubles_in(tree: ast.AST) -> list[tuple[str, ast.AST]]:
         if isinstance(replacement, ast.Name) and replacement.id in by_name:
             found.append((target.value, by_name[replacement.id]))
 
-    # 2. a method named after the function, on any class in the module
+    # 2. patch("...<module>.<Class>.<name>", new=replacement) — the target is a
+    #    dotted string, so neither the setattr form nor a method name matches it.
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and node.args):
+            continue
+        fname = node.func.attr if isinstance(node.func, ast.Attribute) else getattr(node.func, "id", None)
+        if fname not in ("patch", "patch.object"):
+            continue
+        first = node.args[0]
+        if not (isinstance(first, ast.Constant) and isinstance(first.value, str)):
+            continue
+        attr = first.value.rsplit(".", 1)[-1]
+        if attr not in NAMED_RESULTS:
+            continue
+        for kw in node.keywords:
+            if kw.arg == "new" and isinstance(kw.value, ast.Name) and kw.value.id in by_name:
+                found.append((attr, by_name[kw.value.id]))
+
+    # 3. `<mock>.<name>.return_value = payload` — set after construction, so the
+    #    AsyncMock(return_value=...) form above never sees it.
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Assign) and len(node.targets) == 1):
+            continue
+        target = ast.unparse(node.targets[0])
+        for fname in NAMED_RESULTS:
+            if target.endswith(f".{fname}.return_value"):
+                found.append((fname, node))
+                break
+
+    # 4. a method named after the function, on any class in the module
     for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
         for item in cls.body:
             if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name in NAMED_RESULTS:
                 found.append((item.name, item))
+
+    # 5. `<mock>.<name> = AsyncMock(side_effect=fn)` / `(return_value=fn)` — the
+    #    double is the function, not the mock, so neither the setattr target nor
+    #    the mock's own return value names it.
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Assign) and len(node.targets) == 1):
+            continue
+        target_name = ast.unparse(node.targets[0]).rsplit(".", 1)[-1]
+        if target_name not in NAMED_RESULTS or not isinstance(node.value, ast.Call):
+            continue
+        for kw in node.value.keywords:
+            if kw.arg in ("side_effect", "return_value") and isinstance(kw.value, ast.Name):
+                if kw.value.id in by_name:
+                    found.append((target_name, by_name[kw.value.id]))
 
     return found
 
@@ -170,5 +249,126 @@ def test_nothing_unpacks_a_named_result_as_a_tuple():
                     offenders.append(
                         f"{rel}:{node.lineno} treats {name}() as a tuple; "
                         f"it returns {NAMED_RESULTS[name]} — read its fields by name"
+                    )
+    assert not offenders, "\n".join(sorted(set(offenders)))
+
+
+def test_no_call_result_is_used_as_the_parsed_response():
+    """``LLMInterface.call`` hands back the envelope, not the payload.
+
+    ``call`` used to return the parsed response directly (or a ``(response,
+    usage)`` tuple under a flag). It now always returns ``LLMCallResult``, so a
+    site that feeds the awaited value straight into something expecting the
+    parsed model, or annotates it as that model, is reading the envelope as if it
+    were the payload.
+
+    Both consolidation call sites did exactly that and no unpack-side sweep saw
+    it: they assign to a single name, so there is no tuple to notice, and the
+    wrong attribute only surfaces at runtime — as a caught exception that retried
+    three times and skipped the batch, which is quiet enough to reach production.
+    """
+    root = TESTS_DIR.parent / "hindsight_api"
+    offenders = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        rel = path.relative_to(root.parent)
+
+        def is_call(node):
+            return (
+                isinstance(node, ast.Await)
+                and isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Attribute)
+                and node.value.func.attr == "call"
+            )
+
+        for node in ast.walk(tree):
+            # annotated with something other than LLMCallResult
+            if isinstance(node, ast.AnnAssign) and node.value is not None and is_call(node.value):
+                ann = ast.unparse(node.annotation)
+                if "LLMCallResult" not in ann:
+                    offenders.append(f"{rel}:{node.lineno} annotates a call() result as {ann}")
+            # passed straight into another call
+            if isinstance(node, ast.Call):
+                for arg in list(node.args) + [k.value for k in node.keywords]:
+                    if is_call(arg) and not isinstance(node.func, ast.Attribute):
+                        offenders.append(
+                            f"{rel}:{node.lineno} passes a call() result into "
+                            f"{ast.unparse(node.func)}() — pass .content"
+                        )
+            # attribute read directly off the await
+            if isinstance(node, ast.Attribute) and is_call(node.value):
+                if node.attr not in ("content", "usage"):
+                    offenders.append(f"{rel}:{node.lineno} reads .{node.attr} off a call() result")
+    assert not offenders, "\n".join(offenders)
+
+
+def test_a_call_result_binding_is_only_read_through_its_fields():
+    """A name bound from ``await ....call(...)`` must be used as the envelope.
+
+    The shapes already covered are the ones where the misuse is visible at the
+    expression itself — an unpack, a subscript, a wrong annotation. This covers
+    the one that is not: bind the awaited value to a plain name, then treat that
+    name as if it were the payload a few lines later.
+
+    That is how ``tests/llm_judge.py`` broke every LLM-behaviour job at once. It
+    did ``result = await judge.call(...)`` and then ``json.loads(str(result))``,
+    which turned the envelope's repr into a JSONDecodeError — and because the
+    judge is imported by every such test, one stale read failed all six provider
+    acceptance jobs and 36 local tests, while looking exactly like a flaky
+    provider.
+    """
+    #: Reading the whole envelope is legitimate here: these hand it onward
+    #: unchanged rather than treating it as the payload.
+    PASSTHROUGH = {"sanitize_llm_value", "isinstance_ok"}
+
+    offenders = []
+    for path in _source_files():
+        try:
+            tree = ast.parse(path.read_text())
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        rel = path.relative_to(TESTS_DIR.parent)
+        for scope in [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]:
+            bound = {
+                node.targets[0].id: node.lineno
+                for node in ast.walk(scope)
+                if isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and isinstance(node.value, ast.Await)
+                and isinstance(node.value.value, ast.Call)
+                and isinstance(node.value.value.func, ast.Attribute)
+                and node.value.value.func.attr == "call"
+            }
+            if not bound:
+                continue
+            # every Load of those names, minus the legitimate reads
+            ok_nodes = set()
+            for node in ast.walk(scope):
+                if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+                    if node.value.id in bound and node.attr in ("content", "usage"):
+                        ok_nodes.add(id(node.value))
+                if isinstance(node, ast.Return) and isinstance(node.value, ast.Name):
+                    ok_nodes.add(id(node.value))  # handed onward whole
+                if isinstance(node, ast.Call):
+                    fname = getattr(node.func, "id", None) or getattr(node.func, "attr", "")
+                    if fname in PASSTHROUGH:
+                        for a in node.args:
+                            if isinstance(a, ast.Name):
+                                ok_nodes.add(id(a))
+            for node in ast.walk(scope):
+                if (
+                    isinstance(node, ast.Name)
+                    and isinstance(node.ctx, ast.Load)
+                    and node.id in bound
+                    and id(node) not in ok_nodes
+                    and node.lineno > bound[node.id]
+                ):
+                    offenders.append(
+                        f"{rel}:{node.lineno} uses {node.id!r} (bound from await ....call() "
+                        f"at line {bound[node.id]}) as the payload — read .content"
                     )
     assert not offenders, "\n".join(sorted(set(offenders)))

--- a/hindsight-api-slim/tests/test_nous_provider.py
+++ b/hindsight-api-slim/tests/test_nous_provider.py
@@ -8,6 +8,7 @@ provider validation, and the proactive/reactive token-refresh plumbing on
 
 from __future__ import annotations
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 from unittest.mock import patch
 
 import httpx
@@ -114,10 +115,10 @@ async def test_call_refreshes_once_on_401_then_retries() -> None:
                 response=httpx.Response(401, request=httpx.Request("POST", "http://x")),
                 body=None,
             )
-        return "ok"
+        return LLMCallResult(content="ok", usage=TokenUsage())
 
     with patch.object(NousLLM.__bases__[0], "call", side_effect=fake_super_call, autospec=False):
-        result = await llm.call(messages=[{"role": "user", "content": "hi"}])
+        result = (await llm.call(messages=[{"role": "user", "content": "hi"}])).content
 
     assert result == "ok"
     assert calls["n"] == 2  # original + one retry

--- a/hindsight-api-slim/tests/test_ollama_num_ctx_transport.py
+++ b/hindsight-api-slim/tests/test_ollama_num_ctx_transport.py
@@ -70,11 +70,13 @@ async def test_free_form_call_goes_native_and_carries_num_ctx():
     client, patched = _patch_native(_native_response("hello there"))
 
     with patched:
-        result = await llm.call(
-            messages=[{"role": "user", "content": "hi"}],
-            max_completion_tokens=64,
-            max_retries=0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "hi"}],
+                max_completion_tokens=64,
+                max_retries=0,
+            )
+        ).content
 
     payload = client.post.call_args.kwargs["json"]
     assert client.post.call_args.args[0] == "http://localhost:11434/api/chat"
@@ -110,7 +112,7 @@ async def test_free_form_call_without_num_ctx_stays_on_openai_endpoint():
     client, patched = _patch_native(_native_response("unused"))
 
     with patched:
-        result = await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)
+        result = (await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)).content
 
     assert result == "hello there"
     assert create.await_count == 1
@@ -124,11 +126,13 @@ async def test_structured_call_still_validates_against_the_schema():
     client, patched = _patch_native(_native_response(json.dumps({"answer": "42"})))
 
     with patched:
-        result = await llm.call(
-            messages=[{"role": "user", "content": "hi"}],
-            response_format=_Answer,
-            max_retries=0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "hi"}],
+                response_format=_Answer,
+                max_retries=0,
+            )
+        ).content
 
     assert "format" in client.post.call_args.kwargs["json"]
     assert isinstance(result, _Answer)
@@ -142,7 +146,7 @@ async def test_free_form_native_strips_reasoning_tags():
     client, patched = _patch_native(_native_response("<think>weighing it up</think>Paris"))
 
     with patched:
-        result = await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)
+        result = (await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)).content
 
     assert result == "Paris"
 
@@ -154,12 +158,14 @@ async def test_free_form_native_retries_empty_content():
     client, patched = _patch_native(_native_response(""), _native_response("second try"))
 
     with patched:
-        result = await llm.call(
-            messages=[{"role": "user", "content": "hi"}],
-            max_retries=1,
-            initial_backoff=0.0,
-            max_backoff=0.0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "hi"}],
+                max_retries=1,
+                initial_backoff=0.0,
+                max_backoff=0.0,
+            )
+        ).content
 
     assert result == "second try"
     assert client.post.await_count == 2

--- a/hindsight-api-slim/tests/test_openai_compatible_response_hardening.py
+++ b/hindsight-api-slim/tests/test_openai_compatible_response_hardening.py
@@ -89,7 +89,7 @@ async def test_attempt_stage_is_published_only_after_permits_are_acquired():
     await asyncio.wait_for(waiting_for_permit.wait(), timeout=1)
     assert holder.stage == "llm.openai.memory.queued"
     release_permit.set()
-    assert await task == "ok"
+    assert (await task).content == "ok"
 
 
 @pytest.mark.asyncio
@@ -99,11 +99,13 @@ async def test_json_object_call_adds_json_hint_to_user_message():
     llm._client.chat.completions.create = create
 
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "Return whether this worked."}],
-            response_format=SimpleJsonResponse,
-            max_retries=0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "Return whether this worked."}],
+                response_format=SimpleJsonResponse,
+                max_retries=0,
+            )
+        ).content
 
     assert result.ok is True
     sent_messages = create.call_args.kwargs["messages"]
@@ -119,11 +121,13 @@ async def test_json_object_call_strips_gemma_thought_tags_before_parsing():
     llm._client.chat.completions.create = create
 
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "Return whether this worked."}],
-            response_format=SimpleJsonResponse,
-            max_retries=0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "Return whether this worked."}],
+                response_format=SimpleJsonResponse,
+                max_retries=0,
+            )
+        ).content
 
     assert result.ok is True
 
@@ -203,12 +207,14 @@ async def test_missing_choices_are_retryable_provider_response_errors():
         patch("hindsight_api.engine.providers.openai_compatible_llm.asyncio.sleep", new=AsyncMock()) as sleep_mock,
         patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
     ):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "Return whether this worked."}],
-            response_format=SimpleJsonResponse,
-            max_retries=1,
-            initial_backoff=0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "Return whether this worked."}],
+                response_format=SimpleJsonResponse,
+                max_retries=1,
+                initial_backoff=0,
+            )
+        ).content
 
     assert result.ok is True
     assert create.await_count == 2
@@ -250,12 +256,14 @@ async def test_repairable_json_is_recovered_instead_of_being_dropped():
     llm._client.chat.completions.create = create
 
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "Return whether this worked."}],
-            response_format=SimpleJsonResponse,
-            max_retries=1,
-            initial_backoff=0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "Return whether this worked."}],
+                response_format=SimpleJsonResponse,
+                max_retries=1,
+                initial_backoff=0,
+            )
+        ).content
 
     assert result.ok is True
 
@@ -280,12 +288,14 @@ async def test_repeated_output_does_not_cut_the_retry_budget_short():
     llm._client.chat.completions.create = create
 
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "Return whether this worked."}],
-            response_format=SimpleJsonResponse,
-            max_retries=3,
-            initial_backoff=0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "Return whether this worked."}],
+                response_format=SimpleJsonResponse,
+                max_retries=3,
+                initial_backoff=0,
+            )
+        ).content
 
     assert result.ok is True
     assert create.await_count == 3
@@ -309,12 +319,14 @@ async def test_a_changed_response_still_earns_a_fresh_generation():
     llm._client.chat.completions.create = create
 
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "Return whether this worked."}],
-            response_format=SimpleJsonResponse,
-            max_retries=3,
-            initial_backoff=0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "Return whether this worked."}],
+                response_format=SimpleJsonResponse,
+                max_retries=3,
+                initial_backoff=0,
+            )
+        ).content
 
     assert result.ok is True
     assert create.await_count == 3
@@ -339,12 +351,14 @@ async def test_ollama_native_repairs_malformed_json_instead_of_dropping_it():
         ),
         patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"),
     ):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "Return whether this worked."}],
-            response_format=SimpleJsonResponse,
-            max_retries=1,
-            initial_backoff=0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "Return whether this worked."}],
+                response_format=SimpleJsonResponse,
+                max_retries=1,
+                initial_backoff=0,
+            )
+        ).content
 
     assert result.ok is True
 
@@ -471,12 +485,14 @@ async def test_a_malformed_body_that_is_not_truncated_still_gets_repaired():
     llm._client.chat.completions.create = create
 
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "List the facts."}],
-            response_format=FactListResponse,
-            max_retries=1,
-            initial_backoff=0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "List the facts."}],
+                response_format=FactListResponse,
+                max_retries=1,
+                initial_backoff=0,
+            )
+        ).content
 
     assert result.facts == ["alpha", "beta"]
 

--- a/hindsight-api-slim/tests/test_openai_responses_provider.py
+++ b/hindsight-api-slim/tests/test_openai_responses_provider.py
@@ -144,9 +144,9 @@ async def test_call_sends_reasoning_object_and_omits_temperature_for_reasoning_m
     llm = _make_llm()
     create = _mock_create(llm, _fake_response(output_text="hello"))
     with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "hi"}], temperature=0.7, max_completion_tokens=1000
-        )
+        result = (
+            await llm.call(messages=[{"role": "user", "content": "hi"}], temperature=0.7, max_completion_tokens=1000)
+        ).content
 
     kwargs = create.call_args.kwargs
     assert result == "hello"
@@ -175,7 +175,7 @@ async def test_call_splits_reasoning_tokens_out_of_visible_output():
     llm = _make_llm()
     _mock_create(llm, _fake_response(output_text="hi", input_tokens=100, output_tokens=30, reasoning_tokens=12))
     with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
-        _, usage = await llm.call(messages=[{"role": "user", "content": "hi"}], return_usage=True)
+        usage = (await llm.call(messages=[{"role": "user", "content": "hi"}])).usage
 
     assert usage.input_tokens == 100
     assert usage.output_tokens == 18  # 30 - 12 reasoning
@@ -192,11 +192,13 @@ async def test_call_strict_schema_uses_text_format_json_schema():
     llm = _make_llm()
     create = _mock_create(llm, _fake_response(output_text=json.dumps({"answer": "42"})))
     with patch("hindsight_api.engine.providers.openai_responses_llm.get_metrics_collector"):
-        result = await llm.call(
-            messages=[{"role": "user", "content": "q"}],
-            response_format=_Answer,
-            strict_schema=True,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "q"}],
+                response_format=_Answer,
+                strict_schema=True,
+            )
+        ).content
 
     text_format = create.call_args.kwargs["text"]["format"]
     assert text_format["type"] == "json_schema"

--- a/hindsight-api-slim/tests/test_openrouter_null_content.py
+++ b/hindsight-api-slim/tests/test_openrouter_null_content.py
@@ -99,13 +99,15 @@ async def test_null_content_recovers_on_retry():
     with patch.object(llm._client.chat.completions, "create", new_callable=AsyncMock) as mock_create:
         mock_create.side_effect = responses
 
-        result = await llm.call(
-            messages=[{"role": "user", "content": "extract facts"}],
-            response_format=_Response,
-            max_retries=2,
-            initial_backoff=0.0,
-            max_backoff=0.0,
-        )
+        result = (
+            await llm.call(
+                messages=[{"role": "user", "content": "extract facts"}],
+                response_format=_Response,
+                max_retries=2,
+                initial_backoff=0.0,
+                max_backoff=0.0,
+            )
+        ).content
 
     assert isinstance(result, _Response)
     assert result.answer == "ok"

--- a/hindsight-api-slim/tests/test_per_operation_llm_config.py
+++ b/hindsight-api-slim/tests/test_per_operation_llm_config.py
@@ -221,7 +221,7 @@ class TestMockLLMProvider:
             )
 
         result = asyncio.run(make_call())
-        assert result == {"custom": "response"}
+        assert result.content == {"custom": "response"}
 
     def test_mock_provider_returns_usage_when_requested(self):
         """Test that mock provider returns token usage."""
@@ -237,12 +237,9 @@ class TestMockLLMProvider:
         import asyncio
 
         async def make_call():
-            return await provider.call(
-                messages=[{"role": "user", "content": "test"}],
-                return_usage=True,
-            )
+            return await provider.call(messages=[{"role": "user", "content": "test"}])
 
-        result, usage = asyncio.run(make_call())
+        usage = asyncio.run(make_call()).usage
         assert usage.input_tokens == 10
         assert usage.output_tokens == 5
         assert usage.total_tokens == 15

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -28,7 +28,7 @@ from hindsight_api.engine.reflect.agent import (
     _normalize_tool_name,
     run_reflect_agent,
 )
-from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
+from hindsight_api.engine.response_models import LLMCallResult, LLMToolCall, LLMToolCallResult, TokenUsage
 from tests.llm_judge import assert_meets_criteria
 
 
@@ -230,11 +230,11 @@ class TestReflectAgentMocked:
         """Create a mock LLM provider."""
         llm = MagicMock()
         llm.call_with_tools = AsyncMock()
-        # Also mock call() for final iteration fallback - returns (response, usage) tuple
+        # Also mock call() for the final-iteration fallback.
         llm.call = AsyncMock(
-            return_value=(
-                "Fallback answer from final iteration",
-                TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150),
+            return_value=LLMCallResult(
+                content="Fallback answer from final iteration",
+                usage=TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150),
             )
         )
         return llm
@@ -983,9 +983,9 @@ class TestReflectAgentMocked:
             LLMToolCallResult(tool_calls=[], content="I have enough to answer.", finish_reason="stop"),
         ]
         mock_llm.call = AsyncMock(
-            return_value=(
-                "Synthesized final answer.",
-                TokenUsage(input_tokens=40, output_tokens=12, total_tokens=52),
+            return_value=LLMCallResult(
+                content="Synthesized final answer.",
+                usage=TokenUsage(input_tokens=40, output_tokens=12, total_tokens=52),
             )
         )
 
@@ -1216,9 +1216,9 @@ class TestContextOverflowBehavior:
         llm = MagicMock()
         llm.call_with_tools = AsyncMock()
         llm.call = AsyncMock(
-            return_value=(
-                "Synthesized answer from gathered evidence.",
-                TokenUsage(input_tokens=50, output_tokens=20, total_tokens=70),
+            return_value=LLMCallResult(
+                content="Synthesized answer from gathered evidence.",
+                usage=TokenUsage(input_tokens=50, output_tokens=20, total_tokens=70),
             )
         )
         return llm
@@ -1307,9 +1307,9 @@ class TestNoAnswerFailsHard:
         llm.model = "gpt-test"
         llm.call_with_tools = AsyncMock()
         llm.call = AsyncMock(
-            return_value=(
-                "Synthesized answer from gathered evidence.",
-                TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15),
+            return_value=LLMCallResult(
+                content="Synthesized answer from gathered evidence.",
+                usage=TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15),
             )
         )
         return llm
@@ -1380,7 +1380,10 @@ class TestNoAnswerFailsHard:
     @pytest.mark.asyncio
     async def test_empty_final_synthesis_raises(self, mock_llm, mock_functions):
         """The forced final synthesis (tools disabled) returning nothing also fails."""
-        mock_llm.call.return_value = ("   ", TokenUsage(input_tokens=10, output_tokens=0, total_tokens=10))
+        mock_llm.call.return_value = LLMCallResult(
+            content="   ",
+            usage=TokenUsage(input_tokens=10, output_tokens=0, total_tokens=10),
+        )
         # Gather evidence, then stop tool-calling: the agent falls through to the
         # forced synthesis, which is where the empty text comes from.
         mock_llm.call_with_tools.side_effect = [
@@ -1716,7 +1719,7 @@ class _StepCacheProvider:
         return res
 
     async def call(self, *args, **kwargs):  # final-synthesis fallback (unused on the happy path)
-        return ("final", TokenUsage(input_tokens=1, output_tokens=1, total_tokens=2))
+        return LLMCallResult(content="final", usage=TokenUsage(input_tokens=1, output_tokens=1, total_tokens=2))
 
 
 class TestReflectIncrementalCache:

--- a/hindsight-api-slim/tests/test_reflect_page_length_decoupling.py
+++ b/hindsight-api-slim/tests/test_reflect_page_length_decoupling.py
@@ -13,6 +13,7 @@ truncates the visible answer mid-word. These tests pin the decoupled contract:
   text.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -65,7 +66,11 @@ def _mock_llm(final_answer: str = "Synthesized final answer."):
     llm = MagicMock()
     llm.provider = "gemini"
     llm.model = "gemini-2.5-flash"
-    llm.call = AsyncMock(return_value=(final_answer, TokenUsage(input_tokens=40, output_tokens=12, total_tokens=52)))
+    llm.call = AsyncMock(
+        return_value=LLMCallResult(
+            content=final_answer, usage=TokenUsage(input_tokens=40, output_tokens=12, total_tokens=52)
+        )
+    )
     return llm
 
 
@@ -166,7 +171,9 @@ async def test_gemini_warns_on_max_tokens_truncation(caplog):
     llm._provider_impl._client.aio.models.generate_content = AsyncMock(return_value=response)
 
     with caplog.at_level(logging.WARNING):
-        out = await llm._provider_impl.call([{"role": "user", "content": "write a page"}], max_completion_tokens=500)
+        out = (
+            await llm._provider_impl.call([{"role": "user", "content": "write a page"}], max_completion_tokens=500)
+        ).content
 
     assert out == "A page that was cut off mid-wor"
     assert any("truncated at max_output_tokens" in r.message for r in caplog.records)

--- a/hindsight-api-slim/tests/test_reflect_split_synthesis.py
+++ b/hindsight-api-slim/tests/test_reflect_split_synthesis.py
@@ -28,7 +28,7 @@ from hindsight_api.engine.reflect.prompts import (
     split_context_history,
 )
 from hindsight_api.engine.reflect.tokenization import count_prompt_tokens
-from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, TokenUsage
+from hindsight_api.engine.response_models import LLMCallResult, LLMToolCall, LLMToolCallResult, TokenUsage
 
 # The splitter floors its per-chunk budget at _MIN_SPLIT_CHUNK_TOKENS, so tests
 # use budgets above the floor to exercise the packing logic itself.
@@ -144,12 +144,17 @@ class TestSplitSynthesisAgentFlow:
             # the final system prompt. Answer accordingly so the test can tell
             # which output made it into the result.
             if "extract evidence" in messages[0]["content"]:
-                return (
-                    f"- claim from prompt of {count_prompt_tokens(messages[1]['content'])} tokens "
-                    "(mentioned_at: 2026-01-01; occurred: unknown; memory_ids: mem-1)",
-                    TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15),
+                return LLMCallResult(
+                    content=(
+                        f"- claim from prompt of {count_prompt_tokens(messages[1]['content'])} tokens "
+                        "(mentioned_at: 2026-01-01; occurred: unknown; memory_ids: mem-1)"
+                    ),
+                    usage=TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15),
                 )
-            return (final_answer, TokenUsage(input_tokens=20, output_tokens=10, total_tokens=30))
+            return LLMCallResult(
+                content=final_answer,
+                usage=TokenUsage(input_tokens=20, output_tokens=10, total_tokens=30),
+            )
 
         llm.call = AsyncMock(side_effect=_call)
         return llm

--- a/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
+++ b/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
@@ -7,6 +7,7 @@ refresh_mental_model operation must let a monitoring layer distinguish
 ``result_metadata`` alone, without a follow-up content fetch.
 """
 
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import asyncio
 import uuid
 from dataclasses import dataclass, field
@@ -150,7 +151,7 @@ def _patch_delta_llm(monkeypatch, memory: MemoryEngine, *, returns) -> None:
     async def fake_call(*, messages, **kwargs):
         if isinstance(returns, Exception):
             raise returns
-        return DeltaOperationList.model_validate({"operations": returns})
+        return LLMCallResult(content=DeltaOperationList.model_validate({"operations": returns}), usage=TokenUsage())
 
     monkeypatch.setattr(memory._reflect_llm_config, "call", fake_call)
 

--- a/hindsight-api-slim/tests/test_retain.py
+++ b/hindsight-api-slim/tests/test_retain.py
@@ -3250,7 +3250,7 @@ from unittest.mock import patch
 import pytest_asyncio
 
 from hindsight_api.engine.memory_engine import MemoryEngine
-from hindsight_api.engine.response_models import TokenUsage
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 from hindsight_api.engine.task_backend import SyncTaskBackend
 
 
@@ -3261,10 +3261,10 @@ def _make_mock_llm_call():
         from hindsight_api.engine.consolidation.consolidator import _ConsolidationBatchResponse
 
         if kwargs.get("scope") == "consolidation":
-            return_usage = kwargs.get("return_usage", False)
-            if return_usage:
-                return _ConsolidationBatchResponse(), TokenUsage(input_tokens=0, output_tokens=0)
-            return _ConsolidationBatchResponse()
+            return LLMCallResult(
+                content=_ConsolidationBatchResponse(),
+                usage=TokenUsage(input_tokens=0, output_tokens=0),
+            )
 
         messages = kwargs.get("messages", args[0] if args else [])
         user_msg = messages[-1]["content"] if messages else ""
@@ -3290,14 +3290,13 @@ def _make_mock_llm_call():
             )
 
         response_dict = {"facts": facts}
-        return_usage = kwargs.get("return_usage", False)
-        if return_usage:
-            usage = TokenUsage(
+        return LLMCallResult(
+            content=response_dict,
+            usage=TokenUsage(
                 input_tokens=len(user_msg) // 4,
                 output_tokens=len(json.dumps(response_dict)) // 4,
-            )
-            return response_dict, usage
-        return response_dict
+            ),
+        )
 
     return mock_llm_call
 

--- a/hindsight-api-slim/tests/test_retain_reflect_output_language.py
+++ b/hindsight-api-slim/tests/test_retain_reflect_output_language.py
@@ -181,12 +181,14 @@ async def test_reflect_forced_synthesis_configured_output_language_overrides_que
     system_prompt = build_final_system_prompt(_REFLECT_BANK_PROFILE.get("mission"), "English", None)
     prompt = build_final_prompt(_REFLECT_QUERY, context_history, _REFLECT_BANK_PROFILE, llm_output_language="English")
 
-    answer = await llm_config.call(
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": prompt},
-        ],
-        scope="reflect",
-    )
+    answer = (
+        await llm_config.call(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            scope="reflect",
+        )
+    ).content
 
     await _assert_reflect_answer_is_english(answer)

--- a/hindsight-api-slim/tests/test_retain_transient_extraction_failure.py
+++ b/hindsight-api-slim/tests/test_retain_transient_extraction_failure.py
@@ -20,6 +20,7 @@ only on the ``retain_extract_facts`` scope, and assert the operation is retried
 (reset to ``pending`` with ``retry_count`` bumped) rather than silently completed.
 """
 
+from hindsight_api.engine.response_models import TokenUsage
 import json
 import uuid
 

--- a/hindsight-api-slim/tests/test_token_usage_cached_thoughts.py
+++ b/hindsight-api-slim/tests/test_token_usage_cached_thoughts.py
@@ -214,12 +214,12 @@ async def test_openai_compatible_call_extracts_reasoning_into_thoughts_tokens():
     llm = _openai_llm()
     llm._client.chat.completions.create = AsyncMock(return_value=_response(usage=_usage(cached=200, reasoning=80)))
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        _, token_usage = await llm.call(
+        call_result = await llm.call(
             messages=[{"role": "user", "content": "Return whether this worked."}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
+        token_usage = call_result.usage
     # reasoning_tokens must flow into thoughts_tokens (was dropped -> 0 before).
     assert token_usage.thoughts_tokens == 80
     assert token_usage.cached_tokens == 200
@@ -257,12 +257,12 @@ async def test_openai_compatible_call_no_token_details_keeps_thoughts_zero():
         return_value=_response(usage=_usage(cached=None, reasoning=None, prompt=10, completion=5, total=15))
     )
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        _, token_usage = await llm.call(
+        call_result = await llm.call(
             messages=[{"role": "user", "content": "x"}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
+        token_usage = call_result.usage
     assert token_usage.thoughts_tokens == 0
     assert token_usage.cached_tokens == 0
 
@@ -282,12 +282,12 @@ async def test_openai_compatible_output_tokens_exclude_thoughts_like_gemini():
         return_value=_response(usage=_usage(reasoning=64, prompt=20, completion=83, total=103))
     )
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        _, token_usage = await llm.call(
+        call_result = await llm.call(
             messages=[{"role": "user", "content": "17*23?"}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
+        token_usage = call_result.usage
     assert token_usage.thoughts_tokens == 64
     assert token_usage.output_tokens == 83 - 64  # visible-only, no reasoning
     assert token_usage.input_tokens == 20
@@ -320,7 +320,6 @@ async def test_openai_compatible_call_records_cached_and_thoughts_on_metrics():
             messages=[{"role": "user", "content": "Return whether this worked."}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
     recorded = _recorded_llm_call(collector)
     assert recorded["cached_input_tokens"] == 200
@@ -371,7 +370,6 @@ async def test_openai_compatible_metrics_account_for_every_billed_output_token()
             messages=[{"role": "user", "content": "17*23?"}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
     recorded = _recorded_llm_call(collector)
     assert recorded["output_tokens"] == completion - reasoning  # visible-only
@@ -399,12 +397,12 @@ async def test_openai_compatible_call_unfolded_reasoning_keeps_visible_output():
         return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=4692))
     )
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        _, token_usage = await llm.call(
+        call_result = await llm.call(
             messages=[{"role": "user", "content": "Extract facts"}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
+        token_usage = call_result.usage
     assert token_usage.output_tokens == 673  # was 0: max(0, 673 - 909)
     assert token_usage.thoughts_tokens == 909
     assert token_usage.input_tokens == 3110
@@ -448,12 +446,12 @@ async def test_openai_compatible_call_unfolded_reasoning_survives_drifted_total(
         return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=4691))
     )
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        _, token_usage = await llm.call(
+        call_result = await llm.call(
             messages=[{"role": "user", "content": "Extract facts"}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
+        token_usage = call_result.usage
     assert token_usage.output_tokens == 672
     assert token_usage.thoughts_tokens == 909
 
@@ -467,12 +465,12 @@ async def test_openai_compatible_call_folded_reasoning_survives_drifted_total():
         return_value=_response(usage=_usage(reasoning=48, prompt=3340, completion=1337, total=4678))
     )
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        _, token_usage = await llm.call(
+        call_result = await llm.call(
             messages=[{"role": "user", "content": "Query"}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
+        token_usage = call_result.usage
     assert token_usage.output_tokens == (1337 - 48) + 1
     assert token_usage.thoughts_tokens == 48
 
@@ -486,12 +484,12 @@ async def test_openai_compatible_call_missing_total_falls_back_to_folded_reading
         return_value=_response(usage=_usage(reasoning=64, prompt=20, completion=83, total=0))
     )
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        _, token_usage = await llm.call(
+        call_result = await llm.call(
             messages=[{"role": "user", "content": "Query"}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
+        token_usage = call_result.usage
     assert token_usage.output_tokens == 83 - 64
     assert token_usage.thoughts_tokens == 64
     assert token_usage.total_tokens == 20 + (83 - 64)
@@ -512,24 +510,24 @@ async def test_openai_compatible_call_clamps_unusable_total_to_an_admissible_rea
         return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=99))
     )
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        _, low = await llm.call(
+        call_result = await llm.call(
             messages=[{"role": "user", "content": "Query"}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
+        low = call_result.usage
     assert low.output_tokens == 0  # max(0, 673 - 909), the folded reading
 
     llm._client.chat.completions.create = AsyncMock(
         return_value=_response(usage=_usage(reasoning=909, prompt=3110, completion=673, total=999_999))
     )
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        _, high = await llm.call(
+        call_result = await llm.call(
             messages=[{"role": "user", "content": "Query"}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
+        high = call_result.usage
     assert high.output_tokens == 673  # capped at completion_tokens
 
 
@@ -542,12 +540,12 @@ async def test_openai_compatible_call_without_reasoning_reports_completion_verba
         return_value=_response(usage=_usage(reasoning=0, prompt=120, completion=45, total=165))
     )
     with patch("hindsight_api.engine.providers.openai_compatible_llm.get_metrics_collector"):
-        _, token_usage = await llm.call(
+        call_result = await llm.call(
             messages=[{"role": "user", "content": "Query"}],
             response_format=_OkModel,
             max_retries=0,
-            return_usage=True,
         )
+        token_usage = call_result.usage
     assert token_usage.output_tokens == 45
     assert token_usage.thoughts_tokens == 0
     assert token_usage.total_tokens == 165

--- a/hindsight-api-slim/tests/test_vertexai_provider.py
+++ b/hindsight-api-slim/tests/test_vertexai_provider.py
@@ -205,10 +205,12 @@ async def test_vertexai_integration_actual_api():
 
     try:
         # Simple test call
-        response = await provider.call(
-            messages=[{"role": "user", "content": "Say 'ok' and nothing else"}],
-            max_completion_tokens=10,
-        )
+        response = (
+            await provider.call(
+                messages=[{"role": "user", "content": "Say 'ok' and nothing else"}],
+                max_completion_tokens=10,
+            )
+        ).content
 
         assert response is not None
         assert isinstance(response, str)

--- a/hindsight-api-slim/tests/test_vlm_slot.py
+++ b/hindsight-api-slim/tests/test_vlm_slot.py
@@ -16,6 +16,7 @@ from datetime import datetime
 import pytest
 
 from hindsight_api.config import HindsightConfig
+from hindsight_api.engine.response_models import LLMCallResult
 from hindsight_api.engine.retain.attachment_content import (
     LoadedAttachment,
     attachment_placeholder,
@@ -42,7 +43,7 @@ class _RecordingConfig:
         self._calls.append(self.provider)
         from hindsight_api.engine.response_models import TokenUsage
 
-        return {"facts": []}, TokenUsage()
+        return LLMCallResult(content={"facts": []}, usage=TokenUsage())
 
     async def get_or_create_cached_prefix(self, *a, **k):
         return None

--- a/hindsight-api-slim/tests/test_xai_oauth_llm.py
+++ b/hindsight-api-slim/tests/test_xai_oauth_llm.py
@@ -814,7 +814,7 @@ async def test_a_401_refreshes_once_and_retries_once(tmp_path, monkeypatch):
         refresh_replies=[_refresh_ok()],
     )
 
-    result = await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)
+    result = (await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)).content
 
     assert result == "recovered"
     assert len(llm._client.calls) == 2
@@ -904,7 +904,7 @@ async def test_a_429_is_retried_honoring_retry_after(tmp_path, monkeypatch):
         replies=[_FakeResponse(429, "slow down", {"Retry-After": "7"}), _ok_reply("after backoff")],
     )
 
-    result = await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=2, initial_backoff=1.0)
+    result = (await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=2, initial_backoff=1.0)).content
 
     assert result == "after backoff"
     assert slept == [7.0]
@@ -1360,7 +1360,7 @@ def test_output_tokens_survive_when_completion_tokens_is_already_visible_only():
     assert counts.total_tokens == 50
 
 
-async def test_return_usage_surfaces_cached_tokens(tmp_path, monkeypatch):
+async def test_call_usage_surfaces_cached_tokens(tmp_path, monkeypatch):
     usage = {
         "prompt_tokens": 200,
         "completion_tokens": 20,
@@ -1369,7 +1369,7 @@ async def test_return_usage_surfaces_cached_tokens(tmp_path, monkeypatch):
     }
     llm = _make_llm(tmp_path, monkeypatch, replies=[_ok_reply("hi", usage)])
 
-    _, token_usage = await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0, return_usage=True)
+    token_usage = (await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=0)).usage
 
     assert token_usage.input_tokens == 200
     assert token_usage.cached_tokens == 150
@@ -1459,12 +1459,14 @@ class _Answer(BaseModel):
 async def test_structured_output_uses_a_strict_json_schema_when_requested(tmp_path, monkeypatch):
     llm = _make_llm(tmp_path, monkeypatch, replies=[_ok_reply(json.dumps({"answer": "42"}))])
 
-    result = await llm.call(
-        messages=[{"role": "user", "content": "hi"}],
-        response_format=_Answer,
-        strict_schema=True,
-        max_retries=0,
-    )
+    result = (
+        await llm.call(
+            messages=[{"role": "user", "content": "hi"}],
+            response_format=_Answer,
+            strict_schema=True,
+            max_retries=0,
+        )
+    ).content
 
     body = llm._client.calls[0]["json"]
     assert body["response_format"]["type"] == "json_schema"
@@ -1577,7 +1579,7 @@ async def test_a_502_retry_lands_on_a_new_client_not_the_pinned_one(tmp_path, mo
     second_client = _FakeAsyncHttp([_ok_reply("recovered")])
     llm._new_client = lambda: second_client  # type: ignore[method-assign]
 
-    result = await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=1)
+    result = (await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=1)).content
 
     assert result == "recovered"
     assert llm._client is second_client
@@ -1594,7 +1596,7 @@ async def test_a_429_retry_does_not_recycle_the_connection(tmp_path, monkeypatch
     original_client = llm._client
     llm._new_client = _never_called  # type: ignore[method-assign]
 
-    result = await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=1)
+    result = (await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=1)).content
 
     assert result == "ok"
     assert llm._client is original_client
@@ -1713,7 +1715,7 @@ async def test_a_recycle_leaves_a_sibling_request_on_the_stale_client_alive(tmp_
     assert not gated.closed, "the stale client was closed while a sibling was still using it"
 
     gated.gate.set()
-    assert await sibling == "sibling"
+    assert (await sibling).content == "sibling"
 
     await _settle()
     assert gated.closed, "the stale client must still be closed once it drains"
@@ -1823,7 +1825,7 @@ async def test_a_transient_refresh_failure_is_retried_like_any_other_blip(tmp_pa
 
     llm._auth.get_access_token = _flaky  # type: ignore[method-assign]
 
-    assert await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=2) == "recovered"
+    assert (await llm.call(messages=[{"role": "user", "content": "hi"}], max_retries=2)).content == "recovered"
     assert len(attempts) == 2
     assert len(llm._client.calls) == 1
 


### PR DESCRIPTION
``call`` returned either the bare response or a ``(response, TokenUsage)``
tuple, chosen by a ``return_usage: bool`` argument. A boolean that changes the
return type cannot be typed, which is why all fourteen implementations were
annotated ``-> Any`` and neither shape was ever checked: callers that wanted the
cost unpacked two names, callers that did not got the response directly, and
nothing at the call site said which you were looking at.

It now always returns ``LLMCallResult(content, usage)``, mirroring
``call_with_tools``, which has always returned a named ``LLMToolCallResult``.
Usage is available unconditionally, so recording cost no longer means changing a
call's return type to get it.

Not a public break: ``LLMInterface`` is not an extension seam — extensions plug
in at memory-defense, operation-validator, tenant, bank-tables, http and mcp.
``MemoryEngine.retain_batch_async`` keeps its own ``return_usage`` flag; that one
is on the engine API extensions call, and is left for a deprecation cycle.

Two live bugs this surfaced, both in consolidation:

* ``_consolidate_batch_with_llm`` annotated the awaited value as
  ``_ConsolidationBatchResponse`` and read ``response.creates`` off it.
* ``_maybe_dedup_observation`` passed the awaited value straight into
  ``_dedup_decision_from_response``.

Neither is a tuple unpack, so a sweep for unpack sites could not see them, and
both failed quietly: the error was caught, retried three times, and logged as
"skipping batch (the caller will bisect it)".

``sanitize_llm_value`` needed no change but did need re-reading: it special-cased
tuples *because* of ``return_usage`` (the #3729 UTF-8 boundary). It already
descends into ``BaseModel``, so ``LLMCallResult.content`` stays covered — the two
comments describing the old shape are updated rather than left to mislead.

Also removes ``cached_prefix`` / ``cached_prefix_message_count`` from
``openai_responses`` and ``github_copilot``: both declared them, neither read
them, and neither overrides any prompt-caching method, so
``get_or_create_cached_prefix`` returns None for them and a caller could never
pass one. Dead surface that read like a supported feature; removing it also makes
them consistent with the ten providers that never declared it.

Test doubles are the other half of this change, and the reason for the guard.
A double that returns the payload where production now expects the envelope is
invisible to a caller-side sweep and to the type checker — it only shows up as an
AttributeError at runtime, or, worse, as a pipeline that never reaches the
failure a test was waiting for. ``tests/test_named_result_stubs.py`` therefore
asserts over the whole suite rather than any one test, and recognises every way a
double is actually installed here:

* ``monkeypatch.setattr(module, "call", fn)``
* a method named after the function (``FakeGraphRetriever.retrieve``)
* ``AsyncMock(return_value=...)`` and ``AsyncMock(side_effect=fn)``
* ``patch("dotted.path", new=fn)`` and ``patch.object(cls, "call", side_effect=fn)``
* ``<mock>.call.return_value = payload``

and requires the double to plausibly produce the named type — a constructor call,
an await, or a mock factory — rather than merely "not a tuple". That last change
alone found nine stale stubs across seven files. It also checks the other two
directions: nothing may unpack a named result positionally, and nothing may read
a non-``content``/``usage`` attribute off an awaited ``call``.