### PR TITLE
fix(api): give each event loop its own extension context

### DIFF
--- a/hindsight-api-slim/hindsight_api/extensions/base.py
+++ b/hindsight-api-slim/hindsight_api/extensions/base.py
@@ -1,5 +1,6 @@
 """Base Extension class for all Hindsight extensions."""
 
+import threading
 from abc import ABC
 from typing import TYPE_CHECKING
 
@@ -33,6 +34,16 @@ class Extension(ABC):
                     Keys are lowercased with the prefix stripped.
         """
         self.config = config
+        # The context is per-THREAD, because a multi-loop server builds one application per
+        # loop -- each on its own thread, each with its own engine and its own connection
+        # pool -- while the extension instance itself is shared across all of them. A single
+        # attribute keeps only the last writer's context, so every other loop then reaches a
+        # pool that belongs to a foreign loop: asyncpg raises "got Future attached to a
+        # different loop", and under concurrency the connection protocol corrupts outright.
+        self._contexts = threading.local()
+        # ...and the first one set is kept as the fallback for threads that never had one
+        # set on them (a single-loop server, or work handed to an executor thread). Single
+        # loop means exactly one context is ever set, so this is the unchanged behaviour.
         self._context: "ExtensionContext | None" = None
 
     def set_context(self, context: "ExtensionContext") -> None:
@@ -45,7 +56,9 @@ class Extension(ABC):
         Args:
             context: The ExtensionContext providing system APIs.
         """
-        self._context = context
+        self._contexts.value = context
+        if self._context is None:
+            self._context = context
 
     @property
     def context(self) -> "ExtensionContext":
@@ -58,11 +71,14 @@ class Extension(ABC):
         Raises:
             RuntimeError: If context has not been set yet.
         """
-        if self._context is None:
+        context = getattr(self._contexts, "value", None)
+        if context is None:
+            context = self._context
+        if context is None:
             raise RuntimeError(
                 "Extension context not set. Context is available after the extension is loaded by the system."
             )
-        return self._context
+        return context
 
     async def on_startup(self) -> None:
         """

--- a/hindsight-api-slim/hindsight_api/extensions/context.py
+++ b/hindsight-api-slim/hindsight_api/extensions/context.py
@@ -55,6 +55,21 @@ class ExtensionContext(ABC):
         """
         ...
 
+    @property
+    def is_primary(self) -> bool:
+        """Whether this context belongs to the loop that owns process-level work.
+
+        A multi-loop server builds one application per loop and designates exactly one of
+        them primary; that one runs what belongs to the PROCESS rather than to a loop --
+        migrations, the background pollers, and any one-off startup provisioning an
+        extension does. An extension that installs shared infrastructure on startup should
+        guard it with this, or it does that work once per loop.
+
+        Always True for a single-loop server, which is every deployment that does not opt
+        into more, so an extension that ignores this keeps its current behaviour.
+        """
+        return True
+
     @abstractmethod
     def get_memory_engine(self) -> "MemoryEngineInterface":
         """
@@ -86,6 +101,7 @@ class DefaultExtensionContext(ExtensionContext):
         memory_engine: "MemoryEngineInterface | None" = None,
         webhook_manager: "WebhookManager | None" = None,
         current_schema: str | None = None,
+        is_primary: bool = True,
     ):
         """
         Initialize the context.
@@ -95,11 +111,15 @@ class DefaultExtensionContext(ExtensionContext):
             memory_engine: Optional MemoryEngine instance for memory operations.
             webhook_manager: Optional WebhookManager for firing webhooks.
             current_schema: Optional current schema name for tenant context.
+            is_primary: Whether this context's loop owns process-level work. Defaults to
+                True so a single-loop server, and any caller that predates the flag, keeps
+                doing that work.
         """
         self._database_url = database_url
         self._memory_engine = memory_engine
         self.webhook_manager = webhook_manager
         self.current_schema = current_schema
+        self._is_primary = is_primary
 
     async def run_migration(self, schema: str) -> None:
         """Run migrations for a specific schema."""
@@ -155,6 +175,11 @@ class DefaultExtensionContext(ExtensionContext):
             pool = await get_pool()
             async with pool.acquire() as conn:
                 await tenant_extension.provision_bank_tables(conn, schema)
+
+    @property
+    def is_primary(self) -> bool:
+        """Whether this context's loop owns process-level work."""
+        return self._is_primary
 
     def get_memory_engine(self) -> "MemoryEngineInterface":
         """Get the memory engine interface."""

--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -488,8 +488,15 @@ def _serve_multi_loop(args, config, uvicorn_config, operation_validator, tenant_
             run_background_tasks=primary,
         )
         if tenant_extension:
+            # One context per loop, holding THIS loop's engine. build_app runs on the loop's
+            # own thread, and the extension keeps the context per thread, so each loop reaches
+            # its own pool rather than whichever loop happened to be built last.
             tenant_extension.set_context(
-                DefaultExtensionContext(database_url=config.database_url, memory_engine=memory)
+                DefaultExtensionContext(
+                    database_url=config.database_url,
+                    memory_engine=memory,
+                    is_primary=primary,
+                )
             )
         return create_app(
             memory=memory,

--- a/hindsight-api-slim/tests/test_multi_loop.py
+++ b/hindsight-api-slim/tests/test_multi_loop.py
@@ -204,3 +204,67 @@ def _record():
         llm_info=None,
         metadata=None,
     )
+
+
+def test_each_loops_thread_gets_its_own_extension_context():
+    """One extension instance, N loops, N contexts — each thread must see its own.
+
+    ``build_app`` is called once per loop, on that loop's thread, and sets a context holding
+    that loop's engine on the SAME extension object. Keeping one attribute means the last
+    writer wins and every other loop reads an engine — and therefore a connection pool —
+    belonging to a foreign loop, which is the failure this whole module exists to prevent.
+    """
+    import threading
+
+    from hindsight_api.extensions.base import Extension
+
+    class _Ext(Extension):
+        pass
+
+    class _Ctx:
+        def __init__(self, name):
+            self.name = name
+
+    ext = _Ext({})
+    seen: dict[str, str] = {}
+    barrier = threading.Barrier(3)
+
+    def build_and_read(name: str) -> None:
+        ext.set_context(_Ctx(name))
+        # Every loop sets its context before any of them reads one, which is what makes a
+        # single shared attribute lose: without the barrier the threads could interleave
+        # benignly and the test would pass against the broken version.
+        barrier.wait()
+        seen[name] = ext.context.name
+
+    threads = [threading.Thread(target=build_and_read, args=(f"loop{i}",)) for i in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert seen == {"loop0": "loop0", "loop1": "loop1", "loop2": "loop2"}
+
+
+def test_a_thread_with_no_context_of_its_own_falls_back():
+    """A single-loop server sets exactly one context, and work handed to an executor thread
+    still has to find it — so a thread that never had one set reads the first one set."""
+    import threading
+
+    from hindsight_api.extensions.base import Extension
+
+    class _Ext(Extension):
+        pass
+
+    class _Ctx:
+        name = "the-only-one"
+
+    ext = _Ext({})
+    ext.set_context(_Ctx())
+
+    got: list[str] = []
+    t = threading.Thread(target=lambda: got.append(ext.context.name))
+    t.start()
+    t.join()
+
+    assert got == ["the-only-one"]


### PR DESCRIPTION
## The bug

A multi-loop server builds one application per loop, each with its own engine and its own
connection pool. The tenant extension, though, is a single object shared across all of them,
and `build_app` calls `set_context` on that one object once per loop:

```python
def build_app(*, primary: bool):
    memory = MemoryEngine(...)              # fresh per loop — correct
    if tenant_extension:
        tenant_extension.set_context(       # shared instance, overwritten each time
            DefaultExtensionContext(database_url=..., memory_engine=memory)
        )
```

The last loop to be built wins, so every other loop reads an engine — and therefore a pool —
belonging to a foreign loop. `multi_loop.py`'s own docstring says an asyncpg pool belongs to
the loop that created it and that this is why nothing may be shared; the engine and app honour
that, the extension context did not.

## How it shows up

On a six-loop server, five of six loops failed their startup work with:

```
got Future <Future pending ...> attached to a different loop
```

and one run produced `asyncpg InternalClientError: got result for unknown protocol state 3` —
the connection protocol corrupting rather than failing cleanly. It is quiet otherwise, because
extension startup work of this kind is usually best-effort and only logs, so the process comes
up healthy with most of its loops having skipped it.

## The fix

The context is kept per thread. `build_app` runs on its loop's own thread, so each loop reads
back the context it set. A thread that never had one set — a single-loop server, or work handed
to an executor — falls back to the first context set, which is exactly the current single-loop
behaviour.

`ExtensionContext.is_primary` is added alongside it so an extension can tell whether it is on
the loop that owns process-level work, and run one-off startup provisioning once instead of once
per loop. It defaults to `True`, so an extension that ignores it is unaffected.

## Test

`test_each_loops_thread_gets_its_own_extension_context` fails without the fix: three threads each
set a context, a barrier makes them all set before any reads, and they all see the last writer's.
A second test pins the fallback so the single-loop path stays covered.