### PR TITLE
feat(control-plane): banks overview page with bulk delete

### DIFF
--- a/hindsight-control-plane/src/app/[locale]/dashboard/page.tsx
+++ b/hindsight-control-plane/src/app/[locale]/dashboard/page.tsx
@@ -1,38 +1,25 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
 import { BankSelector } from "@/components/bank-selector";
-import { Spinner } from "@/components/ui/spinner";
+import { BanksOverview } from "@/components/banks-overview";
 import { useBank } from "@/lib/bank-context";
-import { bankRoute } from "@/lib/bank-url";
 
 export default function DashboardPage() {
-  const t = useTranslations("dashboard");
-  const router = useRouter();
-  const { currentBank } = useBank();
+  const { setCurrentBank } = useBank();
 
-  // Redirect to bank page if a bank is selected
+  // This page is the "all banks" view, so nothing is selected while it is open.
+  // The selection survives navigating back here from a bank page otherwise, and the
+  // header would keep offering bank-scoped actions for a bank that is not on screen.
   useEffect(() => {
-    if (currentBank) {
-      router.push(bankRoute(currentBank, "?view=data"));
-    }
-  }, [currentBank, router]);
+    setCurrentBank(null);
+  }, [setCurrentBank]);
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <div className="flex-1 flex flex-col">
         <BankSelector />
-
-        <div className="flex items-center justify-center h-[calc(100vh-80px)] bg-muted/20">
-          <div className="text-center p-10 bg-card rounded-lg border-2 border-border shadow-lg max-w-md">
-            {/* Tumbling Hindsight mascot — loops forever as a friendly greeting. */}
-            <Spinner size="xl" variant="jump" className="mx-auto mb-4" />
-            <h3 className="text-2xl font-bold mb-3 text-card-foreground">{t("welcome")}</h3>
-            <p className="text-muted-foreground">{t("selectBank")}</p>
-          </div>
-        </div>
+        <BanksOverview />
       </div>
     </div>
   );

--- a/hindsight-control-plane/src/components/bank-selector.tsx
+++ b/hindsight-control-plane/src/components/bank-selector.tsx
@@ -228,6 +228,14 @@ function BankSelectorInner() {
     return () => window.removeEventListener("hindsight:logo-spin", spin);
   }, []);
 
+  // The banks overview page has its own "create bank" button; the dialog (with its
+  // template import) lives here, so that button asks for it rather than duplicating it.
+  React.useEffect(() => {
+    const openCreate = () => setCreateDialogOpen(true);
+    window.addEventListener("hindsight:create-bank", openCreate);
+    return () => window.removeEventListener("hindsight:create-bank", openCreate);
+  }, []);
+
   // Banks arrive already ordered by last write descending, one page at a time, so the
   // list is rendered in server order — re-sorting here would only shuffle a later page
   // above an earlier one.
@@ -590,7 +598,14 @@ function BankSelectorInner() {
             freely); the wordmark is the right slice of the full lockup (logo.png)
             shown via a cropped background. Their widths sum to the full logo, so
             the two pieces butt together seamlessly at h-10. */}
-        <div className="flex items-center h-10 select-none" aria-label="Hindsight">
+        {/* The logo is the way back to the banks overview, as it is in most apps. */}
+        <button
+          type="button"
+          className="flex items-center h-10 select-none cursor-pointer"
+          aria-label={tNavBank("allBanks")}
+          title={tNavBank("allBanks")}
+          onClick={() => router.push("/dashboard")}
+        >
           <img
             src={withBasePath("/favicon.png")}
             alt=""
@@ -606,7 +621,7 @@ function BankSelectorInner() {
               backgroundRepeat: "no-repeat",
             }}
           />
-        </div>
+        </button>
 
         {/* Separator */}
         <div className="h-8 w-px bg-border" />

--- a/hindsight-control-plane/src/components/banks-overview.tsx
+++ b/hindsight-control-plane/src/components/banks-overview.tsx
@@ -1,0 +1,499 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Trash2, Search, X, Plus } from "lucide-react";
+import { toast } from "sonner";
+
+import { client } from "@/lib/api";
+import { useBank, type BankInfo } from "@/lib/bank-context";
+import { bankRoute } from "@/lib/bank-url";
+import { formatRelativeTime } from "@/lib/relative-time";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Pagination } from "@/components/ui/pagination";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+const ITEMS_PER_PAGE = 50;
+
+/** How many bank names the confirmation dialog spells out before collapsing the rest. */
+const CONFIRM_LIST_LIMIT = 8;
+
+function formatCompact(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}k`;
+  return n.toString();
+}
+
+/** The list endpoint's rows are untyped JSON; fill the optional stats so the table can
+ *  assume numbers and nulls (a missing `fact_count` would poison the bar's max). */
+function toBankInfo(bank: Record<string, unknown>): BankInfo {
+  return {
+    bank_id: String(bank.bank_id),
+    name: (bank.name as string) ?? null,
+    mission: (bank.mission as string) ?? null,
+    created_at: (bank.created_at as string) ?? null,
+    updated_at: (bank.updated_at as string) ?? null,
+    fact_count: (bank.fact_count as number) ?? 0,
+    last_document_at: (bank.last_document_at as string) ?? null,
+    last_write_at: (bank.last_write_at as string) ?? null,
+  };
+}
+
+/** Last write, not last ingestion: appends to an existing document bump `last_write_at` only. */
+function lastActivityOf(bank: BankInfo): string | null {
+  return bank.last_write_at || bank.last_document_at;
+}
+
+interface DeleteFailure {
+  bankId: string;
+  message: string;
+}
+
+interface DeleteProgress {
+  total: number;
+  done: number;
+  failures: DeleteFailure[];
+  /** Set once the loop has finished, so the dialog can switch from progress to result. */
+  finished: boolean;
+}
+
+export function BanksOverview() {
+  const t = useTranslations("banksOverview");
+  const tCommon = useTranslations("common");
+  const tNavBank = useTranslations("nav.bank");
+  const router = useRouter();
+  // The overview pages discretely while the header selector scrolls infinitely, so it
+  // cannot share the selector's cumulative list — it fetches its own page. `loadBanks`
+  // is still used to keep that selector in sync after a bulk delete.
+  const { currentBank, setCurrentBank, loadBanks } = useBank();
+
+  const [banks, setBanks] = React.useState<BankInfo[]>([]);
+  const [total, setTotal] = React.useState(0);
+  const [loading, setLoading] = React.useState(true);
+  const [page, setPage] = React.useState(1);
+  const [search, setSearch] = React.useState("");
+  const [searchDraft, setSearchDraft] = React.useState("");
+
+  const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const [confirmOpen, setConfirmOpen] = React.useState(false);
+  const [confirmText, setConfirmText] = React.useState("");
+  const [progress, setProgress] = React.useState<DeleteProgress | null>(null);
+
+  // Search runs server-side (the list is paginated), so the input holds a draft that is
+  // debounced into a query. A new query always restarts at page 1.
+  React.useEffect(() => {
+    if (searchDraft === search) return;
+    const timer = setTimeout(() => {
+      setSearch(searchDraft);
+      setPage(1);
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [searchDraft, search]);
+
+  // Every fetch bumps this; a response whose stamp is stale is dropped, so paging fast
+  // or typing during a fetch can't leave an earlier page's rows on screen.
+  const requestSeq = React.useRef(0);
+
+  const fetchPage = React.useCallback(async (targetPage: number, query: string) => {
+    const seq = ++requestSeq.current;
+    setLoading(true);
+    try {
+      const response = await client.listBanks({
+        q: query || undefined,
+        limit: ITEMS_PER_PAGE,
+        offset: (targetPage - 1) * ITEMS_PER_PAGE,
+      });
+      if (seq !== requestSeq.current) return;
+      setBanks((response.banks || []).map(toBankInfo));
+      setTotal(response.total ?? 0);
+    } catch (error) {
+      if (seq !== requestSeq.current) return;
+      console.error("Error loading banks:", error);
+    } finally {
+      if (seq === requestSeq.current) setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    fetchPage(page, search);
+  }, [fetchPage, page, search]);
+
+  // Only rows on screen can be selected, so a page change or a new query must drop the
+  // selection — otherwise invisible banks stay armed for deletion.
+  React.useEffect(() => {
+    setSelected(new Set());
+  }, [page, search]);
+
+  const maxFactCount = React.useMemo(() => Math.max(1, ...banks.map((b) => b.fact_count)), [banks]);
+
+  const selectedBanks = banks.filter((b) => selected.has(b.bank_id));
+  const allSelected = banks.length > 0 && selectedBanks.length === banks.length;
+  const isDeleting = progress !== null && !progress.finished;
+
+  const toggleBank = (bankId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(bankId)) next.delete(bankId);
+      else next.add(bankId);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelected(allSelected ? new Set() : new Set(banks.map((b) => b.bank_id)));
+  };
+
+  const runBulkDelete = async () => {
+    const targets = selectedBanks.map((b) => b.bank_id);
+    if (targets.length === 0) return;
+
+    // Deliberately sequential. `delete_bank` drops the bank's partial vector indexes
+    // with DROP INDEX CONCURRENTLY on the shared `memory_units` relation; concurrent
+    // drops wait on each other's virtual xids and deadlock, so a fan-out here would
+    // fail banks at random.
+    setProgress({ total: targets.length, done: 0, failures: [], finished: false });
+    const failures: DeleteFailure[] = [];
+    for (const bankId of targets) {
+      try {
+        await client.deleteBank(bankId, { suppressErrorToast: true });
+        if (bankId === currentBank) setCurrentBank(null);
+      } catch (error) {
+        failures.push({
+          bankId,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+      setProgress((prev) => (prev ? { ...prev, done: prev.done + 1, failures } : prev));
+    }
+
+    const deletedCount = targets.length - failures.length;
+    // The current page may have emptied out; step back rather than showing a blank one.
+    const remaining = total - deletedCount;
+    const lastPage = Math.max(1, Math.ceil(remaining / ITEMS_PER_PAGE));
+    const nextPage = Math.min(page, lastPage);
+    if (nextPage === page) await fetchPage(page, search);
+    else setPage(nextPage);
+    // The header selector holds its own copy of the list.
+    await loadBanks();
+    // Only the banks that survived stay armed, so a retry doesn't re-delete.
+    setSelected(new Set(failures.map((f) => f.bankId)));
+    setProgress({ total: targets.length, done: targets.length, failures, finished: true });
+
+    if (failures.length === 0) {
+      setConfirmOpen(false);
+      setProgress(null);
+      toast.success(t("bulkDeleteDone", { count: deletedCount }));
+    } else {
+      toast.warning(t("bulkDeletePartial", { deleted: deletedCount, failed: failures.length }));
+    }
+  };
+
+  const openBank = (bankId: string) => {
+    setCurrentBank(bankId);
+    // No view param: the bank page defaults to its home view.
+    router.push(bankRoute(bankId));
+  };
+
+  const confirmWord = t("bulkDeleteConfirmWord");
+  const confirmed = confirmText.trim().toLowerCase() === confirmWord.toLowerCase();
+
+  // A server with no banks at all gets the greeting it had before this page existed —
+  // a search box and an empty table say nothing to someone who has yet to create one.
+  // A search that matches nothing still shows the table UI, so the query can be edited.
+  if (!loading && total === 0 && !search) {
+    return (
+      <div className="flex items-center justify-center h-[calc(100vh-80px)] bg-muted/20">
+        <div className="max-w-md rounded-lg border-2 border-border bg-card p-10 text-center shadow-lg">
+          {/* Tumbling Hindsight mascot — loops forever as a friendly greeting. */}
+          <Spinner size="xl" variant="jump" className="mx-auto mb-4" />
+          <h3 className="mb-3 text-2xl font-bold text-card-foreground">{t("welcomeTitle")}</h3>
+          <p className="mb-6 text-muted-foreground">{t("welcomeBody")}</p>
+          <Button onClick={() => window.dispatchEvent(new CustomEvent("hindsight:create-bank"))}>
+            <Plus className="mr-1.5 h-4 w-4" />
+            {tNavBank("create")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-6 py-8">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">{t("title")}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          // The create dialog (with its template import) lives in the header selector;
+          // this asks that component to open it rather than shipping a second copy.
+          onClick={() => window.dispatchEvent(new CustomEvent("hindsight:create-bank"))}
+        >
+          <Plus className="mr-1.5 h-4 w-4" />
+          {tNavBank("create")}
+        </Button>
+      </div>
+
+      <div className="mb-4 flex items-center gap-3">
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={searchDraft}
+            onChange={(e) => setSearchDraft(e.target.value)}
+            placeholder={t("search")}
+            className="pl-9"
+          />
+        </div>
+        {selected.size > 0 && (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground tabular-nums">
+              {t("selectedCount", { count: selected.size })}
+            </span>
+            <Button variant="ghost" size="sm" onClick={() => setSelected(new Set())}>
+              <X className="mr-1 h-3.5 w-3.5" />
+              {tCommon("clear")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setConfirmText("");
+                setProgress(null);
+                setConfirmOpen(true);
+              }}
+              className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+            >
+              <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+              {t("deleteSelected")}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {loading && banks.length === 0 ? (
+        <div className="flex items-center justify-center gap-2 py-16 text-muted-foreground">
+          <Spinner size="sm" />
+          <span>{tCommon("loading")}</span>
+        </div>
+      ) : banks.length === 0 ? (
+        <div className="rounded-xl border border-border bg-card py-16 text-center text-muted-foreground">
+          {t("noSearchResults")}
+        </div>
+      ) : (
+        <>
+          <Table
+            className={cn(
+              "transition-opacity duration-150 motion-reduce:transition-none",
+              loading && "opacity-40"
+            )}
+          >
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10">
+                  <Checkbox
+                    checked={allSelected}
+                    onCheckedChange={toggleAll}
+                    aria-label={t("selectAll")}
+                  />
+                </TableHead>
+                <TableHead>{t("columnBank")}</TableHead>
+                <TableHead className="w-48">{t("columnMemories")}</TableHead>
+                <TableHead className="w-40">{t("columnLastActivity")}</TableHead>
+                <TableHead className="w-40">{t("columnCreated")}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {banks.map((bank, index) => {
+                const lastActivity = lastActivityOf(bank);
+                const barPct = (bank.fact_count / maxFactCount) * 100;
+                return (
+                  <TableRow
+                    key={bank.bank_id}
+                    onClick={() => openBank(bank.bank_id)}
+                    className="cursor-pointer animate-list-row-enter"
+                    style={{ animationDelay: `${Math.min(index, 10) * 18}ms` }}
+                  >
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <Checkbox
+                        checked={selected.has(bank.bank_id)}
+                        onCheckedChange={() => toggleBank(bank.bank_id)}
+                        aria-label={t("selectBank", { bank: bank.name || bank.bank_id })}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <div className="font-medium text-card-foreground">
+                        {bank.name || bank.bank_id}
+                      </div>
+                      {bank.name && bank.name !== bank.bank_id && (
+                        <div className="truncate text-xs text-muted-foreground">{bank.bank_id}</div>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {bank.fact_count > 0 ? (
+                        <div className="flex items-center gap-2">
+                          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+                            <div
+                              className="h-full rounded-full bg-primary/60"
+                              style={{ width: `${barPct}%` }}
+                            />
+                          </div>
+                          <span className="tabular-nums text-xs text-muted-foreground">
+                            {formatCompact(bank.fact_count)}
+                          </span>
+                        </div>
+                      ) : (
+                        <span className="text-xs italic text-muted-foreground/60">
+                          {t("emptyBank")}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {lastActivity ? formatRelativeTime(lastActivity) : t("never")}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {bank.created_at ? formatRelativeTime(bank.created_at) : "—"}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+
+          <Pagination
+            page={page}
+            pageSize={ITEMS_PER_PAGE}
+            total={total}
+            disabled={loading || isDeleting}
+            onPageChange={setPage}
+          />
+        </>
+      )}
+
+      <AlertDialog
+        open={confirmOpen}
+        onOpenChange={(open) => {
+          // The loop keeps running if the dialog is torn down mid-flight, so block it.
+          if (isDeleting) return;
+          setConfirmOpen(open);
+          if (!open) setProgress(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("bulkDeleteTitle", { count: selectedBanks.length })}
+            </AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-3 text-sm text-muted-foreground">
+                {progress?.finished && progress.failures.length > 0 ? (
+                  <>
+                    <p>{t("bulkDeleteFailures")}</p>
+                    <ul className="max-h-48 space-y-1 overflow-y-auto rounded-md bg-muted/40 p-2 font-mono text-xs">
+                      {progress.failures.map((failure) => (
+                        <li key={failure.bankId}>
+                          <span className="text-foreground">{failure.bankId}</span> —{" "}
+                          {failure.message}
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                ) : (
+                  <>
+                    <p>{t("bulkDeletePrompt")}</p>
+                    <ul className="max-h-48 space-y-1 overflow-y-auto rounded-md bg-muted/40 p-2 font-mono text-xs">
+                      {selectedBanks.slice(0, CONFIRM_LIST_LIMIT).map((bank) => (
+                        <li key={bank.bank_id} className="truncate text-foreground">
+                          {bank.bank_id}
+                        </li>
+                      ))}
+                      {selectedBanks.length > CONFIRM_LIST_LIMIT && (
+                        <li>
+                          {t("bulkDeleteMore", {
+                            count: selectedBanks.length - CONFIRM_LIST_LIMIT,
+                          })}
+                        </li>
+                      )}
+                    </ul>
+                    <p className="font-medium text-red-600 dark:text-red-400">
+                      {t("bulkDeleteWarning")}
+                    </p>
+                    <p className="text-xs">{t("bulkDeleteSequentialNote")}</p>
+                    {isDeleting ? (
+                      <p className="flex items-center gap-2 tabular-nums">
+                        <Spinner size="sm" />
+                        {t("bulkDeleteProgress", { done: progress.done, total: progress.total })}
+                      </p>
+                    ) : (
+                      <div className="space-y-1.5">
+                        <label
+                          htmlFor="bulk-delete-confirm"
+                          className="block text-xs font-medium text-foreground"
+                        >
+                          {t("bulkDeleteConfirmLabel", { word: confirmWord })}
+                        </label>
+                        <Input
+                          id="bulk-delete-confirm"
+                          value={confirmText}
+                          onChange={(e) => setConfirmText(e.target.value)}
+                          autoComplete="off"
+                        />
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>
+              {progress?.finished ? tCommon("close") : tCommon("cancel")}
+            </AlertDialogCancel>
+            {!progress?.finished && (
+              <AlertDialogAction
+                onClick={(e) => {
+                  // The dialog closes on action by default; the loop needs it to stay
+                  // open to show progress, and to survive to the failure summary.
+                  e.preventDefault();
+                  runBulkDelete();
+                }}
+                disabled={!confirmed || isDeleting}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {isDeleting ? (
+                  <Spinner size="sm" className="mr-2" />
+                ) : (
+                  <Trash2 className="mr-2 h-4 w-4" />
+                )}
+                {t("deleteSelected")}
+              </AlertDialogAction>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/hindsight-control-plane/src/components/ui/pagination.tsx
+++ b/hindsight-control-plane/src/components/ui/pagination.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * First/prev/next/last pager with a "x-y of n" range, shared by the paginated
+ * tables (documents, entities, mental models, webhooks all render this shape
+ * inline). Renders nothing for a single page, matching those views.
+ */
+interface PaginationProps {
+  /** 1-based. */
+  page: number;
+  pageSize: number;
+  total: number;
+  /** Disables every control while a page is in flight. */
+  disabled?: boolean;
+  onPageChange: (page: number) => void;
+}
+
+export function Pagination({ page, pageSize, total, disabled, onPageChange }: PaginationProps) {
+  const pageCount = Math.ceil(total / pageSize);
+  if (pageCount <= 1) return null;
+
+  const offset = (page - 1) * pageSize;
+
+  return (
+    <div className="flex items-center justify-between mt-3 pt-3 border-t">
+      <div className="text-xs text-muted-foreground">
+        {offset + 1}-{Math.min(offset + pageSize, total)} of {total}
+      </div>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(1)}
+          disabled={page === 1 || disabled}
+          className="h-7 w-7 p-0"
+        >
+          <ChevronsLeft className="h-3 w-3" />
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(page - 1)}
+          disabled={page === 1 || disabled}
+          className="h-7 w-7 p-0"
+        >
+          <ChevronLeft className="h-3 w-3" />
+        </Button>
+        <span className="text-xs px-2">
+          {page} / {pageCount}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(page + 1)}
+          disabled={page === pageCount || disabled}
+          className="h-7 w-7 p-0"
+        >
+          <ChevronRight className="h-3 w-3" />
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(pageCount)}
+          disabled={page === pageCount || disabled}
+          className="h-7 w-7 p-0"
+        >
+          <ChevronsRight className="h-3 w-3" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -362,7 +362,13 @@ export interface BankTemplateImportResponse {
 }
 
 export class ControlPlaneClient {
-  private async fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
+  private async fetchApi<T>(
+    path: string,
+    options?: RequestInit,
+    // Bulk callers loop over many requests and report the failures themselves; one
+    // toast per failed item would bury the screen.
+    { suppressErrorToast = false }: { suppressErrorToast?: boolean } = {}
+  ): Promise<T> {
     try {
       const response = await fetch(withBasePath(path), {
         ...options,
@@ -412,24 +418,26 @@ export class ControlPlaneClient {
         const description = describeErrorDetails(errorDetails) || errorMessage;
         const status = response.status;
 
-        if (isClientError) {
-          // Client errors (4xx) - validation, bad request, etc. - show as warning
-          toast.warning("Client Error", {
-            description,
-            duration: 5000,
-          });
-        } else if (status >= 500) {
-          // Server errors (5xx) - show as error
-          toast.error("Server Error", {
-            description,
-            duration: 5000,
-          });
-        } else {
-          // Other HTTP errors - show as error
-          toast.error("API Error", {
-            description,
-            duration: 5000,
-          });
+        if (!suppressErrorToast) {
+          if (isClientError) {
+            // Client errors (4xx) - validation, bad request, etc. - show as warning
+            toast.warning("Client Error", {
+              description,
+              duration: 5000,
+            });
+          } else if (status >= 500) {
+            // Server errors (5xx) - show as error
+            toast.error("Server Error", {
+              description,
+              duration: 5000,
+            });
+          } else {
+            // Other HTTP errors - show as error
+            toast.error("API Error", {
+              description,
+              duration: 5000,
+            });
+          }
         }
 
         // Still throw error for callers that want to handle it
@@ -442,7 +450,7 @@ export class ControlPlaneClient {
       return response.json();
     } catch (error) {
       // If it's not a response error (network error, etc.), show toast
-      if (!(error as any).status) {
+      if (!(error as any).status && !suppressErrorToast) {
         toast.error("Network Error", {
           description: error instanceof Error ? error.message : "Failed to connect to server",
           duration: 5000,
@@ -1015,14 +1023,18 @@ export class ControlPlaneClient {
   /**
    * Delete an entire memory bank and all its data
    */
-  async deleteBank(bankId: string) {
+  async deleteBank(bankId: string, options?: { suppressErrorToast?: boolean }) {
     return this.fetchApi<{
       success: boolean;
       message: string;
       deleted_count: number;
-    }>(bankApi(bankId), {
-      method: "DELETE",
-    });
+    }>(
+      bankApi(bankId),
+      {
+        method: "DELETE",
+      },
+      { suppressErrorToast: options?.suppressErrorToast }
+    );
   }
 
   /**

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -49,6 +49,7 @@
     "lightMode": "Zum Hellmodus wechseln",
     "bank": {
       "select": "Speicherbank auswählen...",
+      "allBanks": "Alle Speicherbänke",
       "search": "Speicherbänke durchsuchen...",
       "empty": "Noch keine Speicherbänke vorhanden.",
       "noSearchResults": "Keine Banken entsprechen deiner Suche.",
@@ -1638,10 +1639,35 @@
     "blockMoveDown": "Move block down",
     "blockAdd": "Add"
   },
-  "dashboard": {
-    "welcome": "Willkommen bei Hindsight",
-    "selectBank": "Wählen Sie eine Speicherbank aus dem Dropdown oben, um loszulegen.",
-    "sidebarHint": "Die Seitenleiste erscheint, sobald Sie eine Speicherbank ausgewählt haben."
+  "banksOverview": {
+    "title": "Speicherbänke",
+    "subtitle": "Jede Speicherbank ist ein eigenes Gehirn — ein isolierter Speicher für alles, woran sich ein Benutzer, Agent oder Projekt erinnert. Zwischen Bänken wird nichts geteilt.",
+    "welcomeTitle": "Willkommen bei Hindsight",
+    "welcomeBody": "Eine Speicherbank ist ein eigenes Gehirn — ein isolierter Speicher für alles, woran sich ein Benutzer, Agent oder Projekt erinnert. Erstellen Sie Ihre erste, um loszulegen.",
+    "search": "Bänke suchen...",
+    "noSearchResults": "Keine Bänke entsprechen Ihrer Suche.",
+    "columnBank": "Bank",
+    "columnMemories": "Erinnerungen",
+    "columnLastActivity": "Letzte Aktivität",
+    "columnCreated": "Erstellt",
+    "never": "Nie",
+    "emptyBank": "leer",
+    "selectAll": "Alle geladenen Bänke auswählen",
+    "selectBank": "{bank} auswählen",
+    "selectedCount": "{count} ausgewählt",
+    "clearSelection": "Aufheben",
+    "deleteSelected": "Ausgewählte löschen",
+    "bulkDeleteTitle": "{count} Speicherbänke löschen?",
+    "bulkDeletePrompt": "Diese Bänke und ihr gesamter Inhalt werden dauerhaft gelöscht:",
+    "bulkDeleteMore": "und {count} weitere",
+    "bulkDeleteWarning": "Diese Aktion kann nicht rückgängig gemacht werden. Alle Erinnerungen, Entitäten, Dokumente und Bank-Profile werden dauerhaft gelöscht.",
+    "bulkDeleteSequentialNote": "Die Bänke werden nacheinander gelöscht, das kann dauern. Lassen Sie diesen Dialog bis zum Ende geöffnet.",
+    "bulkDeleteConfirmLabel": "Geben Sie zur Bestätigung {word} ein",
+    "bulkDeleteConfirmWord": "delete",
+    "bulkDeleteProgress": "Lösche {done} von {total}...",
+    "bulkDeleteDone": "{count} Bänke gelöscht",
+    "bulkDeletePartial": "{deleted} gelöscht, {failed} fehlgeschlagen",
+    "bulkDeleteFailures": "Diese Bänke konnten nicht gelöscht werden:"
   },
   "login": {
     "title": "Hindsight Control Plane",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -49,6 +49,7 @@
     "lightMode": "Switch to light mode",
     "bank": {
       "select": "Select a memory bank...",
+      "allBanks": "All memory banks",
       "search": "Search memory banks...",
       "empty": "No memory banks yet.",
       "noSearchResults": "No banks match your search.",
@@ -1638,10 +1639,35 @@
     "blockMoveDown": "Move block down",
     "blockAdd": "Add"
   },
-  "dashboard": {
-    "welcome": "Welcome to Hindsight",
-    "selectBank": "Select a memory bank from the dropdown above to get started.",
-    "sidebarHint": "The sidebar will appear once you select a memory bank."
+  "banksOverview": {
+    "title": "Memory banks",
+    "subtitle": "Each memory bank is a separate brain — an isolated store of everything one user, agent or project remembers. Nothing is shared between banks.",
+    "welcomeTitle": "Welcome to Hindsight",
+    "welcomeBody": "A memory bank is a separate brain — an isolated store of everything one user, agent or project remembers. Create your first one to get started.",
+    "search": "Search banks...",
+    "noSearchResults": "No banks match your search.",
+    "columnBank": "Bank",
+    "columnMemories": "Memories",
+    "columnLastActivity": "Last activity",
+    "columnCreated": "Created",
+    "never": "Never",
+    "emptyBank": "empty",
+    "selectAll": "Select all loaded banks",
+    "selectBank": "Select {bank}",
+    "selectedCount": "{count} selected",
+    "clearSelection": "Clear",
+    "deleteSelected": "Delete selected",
+    "bulkDeleteTitle": "Delete {count} memory banks?",
+    "bulkDeletePrompt": "These banks and everything in them will be permanently deleted:",
+    "bulkDeleteMore": "and {count} more",
+    "bulkDeleteWarning": "This action cannot be undone. All memories, entities, documents, and bank profiles will be permanently deleted.",
+    "bulkDeleteSequentialNote": "Banks are deleted one at a time, so this can take a while. Keep this dialog open until it finishes.",
+    "bulkDeleteConfirmLabel": "Type {word} to confirm",
+    "bulkDeleteConfirmWord": "delete",
+    "bulkDeleteProgress": "Deleting {done} of {total}...",
+    "bulkDeleteDone": "{count} banks deleted",
+    "bulkDeletePartial": "{deleted} deleted, {failed} failed",
+    "bulkDeleteFailures": "These banks could not be deleted:"
   },
   "login": {
     "title": "Hindsight Control Plane",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -49,6 +49,7 @@
     "lightMode": "Cambiar a modo claro",
     "bank": {
       "select": "Selecciona un banco de memoria...",
+      "allBanks": "Todos los bancos de memoria",
       "search": "Buscar bancos de memoria...",
       "empty": "Aún no hay bancos de memoria.",
       "noSearchResults": "Ningún banco coincide con tu búsqueda.",
@@ -1638,10 +1639,35 @@
     "blockMoveDown": "Move block down",
     "blockAdd": "Add"
   },
-  "dashboard": {
-    "welcome": "Bienvenido a Hindsight",
-    "selectBank": "Selecciona un banco de memoria del menú superior para comenzar.",
-    "sidebarHint": "La barra lateral aparecerá una vez que selecciones un banco de memoria."
+  "banksOverview": {
+    "title": "Bancos de memoria",
+    "subtitle": "Cada banco de memoria es un cerebro aparte: un almacén aislado de todo lo que recuerda un usuario, agente o proyecto. Nada se comparte entre bancos.",
+    "welcomeTitle": "Bienvenido a Hindsight",
+    "welcomeBody": "Un banco de memoria es un cerebro aparte: un almacén aislado de todo lo que recuerda un usuario, agente o proyecto. Cree el primero para empezar.",
+    "search": "Buscar bancos...",
+    "noSearchResults": "Ningún banco coincide con su búsqueda.",
+    "columnBank": "Banco",
+    "columnMemories": "Memorias",
+    "columnLastActivity": "Última actividad",
+    "columnCreated": "Creado",
+    "never": "Nunca",
+    "emptyBank": "vacío",
+    "selectAll": "Seleccionar todos los bancos cargados",
+    "selectBank": "Seleccionar {bank}",
+    "selectedCount": "{count} seleccionados",
+    "clearSelection": "Limpiar",
+    "deleteSelected": "Eliminar seleccionados",
+    "bulkDeleteTitle": "¿Eliminar {count} bancos de memoria?",
+    "bulkDeletePrompt": "Estos bancos y todo su contenido se eliminarán permanentemente:",
+    "bulkDeleteMore": "y {count} más",
+    "bulkDeleteWarning": "Esta acción no se puede deshacer. Todas las memorias, entidades, documentos y perfiles de banco se eliminarán permanentemente.",
+    "bulkDeleteSequentialNote": "Los bancos se eliminan de uno en uno, así que puede tardar. Mantenga este diálogo abierto hasta que termine.",
+    "bulkDeleteConfirmLabel": "Escriba {word} para confirmar",
+    "bulkDeleteConfirmWord": "delete",
+    "bulkDeleteProgress": "Eliminando {done} de {total}...",
+    "bulkDeleteDone": "{count} bancos eliminados",
+    "bulkDeletePartial": "{deleted} eliminados, {failed} fallidos",
+    "bulkDeleteFailures": "No se pudieron eliminar estos bancos:"
   },
   "login": {
     "title": "Plano de Control de Hindsight",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -49,6 +49,7 @@
     "lightMode": "Passer en mode clair",
     "bank": {
       "select": "Sélectionner une banque de mémoire...",
+      "allBanks": "Toutes les banques mémoire",
       "search": "Rechercher des banques de mémoire...",
       "empty": "Aucune banque de mémoire pour l'instant.",
       "noSearchResults": "Aucune banque ne correspond à votre recherche.",
@@ -1638,10 +1639,35 @@
     "blockMoveDown": "Move block down",
     "blockAdd": "Add"
   },
-  "dashboard": {
-    "welcome": "Bienvenue sur Hindsight",
-    "selectBank": "Sélectionnez une banque de mémoire dans le menu ci-dessus pour commencer.",
-    "sidebarHint": "La barre latérale apparaîtra une fois que vous aurez sélectionné une banque de mémoire."
+  "banksOverview": {
+    "title": "Banques mémoire",
+    "subtitle": "Chaque banque mémoire est un cerveau distinct : un stockage isolé de tout ce dont se souvient un utilisateur, un agent ou un projet. Rien n'est partagé entre les banques.",
+    "welcomeTitle": "Bienvenue dans Hindsight",
+    "welcomeBody": "Une banque mémoire est un cerveau distinct : un stockage isolé de tout ce dont se souvient un utilisateur, un agent ou un projet. Créez la première pour commencer.",
+    "search": "Rechercher des banques...",
+    "noSearchResults": "Aucune banque ne correspond à votre recherche.",
+    "columnBank": "Banque",
+    "columnMemories": "Mémoires",
+    "columnLastActivity": "Dernière activité",
+    "columnCreated": "Créée",
+    "never": "Jamais",
+    "emptyBank": "vide",
+    "selectAll": "Sélectionner toutes les banques chargées",
+    "selectBank": "Sélectionner {bank}",
+    "selectedCount": "{count} sélectionnées",
+    "clearSelection": "Effacer",
+    "deleteSelected": "Supprimer la sélection",
+    "bulkDeleteTitle": "Supprimer {count} banques mémoire ?",
+    "bulkDeletePrompt": "Ces banques et tout ce qu'elles contiennent seront définitivement supprimés :",
+    "bulkDeleteMore": "et {count} de plus",
+    "bulkDeleteWarning": "Cette action est irréversible. Toutes les mémoires, entités, documents et profils de banque seront définitivement supprimés.",
+    "bulkDeleteSequentialNote": "Les banques sont supprimées une par une, cela peut prendre du temps. Gardez cette fenêtre ouverte jusqu'à la fin.",
+    "bulkDeleteConfirmLabel": "Saisissez {word} pour confirmer",
+    "bulkDeleteConfirmWord": "delete",
+    "bulkDeleteProgress": "Suppression de {done} sur {total}...",
+    "bulkDeleteDone": "{count} banques supprimées",
+    "bulkDeletePartial": "{deleted} supprimées, {failed} en échec",
+    "bulkDeleteFailures": "Ces banques n'ont pas pu être supprimées :"
   },
   "login": {
     "title": "Plan de contrôle Hindsight",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -49,6 +49,7 @@
     "lightMode": "ライトモードに切り替え",
     "bank": {
       "select": "メモリバンクを選択...",
+      "allBanks": "すべてのメモリバンク",
       "search": "メモリバンクを検索...",
       "empty": "メモリバンクがありません。",
       "noSearchResults": "検索に一致するバンクはありません。",
@@ -1638,10 +1639,35 @@
     "blockMoveDown": "Move block down",
     "blockAdd": "Add"
   },
-  "dashboard": {
-    "welcome": "Hindsightへようこそ",
-    "selectBank": "上のドロップダウンからメモリバンクを選択して始めましょう。",
-    "sidebarHint": "メモリバンクを選択するとサイドバーが表示されます。"
+  "banksOverview": {
+    "title": "メモリバンク",
+    "subtitle": "メモリバンクはそれぞれ独立した「脳」です。1 人のユーザー、1 つのエージェントまたはプロジェクトが記憶するすべてを隔離して保管します。バンク間で共有されるものはありません。",
+    "welcomeTitle": "Hindsight へようこそ",
+    "welcomeBody": "メモリバンクは独立した「脳」です。1 人のユーザー、1 つのエージェントまたはプロジェクトが記憶するすべてを隔離して保管します。まずは最初のバンクを作成しましょう。",
+    "search": "バンクを検索...",
+    "noSearchResults": "検索条件に一致するバンクはありません。",
+    "columnBank": "バンク",
+    "columnMemories": "メモリ",
+    "columnLastActivity": "最終アクティビティ",
+    "columnCreated": "作成日",
+    "never": "なし",
+    "emptyBank": "空",
+    "selectAll": "読み込み済みのバンクをすべて選択",
+    "selectBank": "{bank} を選択",
+    "selectedCount": "{count} 件選択中",
+    "clearSelection": "クリア",
+    "deleteSelected": "選択項目を削除",
+    "bulkDeleteTitle": "{count} 件のメモリバンクを削除しますか?",
+    "bulkDeletePrompt": "これらのバンクとその中身はすべて完全に削除されます:",
+    "bulkDeleteMore": "他 {count} 件",
+    "bulkDeleteWarning": "この操作は元に戻せません。すべてのメモリ、エンティティ、ドキュメント、およびバンクプロファイルが完全に削除されます。",
+    "bulkDeleteSequentialNote": "バンクは 1 件ずつ削除されるため時間がかかることがあります。完了するまでこのダイアログを開いたままにしてください。",
+    "bulkDeleteConfirmLabel": "確認のため {word} と入力してください",
+    "bulkDeleteConfirmWord": "delete",
+    "bulkDeleteProgress": "{total} 件中 {done} 件を削除中...",
+    "bulkDeleteDone": "{count} 件のバンクを削除しました",
+    "bulkDeletePartial": "{deleted} 件削除、{failed} 件失敗",
+    "bulkDeleteFailures": "これらのバンクは削除できませんでした:"
   },
   "login": {
     "title": "Hindsight コントロールプレーン",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -49,6 +49,7 @@
     "lightMode": "라이트 모드로 전환",
     "bank": {
       "select": "메모리 뱅크 선택...",
+      "allBanks": "모든 메모리 뱅크",
       "search": "메모리 뱅크 검색...",
       "empty": "아직 메모리 뱅크가 없습니다.",
       "noSearchResults": "검색과 일치하는 뱅크가 없습니다.",
@@ -1638,10 +1639,35 @@
     "blockMoveDown": "Move block down",
     "blockAdd": "Add"
   },
-  "dashboard": {
-    "welcome": "Hindsight에 오신 것을 환영합니다",
-    "selectBank": "위의 드롭다운에서 메모리 뱅크를 선택하여 시작하세요.",
-    "sidebarHint": "메모리 뱅크를 선택하면 사이드바가 나타납니다."
+  "banksOverview": {
+    "title": "메모리 뱅크",
+    "subtitle": "각 메모리 뱅크는 별개의 뇌입니다. 한 사용자, 에이전트 또는 프로젝트가 기억하는 모든 것을 격리해 저장하며, 뱅크 간에는 아무것도 공유되지 않습니다.",
+    "welcomeTitle": "Hindsight에 오신 것을 환영합니다",
+    "welcomeBody": "메모리 뱅크는 별개의 뇌입니다. 한 사용자, 에이전트 또는 프로젝트가 기억하는 모든 것을 격리해 저장합니다. 첫 번째 뱅크를 만들어 시작해 보세요.",
+    "search": "뱅크 검색...",
+    "noSearchResults": "검색과 일치하는 뱅크가 없습니다.",
+    "columnBank": "뱅크",
+    "columnMemories": "메모리",
+    "columnLastActivity": "마지막 활동",
+    "columnCreated": "생성일",
+    "never": "없음",
+    "emptyBank": "비어 있음",
+    "selectAll": "불러온 뱅크 모두 선택",
+    "selectBank": "{bank} 선택",
+    "selectedCount": "{count}개 선택됨",
+    "clearSelection": "지우기",
+    "deleteSelected": "선택 항목 삭제",
+    "bulkDeleteTitle": "메모리 뱅크 {count}개를 삭제할까요?",
+    "bulkDeletePrompt": "이 뱅크와 그 안의 모든 내용이 영구적으로 삭제됩니다:",
+    "bulkDeleteMore": "외 {count}개",
+    "bulkDeleteWarning": "이 작업은 되돌릴 수 없습니다. 모든 메모리, 엔티티, 문서 및 뱅크 프로필이 영구적으로 삭제됩니다.",
+    "bulkDeleteSequentialNote": "뱅크는 하나씩 삭제되므로 시간이 걸릴 수 있습니다. 완료될 때까지 이 대화 상자를 열어 두세요.",
+    "bulkDeleteConfirmLabel": "확인하려면 {word}를 입력하세요",
+    "bulkDeleteConfirmWord": "delete",
+    "bulkDeleteProgress": "{total}개 중 {done}개 삭제 중...",
+    "bulkDeleteDone": "뱅크 {count}개를 삭제했습니다",
+    "bulkDeletePartial": "{deleted}개 삭제, {failed}개 실패",
+    "bulkDeleteFailures": "다음 뱅크는 삭제하지 못했습니다:"
   },
   "login": {
     "title": "Hindsight 제어 플레인",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -49,6 +49,7 @@
     "lightMode": "Mudar para modo claro",
     "bank": {
       "select": "Selecione um banco de memória...",
+      "allBanks": "Todos os bancos de memória",
       "search": "Pesquisar bancos de memória...",
       "empty": "Nenhum banco de memória ainda.",
       "noSearchResults": "Nenhum banco corresponde à sua pesquisa.",
@@ -1638,10 +1639,35 @@
     "blockMoveDown": "Move block down",
     "blockAdd": "Add"
   },
-  "dashboard": {
-    "welcome": "Bem-vindo ao Hindsight",
-    "selectBank": "Selecione um banco de memória no menu acima para começar.",
-    "sidebarHint": "A barra lateral aparecerá quando você selecionar um banco de memória."
+  "banksOverview": {
+    "title": "Bancos de memória",
+    "subtitle": "Cada banco de memória é um cérebro separado — um armazenamento isolado de tudo o que um usuário, agente ou projeto lembra. Nada é compartilhado entre bancos.",
+    "welcomeTitle": "Bem-vindo ao Hindsight",
+    "welcomeBody": "Um banco de memória é um cérebro separado — um armazenamento isolado de tudo o que um usuário, agente ou projeto lembra. Crie o primeiro para começar.",
+    "search": "Pesquisar bancos...",
+    "noSearchResults": "Nenhum banco corresponde à sua pesquisa.",
+    "columnBank": "Banco",
+    "columnMemories": "Memórias",
+    "columnLastActivity": "Última atividade",
+    "columnCreated": "Criado",
+    "never": "Nunca",
+    "emptyBank": "vazio",
+    "selectAll": "Selecionar todos os bancos carregados",
+    "selectBank": "Selecionar {bank}",
+    "selectedCount": "{count} selecionados",
+    "clearSelection": "Limpar",
+    "deleteSelected": "Excluir selecionados",
+    "bulkDeleteTitle": "Excluir {count} bancos de memória?",
+    "bulkDeletePrompt": "Estes bancos e tudo o que há neles serão excluídos permanentemente:",
+    "bulkDeleteMore": "e mais {count}",
+    "bulkDeleteWarning": "Esta ação não pode ser desfeita. Todas as memórias, entidades, documentos e perfis de banco serão excluídos permanentemente.",
+    "bulkDeleteSequentialNote": "Os bancos são excluídos um de cada vez, o que pode demorar. Mantenha esta caixa de diálogo aberta até terminar.",
+    "bulkDeleteConfirmLabel": "Digite {word} para confirmar",
+    "bulkDeleteConfirmWord": "delete",
+    "bulkDeleteProgress": "Excluindo {done} de {total}...",
+    "bulkDeleteDone": "{count} bancos excluídos",
+    "bulkDeletePartial": "{deleted} excluídos, {failed} com falha",
+    "bulkDeleteFailures": "Não foi possível excluir estes bancos:"
   },
   "login": {
     "title": "Plano de Controle Hindsight",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -49,6 +49,7 @@
     "lightMode": "切換到淺色模式",
     "bank": {
       "select": "選擇記憶庫...",
+      "allBanks": "所有記憶庫",
       "search": "搜尋記憶庫...",
       "empty": "暫時沒有記憶庫。",
       "noSearchResults": "冇記憶庫符合你嘅搜尋。",
@@ -1638,10 +1639,35 @@
     "blockMoveDown": "Move block down",
     "blockAdd": "Add"
   },
-  "dashboard": {
-    "welcome": "歡迎使用 Hindsight",
-    "selectBank": "請先在上方下拉選單選擇一個記憶庫。",
-    "sidebarHint": "選擇記憶庫後，側邊欄會出現。"
+  "banksOverview": {
+    "title": "記憶庫",
+    "subtitle": "每個記憶庫都係一個獨立嘅大腦——隔離咁儲住某個用戶、代理或者專案記得嘅所有嘢。記憶庫之間唔會共享任何內容。",
+    "welcomeTitle": "歡迎使用 Hindsight",
+    "welcomeBody": "記憶庫係一個獨立嘅大腦——隔離咁儲住某個用戶、代理或者專案記得嘅所有嘢。建立第一個記憶庫開始用啦。",
+    "search": "搵記憶庫...",
+    "noSearchResults": "冇記憶庫符合你嘅搜尋。",
+    "columnBank": "記憶庫",
+    "columnMemories": "記憶",
+    "columnLastActivity": "最近活動",
+    "columnCreated": "建立時間",
+    "never": "從未",
+    "emptyBank": "空",
+    "selectAll": "揀晒所有已載入嘅記憶庫",
+    "selectBank": "揀 {bank}",
+    "selectedCount": "已揀 {count} 個",
+    "clearSelection": "清除",
+    "deleteSelected": "刪除已揀嘅",
+    "bulkDeleteTitle": "刪除 {count} 個記憶庫？",
+    "bulkDeletePrompt": "呢啲記憶庫同入面嘅所有嘢都會永久刪除：",
+    "bulkDeleteMore": "同另外 {count} 個",
+    "bulkDeleteWarning": "此操作無法還原。所有記憶、實體、文件同記憶庫設定都會永久刪除。",
+    "bulkDeleteSequentialNote": "記憶庫會逐個刪除，可能要啲時間。完成之前請唔好閂咗呢個對話框。",
+    "bulkDeleteConfirmLabel": "輸入 {word} 嚟確認",
+    "bulkDeleteConfirmWord": "delete",
+    "bulkDeleteProgress": "正在刪除 {total} 個之中嘅第 {done} 個...",
+    "bulkDeleteDone": "已刪除 {count} 個記憶庫",
+    "bulkDeletePartial": "已刪除 {deleted} 個，失敗 {failed} 個",
+    "bulkDeleteFailures": "以下記憶庫刪唔到："
   },
   "login": {
     "title": "Hindsight 控制面板",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -49,6 +49,7 @@
     "lightMode": "切换到浅色模式",
     "bank": {
       "select": "选择记忆库...",
+      "allBanks": "所有记忆库",
       "search": "搜索记忆库...",
       "empty": "还没有记忆库。",
       "noSearchResults": "没有与搜索匹配的记忆库。",
@@ -1638,10 +1639,35 @@
     "blockMoveDown": "Move block down",
     "blockAdd": "Add"
   },
-  "dashboard": {
-    "welcome": "欢迎使用 Hindsight",
-    "selectBank": "请从上方下拉菜单选择一个记忆库开始使用。",
-    "sidebarHint": "选择记忆库后，侧边栏会出现。"
+  "banksOverview": {
+    "title": "记忆库",
+    "subtitle": "每个记忆库都是一个独立的大脑——隔离存储某个用户、智能体或项目记住的一切。记忆库之间不共享任何内容。",
+    "welcomeTitle": "欢迎使用 Hindsight",
+    "welcomeBody": "记忆库是一个独立的大脑——隔离存储某个用户、智能体或项目记住的一切。创建第一个记忆库开始使用。",
+    "search": "搜索记忆库...",
+    "noSearchResults": "没有与搜索匹配的记忆库。",
+    "columnBank": "记忆库",
+    "columnMemories": "记忆",
+    "columnLastActivity": "最近活动",
+    "columnCreated": "创建时间",
+    "never": "从未",
+    "emptyBank": "空",
+    "selectAll": "选择所有已加载的记忆库",
+    "selectBank": "选择 {bank}",
+    "selectedCount": "已选择 {count} 个",
+    "clearSelection": "清除",
+    "deleteSelected": "删除所选",
+    "bulkDeleteTitle": "删除 {count} 个记忆库？",
+    "bulkDeletePrompt": "这些记忆库及其中的全部内容将被永久删除：",
+    "bulkDeleteMore": "以及另外 {count} 个",
+    "bulkDeleteWarning": "此操作无法撤销。所有记忆、实体、文档和记忆库配置都将永久删除。",
+    "bulkDeleteSequentialNote": "记忆库会逐个删除，可能需要一些时间。请在完成前保持此对话框打开。",
+    "bulkDeleteConfirmLabel": "输入 {word} 以确认",
+    "bulkDeleteConfirmWord": "delete",
+    "bulkDeleteProgress": "正在删除 {total} 个中的第 {done} 个...",
+    "bulkDeleteDone": "已删除 {count} 个记忆库",
+    "bulkDeletePartial": "已删除 {deleted} 个，失败 {failed} 个",
+    "bulkDeleteFailures": "以下记忆库无法删除："
   },
   "login": {
     "title": "Hindsight 控制面板",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -49,6 +49,7 @@
     "lightMode": "切換到淺色模式",
     "bank": {
       "select": "選擇記憶庫...",
+      "allBanks": "所有記憶庫",
       "search": "搜尋記憶庫...",
       "empty": "還沒有記憶庫。",
       "noSearchResults": "沒有符合搜尋的記憶庫。",
@@ -1638,10 +1639,35 @@
     "blockMoveDown": "Move block down",
     "blockAdd": "Add"
   },
-  "dashboard": {
-    "welcome": "歡迎使用 Hindsight",
-    "selectBank": "請從上方下拉選單選擇一個記憶庫開始使用。",
-    "sidebarHint": "選擇記憶庫後，側邊欄會出現。"
+  "banksOverview": {
+    "title": "記憶庫",
+    "subtitle": "每個記憶庫都是一個獨立的大腦——隔離儲存某個使用者、代理或專案記住的一切。記憶庫之間不會共享任何內容。",
+    "welcomeTitle": "歡迎使用 Hindsight",
+    "welcomeBody": "記憶庫是一個獨立的大腦——隔離儲存某個使用者、代理或專案記住的一切。建立第一個記憶庫開始使用。",
+    "search": "搜尋記憶庫...",
+    "noSearchResults": "沒有符合搜尋的記憶庫。",
+    "columnBank": "記憶庫",
+    "columnMemories": "記憶",
+    "columnLastActivity": "最近活動",
+    "columnCreated": "建立時間",
+    "never": "從未",
+    "emptyBank": "空",
+    "selectAll": "選取所有已載入的記憶庫",
+    "selectBank": "選取 {bank}",
+    "selectedCount": "已選取 {count} 個",
+    "clearSelection": "清除",
+    "deleteSelected": "刪除所選",
+    "bulkDeleteTitle": "刪除 {count} 個記憶庫？",
+    "bulkDeletePrompt": "這些記憶庫及其中的所有內容將被永久刪除：",
+    "bulkDeleteMore": "以及另外 {count} 個",
+    "bulkDeleteWarning": "此操作無法復原。所有記憶、實體、文件與記憶庫設定都會永久刪除。",
+    "bulkDeleteSequentialNote": "記憶庫會逐一刪除，可能需要一些時間。請在完成前保持此對話框開啟。",
+    "bulkDeleteConfirmLabel": "輸入 {word} 以確認",
+    "bulkDeleteConfirmWord": "delete",
+    "bulkDeleteProgress": "正在刪除 {total} 個中的第 {done} 個...",
+    "bulkDeleteDone": "已刪除 {count} 個記憶庫",
+    "bulkDeletePartial": "已刪除 {deleted} 個，失敗 {failed} 個",
+    "bulkDeleteFailures": "以下記憶庫無法刪除："
   },
   "login": {
     "title": "Hindsight 控制面板",

--- a/hindsight-control-plane/tests/components/banks-overview.test.tsx
+++ b/hindsight-control-plane/tests/components/banks-overview.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+/**
+ * The overview's bulk delete is the one destructive path in the control plane that
+ * touches many banks at once, so it has two properties worth pinning:
+ *
+ *   1. Deletes run STRICTLY SEQUENTIALLY. `delete_bank` drops the bank's partial
+ *      vector indexes with DROP INDEX CONCURRENTLY on the shared `memory_units`
+ *      relation; concurrent drops deadlock, so a fan-out would fail banks at random.
+ *   2. One failure does not abort the run, and the failed banks are reported and
+ *      left selected rather than silently dropped.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next-intl", () => ({
+  // Keys are echoed back; ICU arguments are appended so counts stay assertable.
+  useTranslations: () => (key: string, values?: Record<string, unknown>) =>
+    values ? `${key}:${Object.values(values).join(",")}` : key,
+}));
+
+const toastSuccess = vi.fn();
+const toastWarning = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (...a: unknown[]) => toastSuccess(...a), warning: (...a: unknown[]) => toastWarning(...a) },
+}));
+
+const deleteBank = vi.fn();
+const listBanks = vi.fn();
+vi.mock("@/lib/api", () => ({
+  client: {
+    deleteBank: (...args: unknown[]) => deleteBank(...args),
+    listBanks: (...args: unknown[]) => listBanks(...args),
+  },
+}));
+
+const setCurrentBank = vi.fn();
+const loadBanks = vi.fn().mockResolvedValue(undefined);
+
+function bank(id: string) {
+  return {
+    bank_id: id,
+    name: null,
+    mission: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: null,
+    fact_count: 10,
+    last_document_at: null,
+    last_write_at: "2026-01-02T00:00:00Z",
+  };
+}
+
+vi.mock("@/lib/bank-context", () => ({
+  useBank: () => ({ currentBank: null, setCurrentBank, loadBanks }),
+}));
+
+const { BanksOverview } = await import("@/components/banks-overview");
+
+/** Selects every row, opens the confirm dialog and types the confirmation word. */
+async function armBulkDelete() {
+  render(<BanksOverview />);
+  fireEvent.click(await screen.findByLabelText("selectAll"));
+  fireEvent.click(screen.getByText("deleteSelected"));
+  // The mocked `t` echoes keys, so the confirmation word is the key itself.
+  const input = await screen.findByLabelText(/bulkDeleteConfirmLabel/);
+  fireEvent.change(input, { target: { value: "bulkDeleteConfirmWord" } });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listBanks.mockResolvedValue({
+    banks: [bank("alpha"), bank("beta"), bank("gamma")],
+    total: 3,
+    limit: 50,
+    offset: 0,
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("BanksOverview bulk delete", () => {
+  it("deletes the selected banks one at a time, never concurrently", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const resolvers: Array<() => void> = [];
+    deleteBank.mockImplementation(() => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return new Promise<void>((resolve) => {
+        resolvers.push(() => {
+          inFlight -= 1;
+          resolve();
+        });
+      });
+    });
+
+    await armBulkDelete();
+    fireEvent.click(screen.getAllByText("deleteSelected")[1]);
+
+    // Drain the queue one request at a time; if the component fanned out, more than
+    // one call would already be pending before the first resolves.
+    for (let i = 0; i < 3; i++) {
+      await waitFor(() => expect(deleteBank).toHaveBeenCalledTimes(i + 1));
+      expect(maxInFlight).toBe(1);
+      resolvers[i]();
+    }
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(deleteBank.mock.calls.map((c) => c[0])).toEqual(["alpha", "beta", "gamma"]);
+    expect(loadBanks).toHaveBeenCalled();
+  });
+
+  it("keeps going after a failure and reports the banks that survived", async () => {
+    deleteBank.mockImplementation((bankId: string) =>
+      bankId === "beta" ? Promise.reject(new Error("bank is busy")) : Promise.resolve()
+    );
+
+    await armBulkDelete();
+    fireEvent.click(screen.getAllByText("deleteSelected")[1]);
+
+    await waitFor(() => expect(toastWarning).toHaveBeenCalledWith("bulkDeletePartial:2,1"));
+    // All three were attempted — the rejection did not abort the loop.
+    expect(deleteBank).toHaveBeenCalledTimes(3);
+    expect(await screen.findByText("bulkDeleteFailures")).toBeTruthy();
+    expect(screen.getByText(/bank is busy/)).toBeTruthy();
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the client's per-request error toast so failures are reported once", async () => {
+    deleteBank.mockResolvedValue(undefined);
+
+    await armBulkDelete();
+    fireEvent.click(screen.getAllByText("deleteSelected")[1]);
+
+    await waitFor(() => expect(deleteBank).toHaveBeenCalled());
+    expect(deleteBank).toHaveBeenCalledWith("alpha", { suppressErrorToast: true });
+  });
+
+  it("fetches the next page by offset and drops the selection when the page changes", async () => {
+    // 120 banks over a page size of 50 => three pages, so the pager renders.
+    listBanks.mockImplementation(({ offset }: { offset: number }) =>
+      Promise.resolve({
+        banks: [bank(`row-${offset}-a`), bank(`row-${offset}-b`)],
+        total: 120,
+        limit: 50,
+        offset,
+      })
+    );
+
+    render(<BanksOverview />);
+    fireEvent.click(await screen.findByLabelText("selectAll"));
+    expect(screen.getByText("selectedCount:2")).toBeTruthy();
+
+    const nextButton = document
+      .querySelector(".lucide-chevron-right")
+      ?.closest("button") as HTMLButtonElement;
+    fireEvent.click(nextButton);
+
+    await waitFor(() => expect(listBanks).toHaveBeenCalledWith({ q: undefined, limit: 50, offset: 50 }));
+    // A selection made on page 1 must not survive onto page 2 — those rows are no
+    // longer on screen and would be deleted unseen.
+    await waitFor(() => expect(screen.queryByText(/^selectedCount/)).toBeNull());
+  });
+
+  it("greets instead of showing an empty table when the server has no banks", async () => {
+    listBanks.mockResolvedValue({ banks: [], total: 0, limit: 50, offset: 0 });
+
+    render(<BanksOverview />);
+
+    expect(await screen.findByText("welcomeTitle")).toBeTruthy();
+    // The search box and table are meaningless with nothing to search or list.
+    expect(screen.queryByPlaceholderText("search")).toBeNull();
+    expect(document.querySelector("table")).toBeNull();
+  });
+
+  it("keeps the search box when a query matches nothing, rather than greeting", async () => {
+    render(<BanksOverview />);
+    await screen.findByLabelText("selectAll");
+
+    // An empty result for a query is not an empty server — the box must stay so the
+    // query can be edited.
+    listBanks.mockResolvedValue({ banks: [], total: 0, limit: 50, offset: 0 });
+    fireEvent.change(screen.getByPlaceholderText("search"), { target: { value: "nope" } });
+
+    expect(await screen.findByText("noSearchResults")).toBeTruthy();
+    expect(screen.queryByText("welcomeTitle")).toBeNull();
+    expect(screen.getByPlaceholderText("search")).toBeTruthy();
+  });
+
+  it("requires the confirmation word before the delete can run", async () => {
+    render(<BanksOverview />);
+    fireEvent.click(await screen.findByLabelText("selectAll"));
+    fireEvent.click(screen.getByText("deleteSelected"));
+
+    const action = screen.getAllByText("deleteSelected")[1].closest("button");
+    expect(action?.disabled).toBe(true);
+
+    fireEvent.change(await screen.findByLabelText(/bulkDeleteConfirmLabel/), {
+      target: { value: "bulkDeleteConfirmWord" },
+    });
+    expect(action?.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
Partially addresses #3640.

## What

The control plane's dashboard showed a "Welcome to Hindsight" placeholder. It now lists every memory bank — name, memory count, last activity, created — so a server running several banks can be surveyed without switching into each one, which is the pain the issue reports.

Rows can be selected and deleted in bulk. Until now deleting a bank meant visiting that bank's own danger zone, so cleaning up ten throwaway banks meant ten round trips.

## Notes for review

- **The deletes are deliberately sequential.** `delete_bank` drops the bank's partial vector indexes with `DROP INDEX CONCURRENTLY` on the shared `memory_units` relation; concurrent drops wait on each other's virtual xids and deadlock (the same mechanism behind the CI teardown flake). A fan-out here would fail banks at random. A test asserts at most one request is ever in flight.
- **A failure does not abort the run.** The remaining banks are still attempted, and the ones that failed are listed with their error and stay selected so the action can be retried. `deleteBank` gained a `suppressErrorToast` option so a bulk run reports once instead of once per failure.
- **Destructive-action guard:** the dialog names the banks and requires typing `delete`.
- **No API change.** The page fetches its own page of banks from the existing `GET /banks` — the header selector scrolls infinitely and the overview pages discretely, so they cannot share one list.
- The first/prev/next/last pager that documents, entities, mental models and webhooks each inline is extracted to `components/ui/pagination.tsx` and used here. Those five views are unchanged; migrating them is a natural follow-up.
- The header logo now links to this page, and a server with no banks at all keeps the old welcome card (mascot and all), with a create button added.

## What this does NOT do

The issue asks for **pending / processing / failed operation counts per bank**. Those are not on `BankListItem` and would need an aggregate query plus a new response field, so they are out of scope here and #3640 should stay open. A fact count does not tell you whether ingestion is stuck, which is the reporter's actual question.

## Testing

Seven new tests in `tests/components/banks-overview.test.tsx` (sequential deletes, partial failure, toast suppression, confirm-word gate, paging by offset, selection cleared on page change, empty-server greeting). 172 control-plane tests pass; lint, knip and `tsc --noEmit` clean.

Verified by hand against a local API: paged through 63 banks, bulk-deleted 3 (toast, list refresh), the logo link, the create dialog, and the zero-bank welcome state.
