### PR TITLE
chore(deps): bump banks to 2.5.0 in the llamaindex integration lock

### DIFF
--- a/hindsight-integrations/llamaindex/uv.lock
+++ b/hindsight-integrations/llamaindex/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "banks"
-version = "2.4.2"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
@@ -248,9 +248,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/51/08fb68d23f4b0f6256fe85dc86e9576941550f890b079352fba719e07b39/banks-2.4.2.tar.gz", hash = "sha256:cda6013bd377ea7b701933578bfb9370fc21ad70bc13cedfc3f5cb2c034ca3dc", size = 188633, upload-time = "2026-04-27T12:15:22.021Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/f0/ce5b3105a8551fdcedb509ab5340066247b3cd1b28e79f9296be2d6d3bf4/banks-2.5.0.tar.gz", hash = "sha256:fdd4fd54b84dbe31cb51a1173c960697c73d683a52fb0b1d1957a557a8d6fcc8", size = 194585, upload-time = "2026-08-08T15:54:16.548Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/b6/8dc5477681b782e2f99de703e7a99828883364b9e03a60d3e2c47053d56a/banks-2.4.2-py3-none-any.whl", hash = "sha256:5fe407cc48c101f3e13d1cf732b83b8246003337612f13c0705d2e81f6faffb7", size = 35050, upload-time = "2026-04-27T12:15:20.785Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9c/7dc7b15cecc03baa47d413b2599487b1fab270169b00feaa5e74978845f3/banks-2.5.0-py3-none-any.whl", hash = "sha256:8804c58f23e41a5aabe9ecfdf64235cdf1d5f3b16ad95ec2a54b6dc738dc1dfc", size = 38620, upload-time = "2026-08-08T15:54:15.505Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Routine dependency maintenance. Lockfile-only, one lockfile, one package.

Closes #1437.

## What changed

`hindsight-integrations/llamaindex/uv.lock` — `banks` 2.4.2 → 2.5.0. Three lines: the version, the sdist entry and the wheel entry. Nothing else in the repo is touched.

`banks` is not a direct dependency; it arrives transitively through `llama-index-core`. There is no pin on it at the currently locked `llama-index-core`, so a scoped upgrade moves it freely:

```
uv lock --upgrade-package banks
```

No `--force`, no `--legacy-peer-deps`, no `[tool.uv] override-dependencies`, no peer relaxation. Since no override was needed, there is no parent import surface to audit.

## Why 2.5.0 rather than the minimum

The advisory (GHSA-x8wg-4xgc-vr54 / CVE-2026-71492) is a path traversal in `DirectoryPromptRegistry.set()`, where a crafted prompt name could escape the registry root and write outside it. It affects `< 2.4.5`, so 2.4.5 is the floor. The scoped upgrade resolves naturally to 2.5.0, the current release, and the suite is green there — so this takes the resolver's own answer rather than pinning to the floor and being re-flagged on the next minor.

## Verification

Run in `hindsight-integrations/llamaindex` on this branch:

| Check | Result |
|---|---|
| `uv build` | built `hindsight_llamaindex-0.1.5` sdist + wheel |
| `uv sync --frozen` | clean — 72 packages, no staleness error |
| `uv run pytest tests` | **92 passed**, 4 warnings, 42.96s |

`git diff --name-only origin/main` lists exactly one path: `hindsight-integrations/llamaindex/uv.lock`.

In CI this maps to `test-llamaindex-integration`, which is gated on the `hindsight-integrations/llamaindex/**` path filter and so actually runs for this change rather than being skipped.

## Note on the open grouped bump

Dependabot's #4101 covers the same advisory, but as part of a wider grouped change: it also carries the root `uv.lock` (+50/-50) and a `json-repair` floor bump in `hindsight-api-slim/pyproject.toml`. This PR is deliberately the narrow half — one lockfile, one package, verified in isolation. #4101 should close itself once this lands; its remaining root-lock content is unaffected by this change and can be handled on its own terms.
