### PR TITLE
fix(consolidation): warn when consolidation_llm_parallelism is configured but not exercised

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1866,6 +1866,15 @@ async def _run_consolidation_job(
             batch_results: list[_BatchDeltas] = [d for gd in group_results for d in gd]
             any_cancelled = any(d.cancelled for d in batch_results)
         else:
+            if llm_parallelism > 1 and len(numbered_groups) <= 1:
+                logger.warning(
+                    "[CONSOLIDATION] bank=%s consolidation_llm_parallelism=%d but only %d "
+                    "tag group(s) in this fetch — memories share a tag set so batches run "
+                    "serially (one LLM call at a time); parallelism is not exercised",
+                    bank_id,
+                    llm_parallelism,
+                    len(numbered_groups),
+                )
             batch_results = []
             any_cancelled = False
             for g in numbered_groups:


### PR DESCRIPTION
## Problem

`consolidation_llm_parallelism > 1` promises parallel consolidation, but when every unconsolidated memory in a fetch shares the same tag set (the common case for uniform retain), they collapse into a **single tag group** and the parallel dispatch path is never taken. The configured parallelism silently does nothing — the operator sees slow serial consolidation and no signal that their setting is inert.

Tracked in #4063.

## Fix

Log a warning in the serial-fallback branch when `llm_parallelism > 1` but `len(numbered_groups) <= 1`:

```
[CONSOLIDATION] bank=hermes consolidation_llm_parallelism=4 but only 1 tag group(s) in this fetch — memories share a tag set so batches run serially (one LLM call at a time); parallelism is not exercised
```

This gives the operator visibility that the parallelism setting is not being exercised, without changing the consolidation behavior or its scope-safety guarantees.

## Scope (explicit)

This PR does **not** parallelize within a single tag group — that is a scope-safety design decision discussed in #4063 and belongs with the maintainers. This PR only closes the "config silently lies" gap by surfacing the inert setting.

## Testing

- `ruff check` on the touched file: passes.
- `ruff format --check`: passes.
- No behavioral change to the serial/parallel dispatch path (warning-only).
