### PR TITLE
fix(operations): let cancel abort a processing operation, not just a pending one

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -6790,8 +6790,13 @@ def _register_routes(app: FastAPI):
     @app.delete(
         "/v1/default/banks/{bank_id}/operations/{operation_id}",
         response_model=CancelOperationResponse,
-        summary="Cancel a pending async operation",
-        description="Cancel a pending async operation by removing it from the queue",
+        summary="Cancel a pending or processing async operation",
+        description=(
+            "Cancel a pending or processing async operation. A pending operation is removed from "
+            "the queue; a processing one has its worker claim released and stops at its next "
+            "checkpoint, which is also how a row orphaned by a worker crash is cleared. Returns "
+            "409 for operations that already reached a terminal status."
+        ),
         operation_id="cancel_operation",
         tags=["Operations"],
     )
@@ -6799,7 +6804,7 @@ def _register_routes(app: FastAPI):
     async def api_cancel_operation(
         bank_id: str, operation_id: str, request_context: RequestContext = Depends(get_request_context)
     ):
-        """Cancel a pending async operation."""
+        """Cancel a pending or processing async operation."""
         try:
             # Validate UUID format
             try:

--- a/hindsight-api-slim/hindsight_api/engine/interface.py
+++ b/hindsight-api-slim/hindsight_api/engine/interface.py
@@ -614,7 +614,10 @@ class MemoryEngineInterface(ABC):
         request_context: "RequestContext",
     ) -> dict[str, Any]:
         """
-        Cancel a pending async operation.
+        Cancel a pending or processing async operation.
+
+        A processing operation is cancellable so that a row orphaned by a worker crash can be
+        released through the API; the claim is dropped and the task stops at its next checkpoint.
 
         Args:
             bank_id: The memory bank ID.

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -18633,29 +18633,53 @@ class MemoryEngine(MemoryEngineInterface):
         op_uuid = uuid.UUID(operation_id)
 
         async with acquire_with_retry(backend) as conn:
-            # Check if operation exists, belongs to this bank, and is in a cancellable state
-            result = await conn.fetchrow(
-                f"SELECT bank_id, status FROM {fq_table('async_operations')} WHERE operation_id = $1 AND bank_id = $2",
+            # One conditional write, like retry_operation: a SELECT-then-UPDATE pair would let a
+            # worker claim a 'pending' row between the two statements and get cancelled out from
+            # under its own claim without releasing it.
+            #
+            # 'processing' is cancellable, not just 'pending' (#4131). A worker crash or restart
+            # leaves rows orphaned in 'processing' — their worker_id never comes back, so the
+            # worker's own recovery pass (which filters on `worker_id = self._worker_id`) cannot
+            # reclaim them, and refusing to cancel left `UPDATE async_operations SET status=...`
+            # by hand as the only way out. Clearing worker_id/claimed_at is what makes the
+            # cancellation stick for a LIVE worker too: its shutdown/startup release path only
+            # touches rows it still owns, so it can no longer resurrect this one as 'pending'.
+            # The task itself stops at its next checkpoint (_check_op_alive) and _mark_completed
+            # is guarded on 'processing', so neither can undo the cancel.
+            cancelled = await conn.fetchrow(
+                f"""
+                UPDATE {fq_table("async_operations")}
+                SET status = 'cancelled',
+                    worker_id = NULL,
+                    claimed_at = NULL,
+                    completed_at = COALESCE(completed_at, now()),
+                    updated_at = now()
+                WHERE operation_id = $1
+                  AND bank_id = $2
+                  AND status IN ('pending', 'processing')
+                RETURNING operation_id
+                """,
                 op_uuid,
                 bank_id,
             )
 
-            if not result:
-                raise ValueError(f"Operation {operation_id} not found for bank {bank_id}")
+            if cancelled is None:
+                row = await conn.fetchrow(
+                    f"SELECT status FROM {fq_table('async_operations')} WHERE operation_id = $1 AND bank_id = $2",
+                    op_uuid,
+                    bank_id,
+                )
 
-            if result["status"] != "pending":
+                if not row:
+                    raise ValueError(f"Operation {operation_id} not found for bank {bank_id}")
+
                 from hindsight_api.extensions import OperationValidationError
 
                 raise OperationValidationError(
-                    f"Operation {operation_id} cannot be cancelled: status is '{result['status']}', only 'pending' operations can be cancelled",
+                    f"Operation {operation_id} cannot be cancelled: status is '{row['status']}', "
+                    f"only 'pending' or 'processing' operations can be cancelled",
                     409,
                 )
-
-            # Mark the operation as cancelled
-            await conn.execute(
-                f"UPDATE {fq_table('async_operations')} SET status = 'cancelled', updated_at = now() WHERE operation_id = $1",
-                op_uuid,
-            )
 
             return {
                 "success": True,

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -870,11 +870,17 @@ class WorkerPoller:
 
         async with self._backend.acquire() as conn:
             async with conn.transaction():
+                # A cancelled row stays cancelled: cancelling a processing operation is now a
+                # supported API call (#4131), and the task it aborts usually surfaces as an error
+                # here. Relabelling it 'failed' would erase what the operator asked for and make
+                # the row look retryable, so leave the terminal state they chose alone. The parent
+                # roll-up below still runs — it reads the child's committed status either way.
                 await conn.execute(
                     f"""
                     UPDATE {table}
                     SET status = 'failed', error_message = $2, completed_at = now(), updated_at = now()
                     WHERE operation_id = $1
+                      AND status <> 'cancelled'
                     """,
                     operation_id,
                     error_message,

--- a/hindsight-api-slim/tests/test_operation_status.py
+++ b/hindsight-api-slim/tests/test_operation_status.py
@@ -5,6 +5,8 @@ are correctly exposed through list and get API endpoints.
 Regression tests:
 - Previously the API collapsed 'processing' into 'pending', hiding the real status.
 - Cancel used to delete the operation row; now it sets status to 'cancelled'.
+- Cancel used to refuse anything but 'pending', so a row orphaned in 'processing' by a worker
+  crash could only be cleared with hand-written SQL (#4131).
 - Retry now accepts both 'failed' and 'cancelled' operations.
 """
 
@@ -189,6 +191,61 @@ async def test_cancel_sets_cancelled_status(api_client, memory, test_bank_id):
 
 
 @pytest.mark.asyncio
+async def test_cancel_processing_operation_releases_the_orphaned_claim(api_client, memory, test_bank_id):
+    """A row orphaned in 'processing' by a worker crash must be cancellable through the API.
+
+    Regression for #4131: cancel accepted only 'pending', so the only way out of an orphaned
+    'processing' row was `UPDATE async_operations` by hand. The claim has to be dropped with it —
+    a worker's release path only touches rows whose worker_id still matches, so leaving the dead
+    worker's id on the row is what let it sit there.
+    """
+    pool = memory._pool
+    await _ensure_bank(pool, test_bank_id)
+
+    op_id = await _insert_operation(pool, test_bank_id, "processing")
+    await pool.execute(
+        "UPDATE async_operations SET worker_id = 'worker-that-died', claimed_at = now() WHERE operation_id = $1",
+        uuid.UUID(op_id),
+    )
+
+    response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
+    assert response.status_code == 200
+    assert response.json()["status"] == "cancelled"
+
+    row = await pool.fetchrow(
+        "SELECT worker_id, claimed_at, completed_at FROM async_operations WHERE operation_id = $1",
+        uuid.UUID(op_id),
+    )
+    assert row["worker_id"] is None
+    assert row["claimed_at"] is None
+    assert row["completed_at"] is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", ["completed", "failed", "cancelled"])
+async def test_cancel_rejects_terminal_operations(api_client, memory, test_bank_id, terminal_status):
+    """Only non-terminal work is cancellable — a finished operation still answers 409."""
+    pool = memory._pool
+    await _ensure_bank(pool, test_bank_id)
+
+    op_id = await _insert_operation(pool, test_bank_id, terminal_status)
+
+    response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
+    assert response.status_code == 409
+    assert terminal_status in response.json()["detail"]
+
+    row = await pool.fetchrow(
+        "SELECT status FROM async_operations WHERE operation_id = $1",
+        uuid.UUID(op_id),
+    )
+    assert row["status"] == terminal_status
+
+
+@pytest.mark.asyncio
 async def test_retry_cancelled_operation(api_client, memory, test_bank_id):
     """POST /operations/{id}/retry should accept cancelled operations."""
     pool = memory._pool
@@ -310,18 +367,6 @@ async def test_retry_rejects_batch_retain_parent(api_client, memory, test_bank_i
     # But it remains deletable as the sanctioned cleanup path.
     response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}/delete")
     assert response.status_code == 200
-
-
-@pytest.mark.asyncio
-async def test_cancel_rejects_non_pending_operations(api_client, memory, test_bank_id):
-    """DELETE /operations/{id} should only cancel pending operations."""
-    pool = memory._pool
-    await _ensure_bank(pool, test_bank_id)
-
-    for status in ("processing", "completed", "failed"):
-        op_id = await _insert_operation(pool, test_bank_id, status)
-        response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
-        assert response.status_code == 409, f"Expected 409 for {status}, got {response.status_code}"
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -320,6 +320,24 @@ class TestWorkerMarkCompleted:
         assert conn.execute_calls
         poller._maybe_update_parent_operation.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_mark_failed_leaves_a_cancelled_row_cancelled(self):
+        """Cancelling a processing operation (#4131) usually makes its task raise in here.
+
+        Relabelling the row 'failed' would erase the operator's cancellation and make it look
+        retryable, so the write has to skip rows that are already cancelled.
+        """
+        poller, conn = self._make_poller("UPDATE 0")
+
+        await poller._mark_failed("op-1", "aborted mid-flight", schema=None)
+
+        query, args = conn.execute_calls[0]
+        assert "status = 'failed'" in query
+        assert "status <> 'cancelled'" in query
+        assert args == ("op-1", "aborted mid-flight")
+        # The parent roll-up still runs: it reads whatever status the child actually committed.
+        poller._maybe_update_parent_operation.assert_awaited_once_with("op-1", None, conn)
+
 
 def test_all_operation_types_have_slot_reservation_config():
     """Every operation_type used in memory_engine must be listed in

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -808,7 +808,7 @@ enum OperationCommands {
         operation_id: String,
     },
 
-    /// Cancel a pending async operation
+    /// Cancel a pending or processing async operation
     Cancel {
         /// Bank ID
         bank_id: String,

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -2771,7 +2771,11 @@ paths:
       - Operations
   /v1/default/banks/{bank_id}/operations/{operation_id}:
     delete:
-      description: Cancel a pending async operation by removing it from the queue
+      description: "Cancel a pending or processing async operation. A pending operation\
+        \ is removed from the queue; a processing one has its worker claim released\
+        \ and stops at its next checkpoint, which is also how a row orphaned by a\
+        \ worker crash is cleared. Returns 409 for operations that already reached\
+        \ a terminal status."
       operationId: cancel_operation
       parameters:
       - explode: false
@@ -2811,7 +2815,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: Cancel a pending async operation
+      summary: Cancel a pending or processing async operation
       tags:
       - Operations
     get:

--- a/hindsight-clients/go/api_operations.go
+++ b/hindsight-clients/go/api_operations.go
@@ -41,9 +41,9 @@ func (r ApiCancelOperationRequest) Execute() (*CancelOperationResponse, *http.Re
 }
 
 /*
-CancelOperation Cancel a pending async operation
+CancelOperation Cancel a pending or processing async operation
 
-Cancel a pending async operation by removing it from the queue
+Cancel a pending or processing async operation. A pending operation is removed from the queue; a processing one has its worker claim released and stops at its next checkpoint, which is also how a row orphaned by a worker crash is cleared. Returns 409 for operations that already reached a terminal status.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId

--- a/hindsight-clients/python/hindsight_client_api/api/operations_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/operations_api.py
@@ -62,9 +62,9 @@ class OperationsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> CancelOperationResponse:
-        """Cancel a pending async operation
+        """Cancel a pending or processing async operation
 
-        Cancel a pending async operation by removing it from the queue
+        Cancel a pending or processing async operation. A pending operation is removed from the queue; a processing one has its worker claim released and stops at its next checkpoint, which is also how a row orphaned by a worker crash is cleared. Returns 409 for operations that already reached a terminal status.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -138,9 +138,9 @@ class OperationsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[CancelOperationResponse]:
-        """Cancel a pending async operation
+        """Cancel a pending or processing async operation
 
-        Cancel a pending async operation by removing it from the queue
+        Cancel a pending or processing async operation. A pending operation is removed from the queue; a processing one has its worker claim released and stops at its next checkpoint, which is also how a row orphaned by a worker crash is cleared. Returns 409 for operations that already reached a terminal status.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -214,9 +214,9 @@ class OperationsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Cancel a pending async operation
+        """Cancel a pending or processing async operation
 
-        Cancel a pending async operation by removing it from the queue
+        Cancel a pending or processing async operation. A pending operation is removed from the queue; a processing one has its worker claim released and stops at its next checkpoint, which is also how a row orphaned by a worker crash is cleared. Returns 409 for operations that already reached a terminal status.
 
         :param bank_id: (required)
         :type bank_id: str

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -1085,9 +1085,9 @@ export const listOperations = <ThrowOnError extends boolean = false>(
   });
 
 /**
- * Cancel a pending async operation
+ * Cancel a pending or processing async operation
  *
- * Cancel a pending async operation by removing it from the queue
+ * Cancel a pending or processing async operation. A pending operation is removed from the queue; a processing one has its worker claim released and stops at its next checkpoint, which is also how a row orphaned by a worker crash is cleared. Returns 409 for operations that already reached a terminal status.
  */
 export const cancelOperation = <ThrowOnError extends boolean = false>(
   options: Options<CancelOperationData, ThrowOnError>

--- a/hindsight-control-plane/src/components/bank-operations-view.tsx
+++ b/hindsight-control-plane/src/components/bank-operations-view.tsx
@@ -657,7 +657,9 @@ export function BankOperationsView() {
                         </div>
                       </TableCell>
                       <TableCell className="w-[150px] whitespace-nowrap">
-                        {op.status === "pending" && (
+                        {/* 'processing' is cancellable too — a row orphaned by a worker crash
+                            sits here forever, and this table is where an operator sees it. */}
+                        {(op.status === "pending" || op.status === "processing") && (
                           <Button
                             variant="ghost"
                             size="sm"
@@ -869,12 +871,14 @@ export function BankOperationsView() {
 
                   {/* Action buttons */}
                   {(selectedOperation.status === "pending" ||
+                    selectedOperation.status === "processing" ||
                     selectedOperation.status === "failed" ||
                     selectedOperation.status === "cancelled" ||
                     selectedOperation.status === "completed" ||
                     selectedOperation.result_metadata?.document_id) && (
                     <div className="flex flex-wrap gap-2">
-                      {selectedOperation.status === "pending" && (
+                      {(selectedOperation.status === "pending" ||
+                        selectedOperation.status === "processing") && (
                         <Button
                           variant="outline"
                           size="sm"

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -666,7 +666,7 @@ export class ControlPlaneClient {
   }
 
   /**
-   * Cancel a pending operation
+   * Cancel a pending or processing operation
    */
   async cancelOperation(bankId: string, operationId: string) {
     return this.fetchApi<{

--- a/hindsight-docs/docs/developer/api/operations.mdx
+++ b/hindsight-docs/docs/developer/api/operations.mdx
@@ -177,9 +177,9 @@ A few response fields are worth calling out:
 | `total` | Total units of work for the operation, when known. |
 | `detail` | Operation-specific counters (e.g. `observations_created`, `round`, `items_in_sub_batch`). |
 
-### Cancel a pending operation
+### Cancel a pending or processing operation
 
-Returns `409` if the operation is already in `processing`, `completed`, or `failed` state.
+A `pending` operation is dropped from the queue. A `processing` one has its worker claim released and stops at its next checkpoint — this is also how you clear a row left orphaned in `processing` by a worker crash or restart. Returns `409` once the operation has reached a terminal status (`completed`, `failed` or `cancelled`).
 
 <Tabs>
 <TabItem value="python" label="Python">

--- a/hindsight-docs/docs/sdks/cli.md
+++ b/hindsight-docs/docs/sdks/cli.md
@@ -275,7 +275,7 @@ hindsight operation list <bank_id>
 # Get operation status
 hindsight operation get <bank_id> <operation_id>
 
-# Cancel a pending operation
+# Cancel a pending or processing operation
 hindsight operation cancel <bank_id> <operation_id>
 
 # Retry a failed operation

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -4074,8 +4074,8 @@
         "tags": [
           "Operations"
         ],
-        "summary": "Cancel a pending async operation",
-        "description": "Cancel a pending async operation by removing it from the queue",
+        "summary": "Cancel a pending or processing async operation",
+        "description": "Cancel a pending or processing async operation. A pending operation is removed from the queue; a processing one has its worker claim released and stops at its next checkpoint, which is also how a row orphaned by a worker crash is cleared. Returns 409 for operations that already reached a terminal status.",
         "operationId": "cancel_operation",
         "parameters": [
           {


### PR DESCRIPTION
## Summary

Fixes #4131. `DELETE /v1/default/banks/{bank}/operations/{id}` accepted only `pending`, so an operation left in `processing` — orphaned by a worker crash or restart — could not be cleared through the API at all. The only way out was `UPDATE async_operations SET status='failed'` by hand plus a container restart.

`processing` is now cancellable, and cancelling it releases the claim.

## Why the claim has to be released with it

The worker's own recovery/release passes filter on `worker_id = self._worker_id` (`_reset_own_processing_rows`, `recover_own_tasks`, `release_own_tasks`), so a row whose worker never comes back is unreachable by design — that is what made these rows permanent. `cancel_operation` therefore clears `worker_id`/`claimed_at` along with the status, which also stops a *live* worker from later resurrecting the row as `pending` through its shutdown release path.

Nothing else can undo the cancel either:

- the task itself notices at its next `_check_op_alive()` checkpoint (that helper already treats `status = 'cancelled'` as "stop") and returns early;
- `_mark_completed` is already guarded on `status = 'processing'`, so it no-ops;
- `_mark_failed` was **not** guarded — an aborted task usually surfaces as an error there, which would have relabelled the row `failed` and made it look retryable. It now skips rows that are already `cancelled`. The parent roll-up still runs; it reads whatever status the child committed.

## Changes

- `engine/memory_engine.py::cancel_operation` — allow `pending` and `processing`, as one conditional `UPDATE ... WHERE status IN ('pending','processing')` instead of SELECT-then-UPDATE (the old pair let a worker claim a pending row between the two statements and get cancelled out from under its own claim without releasing it). Clears `worker_id`/`claimed_at`, sets `completed_at = COALESCE(completed_at, now())` — the same shape the retention path already uses when it cancels a parent. Terminal statuses still answer 409, now with wording that names both cancellable states.
- `worker/poller.py::_mark_failed` — `AND status <> 'cancelled'`.
- `api/http.py`, `engine/interface.py` — summary/description/docstrings say what the endpoint now does. The MCP tool already advertised "Cancel a pending or running async operation", so that surface was promising this behaviour before the engine supported it.
- `hindsight-control-plane` — the Cancel button was gated on `status === "pending"` in both the operations table and the detail dialog, so the one place an operator actually watches a stuck operation could not act on it. Now shown for `processing` too.
- `hindsight-cli/src/main.rs`, `docs/developer/api/operations.mdx`, `docs/sdks/cli.md` — the API doc page explicitly claimed "Returns 409 if the operation is already in `processing`", which is exactly the reported behaviour.
- Regenerated `openapi.json` + Rust/Python/TypeScript/Go clients (description-only diff).

### Removed test

`tests/test_operation_status.py::test_cancel_rejects_non_pending_operations` asserted 409 for `processing` — it encoded the bug. It is replaced by:

- `test_cancel_processing_operation_releases_the_orphaned_claim` — cancels a row stamped with a dead `worker_id`, asserts status `cancelled` and that `worker_id`/`claimed_at` are cleared and `completed_at` set;
- `test_cancel_rejects_terminal_operations[completed|failed|cancelled]` — terminal rows still 409 and keep their status.

Plus `test_worker.py::test_mark_failed_leaves_a_cancelled_row_cancelled` for the poller guard.

## Not done (deliberately)

The issue's second suggestion — auto-failing operations older than X without progress — is a separate policy change needing its own knob and stall definition, and the worker already has stage-progress stuck *detection* (`STUCK_STACK_INITIAL_THRESHOLD_S`) that only logs. This PR makes the manual escape hatch work; an automatic reaper can build on it.

## Testing

- `uv run pytest tests/test_operation_status.py tests/test_worker.py` — pass, including the three new cases.
- `tests/test_op_cancellation.py` — 8 of 9 pass; `TestRetainCheckpoint::test_retain_stops_between_sub_batches_when_cancelled` fails on my machine with `column e.entity_kind does not exist` and a "Database is at a newer migration revision than this code version knows about" warning. Verified pre-existing: it fails identically with my changes stashed (local test DB migrated by a newer checkout).
- `./scripts/hooks/lint.sh` clean; `cargo fmt --check` + `cargo build` clean in `hindsight-cli`.
- `npx tsc --noEmit` in `hindsight-control-plane`: the two errors it reports (`temporal_window` on `RecallRequest`, missing `@testing-library/react`) are pre-existing — identical output with my changes stashed.
- Generated artifacts are in sync: `uv run generate-openapi` + `./scripts/generate-clients.sh` re-run produce no further diff, which is what the CI freshness gate checks.
- Not reproduced end to end against a real crashed worker: the orphaned state is simulated by stamping a dead `worker_id` on a `processing` row, which is the state such a crash leaves behind.
