### PR TITLE
fix(embeddings): one TEI http client per thread, not one per provider

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -894,7 +894,15 @@ class RemoteTEIEmbeddings(Embeddings):
         # A client per thread removes the sharing rather than trying to serialise around it. The
         # cost is one connection pool per executor thread, which is bounded by the executor.
         self._thread_clients = threading.local()
-        self._client: httpx.Client | None = None
+        # An injected client, used by EVERY thread. Tests hand in one httpx.Client wrapping a
+        # MockTransport and then encode, which fans batches across `_request_pool`'s threads —
+        # so a client installed on the calling thread alone would be invisible to the threads
+        # that actually make the requests.
+        self._injected_client: "httpx.Client | None" = None
+        # Separate from the client, because the client is per thread and this is not: encode()
+        # runs on executor threads that never ran initialize(), so "have we initialized" cannot
+        # be answered by asking whether THIS thread has a client yet.
+        self._initialized = False
         self._model_id: str | None = None
         self._dimension: int | None = None
 
@@ -908,8 +916,24 @@ class RemoteTEIEmbeddings(Embeddings):
             raise RuntimeError("Embeddings not initialized. Call initialize() first.")
         return self._dimension
 
+    @property
+    def _client(self) -> httpx.Client | None:
+        """The injected client, else this thread's.
+
+        Kept as an attribute because the suite injects a MockTransport by assigning it.
+        """
+        if self._injected_client is not None:
+            return self._injected_client
+        return getattr(self._thread_clients, "client", None)
+
+    @_client.setter
+    def _client(self, value: "httpx.Client | None") -> None:
+        self._injected_client = value
+
     def _client_for_thread(self) -> httpx.Client:
-        """This thread's client, created on first use."""
+        """This thread's client, created on first use — or the injected one, if a test set it."""
+        if self._injected_client is not None:
+            return self._injected_client
         client = getattr(self._thread_clients, "client", None)
         if client is None or client.is_closed:
             client = httpx.Client(
@@ -985,12 +1009,11 @@ class RemoteTEIEmbeddings(Embeddings):
 
     async def initialize(self) -> None:
         """Initialize the HTTP client and verify server connectivity."""
-        if self._client is not None:
+        if self._initialized:
             return
 
         logger.info(f"Embeddings: initializing TEI provider at {self.base_url}")
-        # Doubles as the "initialized" marker that `encode` checks.
-        self._client = self._client_for_thread()
+        self._initialized = True
 
         # Verify server is reachable and get model info
         try:
@@ -1028,7 +1051,10 @@ class RemoteTEIEmbeddings(Embeddings):
         Returns:
             List of embedding vectors
         """
-        if self._client is None:
+        # Either initialize() ran, or a caller handed us a client outright — the suite builds
+        # providers that way, assigning a MockTransport client and encoding without a server to
+        # initialize against.
+        if not self._initialized and self._client is None:
             raise RuntimeError("Embeddings not initialized. Call initialize() first.")
 
         if not texts:

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -879,6 +879,21 @@ class RemoteTEIEmbeddings(Embeddings):
         self.retry_delay = retry_delay
         self.query_prefix = query_prefix
         self.passage_prefix = passage_prefix
+        # One client per THREAD, not one per provider. `encode` is called through
+        # `run_in_executor`, so several threads share this object, and on a free-threaded build
+        # they genuinely run at once. httpcore's sync pool has at least one unguarded
+        # check-then-use on the shared connection state:
+        #
+        #     keepalive_expired = self._expire_at is not None and now > self._expire_at
+        #
+        # Another thread can null `_expire_at` between the two halves, and the comparison then
+        # raises `'>' not supported between instances of 'float' and 'NoneType'` — surfacing as
+        # a 500 from recall. Under the GIL the window is small enough that it effectively never
+        # happens; without it, it does.
+        #
+        # A client per thread removes the sharing rather than trying to serialise around it. The
+        # cost is one connection pool per executor thread, which is bounded by the executor.
+        self._thread_clients = threading.local()
         self._client: httpx.Client | None = None
         self._model_id: str | None = None
         self._dimension: int | None = None
@@ -893,6 +908,17 @@ class RemoteTEIEmbeddings(Embeddings):
             raise RuntimeError("Embeddings not initialized. Call initialize() first.")
         return self._dimension
 
+    def _client_for_thread(self) -> httpx.Client:
+        """This thread's client, created on first use."""
+        client = getattr(self._thread_clients, "client", None)
+        if client is None or client.is_closed:
+            client = httpx.Client(
+                timeout=self.timeout,
+                limits=httpx.Limits(keepalive_expiry=min(self.timeout, TEI_KEEPALIVE_EXPIRY_SECONDS)),
+            )
+            self._thread_clients.client = client
+        return client
+
     def _request_with_retry(self, method: str, url: str, **kwargs) -> httpx.Response:
         """Make an HTTP request with automatic retries on transient errors."""
         import time
@@ -903,9 +929,9 @@ class RemoteTEIEmbeddings(Embeddings):
         for attempt in range(self.max_retries + 1):
             try:
                 if method == "GET":
-                    response = self._client.get(url, **kwargs)
+                    response = self._client_for_thread().get(url, **kwargs)
                 else:
-                    response = self._client.post(url, **kwargs)
+                    response = self._client_for_thread().post(url, **kwargs)
                 response.raise_for_status()
                 return response
             except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout, httpx.WriteTimeout) as e:
@@ -963,10 +989,8 @@ class RemoteTEIEmbeddings(Embeddings):
             return
 
         logger.info(f"Embeddings: initializing TEI provider at {self.base_url}")
-        self._client = httpx.Client(
-            timeout=self.timeout,
-            limits=httpx.Limits(keepalive_expiry=min(self.timeout, TEI_KEEPALIVE_EXPIRY_SECONDS)),
-        )
+        # Doubles as the "initialized" marker that `encode` checks.
+        self._client = self._client_for_thread()
 
         # Verify server is reachable and get model info
         try:

--- a/hindsight-api-slim/tests/test_tei_client_threads.py
+++ b/hindsight-api-slim/tests/test_tei_client_threads.py
@@ -1,0 +1,41 @@
+"""The TEI client is not shared between threads.
+
+`encode` runs through `run_in_executor`, so several threads use this provider at once. On a
+free-threaded build they run genuinely in parallel, and httpcore's sync pool has an unguarded
+check-then-use on shared connection state:
+
+    keepalive_expired = self._expire_at is not None and now > self._expire_at
+
+Another thread can null `_expire_at` between the two halves, and the comparison raises
+`'>' not supported between instances of 'float' and 'NoneType'` — seen as a 500 out of recall.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from hindsight_api.engine.embeddings import RemoteTEIEmbeddings
+
+
+def test_each_thread_gets_its_own_client():
+    tei = RemoteTEIEmbeddings(base_url="http://tei.invalid")
+    seen: dict[int, int] = {}
+    barrier = threading.Barrier(4)
+
+    def grab(i: int) -> None:
+        barrier.wait()
+        seen[i] = id(tei._client_for_thread())
+
+    threads = [threading.Thread(target=grab, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(set(seen.values())) == 4, f"threads shared a client: {seen}"
+
+
+def test_the_same_thread_reuses_its_client():
+    """Per thread, not per call: a client per request would open a pool per request."""
+    tei = RemoteTEIEmbeddings(base_url="http://tei.invalid")
+    assert tei._client_for_thread() is tei._client_for_thread()


### PR DESCRIPTION
Recall returned a 500 on a free-threaded build:

```
Failed to generate batch embeddings:
  '>' not supported between instances of 'float' and 'NoneType'

httpcore/_sync/http11.py:276  has_expired():
  keepalive_expired = self._expire_at is not None and now > self._expire_at
```

## What is happening

`encode` runs through `run_in_executor`, so several threads use one provider — and therefore
one `httpx.Client` and one `httpcore` connection pool — at the same time.

That line is a check-then-use on shared state. Another thread can null `_expire_at` between the
`is not None` and the `>`, and the comparison raises. Under the GIL the window is small enough
that it effectively never happens; without it, it does.

## The fix

A client per thread, so no two threads share a pool. That removes the sharing rather than
serialising around it, which suits the failure: the pool is the unsafe object. The cost is one
connection pool per executor thread, which the executor already bounds.

## Scope

Measured at **one 500 in ~1100 recalls** on a pod serving from two event loops. It is not
strictly a multi-loop bug — any two executor threads embedding concurrently can hit it — so it
is worth fixing rather than filing under "what happens when you run several loops".

## Test

Fails without the change (`AttributeError`), and pins both halves: four threads get four
distinct clients, and one thread reuses its own rather than opening a pool per call.