### PR TITLE
fix(reranker): give every remote reranker bounded retry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -463,6 +463,13 @@ HINDSIGHT_API_LOG_LEVEL=info
 # Trusted gateway attribution (disabled by default). When enabled, remote
 # reranker requests include X-Hindsight-Bank-Id with the current bank ID.
 # HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER=false
+# Transient upstream failures (5xx, timeouts, connection errors, 429 quota) are
+# retried with jittered exponential backoff; 4xx auth/validation errors are never
+# retried. Applies to every remote provider except "tei", which retries on its own.
+# HINDSIGHT_API_RERANKER_MAX_RETRIES=3        # retries after the first attempt; 0 disables
+# HINDSIGHT_API_RERANKER_INITIAL_BACKOFF=0.5  # seconds; doubles per attempt, with jitter
+# HINDSIGHT_API_RERANKER_MAX_BACKOFF=4.0      # cap on per-retry backoff, seconds
+# HINDSIGHT_API_RERANKER_RETRY_BUDGET=10.0    # wall-clock ceiling per rerank spent retrying
 # For local provider:
 # HINDSIGHT_API_RERANKER_LOCAL_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
 # Force CPU if the local reranker hits MPS/XPC instability on macOS:

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -456,6 +456,16 @@ ENV_EMBEDDINGS_INITIAL_BACKOFF = "HINDSIGHT_API_EMBEDDINGS_INITIAL_BACKOFF"
 ENV_EMBEDDINGS_MAX_BACKOFF = "HINDSIGHT_API_EMBEDDINGS_MAX_BACKOFF"
 ENV_EMBEDDINGS_RETRY_BUDGET = "HINDSIGHT_API_EMBEDDINGS_RETRY_BUDGET"
 
+# Retry/backoff for remote reranker APIs. Rerank sits on the same synchronous recall
+# path as the query embedding, and with no fallback chain configured (the default) a
+# single upstream 429 used to fail the whole recall (#4134). Budgeted tighter than the
+# embedding twin: rerank runs after retrieval, so its latency is added to a request
+# that has already spent time.
+ENV_RERANKER_MAX_RETRIES = "HINDSIGHT_API_RERANKER_MAX_RETRIES"
+ENV_RERANKER_INITIAL_BACKOFF = "HINDSIGHT_API_RERANKER_INITIAL_BACKOFF"
+ENV_RERANKER_MAX_BACKOFF = "HINDSIGHT_API_RERANKER_MAX_BACKOFF"
+ENV_RERANKER_RETRY_BUDGET = "HINDSIGHT_API_RERANKER_RETRY_BUDGET"
+
 # Gemini/Vertex AI embeddings configuration
 ENV_EMBEDDINGS_GEMINI_API_KEY = "HINDSIGHT_API_EMBEDDINGS_GEMINI_API_KEY"
 ENV_EMBEDDINGS_GEMINI_MODEL = "HINDSIGHT_API_EMBEDDINGS_GEMINI_MODEL"
@@ -1145,6 +1155,14 @@ DEFAULT_EMBEDDINGS_MAX_RETRIES = 4
 DEFAULT_EMBEDDINGS_INITIAL_BACKOFF = 0.5
 DEFAULT_EMBEDDINGS_MAX_BACKOFF = 4.0
 DEFAULT_EMBEDDINGS_RETRY_BUDGET = 15.0
+# Reranker retry defaults: 3 retries (4 attempts) with 0.5s -> 4s exponential backoff
+# and a 10s ceiling on the time one rerank may spend retrying. Tighter than the
+# embedding budget because rerank runs after retrieval has already spent time on the
+# same request, and its failure mode is a degraded ranking rather than no answer.
+DEFAULT_RERANKER_MAX_RETRIES = 3
+DEFAULT_RERANKER_INITIAL_BACKOFF = 0.5
+DEFAULT_RERANKER_MAX_BACKOFF = 4.0
+DEFAULT_RERANKER_RETRY_BUDGET = 10.0
 DEFAULT_EMBEDDINGS_GEMINI_MODEL = "gemini-embedding-001"
 DEFAULT_EMBEDDINGS_GEMINI_OUTPUT_DIMENSIONALITY = 768
 DEFAULT_EMBEDDINGS_GEMINI_FORCE_IPV4 = False
@@ -3167,11 +3185,17 @@ class HindsightConfig:
     operation_cleanup_interval_seconds: int = DEFAULT_OPERATION_CLEANUP_INTERVAL_SECONDS
     maintenance_start_jitter_seconds: int = DEFAULT_MAINTENANCE_START_JITTER_SECONDS
 
-    # Retry/backoff applied to remote embedding API calls (see EmbeddingRetryPolicy).
+    # Retry/backoff applied to remote embedding API calls (see engine/remote_retry.py's RetryPolicy).
     embeddings_max_retries: int = DEFAULT_EMBEDDINGS_MAX_RETRIES
     embeddings_initial_backoff: float = DEFAULT_EMBEDDINGS_INITIAL_BACKOFF
     embeddings_max_backoff: float = DEFAULT_EMBEDDINGS_MAX_BACKOFF
     embeddings_retry_budget: float = DEFAULT_EMBEDDINGS_RETRY_BUDGET
+
+    # Retry/backoff applied to remote reranker API calls (see engine/remote_retry.py's RetryPolicy).
+    reranker_max_retries: int = DEFAULT_RERANKER_MAX_RETRIES
+    reranker_initial_backoff: float = DEFAULT_RERANKER_INITIAL_BACKOFF
+    reranker_max_backoff: float = DEFAULT_RERANKER_MAX_BACKOFF
+    reranker_retry_budget: float = DEFAULT_RERANKER_RETRY_BUDGET
 
     # Class-level sets for configuration categorization
 
@@ -3955,6 +3979,26 @@ class HindsightConfig:
                 ENV_EMBEDDINGS_RETRY_BUDGET,
                 os.getenv(ENV_EMBEDDINGS_RETRY_BUDGET),
                 DEFAULT_EMBEDDINGS_RETRY_BUDGET,
+            ),
+            reranker_max_retries=_parse_non_negative_int(
+                ENV_RERANKER_MAX_RETRIES,
+                os.getenv(ENV_RERANKER_MAX_RETRIES),
+                DEFAULT_RERANKER_MAX_RETRIES,
+            ),
+            reranker_initial_backoff=_parse_non_negative_float(
+                ENV_RERANKER_INITIAL_BACKOFF,
+                os.getenv(ENV_RERANKER_INITIAL_BACKOFF),
+                DEFAULT_RERANKER_INITIAL_BACKOFF,
+            ),
+            reranker_max_backoff=_parse_non_negative_float(
+                ENV_RERANKER_MAX_BACKOFF,
+                os.getenv(ENV_RERANKER_MAX_BACKOFF),
+                DEFAULT_RERANKER_MAX_BACKOFF,
+            ),
+            reranker_retry_budget=_parse_non_negative_float(
+                ENV_RERANKER_RETRY_BUDGET,
+                os.getenv(ENV_RERANKER_RETRY_BUDGET),
+                DEFAULT_RERANKER_RETRY_BUDGET,
             ),
             # Cohere embeddings (with backward-compatible fallback to shared API key)
             embeddings_cohere_api_key=os.getenv(ENV_EMBEDDINGS_COHERE_API_KEY) or os.getenv(ENV_COHERE_API_KEY),

--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -45,6 +45,7 @@ from .local_device import (
     resolve_model_device_type,
     select_local_device,
 )
+from .remote_retry import RetryPolicy, acall_with_retry
 from .tei_retry import TEI_KEEPALIVE_EXPIRY_SECONDS, is_retryable_tei_transport_error, tei_retry_delay
 
 logger = logging.getLogger(__name__)
@@ -82,10 +83,19 @@ class CrossEncoderModel(ABC):
         """
         pass
 
-    @abstractmethod
+    # Bounded retry for this member's remote calls, or None to call straight through.
+    # Set by create_cross_encoder for the remote providers; the in-process backends,
+    # the rrf passthrough, TEI (own retry loop) and MultiCrossEncoder (its members
+    # retry individually) leave it None. Living on the base class rather than in each
+    # provider is deliberate: retry then applies to the one method every backend has
+    # to implement, so a new remote reranker inherits it instead of having to
+    # remember — the omission that let a single Cohere 429 fail an entire recall
+    # (#4134).
+    retry_policy: RetryPolicy | None = None
+
     async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         """
-        Score query-document pairs for relevance.
+        Score query-document pairs for relevance, retrying transient failures.
 
         Args:
             pairs: List of (query, document) tuples to score
@@ -93,7 +103,30 @@ class CrossEncoderModel(ABC):
         Returns:
             List of relevance scores (higher = more relevant)
         """
-        pass
+        if self.retry_policy is None:
+            return await self._predict(pairs)
+        # One budget per predict(): rerank is one logical call on the synchronous
+        # recall path, so the worst-case added latency has to stay bounded.
+        return await acall_with_retry(
+            lambda: self._predict(pairs),
+            policy=self.retry_policy,
+            budget=self.retry_policy.new_budget(),
+            provider=self.provider_name,
+        )
+
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+        """Score ``pairs`` without retry — what each backend in this module implements.
+
+        Deliberately not ``@abstractmethod``: ``CrossEncoderModel`` is exported from
+        ``hindsight_api``, and a subclass that overrides ``predict`` directly (the test
+        doubles here, and any downstream implementation) must keep working — it simply
+        opts out of the shared retry. Every backend in this module implements
+        ``_predict`` instead, which ``TestEveryRemoteRerankerRetries`` enforces so the
+        opt-out cannot happen by accident.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement _predict() (or override predict() to opt out of retry)"
+        )
 
 
 class LocalSTCrossEncoder(CrossEncoderModel):
@@ -299,7 +332,7 @@ class LocalSTCrossEncoder(CrossEncoderModel):
         finally:
             release_local_inference_memory(self._device_type)
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         """
         Score query-document pairs for relevance.
 
@@ -555,7 +588,7 @@ class RemoteTEICrossEncoder(CrossEncoderModel):
 
         return all_scores
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         """
         Score query-document pairs using the remote TEI reranker.
 
@@ -725,7 +758,7 @@ class CohereCrossEncoder(CrossEncoderModel):
             self._client = cohere.Client(api_key=self.api_key, timeout=self.timeout)
             logger.info("Reranker: Cohere provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         """
         Score query-document pairs using the Cohere Rerank API.
 
@@ -813,7 +846,7 @@ class ZeroEntropyCrossEncoder(CrossEncoderModel):
         await self._client.initialize()
         logger.info("Reranker: ZeroEntropy provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         return await self._client.predict(pairs)
 
 
@@ -855,7 +888,7 @@ class SiliconFlowCrossEncoder(CrossEncoderModel):
         await self._client.initialize()
         logger.info("Reranker: SiliconFlow provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         return await self._client.predict(pairs)
 
 
@@ -881,7 +914,7 @@ class RRFPassthroughCrossEncoder(CrossEncoderModel):
         """No initialization needed."""
         logger.info("Reranker: RRF passthrough provider initialized (neural reranking disabled)")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         """
         Return neutral scores - actual ranking uses RRF scores from retrieval.
 
@@ -1072,7 +1105,7 @@ class FlashRankCrossEncoder(CrossEncoderModel):
         finally:
             release_local_inference_memory(self._device_type)
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         """
         Score query-document pairs using FlashRank.
 
@@ -1165,7 +1198,7 @@ class LiteLLMCrossEncoder(CrossEncoderModel):
         self._async_client = httpx.AsyncClient(timeout=self.timeout, headers=headers)
         logger.info("Reranker: LiteLLM provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         """
         Score query-document pairs using the LiteLLM proxy's /rerank endpoint.
 
@@ -1285,7 +1318,7 @@ class LiteLLMSDKCrossEncoder(CrossEncoderModel):
         self._initialized = True
         logger.info("Reranker: LiteLLM SDK provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         """
         Score query-document pairs using the LiteLLM SDK.
 
@@ -1444,7 +1477,7 @@ class JinaMLXCrossEncoder(CrossEncoderModel):
 
         return all_scores
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         if self._reranker is None:
             raise RuntimeError("Reranker not initialized. Call initialize() first.")
 
@@ -1590,7 +1623,7 @@ class GoogleCrossEncoder(CrossEncoderModel):
 
         return all_scores
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         """
         Score query-document pairs using Google Discovery Engine Ranking API.
 
@@ -1648,7 +1681,7 @@ class AlibabaCloudCrossEncoder(CrossEncoderModel):
         await self._client.initialize()
         logger.info("Reranker: Alibaba Cloud provider initialized")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         return await self._client.predict(pairs)
 
 
@@ -1661,10 +1694,12 @@ class MultiCrossEncoder(CrossEncoderModel):
     ranking quality (whatever the next member gives) instead of the whole recall.
     Put ``rrf`` last to degrade to the fusion order rather than failing.
 
-    Each member keeps its own retry budget, so we only advance after a member has
-    exhausted its retries and raised. A member that fails to initialize is not
-    fatal — that is the point of the chain — it is retried lazily on the next
-    request that reaches it.
+    Each member keeps its own retry budget (``create_cross_encoder`` gives every
+    remote member a ``retry_policy``), so we only advance after a member has
+    exhausted its retries and raised — an ordinary quota blip does not burn a
+    fallback. This chain holds no policy of its own: retrying here would retry the
+    whole failover sequence rather than the member that stumbled. A member that fails to initialize is not fatal — that is the point of
+    the chain — it is retried lazily on the next request that reaches it.
     """
 
     def __init__(self, members: list[CrossEncoderModel]) -> None:
@@ -1723,7 +1758,7 @@ class MultiCrossEncoder(CrossEncoderModel):
         if not any(self._ready):
             logger.error("Reranker: no member of the failover chain initialized; recall will retry them per request")
 
-    async def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
         """Score ``pairs`` with the first member that answers usably."""
         last_exc: BaseException | None = None
         for index, member in enumerate(self._members):
@@ -1757,6 +1792,34 @@ class MultiCrossEncoder(CrossEncoderModel):
         raise last_exc
 
 
+# Reranker providers that must NOT be given a retry policy, and why. Everything
+# else is a remote API whose transient failures are worth retrying.
+_RERANKER_PROVIDERS_WITHOUT_RETRY = {
+    # In-process: no round trip to fail transiently, and a local failure (a bad
+    # tensor, an OOM) is not fixed by trying again.
+    "local": "in-process model",
+    "flashrank": "in-process model",
+    "jina-mlx": "in-process model",
+    "rrf": "passthrough, does no work",
+    # Already retries internally, including TEI's 429-as-backpressure handling.
+    # A second layer would multiply its attempts by ours.
+    "tei": "own _async_request_with_retry (see tei_retry.py)",
+}
+
+
+def _reranker_retry_policy() -> RetryPolicy:
+    """Build the reranker retry policy from resolved configuration."""
+    from ..config import get_config
+
+    config = get_config()
+    return RetryPolicy(
+        max_retries=config.reranker_max_retries,
+        initial_backoff=config.reranker_initial_backoff,
+        max_backoff=config.reranker_max_backoff,
+        budget_seconds=config.reranker_retry_budget,
+    )
+
+
 def create_cross_encoder(member: RerankerMemberConfig) -> CrossEncoderModel:
     """
     Create a CrossEncoderModel for one member of the reranker chain.
@@ -1765,12 +1828,24 @@ def create_cross_encoder(member: RerankerMemberConfig) -> CrossEncoderModel:
     config) or an indexed fallback. Missing-setting errors name the member's own
     env var, so a chain misconfiguration points at the exact indexed variable.
 
+    Remote members come back carrying a ``retry_policy``, which the base class's
+    ``predict`` applies; see ``_RERANKER_PROVIDERS_WITHOUT_RETRY`` for the ones that
+    deliberately do not get one.
+
     Args:
         member: Resolved settings for this member
 
     Returns:
         Configured CrossEncoderModel instance
     """
+    encoder = _create_cross_encoder_backend(member)
+    if member.provider.lower() not in _RERANKER_PROVIDERS_WITHOUT_RETRY:
+        encoder.retry_policy = _reranker_retry_policy()
+    return encoder
+
+
+def _create_cross_encoder_backend(member: RerankerMemberConfig) -> CrossEncoderModel:
+    """Construct the provider backend itself, before any retry policy is attached."""
     provider = member.provider.lower()
 
     if provider == "tei":

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -16,13 +16,11 @@ import logging
 import os
 import struct
 import threading
-import time
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar, cast
+from typing import TYPE_CHECKING, ClassVar, Literal, cast
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 import httpx
@@ -31,16 +29,12 @@ from pydantic import BaseModel
 from ..config import (
     DEFAULT_EMBEDDINGS_COHERE_MODEL,
     DEFAULT_EMBEDDINGS_GEMINI_MODEL,
-    DEFAULT_EMBEDDINGS_INITIAL_BACKOFF,
     DEFAULT_EMBEDDINGS_LITELLM_MODEL,
     DEFAULT_EMBEDDINGS_LITELLM_SDK_MODEL,
     DEFAULT_EMBEDDINGS_LOCAL_MODEL,
-    DEFAULT_EMBEDDINGS_MAX_BACKOFF,
-    DEFAULT_EMBEDDINGS_MAX_RETRIES,
     DEFAULT_EMBEDDINGS_ONNX_BATCH_SIZE,
     DEFAULT_EMBEDDINGS_ONNX_CPU_MEM_ARENA,
     DEFAULT_EMBEDDINGS_OPENAI_MODEL,
-    DEFAULT_EMBEDDINGS_RETRY_BUDGET,
     DEFAULT_EMBEDDINGS_ZEROENTROPY_BATCH_SIZE,
     DEFAULT_EMBEDDINGS_ZEROENTROPY_DIMENSIONS,
     DEFAULT_EMBEDDINGS_ZEROENTROPY_ENCODING_FORMAT,
@@ -69,224 +63,18 @@ from .local_device import (
     resolve_model_device_type,
     select_local_device,
 )
+from .remote_retry import (
+    RetryBudget,
+    RetryPolicy,
+    acall_with_retry,
+    call_with_retry,
+)
 from .tei_retry import TEI_KEEPALIVE_EXPIRY_SECONDS, is_retryable_tei_transport_error, tei_retry_delay
 
 if TYPE_CHECKING:
     from ..config import HindsightConfig
 
 logger = logging.getLogger(__name__)
-
-T = TypeVar("T")
-
-# 4xx codes that describe a transient condition rather than a bad request.
-# Everything else in the 4xx range (auth, validation, not-found) is a client-side
-# problem that retrying cannot fix.
-_TRANSIENT_STATUS_CODES = frozenset({408, 409, 425, 429})
-
-# Exception class names treated as transient when the exception carries no HTTP
-# status code. Matching by name keeps this module free of a hard litellm/openai
-# import (litellm is imported lazily, and only by the providers that need it).
-_TRANSIENT_EXCEPTION_NAMES = frozenset(
-    {
-        "APIConnectionError",
-        "APIError",
-        "APITimeoutError",
-        "ConnectionError",
-        "InternalServerError",
-        "RateLimitError",
-        "ServiceUnavailableError",
-        "Timeout",
-        "TimeoutError",
-    }
-)
-
-
-@dataclass(frozen=True)
-class EmbeddingRetryPolicy:
-    """
-    Bounded retry policy for remote embedding APIs.
-
-    Recall embeds the query inline on the request path, so a single upstream 5xx
-    would otherwise become a user-visible recall failure. Retries are bounded two
-    ways at once:
-
-    * ``max_retries`` caps the number of extra attempts (0 disables retrying).
-    * ``budget_seconds`` caps the wall-clock time a single ``encode()`` call may
-      *waste* on retries — failed attempts plus backoff sleeps. Successful work
-      never counts against it, so a large multi-batch encode is not penalised for
-      the batches that worked, while the worst-case added latency stays bounded.
-
-    The pairing matters: attempts alone cannot bound latency (an upstream that
-    fails slowly turns 5 attempts into minutes), and a budget alone cannot stop a
-    fast-failing upstream from being hammered.
-    """
-
-    max_retries: int = DEFAULT_EMBEDDINGS_MAX_RETRIES
-    initial_backoff: float = DEFAULT_EMBEDDINGS_INITIAL_BACKOFF
-    max_backoff: float = DEFAULT_EMBEDDINGS_MAX_BACKOFF
-    budget_seconds: float = DEFAULT_EMBEDDINGS_RETRY_BUDGET
-
-    def new_budget(self) -> "_RetryBudget":
-        """Start a fresh retry budget, scoped to one logical embedding call."""
-        return _RetryBudget(self.budget_seconds)
-
-
-class _RetryBudget:
-    """Mutable remaining-retry-time counter shared across the batches of one call.
-
-    The batches of one call now go out concurrently (see ``Embeddings._encode_batched``),
-    so the counter is touched from several threads at once; without the lock a
-    read-modify-write race would under-charge the budget and let retries run past it.
-    """
-
-    __slots__ = ("remaining", "_lock")
-
-    def __init__(self, seconds: float):
-        self.remaining = max(0.0, seconds)
-        self._lock = threading.Lock()
-
-    @property
-    def exhausted(self) -> bool:
-        return self.remaining <= 0.0
-
-    def spend(self, seconds: float) -> None:
-        with self._lock:
-            self.remaining = max(0.0, self.remaining - max(0.0, seconds))
-
-
-def _status_code_of(exc: BaseException) -> int | None:
-    """Best-effort HTTP status extraction across httpx, openai, litellm and google.genai errors."""
-    candidates = (
-        getattr(exc, "status_code", None),
-        getattr(getattr(exc, "response", None), "status_code", None),
-        # google.genai.errors.APIError carries the status on `code`, and leaves
-        # `response` as None on the paths that raise from a parsed error body.
-        getattr(exc, "code", None),
-    )
-    for candidate in candidates:
-        if isinstance(candidate, bool):
-            continue
-        if isinstance(candidate, str) and candidate.isdigit():
-            candidate = int(candidate)
-        # Range-checked because `code` is a common attribute name that is not
-        # always an HTTP status (SystemExit.code, OSError subclasses).
-        if isinstance(candidate, int) and 100 <= candidate <= 599:
-            return candidate
-    return None
-
-
-def _is_transient_embedding_error(exc: BaseException) -> bool:
-    """
-    Return True when ``exc`` is worth retrying.
-
-    A status code, when present, is authoritative: 5xx and the transient 4xx set
-    are retryable, every other 4xx (401/403 auth, 400/422 validation, 404) is
-    permanent and must fail fast. Without a status code we fall back to
-    transport-level exception types and known SDK exception names.
-    """
-    status = _status_code_of(exc)
-    if status is not None:
-        return status >= 500 or status in _TRANSIENT_STATUS_CODES
-    if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
-        return True
-    if isinstance(exc, (TimeoutError, ConnectionError)):
-        return True
-    return type(exc).__name__ in _TRANSIENT_EXCEPTION_NAMES
-
-
-def _retry_delay_for(
-    exc: BaseException,
-    *,
-    attempt: int,
-    attempts: int,
-    policy: EmbeddingRetryPolicy,
-    budget: _RetryBudget,
-    provider: str,
-) -> float | None:
-    """
-    Decide whether ``exc`` should be retried and how long to wait first.
-
-    Returns the sleep duration, or None when the exception must propagate. Logs
-    the decision and charges the sleep to ``budget``. Upstream error text is
-    truncated (matching the LLM providers) so a verbose provider payload cannot
-    flood the log.
-    """
-    if not _is_transient_embedding_error(exc):
-        return None
-
-    status = _status_code_of(exc)
-    status_label = f"HTTP {status}" if status is not None else type(exc).__name__
-    detail = str(exc)[:200]
-
-    if attempt >= attempts - 1:
-        logger.error(f"{provider} embedding call failed after {attempts} attempt(s) ({status_label}): {detail}")
-        return None
-
-    if budget.exhausted:
-        logger.error(
-            f"{provider} embedding call failed on attempt {attempt + 1}/{attempts} ({status_label}) and the "
-            f"{policy.budget_seconds:.1f}s retry budget is exhausted, giving up: {detail}"
-        )
-        return None
-
-    backoff = min(policy.initial_backoff * (2**attempt), policy.max_backoff)
-    jitter = backoff * 0.2 * (2 * (time.time() % 1) - 1)
-    sleep_for = min(max(0.0, backoff + jitter), budget.remaining)
-    budget.spend(sleep_for)
-    logger.warning(
-        f"{provider} embedding call failed (attempt {attempt + 1}/{attempts}, {status_label}), "
-        f"retrying in {sleep_for:.2f}s ({budget.remaining:.1f}s of retry budget left): {detail}"
-    )
-    return sleep_for
-
-
-def _call_with_retry(
-    call: Callable[[], T],
-    *,
-    policy: EmbeddingRetryPolicy,
-    budget: _RetryBudget,
-    provider: str,
-) -> T:
-    """Run a blocking embedding call, retrying transient upstream failures."""
-    attempts = policy.max_retries + 1
-    for attempt in range(attempts):
-        started = time.monotonic()
-        try:
-            return call()
-        except Exception as exc:
-            budget.spend(time.monotonic() - started)
-            delay = _retry_delay_for(
-                exc, attempt=attempt, attempts=attempts, policy=policy, budget=budget, provider=provider
-            )
-            if delay is None:
-                raise
-            time.sleep(delay)
-    raise RuntimeError("unreachable: retry loop exited without returning or raising")
-
-
-async def _acall_with_retry(
-    call: Callable[[], Awaitable[T]],
-    *,
-    policy: EmbeddingRetryPolicy,
-    budget: _RetryBudget,
-    provider: str,
-) -> T:
-    """Async twin of :func:`_call_with_retry`, sharing its policy and classification."""
-    attempts = policy.max_retries + 1
-    for attempt in range(attempts):
-        started = time.monotonic()
-        try:
-            return await call()
-        except Exception as exc:
-            budget.spend(time.monotonic() - started)
-            delay = _retry_delay_for(
-                exc, attempt=attempt, attempts=attempts, policy=policy, budget=budget, provider=provider
-            )
-            if delay is None:
-                raise
-            await asyncio.sleep(delay)
-    raise RuntimeError("unreachable: retry loop exited without returning or raising")
-
 
 ZeroEntropyInputType = Literal["document", "query"]
 ZeroEntropyLatency = Literal["fast", "slow"]
@@ -1316,7 +1104,7 @@ class CohereEmbeddings(Embeddings):
         batch_size: int = 96,
         timeout: float = 60.0,
         input_type: str = "search_document",
-        retry_policy: EmbeddingRetryPolicy | None = None,
+        retry_policy: RetryPolicy | None = None,
     ):
         """
         Initialize Cohere embeddings client.
@@ -1331,7 +1119,7 @@ class CohereEmbeddings(Embeddings):
             input_type: Input type for embeddings (default: search_document).
                        Options: search_document, search_query, classification, clustering
             retry_policy: Bounded retry policy for transient upstream failures
-                (default: EmbeddingRetryPolicy() built-in defaults)
+                (default: RetryPolicy() built-in defaults)
         """
         self.api_key = api_key
         self.model = model
@@ -1340,7 +1128,7 @@ class CohereEmbeddings(Embeddings):
         self.batch_size = batch_size
         self.timeout = timeout
         self.input_type = input_type
-        self.retry_policy = retry_policy or EmbeddingRetryPolicy()
+        self.retry_policy = retry_policy or RetryPolicy()
         self._client = None
         self._dimension: int | None = None
 
@@ -1383,7 +1171,7 @@ class CohereEmbeddings(Embeddings):
             # helper: initialize() is awaited on the event loop, so a blocking call and
             # a time.sleep() backoff would stall the model loads running concurrently
             # with it. Retried so a quota blip at startup does not crash-loop the daemon.
-            response = await _acall_with_retry(
+            response = await acall_with_retry(
                 lambda: asyncio.to_thread(
                     self._client.embed,
                     texts=["test"],
@@ -1417,18 +1205,18 @@ class CohereEmbeddings(Embeddings):
 
         # One retry budget for the whole call: batching must not multiply the
         # worst-case added latency of a single encode(). Shared across the concurrent
-        # batches too, which is why _RetryBudget takes a lock.
+        # batches too, which is why RetryBudget takes a lock.
         budget = self.retry_policy.new_budget()
 
         return self._encode_batched(texts, lambda batch: self._embed_batch(batch, budget))
 
-    def _embed_batch(self, batch: list[str], budget: "_RetryBudget") -> list[list[float]]:
+    def _embed_batch(self, batch: list[str], budget: "RetryBudget") -> list[list[float]]:
         """Embed one batch-sized slice. The Cohere sync client is safe to share across threads."""
         # The Cohere SDK does not retry on its own — its request-level max_retries
         # defaults to 0 — so a single 429 would otherwise fail the whole operation.
         if self.output_dimensions is not None:
             # Use v2 API which supports output_dimension
-            response = _call_with_retry(
+            response = call_with_retry(
                 lambda: self._client.v2.embed(
                     texts=batch,
                     model=self.model,
@@ -1441,7 +1229,7 @@ class CohereEmbeddings(Embeddings):
                 provider=self.provider_name,
             )
             return response.embeddings.float_
-        response = _call_with_retry(
+        response = call_with_retry(
             lambda: self._client.embed(
                 texts=batch,
                 model=self.model,
@@ -1481,7 +1269,7 @@ class ZeroEntropyEmbeddings(Embeddings):
         encoding_format: str = DEFAULT_EMBEDDINGS_ZEROENTROPY_ENCODING_FORMAT,
         latency: str | None = DEFAULT_EMBEDDINGS_ZEROENTROPY_LATENCY,
         timeout: float = 60.0,
-        retry_policy: EmbeddingRetryPolicy | None = None,
+        retry_policy: RetryPolicy | None = None,
     ):
         if dimensions not in self.VALID_DIMENSIONS:
             valid = ", ".join(str(dim) for dim in sorted(self.VALID_DIMENSIONS, reverse=True))
@@ -1506,7 +1294,7 @@ class ZeroEntropyEmbeddings(Embeddings):
         self.encoding_format = cast(ZeroEntropyEncodingFormat, encoding_format)
         self.latency = cast(ZeroEntropyLatency | None, latency)
         self.timeout = timeout
-        self.retry_policy = retry_policy or EmbeddingRetryPolicy()
+        self.retry_policy = retry_policy or RetryPolicy()
         self._client: httpx.Client | None = None
         self._dimension: int | None = None
 
@@ -1562,13 +1350,13 @@ class ZeroEntropyEmbeddings(Embeddings):
 
         # One retry budget for the whole call: batching must not multiply the
         # worst-case added latency of a single encode(). Shared across the concurrent
-        # batches too, which is why _RetryBudget takes a lock.
+        # batches too, which is why RetryBudget takes a lock.
         budget = self.retry_policy.new_budget()
 
         return self._encode_batched(texts, lambda batch: self._embed_batch(batch, input_type, budget))
 
     def _embed_batch(
-        self, batch: list[str], input_type: ZeroEntropyInputType, budget: "_RetryBudget"
+        self, batch: list[str], input_type: ZeroEntropyInputType, budget: "RetryBudget"
     ) -> list[list[float]]:
         """Embed one batch-sized slice. ``httpx.Client`` is safe to share across threads."""
         request = _ZeroEntropyEmbedRequest(
@@ -1584,12 +1372,12 @@ class ZeroEntropyEmbeddings(Embeddings):
             response = self._client.post(self.embed_url, json=request.model_dump(exclude_none=True))
             # Inside the retried closure so a 429 or 5xx is retried rather than raised
             # straight through. The RuntimeError wrap below stays OUTSIDE the retry:
-            # it erases the status code that _is_transient_embedding_error classifies on.
+            # it erases the status code that is_transient_remote_error classifies on.
             response.raise_for_status()
             return response
 
         try:
-            response = _call_with_retry(
+            response = call_with_retry(
                 post_batch,
                 policy=self.retry_policy,
                 budget=budget,
@@ -1645,7 +1433,7 @@ class LiteLLMEmbeddings(Embeddings):
         timeout: float = 60.0,
         query_prefix: str = "",
         passage_prefix: str = "",
-        retry_policy: EmbeddingRetryPolicy | None = None,
+        retry_policy: RetryPolicy | None = None,
     ):
         """
         Initialize LiteLLM embeddings client.
@@ -1668,7 +1456,7 @@ class LiteLLMEmbeddings(Embeddings):
             query_prefix: Prefix prepended to recall/search queries (default: none)
             passage_prefix: Prefix prepended to retained document text (default: none)
             retry_policy: Bounded retry policy for transient upstream failures
-                (default: EmbeddingRetryPolicy() built-in defaults)
+                (default: RetryPolicy() built-in defaults)
         """
         self.api_base = api_base.rstrip("/")
         self.api_key = api_key
@@ -1678,7 +1466,7 @@ class LiteLLMEmbeddings(Embeddings):
         self.timeout = timeout
         self.query_prefix = query_prefix
         self.passage_prefix = passage_prefix
-        self.retry_policy = retry_policy or EmbeddingRetryPolicy()
+        self.retry_policy = retry_policy or RetryPolicy()
         self._client: httpx.Client | None = None
         self._dimension: int | None = None
         self._dimension_verified = False
@@ -1732,7 +1520,7 @@ class LiteLLMEmbeddings(Embeddings):
             # event loop, so a blocking post and a time.sleep() backoff would
             # stall the model loads running concurrently with it and freeze the
             # model_init_timeout watchdog that is supposed to bound this.
-            result = await _acall_with_retry(
+            result = await acall_with_retry(
                 lambda: asyncio.to_thread(probe),
                 policy=self.retry_policy,
                 budget=self.retry_policy.new_budget(),
@@ -1768,14 +1556,14 @@ class LiteLLMEmbeddings(Embeddings):
 
         # One retry budget for the whole call: batching must not multiply the
         # worst-case added latency of a single encode(). Shared across the concurrent
-        # batches too, which is why _RetryBudget takes a lock.
+        # batches too, which is why RetryBudget takes a lock.
         budget = self.retry_policy.new_budget()
 
         all_embeddings = self._encode_batched(texts, lambda batch: self._embed_batch(batch, budget))
         self._check_declared_dimension(all_embeddings)
         return all_embeddings
 
-    def _embed_batch(self, batch: list[str], budget: "_RetryBudget") -> list[list[float]]:
+    def _embed_batch(self, batch: list[str], budget: "RetryBudget") -> list[list[float]]:
         """Embed one batch-sized slice. ``httpx.Client`` is safe to share across threads."""
 
         def post_batch():
@@ -1788,7 +1576,7 @@ class LiteLLMEmbeddings(Embeddings):
             response.raise_for_status()
             return response.json()
 
-        result = _call_with_retry(
+        result = call_with_retry(
             post_batch,
             policy=self.retry_policy,
             budget=budget,
@@ -1847,7 +1635,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
         encoding_format: str | None = "float",
         query_prefix: str = "",
         passage_prefix: str = "",
-        retry_policy: EmbeddingRetryPolicy | None = None,
+        retry_policy: RetryPolicy | None = None,
     ):
         """
         Initialize LiteLLM SDK embeddings client.
@@ -1870,7 +1658,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
             query_prefix: Prefix prepended to recall/search queries (default: none)
             passage_prefix: Prefix prepended to retained document text (default: none)
             retry_policy: Bounded retry policy for transient upstream failures
-                (default: EmbeddingRetryPolicy() built-in defaults)
+                (default: RetryPolicy() built-in defaults)
         """
         self.api_key = api_key
         self.model = model
@@ -1882,7 +1670,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
         self.encoding_format = encoding_format or None
         self.query_prefix = query_prefix
         self.passage_prefix = passage_prefix
-        self.retry_policy = retry_policy or EmbeddingRetryPolicy()
+        self.retry_policy = retry_policy or RetryPolicy()
         self._litellm = None  # Will be set during initialization
         self._dimension: int | None = None
 
@@ -1939,7 +1727,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
             # Use async embedding method (standard in litellm). Retried on transient
             # upstream errors: a flaky provider must not take the whole API down at
             # startup, since dimension detection gates initialization.
-            response = await _acall_with_retry(
+            response = await acall_with_retry(
                 lambda: self._litellm.aembedding(**embed_kwargs),
                 policy=self.retry_policy,
                 budget=self.retry_policy.new_budget(),
@@ -1991,7 +1779,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
 
         # One retry budget for the whole call: batching must not multiply the
         # worst-case added latency of a single encode(). Shared across the concurrent
-        # batches too, which is why _RetryBudget takes a lock.
+        # batches too, which is why RetryBudget takes a lock.
         budget = self.retry_policy.new_budget()
 
         return self._encode_batched(texts, lambda batch: self._embed_batch(batch, input_type, budget))
@@ -2000,7 +1788,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
         self,
         batch: list[str],
         input_type: Literal["query", "document"] | None,
-        budget: "_RetryBudget",
+        budget: "RetryBudget",
     ) -> list[list[float]]:
         """Embed one batch-sized slice through the litellm SDK's sync entrypoint."""
         try:
@@ -2031,7 +1819,7 @@ class LiteLLMSDKEmbeddings(Embeddings):
             # Use sync embedding (litellm doesn't have async in thread-safe way).
             # Recall runs this inline, so transient upstream failures are retried
             # here rather than surfacing as a failed recall.
-            response = _call_with_retry(
+            response = call_with_retry(
                 lambda kwargs=embed_kwargs: self._litellm.embedding(**kwargs),
                 policy=self.retry_policy,
                 budget=budget,
@@ -2091,7 +1879,7 @@ class GeminiEmbeddings(Embeddings):
         output_dimensionality: int | None = None,
         batch_size: int = 100,
         force_ipv4: bool = False,
-        retry_policy: EmbeddingRetryPolicy | None = None,
+        retry_policy: RetryPolicy | None = None,
     ):
         self.model = model
         self.api_key = api_key
@@ -2101,7 +1889,7 @@ class GeminiEmbeddings(Embeddings):
         self.output_dimensionality = output_dimensionality
         self.batch_size = batch_size
         self.force_ipv4 = force_ipv4
-        self.retry_policy = retry_policy or EmbeddingRetryPolicy()
+        self.retry_policy = retry_policy or RetryPolicy()
         self._client = None
         self._httpx_client = None
         self._dimension: int | None = None
@@ -2146,7 +1934,7 @@ class GeminiEmbeddings(Embeddings):
         # loop, so a blocking call and a time.sleep() backoff would stall the model
         # loads running concurrently with it. Retried so a quota blip at startup
         # does not crash-loop the daemon.
-        result = await _acall_with_retry(
+        result = await acall_with_retry(
             lambda: asyncio.to_thread(self._client.models.embed_content, **embed_kwargs),  # type: ignore[union-attr]
             policy=self.retry_policy,
             budget=self.retry_policy.new_budget(),
@@ -2250,7 +2038,7 @@ class GeminiEmbeddings(Embeddings):
 
         # One retry budget for the whole call: batching must not multiply the
         # worst-case added latency of a single encode(). Shared across the concurrent
-        # batches too, which is why _RetryBudget takes a lock.
+        # batches too, which is why RetryBudget takes a lock.
         budget = self.retry_policy.new_budget()
 
         all_embeddings = self._encode_batched(
@@ -2270,7 +2058,7 @@ class GeminiEmbeddings(Embeddings):
 
         return all_embeddings
 
-    def _embed_batch(self, batch: list[str], budget: "_RetryBudget") -> list[list[float]]:
+    def _embed_batch(self, batch: list[str], budget: "RetryBudget") -> list[list[float]]:
         """Embed one batch-sized slice through the google.genai sync client."""
         embed_kwargs = {"model": self.model, "contents": batch}
         if self._embed_config is not None:
@@ -2279,7 +2067,7 @@ class GeminiEmbeddings(Embeddings):
         # Recall runs this inline, and a shared Gemini project hands out 429s well
         # before anything is actually wrong, so transient upstream failures are
         # retried here rather than dead-lettering the whole operation (#4103).
-        result = _call_with_retry(
+        result = call_with_retry(
             lambda: self._client.models.embed_content(**embed_kwargs),
             policy=self.retry_policy,
             budget=budget,
@@ -2295,9 +2083,9 @@ class GeminiEmbeddings(Embeddings):
         return [emb.values for emb in embeddings]
 
 
-def _retry_policy_from_config(config: "HindsightConfig") -> EmbeddingRetryPolicy:
+def _retry_policy_from_config(config: "HindsightConfig") -> RetryPolicy:
     """Build the embedding retry policy from resolved configuration."""
-    return EmbeddingRetryPolicy(
+    return RetryPolicy(
         max_retries=config.embeddings_max_retries,
         initial_backoff=config.embeddings_initial_backoff,
         max_backoff=config.embeddings_max_backoff,

--- a/hindsight-api-slim/hindsight_api/engine/remote_retry.py
+++ b/hindsight-api-slim/hindsight_api/engine/remote_retry.py
@@ -1,0 +1,236 @@
+"""Bounded retry/backoff for remote model APIs (embeddings and rerankers).
+
+Extracted from ``embeddings.py`` so the rerankers can share it rather than grow a
+fourth private copy: TEI had its own loop, the LiteLLM embedding backends had this
+one, and Gemini/Cohere/ZeroEntropy each nearly grew another (#4103, #4134). The
+policy is deliberately provider-agnostic — it classifies on HTTP status and
+transport-level exception shape, never on an SDK type — so a new backend wires in
+by passing a policy rather than by re-deriving what "transient" means.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TypeVar
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+# 4xx codes that describe a transient condition rather than a bad request.
+# Everything else in the 4xx range (auth, validation, not-found) is a client-side
+# problem that retrying cannot fix.
+_TRANSIENT_STATUS_CODES = frozenset({408, 409, 425, 429})
+
+# Exception class names treated as transient when the exception carries no HTTP
+# status code. Matching by name keeps this module free of a hard litellm/openai
+# import (litellm is imported lazily, and only by the providers that need it).
+_TRANSIENT_EXCEPTION_NAMES = frozenset(
+    {
+        "APIConnectionError",
+        "APIError",
+        "APITimeoutError",
+        "ConnectionError",
+        "InternalServerError",
+        "RateLimitError",
+        "ServiceUnavailableError",
+        "Timeout",
+        "TimeoutError",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """
+    Bounded retry policy for a remote model API (embeddings, rerank, ...).
+
+    Recall embeds its query and reranks its candidates inline on the request path,
+    so a single upstream 5xx would otherwise become a user-visible recall failure.
+    Retries are bounded two ways at once:
+
+    * ``max_retries`` caps the number of extra attempts (0 disables retrying).
+    * ``budget_seconds`` caps the wall-clock time a single logical call may
+      *waste* on retries — failed attempts plus backoff sleeps. Successful work
+      never counts against it, so a large multi-batch call is not penalised for the
+      batches that worked, while the worst-case added latency stays bounded.
+
+    The pairing matters: attempts alone cannot bound latency (an upstream that
+    fails slowly turns 5 attempts into minutes), and a budget alone cannot stop a
+    fast-failing upstream from being hammered.
+    """
+
+    # Defaults for a provider constructed without an explicit policy (tests, direct
+    # instantiation). Production paths pass the resolved HINDSIGHT_API_* values; these
+    # mirror the embedding defaults the policy shipped with.
+    max_retries: int = 4
+    initial_backoff: float = 0.5
+    max_backoff: float = 4.0
+    budget_seconds: float = 15.0
+
+    def new_budget(self) -> "RetryBudget":
+        """Start a fresh retry budget, scoped to one logical embedding call."""
+        return RetryBudget(self.budget_seconds)
+
+
+class RetryBudget:
+    """Mutable remaining-retry-time counter shared across the batches of one call.
+
+    The batches of one call may go out concurrently (see ``Embeddings._encode_batched``),
+    so the counter is touched from several threads at once; without the lock a
+    read-modify-write race would under-charge the budget and let retries run past it.
+    """
+
+    __slots__ = ("remaining", "_lock")
+
+    def __init__(self, seconds: float):
+        self.remaining = max(0.0, seconds)
+        self._lock = threading.Lock()
+
+    @property
+    def exhausted(self) -> bool:
+        return self.remaining <= 0.0
+
+    def spend(self, seconds: float) -> None:
+        with self._lock:
+            self.remaining = max(0.0, self.remaining - max(0.0, seconds))
+
+
+def status_code_of(exc: BaseException) -> int | None:
+    """Best-effort HTTP status extraction across httpx, openai, litellm and google.genai errors."""
+    candidates = (
+        getattr(exc, "status_code", None),
+        getattr(getattr(exc, "response", None), "status_code", None),
+        # google.genai.errors.APIError carries the status on `code`, and leaves
+        # `response` as None on the paths that raise from a parsed error body.
+        getattr(exc, "code", None),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, bool):
+            continue
+        if isinstance(candidate, str) and candidate.isdigit():
+            candidate = int(candidate)
+        # Range-checked because `code` is a common attribute name that is not
+        # always an HTTP status (SystemExit.code, OSError subclasses).
+        if isinstance(candidate, int) and 100 <= candidate <= 599:
+            return candidate
+    return None
+
+
+def is_transient_remote_error(exc: BaseException) -> bool:
+    """
+    Return True when ``exc`` is worth retrying.
+
+    A status code, when present, is authoritative: 5xx and the transient 4xx set
+    are retryable, every other 4xx (401/403 auth, 400/422 validation, 404) is
+    permanent and must fail fast. Without a status code we fall back to
+    transport-level exception types and known SDK exception names.
+    """
+    status = status_code_of(exc)
+    if status is not None:
+        return status >= 500 or status in _TRANSIENT_STATUS_CODES
+    if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
+        return True
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return True
+    return type(exc).__name__ in _TRANSIENT_EXCEPTION_NAMES
+
+
+def _retry_delay_for(
+    exc: BaseException,
+    *,
+    attempt: int,
+    attempts: int,
+    policy: RetryPolicy,
+    budget: RetryBudget,
+    provider: str,
+) -> float | None:
+    """
+    Decide whether ``exc`` should be retried and how long to wait first.
+
+    Returns the sleep duration, or None when the exception must propagate. Logs
+    the decision and charges the sleep to ``budget``. Upstream error text is
+    truncated (matching the LLM providers) so a verbose provider payload cannot
+    flood the log.
+    """
+    if not is_transient_remote_error(exc):
+        return None
+
+    status = status_code_of(exc)
+    status_label = f"HTTP {status}" if status is not None else type(exc).__name__
+    detail = str(exc)[:200]
+
+    if attempt >= attempts - 1:
+        logger.error(f"{provider} call failed after {attempts} attempt(s) ({status_label}): {detail}")
+        return None
+
+    if budget.exhausted:
+        logger.error(
+            f"{provider} call failed on attempt {attempt + 1}/{attempts} ({status_label}) and the "
+            f"{policy.budget_seconds:.1f}s retry budget is exhausted, giving up: {detail}"
+        )
+        return None
+
+    backoff = min(policy.initial_backoff * (2**attempt), policy.max_backoff)
+    jitter = backoff * 0.2 * (2 * (time.time() % 1) - 1)
+    sleep_for = min(max(0.0, backoff + jitter), budget.remaining)
+    budget.spend(sleep_for)
+    logger.warning(
+        f"{provider} call failed (attempt {attempt + 1}/{attempts}, {status_label}), "
+        f"retrying in {sleep_for:.2f}s ({budget.remaining:.1f}s of retry budget left): {detail}"
+    )
+    return sleep_for
+
+
+def call_with_retry(
+    call: Callable[[], T],
+    *,
+    policy: RetryPolicy,
+    budget: RetryBudget,
+    provider: str,
+) -> T:
+    """Run a blocking remote call, retrying transient upstream failures."""
+    attempts = policy.max_retries + 1
+    for attempt in range(attempts):
+        started = time.monotonic()
+        try:
+            return call()
+        except Exception as exc:
+            budget.spend(time.monotonic() - started)
+            delay = _retry_delay_for(
+                exc, attempt=attempt, attempts=attempts, policy=policy, budget=budget, provider=provider
+            )
+            if delay is None:
+                raise
+            time.sleep(delay)
+    raise RuntimeError("unreachable: retry loop exited without returning or raising")
+
+
+async def acall_with_retry(
+    call: Callable[[], Awaitable[T]],
+    *,
+    policy: RetryPolicy,
+    budget: RetryBudget,
+    provider: str,
+) -> T:
+    """Async twin of :func:`call_with_retry`, sharing its policy and classification."""
+    attempts = policy.max_retries + 1
+    for attempt in range(attempts):
+        started = time.monotonic()
+        try:
+            return await call()
+        except Exception as exc:
+            budget.spend(time.monotonic() - started)
+            delay = _retry_delay_for(
+                exc, attempt=attempt, attempts=attempts, policy=policy, budget=budget, provider=provider
+            )
+            if delay is None:
+                raise
+            await asyncio.sleep(delay)
+    raise RuntimeError("unreachable: retry loop exited without returning or raising")

--- a/hindsight-api-slim/tests/test_cohere_embeddings_retry.py
+++ b/hindsight-api-slim/tests/test_cohere_embeddings_retry.py
@@ -19,7 +19,7 @@ import pytest
 
 from hindsight_api.engine.embeddings import (
     CohereEmbeddings,
-    EmbeddingRetryPolicy,
+    RetryPolicy,
     create_embeddings_from_env,
 )
 
@@ -63,10 +63,10 @@ class _CohereApiError(Exception):
 
 
 # Fast policy so these tests exercise the retry logic, not the sleeps.
-_FAST_POLICY = EmbeddingRetryPolicy(max_retries=3, initial_backoff=0.01, max_backoff=0.02, budget_seconds=5.0)
+_FAST_POLICY = RetryPolicy(max_retries=3, initial_backoff=0.01, max_backoff=0.02, budget_seconds=5.0)
 
 
-def _make_embeddings(side_effect, policy: EmbeddingRetryPolicy = _FAST_POLICY) -> CohereEmbeddings:
+def _make_embeddings(side_effect, policy: RetryPolicy = _FAST_POLICY) -> CohereEmbeddings:
     emb = CohereEmbeddings(api_key="co-test", model="embed-english-v3.0", retry_policy=policy)
     client = MagicMock()
     client.embed = MagicMock(side_effect=side_effect)
@@ -159,7 +159,7 @@ def test_retry_budget_is_shared_across_batches():
     Four concurrent batches at five retries each would be 24 upstream calls if every
     batch got its own budget; one budget for the whole call cuts it to a handful.
     """
-    policy = EmbeddingRetryPolicy(max_retries=5, initial_backoff=0.05, max_backoff=0.05, budget_seconds=0.06)
+    policy = RetryPolicy(max_retries=5, initial_backoff=0.05, max_backoff=0.05, budget_seconds=0.06)
     calls = {"n": 0}
     lock = threading.Lock()
 

--- a/hindsight-api-slim/tests/test_embedding_retry.py
+++ b/hindsight-api-slim/tests/test_embedding_retry.py
@@ -20,12 +20,14 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
+from hindsight_api.engine.remote_retry import (
+    RetryPolicy,
+    is_transient_remote_error,
+    status_code_of,
+)
 from hindsight_api.engine.embeddings import (
-    EmbeddingRetryPolicy,
     LiteLLMEmbeddings,
     LiteLLMSDKEmbeddings,
-    _is_transient_embedding_error,
-    _status_code_of,
 )
 
 
@@ -55,7 +57,7 @@ def _response_for(texts):
     return response
 
 
-def _make_embeddings(policy: EmbeddingRetryPolicy, batch_size: int = 100) -> LiteLLMSDKEmbeddings:
+def _make_embeddings(policy: RetryPolicy, batch_size: int = 100) -> LiteLLMSDKEmbeddings:
     emb = LiteLLMSDKEmbeddings(
         api_key="test_key",
         model="openai/text-embedding-qwen3-8b",
@@ -70,7 +72,7 @@ def _make_embeddings(policy: EmbeddingRetryPolicy, batch_size: int = 100) -> Lit
 
 
 # Fast policy so the tests exercise the logic, not the sleeps.
-FAST_POLICY = EmbeddingRetryPolicy(max_retries=4, initial_backoff=0.01, max_backoff=0.04, budget_seconds=5.0)
+FAST_POLICY = RetryPolicy(max_retries=4, initial_backoff=0.01, max_backoff=0.04, budget_seconds=5.0)
 
 
 class TestTransientClassification:
@@ -78,41 +80,41 @@ class TestTransientClassification:
 
     @pytest.mark.parametrize("status", [500, 502, 503, 504, 408, 429])
     def test_transient_status_codes(self, status):
-        assert _is_transient_embedding_error(_StatusError(status)) is True
+        assert is_transient_remote_error(_StatusError(status)) is True
 
     @pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
     def test_client_error_status_codes_are_not_transient(self, status):
-        assert _is_transient_embedding_error(_StatusError(status)) is False
+        assert is_transient_remote_error(_StatusError(status)) is False
 
     def test_transport_errors_are_transient(self):
         import httpx
 
-        assert _is_transient_embedding_error(httpx.ConnectError("connection refused")) is True
-        assert _is_transient_embedding_error(httpx.ReadTimeout("read timed out")) is True
-        assert _is_transient_embedding_error(TimeoutError("timed out")) is True
-        assert _is_transient_embedding_error(ConnectionError("reset by peer")) is True
+        assert is_transient_remote_error(httpx.ConnectError("connection refused")) is True
+        assert is_transient_remote_error(httpx.ReadTimeout("read timed out")) is True
+        assert is_transient_remote_error(TimeoutError("timed out")) is True
+        assert is_transient_remote_error(ConnectionError("reset by peer")) is True
 
     def test_named_sdk_errors_are_transient_without_status(self):
         class APITimeoutError(Exception):
             pass
 
-        assert _is_transient_embedding_error(APITimeoutError("no status attribute")) is True
+        assert is_transient_remote_error(APITimeoutError("no status attribute")) is True
 
     def test_unknown_errors_are_not_transient(self):
-        assert _is_transient_embedding_error(ValueError("bad input")) is False
-        assert _is_transient_embedding_error(Exception("API Error")) is False
+        assert is_transient_remote_error(ValueError("bad input")) is False
+        assert is_transient_remote_error(Exception("API Error")) is False
 
     def test_google_genai_status_on_code_attribute(self):
         """google.genai.errors.APIError carries the status on `code`, with `response` often None."""
-        assert _is_transient_embedding_error(SimpleNamespace(code=429, response=None)) is True
-        assert _is_transient_embedding_error(SimpleNamespace(code=503, response=None)) is True
-        assert _is_transient_embedding_error(SimpleNamespace(code=403, response=None)) is False
+        assert is_transient_remote_error(SimpleNamespace(code=429, response=None)) is True
+        assert is_transient_remote_error(SimpleNamespace(code=503, response=None)) is True
+        assert is_transient_remote_error(SimpleNamespace(code=403, response=None)) is False
 
     def test_non_status_code_attributes_are_ignored(self):
         """`code` is a common attribute name; only plausible HTTP statuses may classify."""
-        assert _status_code_of(SimpleNamespace(code="RESOURCE_EXHAUSTED")) is None
-        assert _status_code_of(SimpleNamespace(code=1)) is None
-        assert _status_code_of(SimpleNamespace(code=429)) == 429
+        assert status_code_of(SimpleNamespace(code="RESOURCE_EXHAUSTED")) is None
+        assert status_code_of(SimpleNamespace(code=1)) is None
+        assert status_code_of(SimpleNamespace(code=429)) == 429
 
 
 class TestEncodeRetries:
@@ -166,7 +168,7 @@ class TestEncodeRetries:
         assert emb._litellm.embedding.call_count == 1
 
     def test_retries_disabled_by_zero_max_retries(self):
-        emb = _make_embeddings(EmbeddingRetryPolicy(max_retries=0, budget_seconds=5.0))
+        emb = _make_embeddings(RetryPolicy(max_retries=0, budget_seconds=5.0))
         emb._litellm.embedding.side_effect = _InternalServerError()
 
         with pytest.raises(_InternalServerError):
@@ -181,7 +183,7 @@ class TestRetryBudget:
     def test_budget_cuts_retries_short_and_bounds_wall_clock(self):
         # Each failed attempt burns ~0.2s, so a 0.5s budget cannot fund the full
         # 5 attempts even though max_retries would allow them.
-        policy = EmbeddingRetryPolicy(max_retries=4, initial_backoff=0.05, max_backoff=0.2, budget_seconds=0.5)
+        policy = RetryPolicy(max_retries=4, initial_backoff=0.05, max_backoff=0.2, budget_seconds=0.5)
         emb = _make_embeddings(policy)
 
         def slow_failure(**kwargs):
@@ -203,7 +205,7 @@ class TestRetryBudget:
     def test_budget_is_shared_across_batches(self):
         # 6 texts at batch_size=2 -> 3 batches. A per-batch budget would let the
         # call spend 3x the configured ceiling.
-        policy = EmbeddingRetryPolicy(max_retries=4, initial_backoff=0.05, max_backoff=0.2, budget_seconds=0.4)
+        policy = RetryPolicy(max_retries=4, initial_backoff=0.05, max_backoff=0.2, budget_seconds=0.4)
         emb = _make_embeddings(policy, batch_size=2)
 
         def slow_failure(**kwargs):
@@ -223,7 +225,7 @@ class TestRetryBudget:
     def test_budget_not_consumed_by_successful_batches(self):
         # A long run of successful batches must not starve a later batch of its
         # retries — only failures and backoff sleeps count against the budget.
-        policy = EmbeddingRetryPolicy(max_retries=4, initial_backoff=0.01, max_backoff=0.04, budget_seconds=0.5)
+        policy = RetryPolicy(max_retries=4, initial_backoff=0.01, max_backoff=0.04, budget_seconds=0.5)
         emb = _make_embeddings(policy, batch_size=1)
         calls = {"n": 0}
 
@@ -320,7 +322,7 @@ class TestPolicyFromConfig:
         assert policy.budget_seconds == 7.5
 
     def test_defaults_are_bounded(self):
-        policy = EmbeddingRetryPolicy()
+        policy = RetryPolicy()
 
         assert 3 <= policy.max_retries + 1 <= 5
         assert policy.budget_seconds <= 15.0
@@ -336,7 +338,7 @@ class TestLiteLLMProxyEncodeRetries:
     through to the caller.
     """
 
-    def _make_proxy(self, policy: EmbeddingRetryPolicy, batch_size: int = 100) -> LiteLLMEmbeddings:
+    def _make_proxy(self, policy: RetryPolicy, batch_size: int = 100) -> LiteLLMEmbeddings:
         emb = LiteLLMEmbeddings(
             api_base="https://proxy.invalid",
             api_key="test_key",
@@ -398,7 +400,7 @@ class TestEveryRemoteProviderRetries:
     inheriting none.
     """
 
-    # Providers that legitimately do not take an EmbeddingRetryPolicy, and why.
+    # Providers that legitimately do not take an RetryPolicy, and why.
     _EXEMPT = {
         # In-process: no round trip to fail transiently.
         "LocalSTEmbeddings": "in-process",
@@ -426,7 +428,7 @@ class TestEveryRemoteProviderRetries:
                 missing.append(name)
 
         assert not missing, (
-            f"{missing} take no retry_policy. Wire them through EmbeddingRetryPolicy "
+            f"{missing} take no retry_policy. Wire them through RetryPolicy "
             f"(as the litellm/google/cohere/zeroentropy backends are), or add them to "
             f"_EXEMPT with the reason they retry some other way."
         )

--- a/hindsight-api-slim/tests/test_gemini_embeddings.py
+++ b/hindsight-api-slim/tests/test_gemini_embeddings.py
@@ -20,7 +20,7 @@ import pytest
 
 from hindsight_api.config import HindsightConfig
 from hindsight_api.engine.embeddings import (
-    EmbeddingRetryPolicy,
+    RetryPolicy,
     GeminiEmbeddings,
     _gemini_model_aggregates_inputs,
     create_embeddings_from_env,
@@ -336,7 +336,7 @@ class _GenAIError(Exception):
 
 
 # Fast policy so these tests exercise the retry logic, not the sleeps.
-_FAST_POLICY = EmbeddingRetryPolicy(max_retries=3, initial_backoff=0.01, max_backoff=0.02, budget_seconds=5.0)
+_FAST_POLICY = RetryPolicy(max_retries=3, initial_backoff=0.01, max_backoff=0.02, budget_seconds=5.0)
 
 
 class TestGeminiEmbeddingsRetry:
@@ -347,7 +347,7 @@ class TestGeminiEmbeddingsRetry:
     retain and consolidation operations during an ordinary quota window.
     """
 
-    def _make_embeddings(self, side_effect, policy: EmbeddingRetryPolicy = _FAST_POLICY) -> GeminiEmbeddings:
+    def _make_embeddings(self, side_effect, policy: RetryPolicy = _FAST_POLICY) -> GeminiEmbeddings:
         emb = GeminiEmbeddings(model="gemini-embedding-001", api_key="test-key", retry_policy=policy)
         client = MagicMock()
         client.models.embed_content = MagicMock(side_effect=side_effect)
@@ -417,7 +417,7 @@ class TestGeminiEmbeddingsRetry:
         the whole call bounds it: here four concurrent batches with five retries each
         would be 24 upstream calls unshared, and the shared budget cuts it to a handful.
         """
-        policy = EmbeddingRetryPolicy(max_retries=5, initial_backoff=0.05, max_backoff=0.05, budget_seconds=0.06)
+        policy = RetryPolicy(max_retries=5, initial_backoff=0.05, max_backoff=0.05, budget_seconds=0.06)
         calls = {"n": 0}
         lock = threading.Lock()
 

--- a/hindsight-api-slim/tests/test_litellm_embeddings_retry.py
+++ b/hindsight-api-slim/tests/test_litellm_embeddings_retry.py
@@ -11,7 +11,7 @@ from hindsight_api.config import (
     clear_config_cache,
 )
 from hindsight_api.engine.embeddings import (
-    EmbeddingRetryPolicy,
+    RetryPolicy,
     LiteLLMEmbeddings,
     create_embeddings_from_env,
 )
@@ -39,7 +39,7 @@ async def test_litellm_embeddings_initialize_probe_success() -> None:
     embeddings = LiteLLMEmbeddings(
         api_base="http://test-litellm:4000",
         model="text-embedding-3-small",
-        retry_policy=EmbeddingRetryPolicy(initial_backoff=0.01),
+        retry_policy=RetryPolicy(initial_backoff=0.01),
     )
 
     mock_resp = httpx.Response(
@@ -61,7 +61,7 @@ async def test_litellm_embeddings_probe_retries_on_500_and_recovers() -> None:
     embeddings = LiteLLMEmbeddings(
         api_base="http://test-litellm:4000",
         model="text-embedding-3-small",
-        retry_policy=EmbeddingRetryPolicy(max_retries=3, initial_backoff=0.01),
+        retry_policy=RetryPolicy(max_retries=3, initial_backoff=0.01),
     )
 
     req = httpx.Request("POST", "http://test-litellm:4000/embeddings")
@@ -85,7 +85,7 @@ async def test_litellm_embeddings_probe_retries_on_connect_error_and_recovers() 
     embeddings = LiteLLMEmbeddings(
         api_base="http://test-litellm:4000",
         model="text-embedding-3-small",
-        retry_policy=EmbeddingRetryPolicy(max_retries=3, initial_backoff=0.01),
+        retry_policy=RetryPolicy(max_retries=3, initial_backoff=0.01),
     )
 
     req = httpx.Request("POST", "http://test-litellm:4000/embeddings")
@@ -112,7 +112,7 @@ async def test_litellm_embeddings_probe_exhausts_retries_and_raises() -> None:
     embeddings = LiteLLMEmbeddings(
         api_base="http://test-litellm:4000",
         model="text-embedding-3-small",
-        retry_policy=EmbeddingRetryPolicy(max_retries=2, initial_backoff=0.01),
+        retry_policy=RetryPolicy(max_retries=2, initial_backoff=0.01),
     )
 
     req = httpx.Request("POST", "http://test-litellm:4000/embeddings")
@@ -130,7 +130,7 @@ def _ready_embeddings(dimensions: int | None, dim: int) -> LiteLLMEmbeddings:
         api_base="http://test-litellm:4000",
         model="text-embedding-3-small",
         dimensions=dimensions,
-        retry_policy=EmbeddingRetryPolicy(max_retries=2, initial_backoff=0.01),
+        retry_policy=RetryPolicy(max_retries=2, initial_backoff=0.01),
     )
     embeddings._client = httpx.Client()
     embeddings._dimension = dim
@@ -198,7 +198,7 @@ async def test_litellm_embeddings_probe_does_not_retry_client_error() -> None:
     embeddings = LiteLLMEmbeddings(
         api_base="http://test-litellm:4000",
         model="text-embedding-3-small",
-        retry_policy=EmbeddingRetryPolicy(max_retries=3, initial_backoff=0.01),
+        retry_policy=RetryPolicy(max_retries=3, initial_backoff=0.01),
     )
 
     req = httpx.Request("POST", "http://test-litellm:4000/embeddings")
@@ -216,7 +216,7 @@ async def test_litellm_embeddings_probe_empty_data_names_the_env_var() -> None:
     embeddings = LiteLLMEmbeddings(
         api_base="http://test-litellm:4000",
         model="text-embedding-3-small",
-        retry_policy=EmbeddingRetryPolicy(initial_backoff=0.01),
+        retry_policy=RetryPolicy(initial_backoff=0.01),
     )
 
     req = httpx.Request("POST", "http://test-litellm:4000/embeddings")

--- a/hindsight-api-slim/tests/test_reranker_retry.py
+++ b/hindsight-api-slim/tests/test_reranker_retry.py
@@ -1,0 +1,272 @@
+"""Bounded retry/backoff for remote rerankers (issue #4134).
+
+Rerank sits on the same synchronous recall path as the query embedding, and with no
+fallback chain configured — the default — the reranker is used bare: nothing between
+`CrossEncoderReranker.rerank` and the caller catches anything. Before this a single
+Cohere/Google/SiliconFlow 429 failed the entire recall.
+
+The retry lives on `CrossEncoderModel.predict`, which every backend inherits, so a new
+remote reranker gets it without having to remember. `TestEveryRemoteRerankerRetries`
+is the guard that keeps that true.
+"""
+
+import asyncio
+import inspect
+import time
+from dataclasses import fields
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.config import HindsightConfig
+from hindsight_api.engine import cross_encoder as cross_encoder_module
+from hindsight_api.engine.cross_encoder import (
+    _RERANKER_PROVIDERS_WITHOUT_RETRY,
+    CrossEncoderModel,
+    MultiCrossEncoder,
+    create_cross_encoder_from_env,
+)
+from hindsight_api.engine.remote_retry import RetryPolicy
+
+# Fast policy so these tests exercise the retry logic, not the sleeps.
+_FAST_POLICY = RetryPolicy(max_retries=3, initial_backoff=0.01, max_backoff=0.02, budget_seconds=5.0)
+
+
+class _ApiError(Exception):
+    """Stand-in for a provider SDK error, which exposes `status_code`."""
+
+    def __init__(self, status_code: int):
+        super().__init__(f"upstream error (status {status_code})")
+        self.status_code = status_code
+
+
+class _FlakyReranker(CrossEncoderModel):
+    """A remote-shaped backend that fails `failures` times before answering."""
+
+    def __init__(self, failures: int, status: int = 429, policy: RetryPolicy | None = _FAST_POLICY):
+        self.calls = 0
+        self._failures = failures
+        self._status = status
+        self.retry_policy = policy
+
+    @property
+    def provider_name(self) -> str:
+        return "flaky"
+
+    async def initialize(self) -> None:
+        return None
+
+    async def _predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+        self.calls += 1
+        if self.calls <= self._failures:
+            raise _ApiError(self._status)
+        return [1.0] * len(pairs)
+
+
+PAIRS = [("q", "doc a"), ("q", "doc b")]
+
+
+class TestRemoteRerankerRetries:
+    async def test_transient_status_then_success(self):
+        """A 429 is retried and the later success is returned, not raised at the caller."""
+        reranker = _FlakyReranker(failures=1)
+        assert await reranker.predict(PAIRS) == [1.0, 1.0]
+        assert reranker.calls == 2
+
+    @pytest.mark.parametrize("status", [500, 502, 503, 504, 408])
+    async def test_transient_service_responses_are_retried(self, status):
+        reranker = _FlakyReranker(failures=1, status=status)
+        assert await reranker.predict(PAIRS) == [1.0, 1.0]
+        assert reranker.calls == 2
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+    async def test_permanent_client_errors_fail_fast(self, status):
+        """Auth and validation failures must not be retried — retrying cannot fix them."""
+        reranker = _FlakyReranker(failures=99, status=status)
+        with pytest.raises(_ApiError):
+            await reranker.predict(PAIRS)
+        assert reranker.calls == 1
+
+    async def test_exhausted_retries_propagate(self):
+        """A sustained outage still surfaces, after a bounded attempt count."""
+        reranker = _FlakyReranker(failures=99)
+        with pytest.raises(_ApiError):
+            await reranker.predict(PAIRS)
+        assert reranker.calls == _FAST_POLICY.max_retries + 1
+
+    async def test_no_policy_means_no_retry(self):
+        """The in-process backends and TEI opt out — one attempt, straight through."""
+        reranker = _FlakyReranker(failures=99, policy=None)
+        with pytest.raises(_ApiError):
+            await reranker.predict(PAIRS)
+        assert reranker.calls == 1
+
+    async def test_budget_bounds_the_added_latency(self):
+        """The wall-clock budget caps what one rerank can add to a live recall."""
+        policy = RetryPolicy(max_retries=50, initial_backoff=0.05, max_backoff=0.05, budget_seconds=0.1)
+        reranker = _FlakyReranker(failures=999, policy=policy)
+
+        started = time.monotonic()
+        with pytest.raises(_ApiError):
+            await reranker.predict(PAIRS)
+
+        # Without the budget, 50 retries at 0.05s would be ~2.5s.
+        assert time.monotonic() - started < 1.0
+        assert reranker.calls < policy.max_retries + 1
+
+
+class TestFailoverChainAdvancesOnlyAfterRetries:
+    """`MultiCrossEncoder`'s contract: a member exhausts its own retries first.
+
+    That claim sat in the docstring while only the TEI member could honour it, so an
+    ordinary quota blip on the primary burned a fallback — silently degrading ranking
+    quality over something a one-second backoff absorbs.
+    """
+
+    async def test_primary_recovers_within_its_retries_and_no_fallback_is_touched(self):
+        primary = _FlakyReranker(failures=2)
+        fallback = _FlakyReranker(failures=0)
+        chain = MultiCrossEncoder([primary, fallback])
+
+        assert await chain.predict(PAIRS) == [1.0, 1.0]
+        assert primary.calls == 3
+        assert fallback.calls == 0
+
+    async def test_chain_advances_once_the_primary_exhausts_its_retries(self):
+        primary = _FlakyReranker(failures=99)
+        fallback = _FlakyReranker(failures=0)
+        chain = MultiCrossEncoder([primary, fallback])
+
+        assert await chain.predict(PAIRS) == [1.0, 1.0]
+        assert primary.calls == _FAST_POLICY.max_retries + 1
+        assert fallback.calls == 1
+
+    async def test_the_chain_itself_does_not_add_a_second_retry_layer(self):
+        """Retry is per member; wrapping the chain too would multiply the attempts."""
+        chain = MultiCrossEncoder([_FlakyReranker(failures=0), _FlakyReranker(failures=0)])
+        assert chain.retry_policy is None
+
+
+class TestEveryRemoteRerankerRetries:
+    """A structural guard over the whole reranker family.
+
+    The backend that forgets is by definition the one nobody wrote a test for — that
+    is how every remote reranker but TEI shipped with no retry at all. These assert
+    over the classes and providers enumerated from the module, not over the ones we
+    happened to remember.
+    """
+
+    def _backend_classes(self) -> list[type[CrossEncoderModel]]:
+        return [
+            obj
+            for obj in vars(cross_encoder_module).values()
+            if inspect.isclass(obj)
+            and issubclass(obj, CrossEncoderModel)
+            and obj is not CrossEncoderModel
+            and obj is not MultiCrossEncoder  # a chain, not a backend
+        ]
+
+    def test_every_backend_implements_predict_via_the_shared_entry_point(self):
+        """A backend that overrides `predict` opts itself out of retry silently."""
+        assert self._backend_classes(), "no backends discovered — the guard would vacuously pass"
+        overriding = [c.__name__ for c in self._backend_classes() if "predict" in vars(c)]
+        assert not overriding, (
+            f"{overriding} override predict() and so bypass the shared retry. Implement _predict() instead."
+        )
+
+    def test_every_backend_implements_predict(self):
+        missing = [c.__name__ for c in self._backend_classes() if "_predict" not in vars(c)]
+        assert not missing, f"{missing} implement neither _predict() nor predict()"
+
+    @pytest.mark.parametrize(
+        "provider, extra",
+        [
+            ("cohere", {"reranker_cohere_api_key": "k"}),
+            ("openrouter", {"reranker_openrouter_api_key": "k"}),
+            ("zeroentropy", {"reranker_zeroentropy_api_key": "k"}),
+            (
+                "siliconflow",
+                {"reranker_siliconflow_api_key": "k", "reranker_siliconflow_base_url": "https://example.invalid"},
+            ),
+            ("alibaba", {"reranker_alibaba_api_key": "k"}),
+            ("google", {"reranker_google_project_id": "p"}),
+            ("litellm", {"reranker_litellm_api_base": "https://example.invalid"}),
+            ("litellm-sdk", {"reranker_litellm_sdk_api_key": "k"}),
+        ],
+    )
+    def test_factory_gives_every_remote_provider_a_policy(self, provider, extra):
+        encoder = self._build(provider, extra)
+        assert encoder.retry_policy is not None, f"{provider} was built without a retry policy"
+        assert encoder.retry_policy.max_retries == 7
+        assert encoder.retry_policy.budget_seconds == 42.5
+
+    @pytest.mark.parametrize("provider", sorted(_RERANKER_PROVIDERS_WITHOUT_RETRY))
+    def test_exempt_providers_are_left_alone(self, provider):
+        """In-process backends and TEI (own retry loop) must not gain a second layer."""
+        extra = (
+            {
+                "reranker_tei_url": "https://example.invalid",
+                "reranker_tei_batch_size": 32,
+                "reranker_tei_max_concurrent": 4,
+            }
+            if provider == "tei"
+            else {}
+        )
+        encoder = self._build(provider, extra)
+        assert encoder.retry_policy is None
+
+    def _build(self, provider: str, extra: dict) -> CrossEncoderModel:
+        defaults: dict = {}
+        for f in fields(HindsightConfig):
+            if f.type == "str":
+                defaults[f.name] = ""
+            elif f.type == "int":
+                defaults[f.name] = 0
+            elif f.type == "float":
+                defaults[f.name] = 0.0
+            elif f.type == "bool":
+                defaults[f.name] = False
+            elif str(f.type).startswith("list["):
+                defaults[f.name] = []
+            else:
+                defaults[f.name] = None
+        defaults.update(
+            reranker_provider=provider,
+            reranker_max_retries=7,
+            reranker_initial_backoff=0.25,
+            reranker_max_backoff=2.0,
+            reranker_retry_budget=42.5,
+            **extra,
+        )
+        config = HindsightConfig(**defaults)
+        with patch("hindsight_api.config.get_config", return_value=config):
+            return create_cross_encoder_from_env()
+
+
+def test_retry_runs_on_the_event_loop_without_blocking_it():
+    """The backoff must be `await asyncio.sleep`, not `time.sleep` — rerank is awaited.
+
+    A blocking sleep here would stall every other coroutine on the loop, which on the
+    recall path means stalling unrelated requests.
+    """
+
+    async def scenario() -> bool:
+        reranker = _FlakyReranker(
+            failures=1,
+            policy=RetryPolicy(max_retries=2, initial_backoff=0.2, max_backoff=0.2, budget_seconds=5.0),
+        )
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        tick_task = asyncio.create_task(ticker())
+        await reranker.predict(PAIRS)
+        tick_task.cancel()
+        # The loop kept running other work during the ~0.2s backoff.
+        return ticks > 2
+
+    assert asyncio.run(scenario())

--- a/hindsight-api-slim/tests/test_zeroentropy_embeddings.py
+++ b/hindsight-api-slim/tests/test_zeroentropy_embeddings.py
@@ -295,7 +295,7 @@ def _retrying_embeddings(responses: list[int], policy=None):
     """Build a provider whose transport replays `responses` (HTTP status codes) in order."""
     import threading
 
-    from hindsight_api.engine.embeddings import EmbeddingRetryPolicy, ZeroEntropyEmbeddings
+    from hindsight_api.engine.embeddings import RetryPolicy, ZeroEntropyEmbeddings
 
     statuses = list(responses)
     calls = {"n": 0}
@@ -316,8 +316,7 @@ def _retrying_embeddings(responses: list[int], policy=None):
         api_key="ze-test",
         dimensions=1280,
         batch_size=2,
-        retry_policy=policy
-        or EmbeddingRetryPolicy(max_retries=3, initial_backoff=0.01, max_backoff=0.02, budget_seconds=5.0),
+        retry_policy=policy or RetryPolicy(max_retries=3, initial_backoff=0.01, max_backoff=0.02, budget_seconds=5.0),
     )
     embeddings._client = httpx.Client(
         transport=httpx.MockTransport(handler),

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -1060,6 +1060,10 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_RERANKER_PROVIDER` | Provider: `local`, `tei`, `cohere`, `openrouter`, `zeroentropy`, `siliconflow`, `alibaba`, `google`, `flashrank`, `litellm`, `litellm-sdk`, `jina-mlx`, or `rrf` | `local` |
+| `HINDSIGHT_API_RERANKER_MAX_RETRIES` | Retries after the first attempt when a remote rerank call fails transiently (5xx, timeout, connection error, `429` quota). `0` disables retrying. Applies to every remote provider except `tei`, which has its own retry loop; the in-process providers (`local`, `flashrank`, `jina-mlx`, `rrf`) are unaffected. 4xx auth/validation errors are never retried. | `3` |
+| `HINDSIGHT_API_RERANKER_INITIAL_BACKOFF` | Initial backoff in seconds between rerank retries (doubles per attempt, with jitter) | `0.5` |
+| `HINDSIGHT_API_RERANKER_MAX_BACKOFF` | Cap on the backoff between rerank retries, in seconds | `4.0` |
+| `HINDSIGHT_API_RERANKER_RETRY_BUDGET` | Wall-clock ceiling, in seconds, on the time one rerank may spend retrying (failed attempts plus backoff). Tighter than the embedding budget because rerank runs after retrieval has already spent time on the same request. With a fallback chain configured, each member spends its own budget before the chain advances. | `10.0` |
 | `HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER` | Add `X-Hindsight-Bank-Id: <bank_id>` to remote reranker requests. Enable only for trusted endpoints because this transmits the current bank ID. Covers TEI, Cohere-compatible HTTP, LiteLLM proxy, and LiteLLM SDK transports. | `false` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MODEL` | Model for local provider | `cross-encoder/ms-marco-MiniLM-L-6-v2` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT` | Max concurrent local reranking (prevents CPU thrashing under load) | `4` |

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -463,6 +463,13 @@ HINDSIGHT_API_LOG_LEVEL=info
 # Trusted gateway attribution (disabled by default). When enabled, remote
 # reranker requests include X-Hindsight-Bank-Id with the current bank ID.
 # HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER=false
+# Transient upstream failures (5xx, timeouts, connection errors, 429 quota) are
+# retried with jittered exponential backoff; 4xx auth/validation errors are never
+# retried. Applies to every remote provider except "tei", which retries on its own.
+# HINDSIGHT_API_RERANKER_MAX_RETRIES=3        # retries after the first attempt; 0 disables
+# HINDSIGHT_API_RERANKER_INITIAL_BACKOFF=0.5  # seconds; doubles per attempt, with jitter
+# HINDSIGHT_API_RERANKER_MAX_BACKOFF=4.0      # cap on per-retry backoff, seconds
+# HINDSIGHT_API_RERANKER_RETRY_BUDGET=10.0    # wall-clock ceiling per rerank spent retrying
 # For local provider:
 # HINDSIGHT_API_RERANKER_LOCAL_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
 # Force CPU if the local reranker hits MPS/XPC instability on macOS:

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -1060,6 +1060,10 @@ ZeroEntropy's `zembed-1` supports Matryoshka dimensions: `2560`, `1280`, `640`, 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_RERANKER_PROVIDER` | Provider: `local`, `tei`, `cohere`, `openrouter`, `zeroentropy`, `siliconflow`, `alibaba`, `google`, `flashrank`, `litellm`, `litellm-sdk`, `jina-mlx`, or `rrf` | `local` |
+| `HINDSIGHT_API_RERANKER_MAX_RETRIES` | Retries after the first attempt when a remote rerank call fails transiently (5xx, timeout, connection error, `429` quota). `0` disables retrying. Applies to every remote provider except `tei`, which has its own retry loop; the in-process providers (`local`, `flashrank`, `jina-mlx`, `rrf`) are unaffected. 4xx auth/validation errors are never retried. | `3` |
+| `HINDSIGHT_API_RERANKER_INITIAL_BACKOFF` | Initial backoff in seconds between rerank retries (doubles per attempt, with jitter) | `0.5` |
+| `HINDSIGHT_API_RERANKER_MAX_BACKOFF` | Cap on the backoff between rerank retries, in seconds | `4.0` |
+| `HINDSIGHT_API_RERANKER_RETRY_BUDGET` | Wall-clock ceiling, in seconds, on the time one rerank may spend retrying (failed attempts plus backoff). Tighter than the embedding budget because rerank runs after retrieval has already spent time on the same request. With a fallback chain configured, each member spends its own budget before the chain advances. | `10.0` |
 | `HINDSIGHT_API_RERANKER_SEND_BANK_AS_HEADER` | Add `X-Hindsight-Bank-Id: <bank_id>` to remote reranker requests. Enable only for trusted endpoints because this transmits the current bank ID. Covers TEI, Cohere-compatible HTTP, LiteLLM proxy, and LiteLLM SDK transports. | `false` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MODEL` | Model for local provider | `cross-encoder/ms-marco-MiniLM-L-6-v2` |
 | `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT` | Max concurrent local reranking (prevents CPU thrashing under load) | `4` |


### PR DESCRIPTION
Closes #4134. The reranker twin of #4103 (embeddings), which #4124 and #4129 fixed.

## Problem

Of fourteen `CrossEncoderModel` implementations, only `RemoteTEICrossEncoder` retried anything. Every other remote reranker — Cohere, ZeroEntropy, SiliconFlow, Alibaba, Google, LiteLLM, LiteLLM-SDK — raised the first transient upstream response straight through.

**And nothing absorbs it.** `create_cross_encoder_from_env` returns the reranker bare when no `HINDSIGHT_API_RERANKER_<n>_*` members are configured — the default — and neither `CrossEncoderReranker.rerank` (`search/reranking.py:383`) nor its caller (`memory_engine.py:7978`) catches. So one `429` failed the **entire recall**, synchronously, with the caller waiting. My initial read that `MultiCrossEncoder` degraded this to a ranking-quality loss only holds when a fallback chain is explicitly configured.

## Fix

Retry now lives on `CrossEncoderModel.predict`, which delegates to a `_predict` that each backend implements. Putting it on the shared entry point rather than in each provider is the whole point: retry applies to the one method a backend has to write, so the next remote reranker inherits it instead of having to remember — the omission that caused this.

`_predict` is deliberately **not** `@abstractmethod`: `CrossEncoderModel` is exported from `hindsight_api`, and a subclass that overrides `predict` directly (the test doubles here, and any downstream implementation) must keep working — it simply opts out of retry. The structural guard below is what stops that happening by accident in-repo.

Exempt, with the reason recorded beside each in `_RERANKER_PROVIDERS_WITHOUT_RETRY`:
- `local` / `flashrank` / `jina-mlx` — in-process; a bad tensor is not fixed by trying again
- `rrf` — passthrough, does no work
- `tei` — own retry loop, which a second layer would multiply
- `MultiCrossEncoder` holds no policy of its own, because its members each hold one

## Shared machinery

The policy moves out of `embeddings.py` into **`engine/remote_retry.py`** (`RetryPolicy`, `RetryBudget`, `call_with_retry`, `acall_with_retry`, `is_transient_remote_error`, `status_code_of`), so the rerankers share it rather than growing a fourth private copy — TEI has one, the embedding backends had one, and Gemini/Cohere/ZeroEntropy each nearly grew another. Embedding behaviour is unchanged: same code, provider-agnostic names.

## The stale docstring

`MultiCrossEncoder` has always claimed *"each member keeps its own retry budget, so we only advance after a member has exhausted its retries."* That was true only of the TEI member — every other chain advanced on the **first** blip, burning a fallback and silently degrading ranking quality over something a one-second backoff absorbs. It is now true, and `TestFailoverChainAdvancesOnlyAfterRetries` holds it to it.

## Configuration

Four new static knobs, documented in `configuration.md` and `.env.example` (embed copy re-synced):

| Variable | Default |
|---|---|
| `HINDSIGHT_API_RERANKER_MAX_RETRIES` | `3` |
| `HINDSIGHT_API_RERANKER_INITIAL_BACKOFF` | `0.5` |
| `HINDSIGHT_API_RERANKER_MAX_BACKOFF` | `4.0` |
| `HINDSIGHT_API_RERANKER_RETRY_BUDGET` | `10.0` |

Budgeted tighter than the embedding twin (15s): rerank runs *after* retrieval has already spent time on the same request, and its failure mode is a degraded ranking rather than no answer.

## Tests

`tests/test_reranker_retry.py` (new, 33 cases):
- 429 and transient 5xx/408 retried then success; 400/401/403/404/422 fail fast in exactly one call; exhaustion propagates after a bounded count; no policy means exactly one attempt
- the wall-clock budget caps added latency (50 retries × 0.05s would be ~2.5s)
- the backoff is `await asyncio.sleep`, proven by a concurrent ticker still advancing during it — a blocking sleep here would stall unrelated requests on the recall path
- the chain: a primary that recovers within its retries leaves the fallback untouched; the chain advances only once the primary exhausts; the chain itself adds no second retry layer
- **structural guard** — enumerates every `CrossEncoderModel` subclass from the module and fails if one overrides `predict` (silently opting out) or implements neither; plus a parametrized check that the factory gives all 8 remote providers a policy and all 5 exempt ones none

```
uv run pytest tests/ -k "rerank or cross_encoder or embed or retry or zeroentropy or cohere or gemini"   # 798 passed
./scripts/hooks/lint.sh          # All lints passed
uv run ty check hindsight_api/   # All checks passed
```