### PR TITLE
perf(docker): replace RUN chown with COPY --chown to speed up image building

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -182,13 +182,11 @@ RUN apt-get update && apt-get upgrade -y \
 RUN useradd -m -s /bin/bash hindsight
 
 # Copy API with virtual environment from builder
-COPY --from=api-builder /app/api /app/api
+COPY --chown=hindsight:hindsight --from=api-builder /app/api /app/api
 
 # Copy startup script
-COPY docker/standalone/start-all.sh /app/start-all.sh
+COPY --chown=hindsight:hindsight docker/standalone/start-all.sh /app/start-all.sh
 RUN chmod +x /app/start-all.sh
-
-RUN chown -R hindsight:hindsight /app
 
 USER hindsight
 
@@ -347,24 +345,22 @@ RUN apt-get update && apt-get upgrade -y \
 RUN useradd -m -s /bin/bash hindsight
 
 # Copy API with virtual environment from builder
-COPY --from=api-builder /app/api /app/api
+COPY --chown=hindsight:hindsight --from=api-builder /app/api /app/api
 
 # Copy built SDK
-COPY --from=sdk-builder /app/hindsight-clients/typescript /app/sdk
+COPY --chown=hindsight:hindsight --from=sdk-builder /app/hindsight-clients/typescript /app/sdk
 
 # Copy Control Plane standalone build
 WORKDIR /app/control-plane
-COPY --from=cp-builder /app/memory-poc/hindsight-control-plane/standalone ./
-COPY --from=cp-builder /app/memory-poc/hindsight-control-plane/.next/static ./.next/static
-COPY --from=cp-builder /app/memory-poc/hindsight-control-plane/public ./public
+COPY --chown=hindsight:hindsight --from=cp-builder /app/memory-poc/hindsight-control-plane/standalone ./
+COPY --chown=hindsight:hindsight --from=cp-builder /app/memory-poc/hindsight-control-plane/.next/static ./.next/static
+COPY --chown=hindsight:hindsight --from=cp-builder /app/memory-poc/hindsight-control-plane/public ./public
 
 WORKDIR /app
 
 # Copy startup script
-COPY docker/standalone/start-all.sh /app/start-all.sh
+COPY --chown=hindsight:hindsight docker/standalone/start-all.sh /app/start-all.sh
 RUN chmod +x /app/start-all.sh
-
-RUN chown -R hindsight:hindsight /app
 
 USER hindsight
 

--- a/docker/standalone/Dockerfile.freethreaded
+++ b/docker/standalone/Dockerfile.freethreaded
@@ -103,9 +103,9 @@ RUN apt-get update && apt-get upgrade -y \
 
 # The venv's interpreter lives in /opt/pythons, so it has to come along.
 COPY --from=api-builder-freethreaded /opt/pythons /opt/pythons
-COPY --from=api-builder-freethreaded /app/api /app/api
-COPY docker/standalone/start-all.sh /app/start-all.sh
-RUN chmod +x /app/start-all.sh && chown -R hindsight:hindsight /app
+COPY --chown=hindsight:hindsight --from=api-builder-freethreaded /app/api /app/api
+COPY --chown=hindsight:hindsight docker/standalone/start-all.sh /app/start-all.sh
+RUN chmod +x /app/start-all.sh
 
 USER hindsight
 


### PR DESCRIPTION
## Summary

Replace recursive `RUN chown -R hindsight:hindsight /app` calls across Dockerfile runtime stages with `COPY --chown=hindsight:hindsight`.

## Why

In the runtime stages of `docker/standalone/Dockerfile` (`api-only` and `standalone`) and `docker/standalone/Dockerfile.freethreaded` (`api-only-freethreaded`), files and directories were copied as root and then recursively chowned to `hindsight:hindsight` via `RUN chown -R`.

Because `RUN` creates a new Docker image layer, running `chown -R` across `/app` (which contains large directory trees including the Python virtual environment and Next.js standalone artifacts) duplicates the files into an extra layer. This causes:
1. Significant image build time overhead while processing metadata for every copied file.
2. Unnecessary layer bloat in the final images.

Using `COPY --chown=hindsight:hindsight` applies ownership during file transfer into the image without generating a separate layer.

## Changes

- `docker/standalone/Dockerfile`:
  - `api-only`: Added `--chown=hindsight:hindsight` to `COPY` commands for `/app/api` and `start-all.sh`; removed `RUN chown -R hindsight:hindsight /app`.
  - `standalone`: Added `--chown=hindsight:hindsight` to `COPY` commands for `/app/api`, `/app/sdk`, `/app/control-plane` assets, and `start-all.sh`; removed `RUN chown -R hindsight:hindsight /app`.
- `docker/standalone/Dockerfile.freethreaded`:
  - `api-only-freethreaded`: Added `--chown=hindsight:hindsight` to `COPY` commands for `/app/api` and `start-all.sh`; removed `&& chown -R hindsight:hindsight /app`.

## Testing

- Verified with `hadolint` across both `docker/standalone/Dockerfile` and `docker/standalone/Dockerfile.freethreaded` (no errors/warnings on modified instructions).
- Clean `git diff` with no unintended modifications.