### PR TITLE
fix(coding-agents): read DSH transcript via snapshotEvents

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/transcript-dsh.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-dsh.ts
@@ -2,9 +2,10 @@
  * DeepSeek Harness (dsh) transcript normalizer.
  *
  * dsh keeps a session as an append-only log of typed `SessionEvent`s rather than a chat array, and
- * a plugin reads that log straight off `agent.session.events` — so this is a pure function over
- * those events, like the opencode normalizer, not a file reader. The SAME event vocabulary is what
- * dsh persists to disk, so the backfill reader (core/history.ts) feeds this exact function.
+ * a plugin reads that log straight off the live session (`snapshotEvents()`) — so this is a pure
+ * function over those events, like the opencode normalizer, not a file reader. The SAME event
+ * vocabulary is what dsh persists to disk, so the backfill reader (core/history.ts) feeds this
+ * exact function.
  *
  * Only three of the ~30 event types carry conversation:
  *   - `user/message`      surface, a UserMessage — the human prompt OR an injected plugin context

--- a/hindsight-integrations/coding-agents/src/dsh.test.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { createDshHooks, toDshParameters, type Workspace } from "./dsh";
+import { createDshHooks, dshSessionEvents, toDshParameters, type Workspace } from "./dsh";
+import { readDshEvents } from "./core/transcript-dsh";
 import type { ToolSpec } from "./core/knowledge-tools";
 import { z } from "zod";
 
@@ -145,6 +146,77 @@ describe("dsh session start", () => {
 
     expect(core.seedIfCold).toHaveBeenCalledOnce();
     expect(core.seedIfCold).toHaveBeenCalledWith("/repo");
+  });
+});
+
+
+describe("dshSessionEvents (alpha.4+ transcript source)", () => {
+  const sampleEvents = [
+    {
+      type: "user/message",
+      time: Date.parse("2026-09-05T08:00:00Z"),
+      data: {
+        id: "m-1",
+        role: "user",
+        content: [{ type: "text", text: "why is chatDocs zero?" }],
+        source: { kind: "user" },
+      },
+    },
+    {
+      type: "assistant/message",
+      time: Date.parse("2026-09-05T08:00:01Z"),
+      data: {
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "session.events was removed." }],
+          source: { kind: "model" },
+        },
+      },
+    },
+  ];
+
+  it("reads snapshotEvents when the legacy events property is absent", () => {
+    const session = {
+      header: { id: "s-alpha4", cwd: "/repo" },
+      snapshotEvents: () => sampleEvents,
+    };
+    expect(dshSessionEvents(session)).toEqual(sampleEvents);
+    expect(readDshEvents(dshSessionEvents(session))).toEqual([
+      {
+        role: "user",
+        content: "why is chatDocs zero?",
+        timestamp: "2026-09-05T08:00:00.000Z",
+      },
+      {
+        role: "assistant",
+        content: "session.events was removed.",
+        timestamp: "2026-09-05T08:00:01.000Z",
+      },
+    ]);
+  });
+
+  it("falls back to the legacy events property when snapshotEvents is missing", () => {
+    const session = {
+      header: { id: "s-legacy", cwd: "/repo" },
+      events: sampleEvents,
+    };
+    expect(dshSessionEvents(session)).toBe(sampleEvents);
+    expect(readDshEvents(dshSessionEvents(session))).toHaveLength(2);
+  });
+
+  it("returns an empty log when neither accessor exists (pre-fix alpha.4 breakage)", () => {
+    const session = { header: { id: "s-broken", cwd: "/repo" } };
+    expect(dshSessionEvents(session)).toEqual([]);
+    expect(readDshEvents(dshSessionEvents(session))).toEqual([]);
+  });
+
+  it("prefers snapshotEvents over a stale events property", () => {
+    const session = {
+      header: { id: "s-both", cwd: "/repo" },
+      events: [],
+      snapshotEvents: () => sampleEvents,
+    };
+    expect(dshSessionEvents(session)).toBe(sampleEvents);
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/dsh.test.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.test.ts
@@ -149,7 +149,6 @@ describe("dsh session start", () => {
   });
 });
 
-
 describe("dshSessionEvents (alpha.4+ transcript source)", () => {
   const sampleEvents = [
     {

--- a/hindsight-integrations/coding-agents/src/dsh.test.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.test.ts
@@ -175,10 +175,7 @@ describe("dshSessionEvents (alpha.4+ transcript source)", () => {
   ];
 
   it("reads snapshotEvents when the legacy events property is absent", () => {
-    const session = {
-      header: { id: "s-alpha4", cwd: "/repo" },
-      snapshotEvents: () => sampleEvents,
-    };
+    const session = { snapshotEvents: () => sampleEvents };
     expect(dshSessionEvents(session)).toEqual(sampleEvents);
     expect(readDshEvents(dshSessionEvents(session))).toEqual([
       {
@@ -195,26 +192,19 @@ describe("dshSessionEvents (alpha.4+ transcript source)", () => {
   });
 
   it("falls back to the legacy events property when snapshotEvents is missing", () => {
-    const session = {
-      header: { id: "s-legacy", cwd: "/repo" },
-      events: sampleEvents,
-    };
+    const session = { events: sampleEvents };
     expect(dshSessionEvents(session)).toBe(sampleEvents);
     expect(readDshEvents(dshSessionEvents(session))).toHaveLength(2);
   });
 
   it("returns an empty log when neither accessor exists (pre-fix alpha.4 breakage)", () => {
-    const session = { header: { id: "s-broken", cwd: "/repo" } };
+    const session = {};
     expect(dshSessionEvents(session)).toEqual([]);
     expect(readDshEvents(dshSessionEvents(session))).toEqual([]);
   });
 
   it("prefers snapshotEvents over a stale events property", () => {
-    const session = {
-      header: { id: "s-both", cwd: "/repo" },
-      events: [],
-      snapshotEvents: () => sampleEvents,
-    };
+    const session = { events: [], snapshotEvents: () => sampleEvents };
     expect(dshSessionEvents(session)).toBe(sampleEvents);
   });
 });

--- a/hindsight-integrations/coding-agents/src/dsh.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.ts
@@ -130,7 +130,6 @@ const workspaces = new Map<string, Workspace | null>();
  */
 const liveAgents = new Map<string, DshAgent>();
 
-
 /**
  * Prefer `session.snapshotEvents()` (DeepSeek Harness alpha.4+); fall back to the legacy
  * `session.events` property so older hosts keep working. Missing both yields an empty log —

--- a/hindsight-integrations/coding-agents/src/dsh.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.ts
@@ -137,6 +137,8 @@ const liveAgents = new Map<string, DshAgent>();
  * which is exactly the alpha.4 breakage when callers still read `events` alone.
  */
 export function dshSessionEvents(session: {
+  /** Present on real agents; kept optional so unit tests can pass a bare accessor mock. */
+  header?: { readonly id?: string; readonly cwd?: string; readonly origin?: string };
   snapshotEvents?: () => readonly DshSessionEvent[];
   events?: readonly DshSessionEvent[];
 }): readonly DshSessionEvent[] {

--- a/hindsight-integrations/coding-agents/src/dsh.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.ts
@@ -42,7 +42,13 @@ export const inject = ["agents"];
 
 interface DshSession {
   readonly header: { readonly id: string; readonly cwd?: string; readonly origin?: string };
-  readonly events: readonly DshSessionEvent[];
+  /**
+   * Legacy in-memory event log. Present on DeepSeek Harness < alpha.4; removed in alpha.4+.
+   * Prefer {@link snapshotEvents} when available.
+   */
+  readonly events?: readonly DshSessionEvent[];
+  /** Public accessor on DeepSeek Harness alpha.4+ (replaces the removed `events` property). */
+  snapshotEvents?(): readonly DshSessionEvent[];
 }
 
 interface DshAgent {
@@ -124,6 +130,19 @@ const workspaces = new Map<string, Workspace | null>();
  */
 const liveAgents = new Map<string, DshAgent>();
 
+
+/**
+ * Prefer `session.snapshotEvents()` (DeepSeek Harness alpha.4+); fall back to the legacy
+ * `session.events` property so older hosts keep working. Missing both yields an empty log —
+ * which is exactly the alpha.4 breakage when callers still read `events` alone.
+ */
+export function dshSessionEvents(session: {
+  snapshotEvents?: () => readonly DshSessionEvent[];
+  events?: readonly DshSessionEvent[];
+}): readonly DshSessionEvent[] {
+  return session.snapshotEvents?.() ?? session.events ?? [];
+}
+
 /** Where a session is working. dsh records it on the session header; a session without one is rare. */
 function workspaceRoot(agent: DshAgent): string {
   return agent.session.header.cwd || process.cwd();
@@ -156,7 +175,8 @@ function workspaceFor(root: string): Workspace | undefined {
   // memory, so unlike opencode there is nothing to refetch over HTTP.
   core.setTranscriptSource(async (sessionId) => {
     const agent = liveAgents.get(sessionId);
-    return agent ? readDshEvents(agent.session.events) : [];
+    // alpha.4+ removed Session.events; snapshotEvents() is the public accessor.
+    return agent ? readDshEvents(dshSessionEvents(agent.session)) : [];
   });
   const workspace: Workspace = { core, root };
   workspaces.set(root, workspace);

--- a/hindsight-integrations/coding-agents/src/dsh.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.ts
@@ -135,12 +135,9 @@ const liveAgents = new Map<string, DshAgent>();
  * `session.events` property so older hosts keep working. Missing both yields an empty log —
  * which is exactly the alpha.4 breakage when callers still read `events` alone.
  */
-export function dshSessionEvents(session: {
-  /** Present on real agents; kept optional so unit tests can pass a bare accessor mock. */
-  header?: { readonly id?: string; readonly cwd?: string; readonly origin?: string };
-  snapshotEvents?: () => readonly DshSessionEvent[];
-  events?: readonly DshSessionEvent[];
-}): readonly DshSessionEvent[] {
+export function dshSessionEvents(
+  session: Pick<DshSession, "snapshotEvents" | "events">
+): readonly DshSessionEvent[] {
   return session.snapshotEvents?.() ?? session.events ?? [];
 }
 


### PR DESCRIPTION
## Summary
DeepSeek Harness **alpha.4+** removed `Session.events`. The DSH adapter's `setTranscriptSource` still read `agent.session.events`, so `readDshEvents(undefined)` returned `[]` and every turn write-back (`onSessionIdle` → `onTranscript`) silently no-oped — `chatDocs` stayed `0` and the daemon logged `[chat] no sessions; skipping`.

This switches the live transcript source to `session.snapshotEvents?.() ?? session.events ?? []` (via a small `dshSessionEvents` helper) so alpha.4+ hosts retain conversation turns while older hosts keep working.

Fixes #4147

## Test plan
- [x] `./node_modules/.bin/vitest run src/dsh.test.ts src/core/transcript-dsh.test.ts` → 19 passed (includes alpha.4 session mock without `events`, with `snapshotEvents()` returning events → non-empty transcript)
- [ ] Manual: DSH 0.1.2-alpha.4+ / rc with the plugin mounted; chat a few turns; `hindsight_sync_status` should show `chatDocs` growing