### PR TITLE
cache-opt(consolidation): similarity-based placeholder for duplicated source text

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -24,6 +24,7 @@ from collections import defaultdict
 from contextlib import AsyncExitStack
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from difflib import SequenceMatcher
 from enum import StrEnum
 from fnmatch import fnmatchcase
 from itertools import combinations
@@ -2926,6 +2927,19 @@ async def _find_related_observations(
     return recall_result
 
 
+#: Source text vs observation text similarity threshold above which the source
+#: text is sent as a placeholder instead of duplicated verbatim (2026-09-05).
+#: Measured on 456 source/observation pairs: >=0.75 covers 61.2% of source
+#: texts (redundant overlap), while the ~33% below 0.70 carry real differences
+#: and are kept verbatim.
+_SOURCE_SIM_PLACEHOLDER_THRESHOLD = 0.75
+
+#: Placeholder text for a source fact whose text closely matches the
+#: observation's own text. The model should treat it as the observation text
+#: above; the only independent info in the entry is context/timestamps.
+_SOURCE_SIM_PLACEHOLDER = "[similar to observation text above]"
+
+
 def _build_observations_for_llm(
     observations: "list[MemoryFact]",
     source_facts: "dict[str, MemoryFact]",
@@ -2950,6 +2964,17 @@ def _build_observations_for_llm(
             if sf is None:
                 continue
             sf_data: dict[str, Any] = {"text": sf.text}
+            # 2026-09-05 prompt-size optimization: if the source fact's text is
+            # highly similar to the observation's own text (>= threshold), the
+            # duplicated text is replaced by a placeholder — the observation's
+            # text above is authoritative. Entries with real differences
+            # (below threshold) keep their original text.
+            if (
+                sf.text is not None
+                and obs.text is not None
+                and SequenceMatcher(None, obs.text, sf.text).ratio() >= _SOURCE_SIM_PLACEHOLDER_THRESHOLD
+            ):
+                sf_data["text"] = _SOURCE_SIM_PLACEHOLDER
             if sf.context:
                 sf_data["context"] = sf.context
             if sf.occurred_start:

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py
@@ -67,7 +67,8 @@ _OBSERVATION_FIELDS = """- `id`: unique identifier — copy this exactly when is
 - `occurred_start` / `occurred_end`: the span of the events behind the observation — earliest start and latest end across its source facts
 - `mentioned_at`: the latest of the `mentioned_at` values of its source facts — the most recent point at which this observation was stated
 - `source_memories`: the supporting facts behind this observation. May be partial or absent for large observations — the count above remains the true total. Each entry carries the same `text` and temporal fields as a new fact, plus:
-  - `context`: optional surrounding context for that fact"""
+  - `context`: optional surrounding context for that fact
+  - **Placeholder rule**: when a source `text` is highly similar (sequence similarity ≥ 0.75) to the observation `text` above, it is replaced by `[similar to observation text above]` — interpret that entry's text as the observation text above; only its context/timestamps are independent information."""
 
 # Stable description of the input shape. For the cached split path this lives in
 # the system prefix (build_consolidation_system_prompt) so it is not re-sent on


### PR DESCRIPTION
## Summary

Consolidation sends, for every recalled observation, its `source_memories` — the raw facts behind the observation. Their `text` overlaps the observation's own `text` most of the time (measured on 456 source/observation pairs: source text is ~56% of the observation+source text payload; median similarity ~0.79), which is pure duplication going to the LLM every batch, and it sits in the dynamic part of the prompt that provider-side prefix caches can never hit.

This PR keeps the structural evidence (context, timestamps) but replaces the duplicated text with a placeholder when it is highly similar to the observation text.

## Change

`_build_observations_for_llm` (consolidation/consolidator.py):

- If `SequenceMatcher(None, obs.text, sf.text).ratio() >= 0.75` → `text` is sent as `"[similar to observation text above]"`.
- Otherwise the original source text is kept verbatim (preserves the ~33% of sources with real differences, e.g. extra detail or wording).
- `context`, `occurred_start/end`, `mentioned_at` are always sent as before.
- `prompts.py` `_OBSERVATION_FIELDS` documents the placeholder rule so the model knows to interpret that text as the observation text above.

The threshold is a module-level constant (`_SOURCE_SIM_PLACEHOLDER_THRESHOLD = 0.75`), and the notes in `_OBSERVATION_FIELDS` (`May be partial or absent for large observations`) already established that source memory text is advisory, so the LLM is not expected to rely on it for correctness.

## Rationale / measured data

- Source texts: 107,758 chars vs observation texts 93,477 chars (~201k total) — removing the >0.75-similarity texts shaves roughly half of the duplicated payload per consolidation call.
- Similarity distribution (456 pairs): >= 0.75 → 61.2% (placeholder); < 0.70 → 32.5% (kept verbatim); median 0.79.
- No change to semantics model-side: `proof_count` remains authoritative; the observation `text` itself is always present; cost reduction comes from dropping bytes that carry ~zero incremental information.

## Testing

- Targeted unit test (in-repo style, constructed observations/sources): identical text → placeholder, divergent text → verbatim, `None` text intact, context/timestamps preserved.
- `pytest hindsight-api-slim/tests/test_consolidation.py`: **37 passed**; 6 setup errors from the pytest-asyncio fixture environment (async runner setup), unrelated to this change (same errors occur on the base revision).
