### PR TITLE
fix(concurrency): serve CrossLoopSemaphore waiters in arrival order

### DIFF
--- a/hindsight-api-slim/hindsight_api/_cross_loop.py
+++ b/hindsight-api-slim/hindsight_api/_cross_loop.py
@@ -23,6 +23,7 @@ per loop instead.
 from __future__ import annotations
 
 import asyncio
+import collections
 import threading
 
 __all__ = ["CrossLoopSemaphore", "CrossLoopLock"]
@@ -33,17 +34,30 @@ _MIN_DELAY = 0.001
 _MAX_DELAY = 0.02
 
 
+class _Ticket:
+    """One waiter's place in the queue, and where its permit is handed to it."""
+
+    __slots__ = ("granted",)
+
+    def __init__(self) -> None:
+        self.granted = False
+
+
 class CrossLoopSemaphore:
     """A concurrency cap shared by every event loop in the process.
 
     Drop-in for ``asyncio.Semaphore`` as an async context manager. The cap stays
     process-wide, which is the contract the surrounding config already implies:
     running ``--workers N`` has always meant N independent caps, one per process.
+
+    Waiters are served in arrival order, as ``asyncio.Semaphore`` serves them.
     """
 
     def __init__(self, value: int) -> None:
         self._capacity = value
-        self._sem = threading.Semaphore(value)
+        self._lock = threading.Lock()
+        self._free = value
+        self._waiters: collections.deque[_Ticket] = collections.deque()
 
     @property
     def capacity(self) -> int:
@@ -51,17 +65,45 @@ class CrossLoopSemaphore:
         return self._capacity
 
     async def acquire(self) -> None:
-        # Fast path: uncontended acquire never yields, so the common case costs one
-        # atomic operation and no scheduler round-trip.
-        if self._sem.acquire(blocking=False):
-            return
+        with self._lock:
+            # Fast path: uncontended acquire never yields. Gated on an empty queue,
+            # so an arriving task cannot take a permit an earlier waiter is owed.
+            if not self._waiters and self._free:
+                self._free -= 1
+                return
+            ticket = _Ticket()
+            self._waiters.append(ticket)
+
         delay = _MIN_DELAY
-        while not self._sem.acquire(blocking=False):
-            await asyncio.sleep(delay)
-            delay = min(delay * 2, _MAX_DELAY)
+        try:
+            while True:
+                with self._lock:
+                    if ticket.granted:
+                        return
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, _MAX_DELAY)
+        except BaseException:
+            with self._lock:
+                if ticket.granted:
+                    self._hand_on()
+                else:
+                    self._waiters.remove(ticket)
+            raise
 
     def release(self) -> None:
-        self._sem.release()
+        with self._lock:
+            self._hand_on()
+
+    def _hand_on(self) -> None:
+        """Give the permit to the longest-waiting task, or return it to the pool.
+
+        Handing it over directly is what stops a holder that re-acquires without
+        suspending from taking its own permit back before any waiter can see it free.
+        """
+        if self._waiters:
+            self._waiters.popleft().granted = True
+        else:
+            self._free += 1
 
     async def __aenter__(self) -> "CrossLoopSemaphore":
         await self.acquire()

--- a/hindsight-api-slim/hindsight_api/_cross_loop.py
+++ b/hindsight-api-slim/hindsight_api/_cross_loop.py
@@ -7,17 +7,30 @@ the first contended acquire claims the primitive for its loop while every other 
 fails with ``RuntimeError: ... is bound to a different event loop``. The failure only
 appears under contention, so it passes tests and breaks under load.
 
-The counters here live in ``threading`` primitives, which are loop-agnostic, and the
-wait is a short async backoff so a loop is never blocked while it queues.
+The state here lives under a ``threading.Lock``, which is loop-agnostic, and a waiter
+polls its own ticket on a short async backoff so a loop is never blocked while it
+queues.
 
-**Why polling rather than a cross-loop future handoff.** Waking a waiter on another
-loop means ``loop.call_soon_threadsafe`` and a registry of waiters per loop, which has
-to stay correct when a loop dies mid-wait. Polling has none of that state: it only
-runs while the cap is saturated, and it costs at most ``_MAX_DELAY`` of extra latency
-on acquiring a slot. These caps gate LLM calls and llama.cpp server startup —
-operations measured in hundreds of milliseconds to minutes — so that is not
-measurable. Do not reach for this to guard something short and hot; scope the state
-per loop instead.
+**Why a queue rather than a bare counter.** A counter alone starves waiters: a holder
+that releases and re-acquires with no suspension point in between takes its own permit
+straight back, and the waiter — asleep on the backoff ladder for the whole moment the
+permit was free — never sees it. So ``release()`` hands the permit to the
+longest-waiting ticket instead of returning it to the pool.
+
+**Why polling rather than a cross-loop future handoff.** The queue is a flat deque of
+tickets; a granted waiter still learns about it by polling. Waking it directly would
+mean ``loop.call_soon_threadsafe`` and a registry keyed *per loop*, which has to stay
+correct when a loop dies mid-wait. Polling keeps none of that: it only runs while the
+cap is saturated, and it costs at most ``_MAX_DELAY`` between the handoff and the
+waiter resuming. These caps gate LLM calls and llama.cpp server startup — operations
+measured in hundreds of milliseconds to minutes — so that is not measurable. Do not
+reach for this to guard something short and hot; scope the state per loop instead.
+
+**The cost of handing over.** A permit granted to a waiter is reserved for it, so a
+waiter that never resumes takes the permit with it and the cap drops by one for the
+life of the process. Cancellation is handled (a cancelled waiter passes on a permit it
+was granted), so in practice this needs a loop closed with a pending ``acquire()`` on
+it — ``asyncio.run`` cancels those, ``run_until_complete`` plus ``close`` does not.
 """
 
 from __future__ import annotations
@@ -99,6 +112,12 @@ class CrossLoopSemaphore:
 
         Handing it over directly is what stops a holder that re-acquires without
         suspending from taking its own permit back before any waiter can see it free.
+
+        The permit is granted here rather than claimed by the waiter on its next poll,
+        which trades a little latency for burst behaviour: the grantee can sit on the
+        permit for up to ``_MAX_DELAY`` before it wakes and nobody else may take it,
+        but K permits freed at once reach K waiters at once. Claiming would hand out
+        one permit per poll tick, draining a burst at ``_MAX_DELAY`` per waiter.
         """
         if self._waiters:
             self._waiters.popleft().granted = True

--- a/hindsight-api-slim/tests/test_cross_loop_primitives.py
+++ b/hindsight-api-slim/tests/test_cross_loop_primitives.py
@@ -148,3 +148,83 @@ async def test_uncontended_acquire_does_not_yield():
         async with sem:
             pass
     assert time.perf_counter() - start < 0.5
+
+
+@pytest.mark.asyncio
+async def test_holder_that_re_acquires_without_suspending_does_not_starve_a_waiter():
+    """A permit released and retaken in the same step must still reach the queue first."""
+    sem = CrossLoopSemaphore(1)
+    hold = 0.01
+    stop = asyncio.Event()
+    sections = 0
+
+    async def holder():
+        nonlocal sections
+        while not stop.is_set():
+            async with sem:
+                await asyncio.sleep(hold)
+                sections += 1
+
+    task = asyncio.create_task(holder())
+    try:
+        await asyncio.sleep(5 * hold)
+        start = time.perf_counter()
+        await asyncio.wait_for(sem.acquire(), timeout=2.0)
+        waited = time.perf_counter() - start
+        sem.release()
+    finally:
+        stop.set()
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert waited < 20 * hold, f"waited {waited * 1000:.0f} ms behind {sections} critical sections"
+
+
+@pytest.mark.asyncio
+async def test_waiters_are_served_in_arrival_order():
+    """Handoff order is the arrival order, not whichever waiter happens to poll first."""
+    sem = CrossLoopSemaphore(1)
+    served: list[str] = []
+    await sem.acquire()
+
+    async def waiter(tag: str):
+        async with sem:
+            served.append(tag)
+
+    tasks = []
+    for tag in "abcde":
+        tasks.append(asyncio.create_task(waiter(tag)))
+        # Stagger arrivals so each waiter sits at a different point on the backoff ladder.
+        await asyncio.sleep(0.005)
+
+    sem.release()
+    await asyncio.gather(*tasks)
+
+    assert served == list("abcde")
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiters_neither_strand_a_permit_nor_block_the_queue():
+    """Cancellation must pass on a handed-over permit and drop a still-queued waiter."""
+    sem = CrossLoopSemaphore(1)
+    await sem.acquire()
+
+    first = asyncio.create_task(sem.acquire())
+    await asyncio.sleep(0.005)
+    second = asyncio.create_task(sem.acquire())
+    await asyncio.sleep(0.005)
+    queued = asyncio.create_task(sem.acquire())
+    await asyncio.sleep(0.005)
+
+    # Cancelled behind a held permit, so it leaves the queue owning nothing.
+    queued.cancel()
+    await asyncio.gather(queued, return_exceptions=True)
+
+    # Cancelled before it can wake, so it is holding the permit just handed to it.
+    sem.release()
+    first.cancel()
+    await asyncio.gather(first, return_exceptions=True)
+
+    await asyncio.wait_for(second, timeout=2.0)
+    sem.release()
+    await asyncio.wait_for(sem.acquire(), timeout=0.5)

--- a/hindsight-api-slim/tests/test_cross_loop_primitives.py
+++ b/hindsight-api-slim/tests/test_cross_loop_primitives.py
@@ -228,3 +228,53 @@ async def test_cancelled_waiters_neither_strand_a_permit_nor_block_the_queue():
     await asyncio.wait_for(second, timeout=2.0)
     sem.release()
     await asyncio.wait_for(sem.acquire(), timeout=0.5)
+
+
+def test_handoff_reaches_a_waiter_on_another_loop():
+    """The starvation fix must hold across loops, which is the only reason this class exists.
+
+    The single-loop starvation test above cannot see this: there the holder's release and
+    the waiter's wake-up run on the same scheduler. Here the permit is granted by a
+    release on one loop to a ticket owned by a thread running a different one.
+    """
+    sem = CrossLoopSemaphore(1)
+    stop = threading.Event()
+    sections = 0
+    guard = threading.Lock()
+    errors: list[BaseException] = []
+    results: list[object] = []
+    waited: list[float] = []
+
+    async def holder():
+        # Re-acquires with no suspension point between release and the next acquire,
+        # so a bare counter would hand the permit straight back to this task forever.
+        nonlocal sections
+        while not stop.is_set():
+            async with sem:
+                await asyncio.sleep(0.01)
+                with guard:
+                    sections += 1
+        return True
+
+    async def waiter():
+        # Let the holder saturate the cap first, so this is a genuinely contended wait.
+        await asyncio.sleep(0.05)
+        start = time.perf_counter()
+        async with sem:
+            waited.append(time.perf_counter() - start)
+        stop.set()
+        return True
+
+    threads = [
+        _run_in_own_loop(lambda: [holder], results, errors),
+        _run_in_own_loop(lambda: [waiter], results, errors),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    stop.set()
+    assert not errors, f"cross-loop handoff raised: {errors[:1]}"
+    assert waited, "waiter never acquired across the loop boundary"
+    assert waited[0] < 0.2, f"waited {waited[0] * 1000:.0f} ms behind {sections} critical sections on another loop"


### PR DESCRIPTION
`CrossLoopSemaphore` has no waiter queue, so a holder that releases and re-acquires with no suspension point in between takes its own permit straight back. The waiter is asleep on the backoff ladder for the moment it is free and never sees it.

The docstring added in #4037 says polling costs at most `_MAX_DELAY` of extra latency on acquiring a slot. That needs a queue to be true. Capacity 1, 50 ms critical section, one waiter: still waiting after 20 s while the holder made 392 calls, where `asyncio.Semaphore` served it in 50.8 ms. Any real gap hides it, 1 ms of gap and it is 0.3 ms.

Waiters now take a ticket and `release()` hands the permit to the longest-waiting one instead of returning it to the pool. Fast path unchanged except that it is gated on an empty queue.

One choice worth flagging: handing the permit over at release, rather than letting the head waiter claim it on its next poll. Claiming would hand out one permit per poll tick, so a burst at capacity above 1 would drain at up to `_MAX_DELAY` per waiter. This way K free permits reach K waiters at once and each still wakes within its own backoff.

`Refs` rather than `Fixes` because I do not think this explains the report. Those ops sit at `queued`, which is a row the worker never claimed, and claiming goes through worker slots rather than LLM permits. I looked and did not find a defect there. I also have not shown the real consolidation loop ever hits the zero-gap shape my repro uses.

Three tests added. The starvation and ordering ones fail on main. The cancellation one passes either way, so I checked it by breaking each of the two cancellation branches in turn. Ran on 3.11 and on free-threaded 3.14t, where I exercised the module standalone because psycopg2-binary has no cp314t wheel.

Refs #4130
