### PR TITLE
fix(consolidation): name observation_id as the delete key

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -30,7 +30,7 @@ from itertools import combinations
 from typing import TYPE_CHECKING, Any, Literal
 
 import asyncpg
-from pydantic import BaseModel, ValidationError, field_validator
+from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator
 
 from ...config import get_config
 from ...worker.stage import set_stage
@@ -827,7 +827,8 @@ class _UpdateAction(BaseModel):
 
 
 class _DeleteAction(BaseModel):
-    observation_id: str  # UUID of the observation to remove
+    # `id` too: that is the key the observation arrives under in the prompt's INPUT section.
+    observation_id: str = Field(validation_alias=AliasChoices("observation_id", "id"))
     reason: str = ""  # LLM's one-sentence justification (diagnostic only)
 
 

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py
@@ -61,7 +61,7 @@ _FACT_FIELDS = """One per line, formatted as `[uuid] fact text (temporal fields)
 - `occurred_start` / `occurred_end`: when the described event happened. This can be long before the fact was stated — a fact recorded today may describe a 2019 event.
 - `mentioned_at`: when the source material that states this fact was written. This is the fact's recency: how up to date the statement is, NOT when it was added to memory. A fact taken from an old document keeps its old `mentioned_at` even if it was only just processed."""
 
-_OBSERVATION_FIELDS = """- `id`: unique identifier — copy this exactly when issuing an UPDATE or DELETE
+_OBSERVATION_FIELDS = """- `id`: unique identifier, copy it verbatim into `observation_id` when issuing an UPDATE or DELETE
 - `text`: the observation content
 - `proof_count`: how many source facts this observation has already merged
 - `occurred_start` / `occurred_end`: the span of the events behind the observation — earliest start and latest end across its source facts
@@ -152,7 +152,7 @@ Expected output (UPDATE for the state change; CREATE for the unrelated work-hour
 - `observation_id`: copy the EXACT `id` UUID string from existing observations.
 - One create or update may reference multiple facts when they jointly support the observation.
 - **AT MOST ONE UPDATE PER `observation_id`**: if several new facts all update the same existing observation, emit a single `updates` entry that lists all contributing `source_fact_ids` and a single consolidated `text`. Never emit two `updates` entries with the same `observation_id` in one response — they would silently overwrite each other.
-- `deletes`: only when an observation is directly superseded or contradicted by new facts.
+- `deletes`: only when an observation is directly superseded or contradicted by new facts. Key each entry by `observation_id`, exactly as an update does.
 - `reason`: REQUIRED on every create/update/delete — one sentence explaining the choice. For a CREATE, state which existing observation(s) you considered and why none matched (a near-identical existing observation means you should UPDATE, not CREATE). This is audited to catch duplicate creates.
 - Do NOT include `tags` — handled automatically.
 - Return `{{"creates": [], "updates": [], "deletes": []}}` if nothing durable is found."""

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -2459,6 +2459,53 @@ class TestBuildResponseModel:
         assert len(result.creates) == expected_creates
 
 
+class TestDeleteActionObservationId:
+    """A DELETE entry is keyed by `observation_id`, and the prompt has to say so.
+
+    `_OBSERVATION_FIELDS` describes the observation's own key as `id`, so a model
+    that follows it literally emits `{"id": ...}` for a delete. `ValidationError`
+    is FAIL_FAST in `_classify_batch_failure`, so one such entry loses the whole
+    batch with no retry and nothing deleted (#4152).
+    """
+
+    OBS_ID = "e5f6a7b8-c9d0-1234-efab-345678901234"
+
+    def test_prompt_names_observation_id_for_deletes(self):
+        from hindsight_api.engine.consolidation.prompts import build_consolidation_system_prompt
+
+        rules = [line for line in build_consolidation_system_prompt().splitlines() if line.startswith("- `deletes`:")]
+        assert len(rules) == 1
+        assert "observation_id" in rules[0]
+
+    def test_delete_accepts_the_key_the_observation_arrives_under(self):
+        from hindsight_api.engine.consolidation.consolidator import _ConsolidationBatchResponse
+
+        response = _ConsolidationBatchResponse.model_validate(
+            {"creates": [], "updates": [], "deletes": [{"id": self.OBS_ID, "reason": "superseded"}]}
+        )
+        assert [d.observation_id for d in response.deletes] == [self.OBS_ID]
+
+    def test_delete_still_accepts_observation_id(self):
+        from hindsight_api.engine.consolidation.consolidator import _ConsolidationBatchResponse
+
+        response = _ConsolidationBatchResponse.model_validate(
+            {"creates": [], "updates": [], "deletes": [{"observation_id": self.OBS_ID}]}
+        )
+        assert [d.observation_id for d in response.deletes] == [self.OBS_ID]
+
+    def test_delete_wire_contract_is_unchanged(self):
+        """Providers keep receiving `observation_id`, and so does `model_dump`."""
+        from hindsight_api.engine.consolidation.consolidator import _DeleteAction
+
+        schema = _DeleteAction.model_json_schema()
+        assert sorted(schema["properties"]) == ["observation_id", "reason"]
+        assert schema["required"] == ["observation_id"]
+        assert _DeleteAction(observation_id=self.OBS_ID).model_dump() == {
+            "observation_id": self.OBS_ID,
+            "reason": "",
+        }
+
+
 class TestDedupeUpdates:
     """`_dedupe_updates` collapses LLM responses that target one observation_id
     multiple times — without this, the second `_execute_update_action` call


### PR DESCRIPTION
Answering the open question at the bottom of your report: tightened, not made optional. A delete with no target isn't actionable, so `observation_id` stays required.

The prompt never told the model which key a delete goes on. `_OBSERVATION_FIELDS` says "`id`: unique identifier, copy this exactly when issuing an UPDATE or DELETE" and that is the only place it names a field for one. Updates get corrected twice after that, in the DECISION GUIDE and in the `observation_id` field rule; deletes get neither, and the one worked example that showed a populated `deletes` entry went out in #1759 with the old single example. So a model that follows the prompt literally emits `{"id": ...}`, `_DeleteAction` requires `observation_id`, and `_classify_batch_failure` has ValidationError in FAIL_FAST. That's the 15 discarded calls and the 0.

Two changes. The input-field line now names the destination, `copy it verbatim into observation_id`, matching the `[uuid]` line for `source_fact_ids` just above it, and the `deletes` field rule says it too. And `_DeleteAction` takes `id` as a validation alias, since with `llm_strict_schema_consolidation` off the prompt is guidance rather than a grammar, and a model echoing the input key shouldn't cost the batch.

What providers receive is unchanged: one property `observation_id`, still required, from both the plain and the strict schema generator, and `model_dump` is the same. Updates still take `observation_id` only.

Four tests. The prompt one and the `id`-keyed delete one fail on main. The other two pin the wire contract and the canonical key and pass either way, so I checked them by flipping the alias order and then dropping the canonical name, which turns each of them red.

I haven't touched the other half of your report, that a run with a dead delete path looks like a healthy one at the counter level. Separate change and I'd rather not bundle it.

Refs #4152
