### PR TITLE
fix(codex): defer work until quota reset

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_llm.py
@@ -22,12 +22,19 @@ import time
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable
 
 import httpx
 
-from hindsight_api.engine.llm_interface import LLM_TOOL_CHOICE_AUTO, LLMInterface, LLMToolChoice, LLMToolChoiceMode
+from hindsight_api.engine.llm_interface import (
+    LLM_TOOL_CHOICE_AUTO,
+    LLMInterface,
+    LLMToolChoice,
+    LLMToolChoiceMode,
+    ProviderRateLimitResetError,
+)
 from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
 from hindsight_api.engine.llm_transport import build_sdk_timeout
 from hindsight_api.engine.providers.llm_debug import dump_request_on_4xx
@@ -127,6 +134,42 @@ _DEFAULT_CODEX_TIMEOUT = 120.0
 # by ``max_completion_tokens`` never approaches this, so blowing past it means
 # the stream is not going to end on its own.
 _MAX_SSE_BODY_CHARS = 4 * 1024 * 1024
+
+
+def _codex_quota_retry_at(response: httpx.Response) -> datetime | None:
+    """Return a future reset time from a Codex usage-limit response."""
+    if response.status_code != 429:
+        return None
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict) or error.get("type") != "usage_limit_reached":
+        return None
+    resets_at = error.get("resets_at")
+    if isinstance(resets_at, bool) or not isinstance(resets_at, (int, float)):
+        return None
+    try:
+        retry_at = datetime.fromtimestamp(resets_at, UTC)
+    except (OSError, OverflowError, ValueError):
+        return None
+    return retry_at if retry_at > datetime.now(UTC) else None
+
+
+def _raise_codex_quota_defer(
+    response: httpx.Response, *, provider: str, model: str, scope: str, max_backoff: float
+) -> None:
+    """Turn a long Codex quota window into the engine's defer signal."""
+    retry_at = _codex_quota_retry_at(response)
+    if retry_at is None or (retry_at - datetime.now(UTC)).total_seconds() <= max_backoff:
+        return
+    raise ProviderRateLimitResetError(
+        retry_at=retry_at,
+        message=f"Codex quota exhausted ({provider}/{model}, scope={scope}); retry at {retry_at.isoformat()}",
+    )
 
 
 class CodexRunawayStreamError(httpx.RequestError):
@@ -723,6 +766,14 @@ class CodexLLM(LLMInterface):
                         "Run 'codex auth login' to re-authenticate."
                     ) from e
 
+                _raise_codex_quota_defer(
+                    e.response,
+                    provider=self.provider,
+                    model=self.model,
+                    scope=scope,
+                    max_backoff=max_backoff,
+                )
+
                 # Diagnostic dump (opt-in) of the exact request behind any 4xx.
                 dump_request_on_4xx(scope=scope, provider=self.provider, model=self.model, err=e, request=payload)
 
@@ -987,6 +1038,13 @@ class CodexLLM(LLMInterface):
                 set_stage(f"llm.codex.tools.attempt={attempt}/2")
                 async with self._stream_request(url, payload, headers) as response:
                     if response.status_code != 200:
+                        _raise_codex_quota_defer(
+                            response,
+                            provider=self.provider,
+                            model=self.model,
+                            scope=scope,
+                            max_backoff=max_backoff,
+                        )
                         # 401/403 on the first attempt may still be recovered by the
                         # reactive token refresh below — don't log those as errors yet.
                         detail = f"Codex API error {response.status_code}: {response.text[:500]}"

--- a/hindsight-api-slim/tests/test_codex_quota_reset_defer.py
+++ b/hindsight-api-slim/tests/test_codex_quota_reset_defer.py
@@ -1,0 +1,110 @@
+"""Codex usage-limit responses defer work until the reported reset."""
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from hindsight_api.engine.llm_interface import ProviderRateLimitResetError
+from hindsight_api.engine.providers.codex_llm import CodexLLM
+from tests.codex_stream_stub import stub_codex_stream
+
+
+def _build_llm() -> CodexLLM:
+    with (
+        patch.object(CodexLLM, "_load_codex_auth", return_value=("token", "account")),
+        patch.object(CodexLLM, "_load_codex_refresh_token", return_value=None),
+    ):
+        return CodexLLM(
+            provider="openai-codex",
+            api_key="ignored",
+            base_url="https://chatgpt.com/backend-api",
+            model="gpt-test",
+        )
+
+
+def _quota_response(resets_at: object, *, private_detail: str = "private diagnostic") -> httpx.Response:
+    request = httpx.Request("POST", "https://chatgpt.com/backend-api/codex/responses")
+    return httpx.Response(
+        429,
+        request=request,
+        json={
+            "error": {
+                "type": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+                "plan_type": private_detail,
+                "resets_at": resets_at,
+                "resets_in_seconds": 3600,
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["call", "call_with_tools"])
+async def test_usage_limit_with_valid_reset_defers_both_call_paths_without_retry(method: str) -> None:
+    llm = _build_llm()
+    retry_at = (datetime.now(UTC) + timedelta(hours=2)).replace(microsecond=0)
+    response = _quota_response(int(retry_at.timestamp()))
+
+    with (
+        stub_codex_stream(llm, response) as stream,
+        patch("hindsight_api.engine.providers.codex_llm.asyncio.sleep", new_callable=AsyncMock) as sleep,
+        pytest.raises(ProviderRateLimitResetError) as exc_info,
+    ):
+        if method == "call":
+            await llm.call(messages=[{"role": "user", "content": "x"}], max_retries=2)
+        else:
+            await llm.call_with_tools(messages=[{"role": "user", "content": "x"}], tools=[], max_retries=2)
+
+    assert stream.call_count == 1
+    sleep.assert_not_awaited()
+    assert exc_info.value.retry_at == retry_at
+
+
+@pytest.mark.asyncio
+async def test_invalid_reset_timestamp_keeps_normal_call_retry_behavior() -> None:
+    llm = _build_llm()
+    response = _quota_response("not-an-epoch")
+
+    with (
+        stub_codex_stream(llm, response) as stream,
+        patch("hindsight_api.engine.providers.codex_llm.asyncio.sleep", new_callable=AsyncMock) as sleep,
+        pytest.raises(httpx.HTTPStatusError),
+    ):
+        await llm.call(messages=[{"role": "user", "content": "x"}], max_retries=2)
+
+    assert stream.call_count == 3
+    assert sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_invalid_reset_timestamp_keeps_tool_call_http_error() -> None:
+    llm = _build_llm()
+    response = _quota_response(None)
+
+    with stub_codex_stream(llm, response) as stream, pytest.raises(httpx.HTTPStatusError):
+        await llm.call_with_tools(messages=[{"role": "user", "content": "x"}], tools=[])
+
+    assert stream.call_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["call", "call_with_tools"])
+async def test_quota_defer_message_and_logs_do_not_expose_response_body(method: str, caplog) -> None:
+    llm = _build_llm()
+    retry_at = datetime.now(UTC) + timedelta(hours=2)
+    private_detail = "customer-private-plan-marker"
+    response = _quota_response(int(retry_at.timestamp()), private_detail=private_detail)
+
+    with stub_codex_stream(llm, response), pytest.raises(ProviderRateLimitResetError) as exc_info:
+        if method == "call":
+            await llm.call(messages=[{"role": "user", "content": "x"}], max_retries=2)
+        else:
+            await llm.call_with_tools(messages=[{"role": "user", "content": "x"}], tools=[], max_retries=2)
+
+    assert private_detail not in str(exc_info.value)
+    assert private_detail not in caplog.text
+    assert json.dumps(response.json()) not in caplog.text


### PR DESCRIPTION
## Summary
Closes #4160.

Translate explicit Codex quota exhaustion with a validated future reset into the existing ProviderRateLimitResetError control signal in both provider call paths. Preserve existing handling for other responses. Avoid logging quota-response bodies when deferring.

## Verification
Provider regression tests and consolidation retry tests were exercised locally, alongside the repository lint hook and independent review. Added tests cover both call paths, timestamp validation, privacy, and preservation of ordinary rate-limit behavior.

## Scope
No configuration, schema, credential rotation, or automatic recovery changes. Existing failed facts still require explicit recovery.