### PR TITLE
fix(consolidation): expose failed LLM batches

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -33,6 +33,7 @@ import asyncpg
 from pydantic import BaseModel, ValidationError, field_validator
 
 from ...config import get_config
+from ...metrics import get_metrics_collector
 from ...worker.stage import set_stage
 from ..db import DatabaseBackend
 from ..db_utils import acquire_with_retry
@@ -3242,6 +3243,12 @@ async def _consolidate_batch_with_llm(
         f"[CONSOLIDATION] LLM batch call failed after {attempts_made}/{max_attempts} attempt(s) for "
         f"{batch_label}, skipping batch (the caller will bisect it). Last error: {last_exc}"
     )
+    failure_reason = (
+        "response_validation"
+        if isinstance(last_exc, json.JSONDecodeError | ValidationError | OutputTooLongError)
+        else "provider"
+    )
+    get_metrics_collector().record_consolidation_batch_failure(failure_reason)
     return _BatchLLMResult(
         obs_count=len(union_observations), prompt_chars=len(system_prompt) + len(user_content), failed=True
     )

--- a/hindsight-api-slim/hindsight_api/metrics.py
+++ b/hindsight-api-slim/hindsight_api/metrics.py
@@ -296,6 +296,10 @@ class MetricsCollectorBase:
         """Record the fact-extraction outcome of one document processed by retain."""
         raise NotImplementedError
 
+    def record_consolidation_batch_failure(self, reason: str):
+        """Record one exhausted consolidation batch, classified by bounded reason."""
+        raise NotImplementedError
+
     def record_db_acquire_wait(self, wait_seconds: float):
         """Record how long a caller waited to acquire a pooled DB connection."""
         raise NotImplementedError
@@ -375,6 +379,10 @@ class NoOpMetricsCollector(MetricsCollectorBase):
 
     def record_retain_document(self, bank_id: str, memory_unit_count: int):
         """No-op retain document outcome recording."""
+        pass
+
+    def record_consolidation_batch_failure(self, reason: str):
+        """No-op consolidation batch failure recording."""
         pass
 
     def record_db_acquire_wait(self, wait_seconds: float):
@@ -470,6 +478,12 @@ class MetricsCollector(MetricsCollectorBase):
             name="hindsight.retain.documents.total",
             description="Documents processed by retain, labelled by extraction outcome (facts/no_facts)",
             unit="documents",
+        )
+
+        self.consolidation_batch_failures = self.meter.create_counter(
+            name="hindsight.consolidation.batch_failures",
+            description="Consolidation LLM batches that exhausted their retry policy",
+            unit="batches",
         )
 
         # HTTP request metrics
@@ -675,6 +689,14 @@ class MetricsCollector(MetricsCollectorBase):
             attributes["bank_id"] = bank_id
 
         self.retain_documents_total.add(1, attributes)
+
+    def record_consolidation_batch_failure(self, reason: str):
+        """Record one failed batch after its retry policy is exhausted.
+
+        ``reason`` is intentionally a small classifier owned by the consolidator,
+        not an exception message or type, so the metric cannot grow unbounded.
+        """
+        self.consolidation_batch_failures.add(1, {"reason": reason, "tenant": _get_tenant()})
 
     def record_llm_call(
         self,

--- a/hindsight-api-slim/tests/test_consolidation.py
+++ b/hindsight-api-slim/tests/test_consolidation.py
@@ -4,7 +4,6 @@ These tests exercise the real consolidation implementation with actual database 
 Note: Consolidation runs automatically after retain via SyncTaskBackend in tests.
 """
 
-from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -26,6 +25,7 @@ from hindsight_api.engine.reflect.tools import (
     tool_search_mental_models,
     tool_search_observations,
 )
+from hindsight_api.engine.response_models import LLMCallResult, TokenUsage
 from tests.llm_judge import assert_meets_criteria
 
 
@@ -2457,6 +2457,71 @@ class TestBuildResponseModel:
         response_model = llm_config.call.await_args.kwargs["response_format"]
         assert response_model is _ConsolidationBatchResponse
         assert len(result.creates) == expected_creates
+
+    @staticmethod
+    def _batch_config(max_attempts: int = 3) -> SimpleNamespace:
+        return SimpleNamespace(
+            llm_output_language=None,
+            observations_mission=None,
+            llm_strict_schema_consolidation=False,
+            llm_supports_max_items=True,
+            consolidation_max_attempts=max_attempts,
+            consolidation_llm_max_retries=None,
+            consolidation_max_completion_tokens=None,
+            llm_temperature_consolidation=0.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_validation_failure_records_one_failed_batch(self) -> None:
+        from pydantic import ValidationError
+        from hindsight_api.engine.consolidation.consolidator import (
+            _ConsolidationBatchResponse,
+            _consolidate_batch_with_llm,
+        )
+
+        try:
+            _ConsolidationBatchResponse.model_validate({"creates": [{"text": "missing ids"}]})
+        except ValidationError as validation_error:
+            error = validation_error
+        metrics = MagicMock()
+        llm_config = SimpleNamespace(_provider_impl=None, call=AsyncMock(side_effect=error))
+
+        with patch("hindsight_api.engine.consolidation.consolidator.get_metrics_collector", return_value=metrics):
+            result = await _consolidate_batch_with_llm(
+                llm_config,
+                [{"id": "fact-0", "text": "a fact"}],
+                [],
+                {},
+                self._batch_config(),
+            )
+
+        assert result.failed is True
+        llm_config.call.assert_awaited_once()
+        metrics.record_consolidation_batch_failure.assert_called_once_with("response_validation")
+
+    @pytest.mark.asyncio
+    async def test_success_does_not_record_failed_batch(self) -> None:
+        from hindsight_api.engine.consolidation.consolidator import (
+            _ConsolidationBatchResponse,
+            _consolidate_batch_with_llm,
+        )
+
+        metrics = MagicMock()
+        llm_config = SimpleNamespace(
+            _provider_impl=None,
+            call=AsyncMock(return_value=LLMCallResult(content=_ConsolidationBatchResponse(), usage=TokenUsage())),
+        )
+        with patch("hindsight_api.engine.consolidation.consolidator.get_metrics_collector", return_value=metrics):
+            result = await _consolidate_batch_with_llm(
+                llm_config,
+                [{"id": "fact-0", "text": "a fact"}],
+                [],
+                {},
+                self._batch_config(),
+            )
+
+        assert result.failed is False
+        metrics.record_consolidation_batch_failure.assert_not_called()
 
 
 class TestDedupeUpdates:

--- a/hindsight-api-slim/tests/test_metrics.py
+++ b/hindsight-api-slim/tests/test_metrics.py
@@ -57,6 +57,7 @@ class TestNoOpMetricsCollector:
             output_tokens=50,
             success=True,
         )
+        collector.record_consolidation_batch_failure("response_validation")
 
 
 class TestMetricsCollector:
@@ -238,6 +239,14 @@ class TestMetricsCollector:
         assert count == 1
         assert attributes["outcome"] == "facts"
         assert "bank_id" not in attributes  # excluded by default, like every other metric
+
+    def test_record_consolidation_batch_failure_uses_bounded_reason(self, collector):
+        collector.record_consolidation_batch_failure("response_validation")
+
+        count, attributes = collector.consolidation_batch_failures.add.call_args[0]
+        assert count == 1
+        assert attributes["reason"] == "response_validation"
+        assert "tenant" in attributes
 
     def test_record_retain_document_labels_no_facts_outcome(self, collector):
         """A document left with zero memory units is the alertable case (#3040)."""


### PR DESCRIPTION
Closes #4151.

## What changed

Add `hindsight.consolidation.batch_failures`, a counter for LLM batches that exhaust consolidation's retry policy. It uses a bounded `reason` label:

- `response_validation` for malformed JSON, schema validation, and output-length failures
- `provider` for other exhausted provider failures

The existing `failed_consolidation` gauge remains unchanged: it counts source memories permanently marked failed after adaptive bisection reaches a singleton. The new counter makes recoverable batch-level failures visible without changing that state-based contract.

Each failed batch increments once after its retry ladder, rather than once per attempt. Successful batches do not increment it.

## Verification

- `tests/test_metrics.py`: 34 passed
- `TestBuildResponseModel`: 10 passed
- focused Ruff check and format check passed
- `git diff --check` passed

The repository hook reached the control-plane lint step but could not load `@eslint/js` because Node dependencies are not installed in this worktree. The changed Python files and tests passed their focused gates.
