### PR TITLE
fix(dsh): adapt to dsh 0.1.2 snapshotEvents() API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ hindsight-integrations/_drafts/
 
 blog-post*
 .worktrees/
+*.bak-*

--- a/hindsight-integrations/coding-agents/src/core/transcript-dsh.ts
+++ b/hindsight-integrations/coding-agents/src/core/transcript-dsh.ts
@@ -2,7 +2,8 @@
  * DeepSeek Harness (dsh) transcript normalizer.
  *
  * dsh keeps a session as an append-only log of typed `SessionEvent`s rather than a chat array, and
- * a plugin reads that log straight off `agent.session.events` — so this is a pure function over
+ * a plugin reads that log straight off `agent.session.snapshotEvents()` (0.1.2-rc.1 起 `session.events`
+ * 为私有字段，须用快照方法) — so this is a pure function over
  * those events, like the opencode normalizer, not a file reader. The SAME event vocabulary is what
  * dsh persists to disk, so the backfill reader (core/history.ts) feeds this exact function.
  *

--- a/hindsight-integrations/coding-agents/src/dsh.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.ts
@@ -156,7 +156,7 @@ function workspaceFor(root: string): Workspace | undefined {
   // memory, so unlike opencode there is nothing to refetch over HTTP.
   core.setTranscriptSource(async (sessionId) => {
     const agent = liveAgents.get(sessionId);
-    return agent ? readDshEvents(agent.session.events) : [];
+    return agent ? readDshEvents(agent.session.snapshotEvents()) : [];
   });
   const workspace: Workspace = { core, root };
   workspaces.set(root, workspace);


### PR DESCRIPTION
dsh 0.1.2-rc.1 made `agent.session.events` a private field; integrations must read the session log via the `snapshotEvents()` snapshot method instead.

This adapts the dsh integration (transcript normalizer + live transcript source) to the new API. Without it, the dsh integration breaks on dsh >= 0.1.2-rc.1.

Also adds `*.bak-*` to the coding-agents .gitignore for local backup files.