### PR TITLE
fix(db): prevent nested-loop observation scoring

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -936,6 +936,14 @@ class PostgreSQLOps(DataAccessOps):
         # grow hubs far past that, re-measure before assuming this is still the
         # right shape.
         #
+        # Even with that traceable column, bank-wide unit_id statistics can still
+        # collapse the connected_sources estimate to one row (#4163). An inner
+        # join may then become a nested loop over every candidate/source pair.
+        # Keep scored materialized and use a FULL JOIN: PostgreSQL cannot execute
+        # an equality FULL JOIN as a nested loop, so it must hash or merge even
+        # when the estimate is wrong. Unmatched rows form a single NULL-id group
+        # which the following inner join to candidates naturally discards.
+        #
         # Entity/source traversal and semantic/causal expansion run as ONE query
         # (#3857): the observation entity arm is fused into the semantic/causal CTE
         # query behind an 'entity' source discriminator, like the non-observation
@@ -987,11 +995,11 @@ class PostgreSQLOps(DataAccessOps):
                   AND mu.source_memory_ids && ca.source_ids
                   {window.clause("mu")}
             ),
-            scored AS (
+            scored AS MATERIALIZED (
                 SELECT c.id, COUNT(DISTINCT cs.source_id)::float AS score
                 FROM candidates c
                 CROSS JOIN LATERAL unnest(c.source_memory_ids) AS s(source_id)
-                JOIN connected_sources cs ON cs.source_id = s.source_id
+                FULL OUTER JOIN connected_sources cs ON cs.source_id = s.source_id
                 GROUP BY c.id
             ),
             observation_entity_expanded AS (

--- a/hindsight-api-slim/tests/test_observation_expansion_single_fetch.py
+++ b/hindsight-api-slim/tests/test_observation_expansion_single_fetch.py
@@ -419,6 +419,29 @@ async def test_postgresql_fused_query_is_one_statement():
 
 
 @pytest.mark.asyncio
+async def test_postgresql_scoring_join_excludes_nested_loop_plan():
+    """The scored join stays hash/merge-capable when source estimates collapse (#4163)."""
+    conn = AsyncMock()
+    conn.fetch.return_value = []
+
+    await PostgreSQLOps().expand_observations(
+        conn,
+        "memory_units",
+        "unit_entities",
+        "memory_links",
+        [uuid.uuid4()],
+        100,
+        200,
+        UpdatedWindow(after=None, before=None, first_param_index=3),
+    )
+
+    normalized_sql = " ".join(conn.fetch.await_args.args[0].split())
+    assert "scored AS MATERIALIZED" in normalized_sql
+    assert "FULL OUTER JOIN connected_sources cs ON cs.source_id = s.source_id" in normalized_sql
+    assert "GROUP BY c.id" in normalized_sql
+
+
+@pytest.mark.asyncio
 async def test_oracle_fused_query_is_one_statement():
     """Structural (no Oracle runtime): Oracle emits ONE statement, three arms.
 


### PR DESCRIPTION
## Summary

- materialize the observation `scored` CTE and use an equality `FULL OUTER JOIN`, which PostgreSQL must execute as a hash or merge join even when `connected_sources` is estimated at one row
- preserve the existing distinct shared-source score; unmatched connected sources collapse into a null-id group that the downstream candidates join discards
- pin the planner-safe SQL shape with a structural regression test

This intentionally does not add `MATERIALIZED` to `connected_sources`: it is already referenced twice and therefore materialized by PostgreSQL, and an explicit keyword did not change the bad cardinality estimate in PostgreSQL 18.

Closes #4163

## Validation

- PostgreSQL 18 live semantic check: candidates sharing 3 and 1 connected sources still score `3.0` and `1.0`
- PostgreSQL 18 `EXPLAIN ANALYZE`, normal statistics: 73ms total versus 75ms for the original query in the same 37.7k-unit/150.8k-edge fixture
- PostgreSQL 18 forced one-row estimate (actual ~10k): `Hash Full Join` retained; scoring join ~1.3ms
- `uv run --extra embedded-db pytest tests/test_observation_expansion_single_fetch.py tests/test_observation_expansion_scoring.py -q -n0` (3 passed, 7 skipped because local ML extras are unavailable)
- `uv run --frozen ruff check hindsight_api/engine/db/ops_postgresql.py tests/test_observation_expansion_single_fetch.py`
- `uv run --frozen ruff format --check hindsight_api/engine/db/ops_postgresql.py tests/test_observation_expansion_single_fetch.py`
- `uv run --frozen ty check hindsight_api`
- `git diff --check`

The repository-wide lint hook also ran; all Python checks passed, while the unrelated control-plane ESLint task could not start because `@eslint/js` is not installed in this checkout.

## CI follow-up

The only red job is the free-threaded 3.14 full-suite run. Two of its three failures are the same untouched OpenCode/named-result failures present on recent unrelated runs for #4164, #4159, and #4158. The remaining `test_parallel_fans_out_across_schemas` short count is also outside this diff and passed 3/3 isolated repetitions locally. All other 14 executed jobs passed, including generated-file verification and Python 3.11–3.14 builds; no changed SQL/test failure was reported, so the verified head is unchanged.
