### PR TITLE
fix(memories): use GIN for tagged mental-model staleness negatives

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/reads.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/reads.py
@@ -547,23 +547,25 @@ async def any_memory_updated_since_batch(
 
     The knowledge tree and the mental-model list ask this for every model in the
     bank on a poll, and one round-trip each is what made the exact answer look
-    expensive — the scans themselves are microseconds once
-    ``idx_memory_units_bank_updated_at`` exists. Scopes are grouped by the tag
-    clause they generate (a bank's pages almost always share one), each group is
-    joined against its scope set as JSON, and every group is a single prepared
-    plan however many pages it covers.
+    expensive. Scopes are grouped by the tag clause they generate (a bank's pages
+    almost always share one), each group is joined against its scope set as JSON,
+    and every group is a single prepared plan however many pages it covers.
 
-    Two details in the SQL are load-bearing:
+    The LATERAL shape depends on whether the group has a tag filter:
 
-    * ``ORDER BY mu.updated_at DESC`` inside the LATERAL. It does not change the
-      answer — we only ask whether a row exists — but without it the planner
-      estimates the ``LIMIT 1`` will be satisfied early, picks a sequential scan,
-      and the whole point is lost (measured: 13 ms per scope instead of 0.03 ms).
-      The ORDER BY makes the ``(bank_id, updated_at DESC)`` index the obvious way
-      to run the join, which is also the cheapest.
+    * Untagged scopes keep ``ORDER BY mu.updated_at DESC LIMIT 1`` so the planner
+      walks ``idx_memory_units_bank_updated_at`` and stops at the first hit — the
+      common positive case for a whole-bank watermark.
+    * Tagged scopes use ``bool_or(mu.updated_at > s.since)`` with the tag
+      predicate in ``WHERE`` (and *without* an ``updated_at`` range predicate).
+      Putting ``updated_at > s.since`` in the aggregate lets Postgres drive from
+      ``idx_memory_units_tags`` instead of walking every newer bank row and
+      rejecting off-tag ones. That negative case is the common one once a bank is
+      mostly caught up, and the btree walk was timing out ``GET /mental-models``
+      under production load (#4169).
     * ``LEFT JOIN LATERAL`` rather than a correlated ``EXISTS``. A scalar subquery
       over a function scan gets no useful row estimate and falls back to a
-      sequential scan for the same reason.
+      sequential scan.
 
     Compound ``tag_groups`` scopes cannot be expressed against a joined row, so
     they fall back to one :func:`any_memory_updated_since` each — they are rare,
@@ -571,9 +573,7 @@ async def any_memory_updated_since_batch(
 
     Postgres only. This module backs both SQL dialects, and Oracle reaches it
     through a regex rewriter that does not model ``jsonb_to_recordset`` or
-    ``LATERAL``, so an Oracle connection takes the same per-scope path. It is the
-    round-trips that are saved here, not the scans — the scans are cheap on both
-    dialects once the ``(bank_id, updated_at)`` index exists.
+    ``LATERAL``, so an Oracle connection takes the same per-scope path.
     """
     if not scopes:
         return {}
@@ -631,29 +631,44 @@ async def any_memory_updated_since_batch(
             }
             for scope in group
         ]
+        # Tagged scopes: GIN-friendly aggregate (see docstring). Untagged scopes:
+        # keep the btree early-exit plan that #3589 tuned for the whole-bank case.
+        if tag_clause:
+            lateral = f"""
+                SELECT bool_or(mu.updated_at > s.since) AS hit
+                FROM {table} mu
+                WHERE mu.bank_id = $1
+                  {tag_clause}
+                  AND (s.fact_types IS NULL OR mu.fact_type = ANY(s.fact_types))
+            """
+            select_stale = "COALESCE(h.hit, false) AS stale"
+        else:
+            lateral = f"""
+                SELECT 1 AS hit
+                FROM {table} mu
+                WHERE mu.bank_id = $1
+                  AND mu.updated_at > s.since
+                  AND (s.fact_types IS NULL OR mu.fact_type = ANY(s.fact_types))
+                ORDER BY mu.updated_at DESC
+                LIMIT 1
+            """
+            select_stale = "(h.hit IS NOT NULL) AS stale"
         rows = await conn.fetch(
             f"""
-            SELECT s.scope_key, (h.hit IS NOT NULL) AS stale
+            SELECT s.scope_key, {select_stale}
             FROM jsonb_to_recordset($2::jsonb)
                  -- `tags` must be varchar[], matching memory_units.tags: there is no
                  -- `varchar[] @> text[]` operator, so a text[] column here fails to
                  -- resolve the containment operators the tag clauses are built from.
                  AS s(scope_key text, since timestamptz, tags varchar[], fact_types text[])
             LEFT JOIN LATERAL (
-                SELECT 1 AS hit
-                FROM {table} mu
-                WHERE mu.bank_id = $1
-                  AND mu.updated_at > s.since
-                  {tag_clause}
-                  AND (s.fact_types IS NULL OR mu.fact_type = ANY(s.fact_types))
-                ORDER BY mu.updated_at DESC
-                LIMIT 1
+                {lateral}
             ) h ON TRUE
             """,
             bank_id,
             json.dumps(payload),
         )
-        results.update({row["scope_key"]: row["stale"] for row in rows})
+        results.update({row["scope_key"]: bool(row["stale"]) for row in rows})
 
     return results
 

--- a/hindsight-api-slim/tests/test_any_memory_updated_since_batch_gin_4169.py
+++ b/hindsight-api-slim/tests/test_any_memory_updated_since_batch_gin_4169.py
@@ -1,0 +1,101 @@
+"""#4169: tagged batch staleness must use the GIN-friendly aggregate path."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from hindsight_api.engine.memories.base import MemoryScopeWatermark
+from hindsight_api.engine.memories.pg import reads
+
+
+class _FakeConn:
+    backend_type = "postgresql"
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    async def fetch(self, query: str, *args: Any):
+        self.queries.append(query)
+        # One row per scope_key in the JSON payload — parse keys loosely.
+        import json
+
+        payload = json.loads(args[1])
+        return [{"scope_key": item["scope_key"], "stale": False} for item in payload]
+
+
+@pytest.mark.asyncio
+async def test_tagged_batch_uses_bool_or_not_btree_walk():
+    conn = _FakeConn()
+    scopes = [
+        MemoryScopeWatermark(
+            key="mm-a",
+            since=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            tags=["project:example"],
+            tags_match="all_strict",
+        )
+    ]
+    out = await reads.any_memory_updated_since_batch(
+        conn=conn,
+        fq_table=lambda name: name,
+        bank_id="bank",
+        scopes=scopes,
+    )
+    assert out == {"mm-a": False}
+    assert len(conn.queries) == 1
+    sql = conn.queries[0]
+    assert "bool_or(mu.updated_at > s.since)" in sql
+    assert "ORDER BY mu.updated_at DESC" not in sql
+    assert "LIMIT 1" not in sql
+
+
+@pytest.mark.asyncio
+async def test_untagged_batch_keeps_btree_early_exit():
+    conn = _FakeConn()
+    scopes = [
+        MemoryScopeWatermark(
+            key="mm-b",
+            since=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            tags=None,
+            tags_match="any",
+        )
+    ]
+    out = await reads.any_memory_updated_since_batch(
+        conn=conn,
+        fq_table=lambda name: name,
+        bank_id="bank",
+        scopes=scopes,
+    )
+    assert out == {"mm-b": False}
+    sql = conn.queries[0]
+    assert "ORDER BY mu.updated_at DESC" in sql
+    assert "LIMIT 1" in sql
+    assert "bool_or" not in sql
+
+
+@pytest.mark.asyncio
+async def test_four_tag_modes_all_use_gin_path_when_tagged():
+    conn = _FakeConn()
+    scopes = [
+        MemoryScopeWatermark(
+            key=mode,
+            since=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            tags=["a", "b"],
+            tags_match=mode,
+        )
+        for mode in ("any", "all", "any_strict", "all_strict")
+    ]
+    out = await reads.any_memory_updated_since_batch(
+        conn=conn,
+        fq_table=lambda name: name,
+        bank_id="bank",
+        scopes=scopes,
+    )
+    assert set(out) == {"any", "all", "any_strict", "all_strict"}
+    # Modes with different clauses may split into multiple group queries.
+    assert conn.queries
+    for sql in conn.queries:
+        assert "bool_or(mu.updated_at > s.since)" in sql
+        assert "ORDER BY mu.updated_at DESC" not in sql

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -1401,9 +1401,14 @@ class TestMentalModelStaleness:
             ("untagged", None, None),
             ("flat-default", ["user_a"], None),
             ("flat-any", ["user_a", "user_b"], {"tags_match": "any"}),
+            ("flat-all", ["user_a", "user_b"], {"tags_match": "all"}),
+            ("flat-any-strict", ["user_a"], {"tags_match": "any_strict"}),
             ("flat-strict", ["user_a", "team_red"], {"tags_match": "all_strict"}),
             ("fact-typed", ["user_a"], {"fact_types": ["world"]}),
             ("grouped", None, {"tag_groups": [{"and": [{"tags": ["user_a"]}, {"tags": ["proj_x"]}]}]}),
+            # Quiet tagged scope: watermark after the only in-scope write so the
+            # batch negative path (GIN / bool_or) must still agree with one-at-a-time.
+            ("quiet-strict", ["quiet_tag"], {"tags_match": "all_strict"}),
         ]
         models = {}
         for name, tags, trigger in specs:
@@ -1421,9 +1426,16 @@ class TestMentalModelStaleness:
         # a batch that returned one blanket answer would still pass otherwise.
         await self._insert_memory(memory, bank_id, tags=["user_a"], fact_type="experience")
         await self._insert_memory(memory, bank_id, tags=["user_b", "proj_x"], fact_type="world")
+        await self._insert_memory(memory, bank_id, tags=["quiet_tag"], fact_type="world")
 
         pool = await memory._get_pool()
         async with pool.acquire() as conn:
+            await conn.execute(
+                f"UPDATE {fq_table('mental_models')} SET last_refreshed_at = NOW() "
+                f"WHERE bank_id = $1 AND id = $2",
+                bank_id,
+                models["quiet-strict"]["id"],
+            )
             rows = {
                 name: await conn.fetchrow(
                     f"SELECT id, tags, trigger, last_refreshed_at, last_memory_seen_at "

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -1431,8 +1431,7 @@ class TestMentalModelStaleness:
         pool = await memory._get_pool()
         async with pool.acquire() as conn:
             await conn.execute(
-                f"UPDATE {fq_table('mental_models')} SET last_refreshed_at = NOW() "
-                f"WHERE bank_id = $1 AND id = $2",
+                f"UPDATE {fq_table('mental_models')} SET last_refreshed_at = NOW() WHERE bank_id = $1 AND id = $2",
                 bank_id,
                 models["quiet-strict"]["id"],
             )


### PR DESCRIPTION
## What Problem
`any_memory_updated_since_batch` (from #3589) is fast when a scope finds a matching write quickly, but in the common "already fresh" case a tagged scope walks the whole bank via `idx_memory_units_bank_updated_at` and filters tags row by row. Under production load that shows up as Envoy ~15s `504`s and asyncpg `TimeoutError` on `GET .../mental-models` (see #4169).

## Why
For tagged scopes, move `updated_at > s.since` into `bool_or(...)` and keep the tag predicate in `WHERE`, so Postgres can drive from `idx_memory_units_tags` instead of the btree walk. Untagged scopes still use the `ORDER BY ... LIMIT 1` plan that #3589 tuned for whole-bank watermarks. `tag_groups` still fall back one-at-a-time.

## How verified
- `pytest tests/test_any_memory_updated_since_batch_gin_4169.py` — tagged path uses `bool_or` (no btree `ORDER BY`/`LIMIT 1`); untagged keeps early-exit; all four `tags_match` modes use the GIN path when tagged (3 passed).
- Extended `test_batched_staleness_matches_the_single_model_answer` with `any`/`all`/`any_strict`/`all_strict` plus a quiet tagged negative scope so batch and one-at-a-time stay aligned.

Fixes #4169