### PR TITLE
fix(embeddings): include prefixes in input token cap

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
@@ -27,7 +27,12 @@ class EmbeddingsBackend(Protocol):
     def encode_documents(self, texts: list[str]) -> list[list[float]]: ...
 
 
-def _truncate_inputs(texts: list[str], max_input_tokens: int, backend: EmbeddingsBackend) -> list[str]:
+def _truncate_inputs(
+    texts: list[str],
+    max_input_tokens: int,
+    backend: EmbeddingsBackend,
+    input_type: EmbeddingInputType = "document",
+) -> list[str]:
     """Cap each input at ``max_input_tokens`` tokens before it reaches the provider.
 
     Remote providers with a fixed input-token limit (e.g. Bedrock Titan V2's hard 8192
@@ -36,8 +41,17 @@ def _truncate_inputs(texts: list[str], max_input_tokens: int, backend: Embedding
     One oversized memory then fails the whole retain/recall batch. This is provider-
     agnostic on purpose: the cap is applied here, once, before any backend's `encode()`.
     """
-    results = truncate_many_to_tokens(texts, max_input_tokens)
-    truncated = [result.text for result in results]
+    # Plain text-in backends prepend asymmetric-model instructions inside
+    # encode_query()/encode_documents(). Include that prefix in the token budget
+    # here, then remove it before handing the text to the backend so it is added
+    # exactly once. Previously an input truncated to the configured limit could
+    # cross the provider's hard context bound when the prefix was added later.
+    prefix = getattr(backend, "query_prefix" if input_type == "query" else "passage_prefix", "")
+    prefixed_texts = [f"{prefix}{text}" for text in texts] if prefix else texts
+    results = truncate_many_to_tokens(prefixed_texts, max_input_tokens)
+    if prefix and any(not result.text.startswith(prefix) for result in results):
+        raise ValueError(f"embedding input token cap {max_input_tokens} is too small for the configured prefix")
+    truncated = [result.text[len(prefix) :] if prefix else result.text for result in results]
     original_token_counts = [r.original_tokens for r in results if r.original_tokens > max_input_tokens]
     if original_token_counts:
         logger.warning(
@@ -93,7 +107,7 @@ async def generate_embeddings_batch(
     # recall queries, consolidation, import) gets identical, model-agnostic truncation.
     max_input_tokens = get_config().embeddings_max_input_tokens
     if max_input_tokens is not None and texts:
-        texts = _truncate_inputs(texts, max_input_tokens, embeddings_backend)
+        texts = _truncate_inputs(texts, max_input_tokens, embeddings_backend, input_type)
 
     try:
         loop = asyncio.get_event_loop()

--- a/hindsight-api-slim/tests/test_embeddings_max_input_tokens.py
+++ b/hindsight-api-slim/tests/test_embeddings_max_input_tokens.py
@@ -77,6 +77,24 @@ class TestTruncateInputs:
         assert result == ["short text"]
         assert not any("truncated" in r.message for r in caplog.records)
 
+    def test_passage_prefix_is_included_in_cap(self):
+        backend = _FakeBackend()
+        backend.passage_prefix = "passage: "
+        text = "word " * 50
+
+        result = embedding_utils._truncate_inputs([text], 20, backend)
+
+        assert count_tokens(f"{backend.passage_prefix}{result[0]}") <= 20
+
+    def test_query_prefix_is_included_in_cap(self):
+        backend = _FakeBackend()
+        backend.query_prefix = "query: "
+        text = "word " * 50
+
+        result = embedding_utils._truncate_inputs([text], 20, backend, "query")
+
+        assert count_tokens(f"{backend.query_prefix}{result[0]}") <= 20
+
 
 @pytest.mark.asyncio
 class TestGenerateEmbeddingsBatch:
@@ -97,6 +115,15 @@ class TestGenerateEmbeddingsBatch:
             await embedding_utils.generate_embeddings_batch(backend, [long_text])
 
         assert backend.received == [long_text]
+
+    async def test_cap_accounts_for_prefix_added_by_backend(self):
+        backend = _FakeBackend()
+        backend.passage_prefix = "passage: "
+        long_text = "word " * 500
+        with _patch_cap(50):
+            await embedding_utils.generate_embeddings_batch(backend, [long_text])
+
+        assert count_tokens(f"{backend.passage_prefix}{backend.received[0]}") <= 50
 
 
 class TestConfigWiring:


### PR DESCRIPTION
## Problem

Embedding inputs are truncated before asymmetric query/passage prefixes are added. An input at the configured token cap can therefore exceed the provider's hard context limit after the backend prepends its prefix, producing a permanent 400 and failing the owning task.

## Fix

Include the selected query or passage prefix while truncating, then remove it before dispatch so the backend adds it exactly once. This preserves the existing backend contract while making the configured cap apply to the actual wire text.

## Test

- `uv run pytest tests/test_embeddings_max_input_tokens.py tests/test_token_encoding.py -q` (29 passed)
- `uv run ruff check hindsight_api/engine/retain/embedding_utils.py tests/test_embeddings_max_input_tokens.py`
- `uv run ruff format --check hindsight_api/engine/retain/embedding_utils.py tests/test_embeddings_max_input_tokens.py`
- `uv run ty check hindsight_api/engine/retain/embedding_utils.py`

## Risk

Low. The behavior changes only when a token cap and a query/passage prefix are both configured. Empty-prefix and uncapped paths remain unchanged. A cap too small to contain the prefix now fails with a clear configuration error.

Closes #4165.
