### PR TITLE
test: read OpenCode response from LLMCallResult content

### DIFF
--- a/hindsight-api-slim/tests/test_opencode_go_session_header.py
+++ b/hindsight-api-slim/tests/test_opencode_go_session_header.py
@@ -107,7 +107,7 @@ async def test_session_id_is_stable_across_provider_retries():
             initial_backoff=0,
         )
 
-    assert result.ok is True
+    assert result.content.ok is True
     first, second = _sent_session_ids(create)
     assert first and second
     assert first == second, "retries of one operation must reuse the session id"


### PR DESCRIPTION
The OpenCode session-header regression reads `.ok` directly from `LLMCallResult`, but structured responses are exposed through its `.content` field. This makes the test and the named-result static guard fail on current `main`, including the free-threaded Python 3.14 job.

This updates the assertion to inspect the parsed response through `result.content` while preserving the session-id behavior under test.

Validation:
- `uv run pytest tests/test_opencode_go_session_header.py::test_session_id_is_stable_across_provider_retries tests/test_named_result_stubs.py::test_a_call_result_binding_is_only_read_through_its_fields -q` (2 passed)
- `uv run ruff check tests/test_opencode_go_session_header.py`
- `uv run ruff format --check tests/test_opencode_go_session_header.py`