### PR TITLE
fix(operations): allow cancelling in-flight operations (#4131)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -7158,8 +7158,14 @@ def _register_routes(app: FastAPI):
     @app.delete(
         "/v1/default/banks/{bank_id}/operations/{operation_id}",
         response_model=CancelOperationResponse,
-        summary="Cancel a pending async operation",
-        description="Cancel a pending async operation by removing it from the queue",
+        summary="Cancel a pending or in-flight async operation",
+        description=(
+            "Cancel a queued or running async operation. A 'pending' operation is never started. "
+            "A 'processing' one is cancelled cooperatively: the row is marked 'cancelled' immediately "
+            "and the worker running it stops at its next checkpoint, so work already in flight may "
+            "finish the batch it is on. This also clears operations stranded in 'processing' by a "
+            "crashed worker. Returns 409 for operations that already reached a terminal state."
+        ),
         operation_id="cancel_operation",
         tags=["Operations"],
     )
@@ -7167,7 +7173,7 @@ def _register_routes(app: FastAPI):
     async def api_cancel_operation(
         bank_id: str, operation_id: str, request_context: RequestContext = Depends(get_request_context)
     ):
-        """Cancel a pending async operation."""
+        """Cancel a pending or in-flight async operation."""
         try:
             # Validate UUID format
             try:

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -1707,9 +1707,7 @@ async def _run_consolidation_job(
 
             cancelled_local = False
             if operation_id and not await memory_engine._check_op_alive(operation_id):
-                logger.info(
-                    f"[CONSOLIDATION] bank={bank_id} operation {operation_id} cancelled (bank deleted), stopping early"
-                )
+                logger.info(f"[CONSOLIDATION] bank={bank_id} operation {operation_id} cancelled, stopping early")
                 cancelled_local = True
 
             # Per-batch local stats; merged into outer state once, serially,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -3916,6 +3916,12 @@ class MemoryEngine(MemoryEngineInterface):
 
         Long-running operations should call this at natural checkpoints (e.g. after each
         committed batch) to detect cancellation or bank deletion early and abort cleanly.
+
+        This is how `DELETE /operations/{id}` stops work that is already 'processing'
+        (issue #4131): the API only flips the status, and the running task stops at its
+        next checkpoint. Adding a checkpoint to a long-running op type is therefore all
+        it takes to make that op type cancellable — no per-batch bookkeeping, and the
+        check is one indexed primary-key read at a boundary that already touches the DB.
         """
         try:
             backend = await self._get_backend()
@@ -3977,6 +3983,10 @@ class MemoryEngine(MemoryEngineInterface):
 
         Also checks if this is a child operation and updates the parent if all siblings are done.
         Uses a single transaction to avoid race conditions when multiple children fail simultaneously.
+
+        Never overwrites 'cancelled' (issue #4131): cancellation is cooperative, so a task
+        can raise after an operator cancelled it, and 'failed' would hide their decision
+        (and make the row retryable as if it had failed on its own).
         """
         try:
             backend = await self._get_backend()
@@ -3991,14 +4001,17 @@ class MemoryEngine(MemoryEngineInterface):
                         f"""
                         UPDATE {fq_table("async_operations")}
                         SET status = 'failed', error_message = $2, updated_at = NOW()
-                        WHERE operation_id = $1
+                        WHERE operation_id = $1 AND status <> 'cancelled'
                         RETURNING operation_id
                         """,
                         uuid.UUID(operation_id),
                         truncated_error,
                     )
                     if row is None:
-                        logger.info(f"Operation {operation_id} no longer exists (bank deleted), skipping mark-failed")
+                        logger.info(
+                            f"Operation {operation_id} was cancelled or no longer exists "
+                            "(bank deleted), skipping mark-failed"
+                        )
                         return
                     logger.info(f"Marked async operation as failed: {operation_id}")
 
@@ -4349,12 +4362,15 @@ class MemoryEngine(MemoryEngineInterface):
             bank_id = row["bank_id"]
 
             # Lock the parent operation to prevent concurrent updates from other children
-            # Use FOR UPDATE to ensure only one child can update the parent at a time
+            # Use FOR UPDATE to ensure only one child can update the parent at a time.
+            # A cancelled parent is excluded: the operator cancelled the whole batch,
+            # and a child finishing afterwards must not roll it back to a completed or
+            # failed state (issue #4131).
             parent_row = await conn.fetchrow(
                 f"""
                 SELECT operation_id
                 FROM {fq_table("async_operations")}
-                WHERE operation_id = $1 AND bank_id = $2
+                WHERE operation_id = $1 AND bank_id = $2 AND status <> 'cancelled'
                 FOR UPDATE
                 """,
                 uuid.UUID(parent_operation_id),
@@ -4362,7 +4378,7 @@ class MemoryEngine(MemoryEngineInterface):
             )
 
             if not parent_row:
-                # Parent doesn't exist (shouldn't happen)
+                # Parent doesn't exist, or was cancelled
                 return
 
             # Get all sibling operations (including this one).
@@ -4388,16 +4404,21 @@ class MemoryEngine(MemoryEngineInterface):
             if not siblings:
                 return
 
-            # Check if all siblings are done (completed or failed)
+            # Check if all siblings are done. 'cancelled' counts as done (issue #4131):
+            # an operator can now cancel an individual child, and leaving it out of this
+            # set strands the parent in 'processing' forever — exactly the wedge this
+            # endpoint exists to clear.
             all_completed = all(sib["status"] == "completed" for sib in siblings)
             any_failed = any(sib["status"] == "failed" for sib in siblings)
-            all_done = all(sib["status"] in ("completed", "failed") for sib in siblings)
+            any_cancelled = any(sib["status"] == "cancelled" for sib in siblings)
+            all_done = all(sib["status"] in ("completed", "failed", "cancelled") for sib in siblings)
 
             if not all_done:
                 # Some siblings still pending/processing
                 return
 
-            # All siblings are done - update parent status
+            # All siblings are done - update parent status. A real failure outranks a
+            # cancellation: it carries a cause the operator still needs to see.
             if any_failed:
                 new_status = "failed"
                 # Set parent error message to indicate child failure. Inherit
@@ -4415,6 +4436,18 @@ class MemoryEngine(MemoryEngineInterface):
                     uuid.UUID(parent_operation_id),
                     new_status,
                     _summarise_child_error_messages(siblings),
+                )
+            elif any_cancelled:
+                # No error_message and no completed_at: the batch was stopped, not finished.
+                new_status = "cancelled"
+                await conn.execute(
+                    f"""
+                    UPDATE {fq_table("async_operations")}
+                    SET status = $2, updated_at = NOW()
+                    WHERE operation_id = $1
+                    """,
+                    uuid.UUID(parent_operation_id),
+                    new_status,
                 )
             elif all_completed:
                 new_status = "completed"
@@ -5370,11 +5403,11 @@ class MemoryEngine(MemoryEngineInterface):
             total_processed_content_tokens = 0
             cancelled = False
             for group_idx, group in enumerate(groups):
-                # Checkpoint: abort if the operation was deleted (bank deleted)
-                # between documents, mirroring the sub-batch loop's checkpoint.
+                # Checkpoint: abort if the operation was cancelled or deleted (bank
+                # deleted) between documents, mirroring the sub-batch loop's checkpoint.
                 if operation_id and not await self._check_op_alive(operation_id):
                     logger.info(
-                        f"[BATCH_RETAIN] bank={bank_id} operation {operation_id} cancelled (bank deleted), "
+                        f"[BATCH_RETAIN] bank={bank_id} operation {operation_id} cancelled, "
                         f"stopping after {group_idx}/{len(groups)} documents"
                     )
                     cancelled = True
@@ -5846,11 +5879,12 @@ class MemoryEngine(MemoryEngineInterface):
                     i = sub.index
                     sub_batch = sub.contents
                     sub_origins = sub.origins
-                    # Checkpoint: abort if the operation was deleted (bank was deleted) between sub-batches.
+                    # Checkpoint: abort if the operation was cancelled, or deleted because
+                    # the bank was deleted, between sub-batches.
                     if operation_id and not await self._check_op_alive(operation_id):
                         logger.info(
-                            f"[BATCH_RETAIN] bank={bank_id} operation {operation_id} cancelled "
-                            f"(bank deleted), stopping after {i - 1} sub-batches"
+                            f"[BATCH_RETAIN] bank={bank_id} operation {operation_id} cancelled, "
+                            f"stopping after {i - 1} sub-batches"
                         )
                         cancelled = True
                         # Cancel what is already in flight. Without this the gather below would run
@@ -19284,7 +19318,19 @@ class MemoryEngine(MemoryEngineInterface):
         *,
         request_context: "RequestContext",
     ) -> dict[str, Any]:
-        """Cancel a pending async operation."""
+        """Cancel a pending or in-flight async operation.
+
+        Cancellation is cooperative and never immediate: the row is flipped to
+        'cancelled' and the worker running it notices at its next checkpoint
+        (`_check_op_alive`), stopping after the batch/document it is on. An
+        operation whose worker died (SIGKILL, OOM) has no one to notice — the
+        flip is the whole fix there, and it is what unwedges a row stranded in
+        'processing' without hand-editing the database (issue #4131).
+
+        Every non-cancel status write in the worker is guarded against
+        overwriting 'cancelled', so a task that runs to completion past the
+        flip, or fails, cannot resurrect the row.
+        """
         await self._authenticate_tenant(request_context)
         if self._operation_validator:
             from hindsight_api.extensions import BankWriteContext, BankWriteOperation
@@ -19308,19 +19354,40 @@ class MemoryEngine(MemoryEngineInterface):
             if not result:
                 raise ValueError(f"Operation {operation_id} not found for bank {bank_id}")
 
-            if result["status"] != "pending":
+            if result["status"] not in ("pending", "processing"):
                 from hindsight_api.extensions import OperationValidationError
 
                 raise OperationValidationError(
-                    f"Operation {operation_id} cannot be cancelled: status is '{result['status']}', only 'pending' operations can be cancelled",
+                    f"Operation {operation_id} cannot be cancelled: status is '{result['status']}', "
+                    "only 'pending' and 'processing' operations can be cancelled",
                     409,
                 )
 
-            # Mark the operation as cancelled
-            await conn.execute(
-                f"UPDATE {fq_table('async_operations')} SET status = 'cancelled', updated_at = now() WHERE operation_id = $1",
+            # Mark the operation as cancelled. Re-checks the status in the UPDATE
+            # so a task that reaches its terminal write between the SELECT above
+            # and here wins the race rather than being reported as cancelled.
+            updated = await conn.fetchrow(
+                f"UPDATE {fq_table('async_operations')} SET status = 'cancelled', updated_at = now() "
+                f"WHERE operation_id = $1 AND status IN ('pending', 'processing') RETURNING status",
                 op_uuid,
             )
+            if updated is None:
+                from hindsight_api.extensions import OperationValidationError
+
+                raise OperationValidationError(
+                    f"Operation {operation_id} cannot be cancelled: it reached a terminal state concurrently",
+                    409,
+                )
+
+            # If this was the last outstanding child of a batch_retain, terminalize the
+            # parent now — nothing else will, and a parent left in 'processing' is the
+            # very wedge this endpoint exists to clear. Best-effort: the cancellation
+            # itself is already committed and must stand even if the rollup fails.
+            try:
+                async with conn.transaction():
+                    await self._maybe_update_parent_operation(operation_id, conn)
+            except Exception as e:
+                logger.warning(f"Failed to roll cancellation of {operation_id} up to its parent: {e}")
 
             return {
                 "success": True,

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -863,22 +863,31 @@ class WorkerPoller:
                     await self._maybe_update_parent_operation(operation_id, schema, conn)
 
     async def _mark_failed(self, operation_id: str, error_message: str, schema: str | None):
-        """Mark a task as failed with error message, then propagate to parent if applicable."""
+        """Mark a task as failed with error message, then propagate to parent if applicable.
+
+        Guarded against 'cancelled' (issue #4131): cancellation is cooperative, so
+        a task can still raise after an operator cancelled it — stamping 'failed'
+        over the cancellation would lose the operator's decision. When the row is
+        already cancelled the parent rollup is skipped too, since nothing changed.
+        """
         table = fq_table("async_operations", schema)
         # Truncate error message if too long (max 5000 chars in schema)
         error_message = error_message[:5000] if len(error_message) > 5000 else error_message
 
         async with self._backend.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(
+                result = await conn.execute(
                     f"""
                     UPDATE {table}
                     SET status = 'failed', error_message = $2, completed_at = now(), updated_at = now()
-                    WHERE operation_id = $1
+                    WHERE operation_id = $1 AND status <> 'cancelled'
                     """,
                     operation_id,
                     error_message,
                 )
+                if not _updated_row_count(result):
+                    logger.info(f"Operation {operation_id} was cancelled or deleted, skipping mark-failed")
+                    return
                 await self._maybe_update_parent_operation(operation_id, schema, conn)
 
     async def _maybe_update_parent_operation(self, child_operation_id: str, schema: str | None, conn) -> None:
@@ -912,9 +921,12 @@ class WorkerPoller:
 
             bank_id = row["bank_id"]
 
-            # Lock parent to prevent concurrent sibling updates
+            # Lock parent to prevent concurrent sibling updates. A cancelled parent
+            # is left alone: the operator cancelled the whole batch, and a child
+            # that finished afterwards must not flip it back to completed/failed.
             parent_row = await conn.fetchrow(
-                f"SELECT operation_id FROM {table} WHERE operation_id = $1 AND bank_id = $2 FOR UPDATE",
+                f"SELECT operation_id FROM {table} WHERE operation_id = $1 AND bank_id = $2 "
+                f"AND status <> 'cancelled' FOR UPDATE",
                 uuid.UUID(parent_operation_id),
                 bank_id,
             )
@@ -935,11 +947,17 @@ class WorkerPoller:
                 bank_id,
                 json.dumps({"parent_operation_id": parent_operation_id}),
             )
-            if not siblings or not all(s["status"] in ("completed", "failed") for s in siblings):
+            # 'cancelled' counts as done (issue #4131): an operator can cancel an
+            # individual child, and leaving it out of this set strands the parent in
+            # 'processing' forever. Mirrors MemoryEngine._maybe_update_parent_operation.
+            if not siblings or not all(s["status"] in ("completed", "failed", "cancelled") for s in siblings):
                 return
 
             any_failed = any(s["status"] == "failed" for s in siblings)
+            any_cancelled = any(s["status"] == "cancelled" for s in siblings)
             if any_failed:
+                # A real failure outranks a cancellation: it carries a cause to surface.
+                parent_status = "failed"
                 await conn.execute(
                     f"""
                     UPDATE {table}
@@ -949,7 +967,19 @@ class WorkerPoller:
                     uuid.UUID(parent_operation_id),
                     _summarise_child_error_messages(siblings),
                 )
+            elif any_cancelled:
+                # No completed_at: the batch was stopped, not finished.
+                parent_status = "cancelled"
+                await conn.execute(
+                    f"""
+                    UPDATE {table}
+                    SET status = 'cancelled', updated_at = now()
+                    WHERE operation_id = $1
+                    """,
+                    uuid.UUID(parent_operation_id),
+                )
             else:
+                parent_status = "completed"
                 await conn.execute(
                     f"""
                     UPDATE {table}
@@ -958,10 +988,7 @@ class WorkerPoller:
                     """,
                     uuid.UUID(parent_operation_id),
                 )
-            logger.info(
-                f"Poller updated parent operation {parent_operation_id} to "
-                f"{'failed' if any_failed else 'completed'} (all siblings done)"
-            )
+            logger.info(f"Poller updated parent operation {parent_operation_id} to {parent_status} (all siblings done)")
         except Exception as e:
             # Log but don't re-raise — the child has already been marked failed,
             # which is the critical state change. A stuck parent will be caught on
@@ -969,21 +996,29 @@ class WorkerPoller:
             logger.error(f"Failed to update parent operation for child {child_operation_id}: {e}")
 
     async def _schedule_retry(self, operation_id: str, retry_at: "Any", error_message: str, schema: str | None):
-        """Reset task to pending with a future retry timestamp."""
+        """Reset task to pending with a future retry timestamp.
+
+        Guarded against 'cancelled' (issue #4131) — this is the write that would
+        actually resurrect cancelled work: without the guard a task that fails
+        after being cancelled goes back to 'pending' and gets re-claimed.
+        """
         table = fq_table("async_operations", schema)
         error_message = error_message[:5000] if len(error_message) > 5000 else error_message
         async with self._backend.acquire() as conn:
-            await conn.execute(
+            result = await conn.execute(
                 f"""
                 UPDATE {table}
                 SET status = 'pending', next_retry_at = $2, worker_id = NULL, claimed_at = NULL,
                     retry_count = retry_count + 1, error_message = $3, updated_at = now()
-                WHERE operation_id = $1
+                WHERE operation_id = $1 AND status <> 'cancelled'
                 """,
                 operation_id,
                 retry_at,
                 error_message,
             )
+        if not _updated_row_count(result):
+            logger.info(f"Task {operation_id} was cancelled or deleted, not scheduling a retry")
+            return
         logger.warning(f"Task {operation_id} scheduled for retry at {retry_at}: {error_message}")
 
     async def _defer_operation(self, operation_id: str, exec_date: "Any", reason: str, schema: str | None):
@@ -994,16 +1029,19 @@ class WorkerPoller:
         """
         table = fq_table("async_operations", schema)
         async with self._backend.acquire() as conn:
-            await conn.execute(
+            result = await conn.execute(
                 f"""
                 UPDATE {table}
                 SET status = 'pending', next_retry_at = $2, worker_id = NULL, claimed_at = NULL,
                     updated_at = now()
-                WHERE operation_id = $1
+                WHERE operation_id = $1 AND status <> 'cancelled'
                 """,
                 operation_id,
                 exec_date,
             )
+        if not _updated_row_count(result):
+            logger.info(f"Task {operation_id} was cancelled or deleted, not deferring")
+            return
         logger.info(f"Task {operation_id} deferred until {exec_date}: {reason}")
 
     async def execute_task(self, task: ClaimedTask):

--- a/hindsight-api-slim/tests/test_op_cancellation.py
+++ b/hindsight-api-slim/tests/test_op_cancellation.py
@@ -1,11 +1,12 @@
-"""Tests for operation cancellation when a bank is deleted.
+"""Tests for operation cancellation — by an operator, or by the bank being deleted.
 
 Covers:
 - CASCADE DELETE: deleting a bank removes async_operations and webhooks rows
-- _check_op_alive: returns True when op exists, False when deleted
-- _mark_operation_completed / _mark_operation_failed: graceful no-op when row is gone
-- Consolidation checkpoint: stops early after a batch commit if op was deleted
-- Retain checkpoint: stops between sub-batches if op was deleted
+- _check_op_alive: returns True when op exists, False when deleted or cancelled
+- _mark_operation_completed / _mark_operation_failed: graceful no-op when the row is
+  gone, and never overwriting an operator's 'cancelled' (issue #4131)
+- Consolidation checkpoint: stops early after a batch commit if op was cancelled
+- Retain checkpoint: stops between sub-batches if op was cancelled
 """
 
 import uuid
@@ -171,6 +172,31 @@ class TestCheckOpAlive:
 
         assert await memory._check_op_alive(str(op_id)) is False
 
+    @pytest.mark.asyncio
+    async def test_returns_false_when_op_cancelled(self, memory: MemoryEngine, request_context):
+        """A cancelled 'processing' row stops the running task at its next checkpoint.
+
+        This is what makes `DELETE /operations/{id}` work on in-flight operations
+        (issue #4131) — the API only flips the status, the task does the stopping.
+        """
+        bank_id = f"{_BANK_PREFIX}-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        op_id = uuid.uuid4()
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO async_operations (operation_id, bank_id, operation_type, status)
+                VALUES ($1, $2, 'consolidation', 'processing')
+                """,
+                op_id,
+                bank_id,
+            )
+            assert await memory._check_op_alive(str(op_id)) is True
+            await conn.execute("UPDATE async_operations SET status = 'cancelled' WHERE operation_id = $1", op_id)
+
+        assert await memory._check_op_alive(str(op_id)) is False
+
 
 # ---------------------------------------------------------------------------
 # _mark_operation_completed / _mark_operation_failed graceful no-op
@@ -188,6 +214,58 @@ class TestMarkOperationGracefulOnMissingRow:
     async def test_mark_failed_does_not_raise_when_row_missing(self, memory: MemoryEngine):
         missing_id = str(uuid.uuid4())
         await memory._mark_operation_failed(missing_id, "some error", "traceback here")  # no exception
+
+    @pytest.mark.asyncio
+    async def test_mark_failed_does_not_overwrite_cancelled(self, memory: MemoryEngine, request_context):
+        """A task that raises after being cancelled must not report 'failed' (issue #4131).
+
+        'failed' would both hide the operator's decision and make the row look like it
+        died on its own, which is a different thing to retry.
+        """
+        bank_id = f"{_BANK_PREFIX}-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        op_id = uuid.uuid4()
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO async_operations (operation_id, bank_id, operation_type, status)
+                VALUES ($1, $2, 'consolidation', 'cancelled')
+                """,
+                op_id,
+                bank_id,
+            )
+
+        await memory._mark_operation_failed(str(op_id), "boom", "traceback here")
+
+        async with memory._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT status, error_message FROM async_operations WHERE operation_id = $1", op_id
+            )
+        assert row["status"] == "cancelled"
+        assert row["error_message"] is None
+
+    @pytest.mark.asyncio
+    async def test_mark_completed_does_not_overwrite_cancelled(self, memory: MemoryEngine, request_context):
+        bank_id = f"{_BANK_PREFIX}-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+        op_id = uuid.uuid4()
+        async with memory._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO async_operations (operation_id, bank_id, operation_type, status)
+                VALUES ($1, $2, 'consolidation', 'cancelled')
+                """,
+                op_id,
+                bank_id,
+            )
+
+        await memory._mark_operation_completed(str(op_id))
+
+        async with memory._pool.acquire() as conn:
+            status = await conn.fetchval("SELECT status FROM async_operations WHERE operation_id = $1", op_id)
+        assert status == "cancelled"
 
     @pytest.mark.asyncio
     async def test_mark_completed_and_fire_webhook_does_not_raise_when_row_missing(self, memory: MemoryEngine):

--- a/hindsight-api-slim/tests/test_operation_status.py
+++ b/hindsight-api-slim/tests/test_operation_status.py
@@ -313,15 +313,84 @@ async def test_retry_rejects_batch_retain_parent(api_client, memory, test_bank_i
 
 
 @pytest.mark.asyncio
-async def test_cancel_rejects_non_pending_operations(api_client, memory, test_bank_id):
-    """DELETE /operations/{id} should only cancel pending operations."""
+async def test_cancel_rejects_terminal_operations(api_client, memory, test_bank_id):
+    """DELETE /operations/{id} should refuse operations that already finished."""
     pool = memory._pool
     await _ensure_bank(pool, test_bank_id)
 
-    for status in ("processing", "completed", "failed"):
+    for status in ("completed", "failed", "cancelled"):
         op_id = await _insert_operation(pool, test_bank_id, status)
         response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
         assert response.status_code == 409, f"Expected 409 for {status}, got {response.status_code}"
+
+
+@pytest.mark.asyncio
+async def test_cancel_processing_operation(api_client, memory, test_bank_id):
+    """DELETE /operations/{id} should cancel an in-flight operation (issue #4131).
+
+    This is the only way to clear a row stranded in 'processing' by a worker that
+    was killed before it could write a terminal status.
+    """
+    pool = memory._pool
+    await _ensure_bank(pool, test_bank_id)
+
+    op_id = await _insert_operation(pool, test_bank_id, "processing")
+
+    response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+    response = await api_client.get(f"/v1/default/banks/{test_bank_id}/operations/{op_id}")
+    assert response.status_code == 200
+    assert response.json()["status"] == "cancelled"
+
+    # And the stranded work can be re-queued once it is unwedged.
+    response = await api_client.post(f"/v1/default/banks/{test_bank_id}/operations/{op_id}/retry")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_cancelling_last_child_terminalises_parent(api_client, memory, test_bank_id):
+    """A cancelled child must not strand its batch_retain parent in 'processing' (issue #4131).
+
+    'cancelled' is a done state for the sibling rollup, and the cancel itself performs the
+    rollup — otherwise nothing else ever writes the parent's terminal status and the batch
+    sits in 'processing' forever, which is the exact wedge this endpoint clears.
+    """
+    pool = memory._pool
+    await _ensure_bank(pool, test_bank_id)
+
+    parent_id = uuid.uuid4()
+    await pool.execute(
+        """
+        INSERT INTO async_operations (operation_id, bank_id, operation_type, status, result_metadata)
+        VALUES ($1, $2, 'batch_retain', 'processing', '{"is_parent": true}'::jsonb)
+        """,
+        parent_id,
+        test_bank_id,
+    )
+
+    child_ids = []
+    for status in ("completed", "processing"):
+        child_id = uuid.uuid4()
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, result_metadata)
+            VALUES ($1, $2, 'retain', $3, $4::jsonb)
+            """,
+            child_id,
+            test_bank_id,
+            status,
+            f'{{"parent_operation_id": "{parent_id}"}}',
+        )
+        child_ids.append(child_id)
+
+    # Cancel the one child still in flight — it is the last outstanding sibling.
+    response = await api_client.delete(f"/v1/default/banks/{test_bank_id}/operations/{child_ids[1]}")
+    assert response.status_code == 200
+
+    parent_status = await pool.fetchval("SELECT status FROM async_operations WHERE operation_id = $1", parent_id)
+    assert parent_status == "cancelled", "parent must not be left in 'processing'"
 
 
 @pytest.mark.asyncio

--- a/hindsight-api-slim/tests/test_worker.py
+++ b/hindsight-api-slim/tests/test_worker.py
@@ -3417,6 +3417,89 @@ class TestMarkFailedParentPropagation:
         )
 
     @pytest.mark.asyncio
+    async def test_cancelled_sibling_counts_as_done_and_settles_parent(self, pool, backend, clean_operations):
+        """A cancelled child must not strand the parent in 'processing' (issue #4131).
+
+        The poller's copy of the rollup mirrors MemoryEngine._maybe_update_parent_operation:
+        'cancelled' is a done state, and with no failures the parent settles on 'cancelled'.
+        """
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        parent_id = uuid.uuid4()
+        cancelled_child_id = uuid.uuid4()
+        last_child_id = uuid.uuid4()
+
+        await self._insert_op(
+            pool, op_id=parent_id, bank_id=bank_id, operation_type="batch_retain", status="processing"
+        )
+        await self._insert_op(
+            pool,
+            op_id=cancelled_child_id,
+            bank_id=bank_id,
+            operation_type="retain",
+            status="cancelled",
+            result_metadata={"parent_operation_id": str(parent_id)},
+        )
+        await self._insert_op(
+            pool,
+            op_id=last_child_id,
+            bank_id=bank_id,
+            operation_type="retain",
+            status="processing",
+            result_metadata={"parent_operation_id": str(parent_id)},
+        )
+
+        poller = WorkerPoller(backend=backend, worker_id="test-worker-1", executor=lambda x: None)
+        await poller._mark_completed(str(last_child_id), None)
+
+        parent_status = await pool.fetchval("SELECT status FROM async_operations WHERE operation_id = $1", parent_id)
+        assert parent_status == "cancelled", f"parent must not be left in 'processing', got '{parent_status}'"
+
+    @pytest.mark.asyncio
+    async def test_failed_sibling_outranks_cancelled_one(self, pool, backend, clean_operations):
+        """A real failure still wins over a cancellation — it carries a cause to surface."""
+        from hindsight_api.worker import WorkerPoller
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(pool, bank_id)
+
+        parent_id = uuid.uuid4()
+        cancelled_child_id = uuid.uuid4()
+        last_child_id = uuid.uuid4()
+
+        await self._insert_op(
+            pool, op_id=parent_id, bank_id=bank_id, operation_type="batch_retain", status="processing"
+        )
+        await self._insert_op(
+            pool,
+            op_id=cancelled_child_id,
+            bank_id=bank_id,
+            operation_type="retain",
+            status="cancelled",
+            result_metadata={"parent_operation_id": str(parent_id)},
+        )
+        await self._insert_op(
+            pool,
+            op_id=last_child_id,
+            bank_id=bank_id,
+            operation_type="retain",
+            status="processing",
+            result_metadata={"parent_operation_id": str(parent_id)},
+        )
+
+        poller = WorkerPoller(backend=backend, worker_id="test-worker-1", executor=lambda x: None)
+        await poller._mark_failed(str(last_child_id), "DB constraint violation", schema=None)
+
+        parent_row = await pool.fetchrow(
+            "SELECT status, error_message FROM async_operations WHERE operation_id = $1", parent_id
+        )
+        assert parent_row["status"] == "failed"
+        assert "DB constraint violation" in parent_row["error_message"]
+
+    @pytest.mark.asyncio
     async def test_mark_failed_finalises_parent_when_last_sibling_fails(self, pool, backend, clean_operations):
         """When the last pending child fails, parent batch_retain is marked failed."""
         from hindsight_api.worker import WorkerPoller
@@ -5056,3 +5139,114 @@ class TestTerminalOperationRetention:
             'ALTER SESSION SET CURRENT_SCHEMA = "APP_USER"',
         ]
         assert backend._default_schema == "APP_USER"
+
+
+class TestCancelledStatusIsFinal:
+    """`DELETE /operations/{id}` may now cancel a 'processing' row (issue #4131).
+
+    Cancellation is cooperative: the worker running the operation only notices at
+    its next checkpoint, so every one of its status writes can still land *after*
+    an operator cancelled. None of them may overwrite 'cancelled' — otherwise the
+    operator's decision is silently reverted, and `_schedule_retry` in particular
+    would put the cancelled work back on the queue to be re-claimed.
+    """
+
+    async def _cancelled_op(self, pool, op_type: str = "consolidation") -> uuid.UUID:
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        op_id = uuid.uuid4()
+        await _ensure_bank(pool, bank_id)
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, worker_id)
+            VALUES ($1, $2, $3, 'cancelled', 'test-worker-1')
+            """,
+            op_id,
+            bank_id,
+            op_type,
+        )
+        return op_id
+
+    def _poller(self, backend):
+        from hindsight_api.worker import WorkerPoller
+
+        return WorkerPoller(backend=backend, worker_id="test-worker-1", executor=AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_mark_failed_does_not_overwrite_cancelled(self, pool, backend, clean_operations):
+        op_id = await self._cancelled_op(pool)
+
+        await self._poller(backend)._mark_failed(str(op_id), "boom", None)
+
+        row = await pool.fetchrow("SELECT status, error_message FROM async_operations WHERE operation_id = $1", op_id)
+        assert row["status"] == "cancelled"
+        assert row["error_message"] is None
+
+    @pytest.mark.asyncio
+    async def test_schedule_retry_does_not_requeue_cancelled(self, pool, backend, clean_operations):
+        """The important one: without the guard the row goes back to 'pending' and is re-claimed."""
+        op_id = await self._cancelled_op(pool)
+
+        retry_at = datetime.now(UTC) + timedelta(seconds=60)
+        await self._poller(backend)._schedule_retry(str(op_id), retry_at, "transient", None)
+
+        row = await pool.fetchrow(
+            "SELECT status, retry_count, next_retry_at FROM async_operations WHERE operation_id = $1", op_id
+        )
+        assert row["status"] == "cancelled"
+        assert (row["retry_count"] or 0) == 0
+        assert row["next_retry_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_defer_does_not_requeue_cancelled(self, pool, backend, clean_operations):
+        op_id = await self._cancelled_op(pool)
+
+        exec_date = datetime.now(UTC) + timedelta(seconds=60)
+        await self._poller(backend)._defer_operation(str(op_id), exec_date, "quota", None)
+
+        row = await pool.fetchrow("SELECT status FROM async_operations WHERE operation_id = $1", op_id)
+        assert row["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_mark_completed_does_not_overwrite_cancelled(self, pool, backend, clean_operations):
+        """Already guarded on status='processing' — asserted here so it stays that way."""
+        op_id = await self._cancelled_op(pool)
+
+        await self._poller(backend)._mark_completed(str(op_id), None)
+
+        row = await pool.fetchrow("SELECT status FROM async_operations WHERE operation_id = $1", op_id)
+        assert row["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_executor_failure_after_cancel_leaves_row_cancelled(self, pool, backend, clean_operations):
+        """End-to-end: a task cancelled mid-flight that then raises stays 'cancelled'."""
+        from hindsight_api.worker import WorkerPoller
+        from hindsight_api.worker.poller import ClaimedTask
+
+        bank_id = f"test-worker-{uuid.uuid4().hex[:8]}"
+        op_id = uuid.uuid4()
+        payload = json.dumps({"type": "consolidation", "operation_id": str(op_id), "bank_id": bank_id})
+        await _ensure_bank(pool, bank_id)
+        await pool.execute(
+            """
+            INSERT INTO async_operations (operation_id, bank_id, operation_type, status, task_payload, worker_id)
+            VALUES ($1, $2, 'consolidation', 'processing', $3::jsonb, 'test-worker-1')
+            """,
+            op_id,
+            bank_id,
+            payload,
+        )
+
+        async def cancel_then_fail(task_dict):
+            # An operator cancels while the task is running, then the task raises.
+            await pool.execute(
+                "UPDATE async_operations SET status = 'cancelled', updated_at = now() WHERE operation_id = $1",
+                op_id,
+            )
+            raise RuntimeError("boom")
+
+        poller = WorkerPoller(backend=backend, worker_id="test-worker-1", executor=cancel_then_fail)
+        await poller.execute_task(ClaimedTask(operation_id=str(op_id), task_dict=json.loads(payload), schema=None))
+        assert await poller.wait_for_active_tasks(timeout=5.0)
+
+        row = await pool.fetchrow("SELECT status FROM async_operations WHERE operation_id = $1", op_id)
+        assert row["status"] == "cancelled", "a cancelled operation must not be resurrected by the failure path"

--- a/hindsight-cli/src/main.rs
+++ b/hindsight-cli/src/main.rs
@@ -794,7 +794,7 @@ enum OperationCommands {
         operation_id: String,
     },
 
-    /// Cancel a pending async operation
+    /// Cancel a pending or in-flight async operation
     Cancel {
         /// Bank ID
         bank_id: String,

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -2771,7 +2771,12 @@ paths:
       - Operations
   /v1/default/banks/{bank_id}/operations/{operation_id}:
     delete:
-      description: Cancel a pending async operation by removing it from the queue
+      description: "Cancel a queued or running async operation. A 'pending' operation\
+        \ is never started. A 'processing' one is cancelled cooperatively: the row\
+        \ is marked 'cancelled' immediately and the worker running it stops at its\
+        \ next checkpoint, so work already in flight may finish the batch it is on.\
+        \ This also clears operations stranded in 'processing' by a crashed worker.\
+        \ Returns 409 for operations that already reached a terminal state."
       operationId: cancel_operation
       parameters:
       - explode: false
@@ -2811,7 +2816,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: Cancel a pending async operation
+      summary: Cancel a pending or in-flight async operation
       tags:
       - Operations
     get:

--- a/hindsight-clients/go/api_operations.go
+++ b/hindsight-clients/go/api_operations.go
@@ -41,9 +41,9 @@ func (r ApiCancelOperationRequest) Execute() (*CancelOperationResponse, *http.Re
 }
 
 /*
-CancelOperation Cancel a pending async operation
+CancelOperation Cancel a pending or in-flight async operation
 
-Cancel a pending async operation by removing it from the queue
+Cancel a queued or running async operation. A 'pending' operation is never started. A 'processing' one is cancelled cooperatively: the row is marked 'cancelled' immediately and the worker running it stops at its next checkpoint, so work already in flight may finish the batch it is on. This also clears operations stranded in 'processing' by a crashed worker. Returns 409 for operations that already reached a terminal state.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param bankId

--- a/hindsight-clients/python/hindsight_client_api/api/operations_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/operations_api.py
@@ -62,9 +62,9 @@ class OperationsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> CancelOperationResponse:
-        """Cancel a pending async operation
+        """Cancel a pending or in-flight async operation
 
-        Cancel a pending async operation by removing it from the queue
+        Cancel a queued or running async operation. A 'pending' operation is never started. A 'processing' one is cancelled cooperatively: the row is marked 'cancelled' immediately and the worker running it stops at its next checkpoint, so work already in flight may finish the batch it is on. This also clears operations stranded in 'processing' by a crashed worker. Returns 409 for operations that already reached a terminal state.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -138,9 +138,9 @@ class OperationsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[CancelOperationResponse]:
-        """Cancel a pending async operation
+        """Cancel a pending or in-flight async operation
 
-        Cancel a pending async operation by removing it from the queue
+        Cancel a queued or running async operation. A 'pending' operation is never started. A 'processing' one is cancelled cooperatively: the row is marked 'cancelled' immediately and the worker running it stops at its next checkpoint, so work already in flight may finish the batch it is on. This also clears operations stranded in 'processing' by a crashed worker. Returns 409 for operations that already reached a terminal state.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -214,9 +214,9 @@ class OperationsApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Cancel a pending async operation
+        """Cancel a pending or in-flight async operation
 
-        Cancel a pending async operation by removing it from the queue
+        Cancel a queued or running async operation. A 'pending' operation is never started. A 'processing' one is cancelled cooperatively: the row is marked 'cancelled' immediately and the worker running it stops at its next checkpoint, so work already in flight may finish the batch it is on. This also clears operations stranded in 'processing' by a crashed worker. Returns 409 for operations that already reached a terminal state.
 
         :param bank_id: (required)
         :type bank_id: str

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -1088,9 +1088,9 @@ export const listOperations = <ThrowOnError extends boolean = false>(
   });
 
 /**
- * Cancel a pending async operation
+ * Cancel a pending or in-flight async operation
  *
- * Cancel a pending async operation by removing it from the queue
+ * Cancel a queued or running async operation. A 'pending' operation is never started. A 'processing' one is cancelled cooperatively: the row is marked 'cancelled' immediately and the worker running it stops at its next checkpoint, so work already in flight may finish the batch it is on. This also clears operations stranded in 'processing' by a crashed worker. Returns 409 for operations that already reached a terminal state.
  */
 export const cancelOperation = <ThrowOnError extends boolean = false>(
   options: Options<CancelOperationData, ThrowOnError>

--- a/hindsight-control-plane/src/components/bank-operations-view.tsx
+++ b/hindsight-control-plane/src/components/bank-operations-view.tsx
@@ -615,7 +615,7 @@ export function BankOperationsView() {
                         appears/disappears as an operation starts or finishes. */}
                     <TableHead className="w-[300px]">{t("table.status")}</TableHead>
                     {/* Fixed width + always-present label so the column doesn't grow
-                        when a pending/failed row's Cancel/Retry button appears. */}
+                        when a row's Cancel/Retry button appears. */}
                     <TableHead className="w-[150px]">{t("table.actions")}</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -657,7 +657,7 @@ export function BankOperationsView() {
                         </div>
                       </TableCell>
                       <TableCell className="w-[150px] whitespace-nowrap">
-                        {op.status === "pending" && (
+                        {(op.status === "pending" || op.status === "processing") && (
                           <Button
                             variant="ghost"
                             size="sm"
@@ -869,12 +869,14 @@ export function BankOperationsView() {
 
                   {/* Action buttons */}
                   {(selectedOperation.status === "pending" ||
+                    selectedOperation.status === "processing" ||
                     selectedOperation.status === "failed" ||
                     selectedOperation.status === "cancelled" ||
                     selectedOperation.status === "completed" ||
                     selectedOperation.result_metadata?.document_id) && (
                     <div className="flex flex-wrap gap-2">
-                      {selectedOperation.status === "pending" && (
+                      {(selectedOperation.status === "pending" ||
+                        selectedOperation.status === "processing") && (
                         <Button
                           variant="outline"
                           size="sm"

--- a/hindsight-control-plane/src/lib/api.ts
+++ b/hindsight-control-plane/src/lib/api.ts
@@ -699,7 +699,7 @@ export class ControlPlaneClient {
   }
 
   /**
-   * Cancel a pending operation
+   * Cancel a pending or in-flight operation
    */
   async cancelOperation(bankId: string, operationId: string) {
     return this.fetchApi<{

--- a/hindsight-docs/docs/developer/api/operations.mdx
+++ b/hindsight-docs/docs/developer/api/operations.mdx
@@ -36,7 +36,7 @@ By default, every operation runs in-process: no external queue, no extra process
 | `processing` | A worker has claimed the row and is actively running the handler. |
 | `completed` | The handler returned successfully. |
 | `failed` | The handler raised. `error_message` carries the reason; you can re-queue with `POST /…/retry`. |
-| `cancelled` | The operation was cancelled via `DELETE /…/operations/{id}` before a worker picked it up. Cancelling a `processing` operation is not supported. |
+| `cancelled` | The operation was cancelled via `DELETE /…/operations/{id}`. Works on `pending` and `processing` operations alike. |
 
 The worker retries failed operations up to `HINDSIGHT_API_WORKER_MAX_RETRIES` times before settling on `failed`. Deterministic failures (e.g., invalid embedding dimensions, integrity violations) skip retries — they won't succeed by re-running.
 
@@ -177,9 +177,21 @@ A few response fields are worth calling out:
 | `total` | Total units of work for the operation, when known. |
 | `detail` | Operation-specific counters (e.g. `observations_created`, `round`, `items_in_sub_batch`). |
 
-### Cancel a pending operation
+### Cancel an operation
 
-Returns `409` if the operation is already in `processing`, `completed`, or `failed` state.
+Cancels a `pending` or `processing` operation. Returns `409` if it has already reached a
+terminal state (`completed`, `failed`, `cancelled`).
+
+The row is marked `cancelled` straight away, but cancelling running work is **cooperative
+and not immediate**. A worker executing the operation notices at its next checkpoint — the
+boundary between sub-batches or documents for retain, between LLM batches for consolidation —
+and stops there, so whatever it had already committed stays committed and the batch in
+progress may still finish. Operation types without checkpoints run to the end; the row stays
+`cancelled` either way, because no worker write may overwrite that status.
+
+This is also how you clear an operation stranded in `processing` by a worker that was killed
+before it could finish: nothing is running, so the cancel takes effect immediately. Use
+`POST /…/operations/{id}/retry` to re-queue the work afterwards.
 
 <Tabs>
 <TabItem value="python" label="Python">

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -4074,8 +4074,8 @@
         "tags": [
           "Operations"
         ],
-        "summary": "Cancel a pending async operation",
-        "description": "Cancel a pending async operation by removing it from the queue",
+        "summary": "Cancel a pending or in-flight async operation",
+        "description": "Cancel a queued or running async operation. A 'pending' operation is never started. A 'processing' one is cancelled cooperatively: the row is marked 'cancelled' immediately and the worker running it stops at its next checkpoint, so work already in flight may finish the batch it is on. This also clears operations stranded in 'processing' by a crashed worker. Returns 409 for operations that already reached a terminal state.",
         "operationId": "cancel_operation",
         "parameters": [
           {

--- a/skills/hindsight-docs/references/developer/api/operations.md
+++ b/skills/hindsight-docs/references/developer/api/operations.md
@@ -24,7 +24,7 @@ By default, every operation runs in-process: no external queue, no extra process
 | `processing` | A worker has claimed the row and is actively running the handler. |
 | `completed` | The handler returned successfully. |
 | `failed` | The handler raised. `error_message` carries the reason; you can re-queue with `POST /…/retry`. |
-| `cancelled` | The operation was cancelled via `DELETE /…/operations/{id}` before a worker picked it up. Cancelling a `processing` operation is not supported. |
+| `cancelled` | The operation was cancelled via `DELETE /…/operations/{id}`. Works on `pending` and `processing` operations alike. |
 
 The worker retries failed operations up to `HINDSIGHT_API_WORKER_MAX_RETRIES` times before settling on `failed`. Deterministic failures (e.g., invalid embedding dimensions, integrity violations) skip retries — they won't succeed by re-running.
 
@@ -215,9 +215,21 @@ A few response fields are worth calling out:
 | `total` | Total units of work for the operation, when known. |
 | `detail` | Operation-specific counters (e.g. `observations_created`, `round`, `items_in_sub_batch`). |
 
-### Cancel a pending operation
+### Cancel an operation
 
-Returns `409` if the operation is already in `processing`, `completed`, or `failed` state.
+Cancels a `pending` or `processing` operation. Returns `409` if it has already reached a
+terminal state (`completed`, `failed`, `cancelled`).
+
+The row is marked `cancelled` straight away, but cancelling running work is **cooperative
+and not immediate**. A worker executing the operation notices at its next checkpoint — the
+boundary between sub-batches or documents for retain, between LLM batches for consolidation —
+and stops there, so whatever it had already committed stays committed and the batch in
+progress may still finish. Operation types without checkpoints run to the end; the row stays
+`cancelled` either way, because no worker write may overwrite that status.
+
+This is also how you clear an operation stranded in `processing` by a worker that was killed
+before it could finish: nothing is running, so the cancel takes effect immediately. Use
+`POST /…/operations/{id}/retry` to re-queue the work afterwards.
 
 ### Python
 

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -4074,8 +4074,8 @@
         "tags": [
           "Operations"
         ],
-        "summary": "Cancel a pending async operation",
-        "description": "Cancel a pending async operation by removing it from the queue",
+        "summary": "Cancel a pending or in-flight async operation",
+        "description": "Cancel a queued or running async operation. A 'pending' operation is never started. A 'processing' one is cancelled cooperatively: the row is marked 'cancelled' immediately and the worker running it stops at its next checkpoint, so work already in flight may finish the batch it is on. This also clears operations stranded in 'processing' by a crashed worker. Returns 409 for operations that already reached a terminal state.",
         "operationId": "cancel_operation",
         "parameters": [
           {


### PR DESCRIPTION
Fixes #4131.

## The problem

`DELETE /v1/default/banks/{bank}/operations/{id}` only accepted `pending` operations. An operation stranded in `processing` — orphaned when a worker was killed before it could write a terminal status — could only be cleared by hand-editing `async_operations` and restarting the container.

## The approach: no heartbeat

The obvious design is a heartbeat column plus a staleness reaper, but that adds a periodic write per in-flight operation and a threshold to tune. It isn't needed: `_check_op_alive()` already exists and is already called at the natural checkpoints — between retain sub-batches and documents, between consolidation LLM batches. Cancel only has to flip the status; the running task notices at its next checkpoint and stops there.

So cancellation stays **cooperative and is never immediate**. Whatever was already committed stays committed, and the batch in progress may still finish. Operation types without checkpoints run to the end — the row stays `cancelled` either way, because no worker write may overwrite that status. For the orphaned case in the issue nothing is running at all, so the flip is the entire fix.

## What changed

**Cancel accepts `processing`** (`memory_engine.py`), re-checking the status inside the `UPDATE` so a task that reaches its terminal write concurrently wins the race rather than being reported as cancelled. Terminal states still return 409.

**Four worker writes had no status guard** and would have silently reverted the cancellation:

| Write | Consequence without the guard |
|---|---|
| `poller._schedule_retry` | **The one that actually resurrected work** — a task failing after cancellation went back to `pending` and was re-claimed |
| `poller._mark_failed` | `failed` stamped over `cancelled`, hiding the operator's decision and making the row look like it died on its own |
| `poller._defer_operation` | same requeue as `_schedule_retry`, via the defer path |
| `engine._mark_operation_failed` | as above, on the engine's own failure path |

`_mark_completed` already guarded on `status='processing'`; tests now pin that so it stays.

**Batch parents no longer strand.** The sibling rollup counted only `completed`/`failed` as done, so a cancelled child left its `batch_retain` parent in `processing` forever — the same wedge one level up. Both copies of the rollup (engine and poller) now treat `cancelled` as done and settle the parent on `cancelled`; a real failure still outranks a cancellation, since it carries a cause the operator needs. Cancel performs the rollup itself, so cancelling the last outstanding child terminalizes the parent, and a cancelled parent is never flipped back by a child that finishes later.

**Control plane:** the Cancel button was gated on `pending`, which hid the fix from the UI an operator would actually reach for. It now shows for `processing` rows too, in both the table and the detail dialog.

Docs, OpenAPI and the generated clients are regenerated; the CLI and `lib/api.ts` doc comments follow.

## Testing

13 new tests, 271 passing across the touched suites (`test_worker`, `test_operation_status`, `test_op_cancellation`, `test_batch_api`, `test_async_batch_retain`, `test_operation_progress`, `test_operation_completion`, `test_http_api_integration`):

- cancelling a `processing` operation end to end, and retrying it afterwards
- each of the four guards, against a real DB
- an end-to-end case: a task cancelled mid-flight that then raises stays `cancelled`
- `_check_op_alive` returning False for a *cancelled* row, not only a deleted one
- the parent rollup, on both the engine and poller copies, including failure-outranks-cancellation
