### PR TITLE
fix(openclaw): restore compatibility with OpenClaw 2026.8.1+

### DIFF
--- a/hindsight-docs/docs-integrations/openclaw.md
+++ b/hindsight-docs/docs-integrations/openclaw.md
@@ -404,6 +404,42 @@ uvx hindsight-embed@latest -p openclaw memory list openclaw --limit 10
 uvx hindsight-embed@latest -p openclaw ui
 ```
 
+## OpenClaw compatibility
+
+The plugin is tested against the current OpenClaw release and against older ones.
+Version 0.12.0 and later work with **OpenClaw 2026.7.x through 2026.9.x**.
+
+**If you are on OpenClaw 2026.8.1 or later, upgrade to plugin 0.12.0.** OpenClaw
+2026.8.1 changed how it labels the conversation metadata it attaches to each
+message. Earlier plugin versions no longer recognised those labels, which caused
+three problems on affected setups:
+
+- Turns were skipped instead of being remembered, with
+  `missing stable sender identity` in the gateway log.
+- OpenClaw's internal routing details (sender and channel IDs) were stored as if
+  they were part of the conversation, so they could surface in later recalls.
+- Automatic recall sometimes searched using that metadata instead of what you
+  actually said, returning irrelevant memories.
+
+0.12.0 reads both the old and new labels, so it is safe on any supported OpenClaw
+version — you do not need to match plugin and OpenClaw versions.
+
+Two things to expect after installing on OpenClaw 2026.8.1 or later:
+
+- Install prints
+  `Exclusive slot "memory" switched from "memory-core" to "hindsight-openclaw"`.
+  This is correct: Hindsight replaces OpenClaw's built-in memory.
+- `openclaw plugins doctor` then reports that `memory-core` is not selected for
+  the memory slot. This is expected and not an error — it is OpenClaw noting that
+  its built-in memory stepped aside.
+
+:::note Upgrading from 0.11.1 or earlier
+Installing 0.11.x could fail with
+`npm error Cannot read properties of null (reading 'edgesOut')`. That was a
+packaging problem in the plugin, triggered by a change in the npm registry, and
+it is fixed in 0.12.0 — retry the install with the new version.
+:::
+
 ## Troubleshooting
 
 ### Plugin not loading

--- a/hindsight-integrations/openclaw/.gitignore
+++ b/hindsight-integrations/openclaw/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.log
 .DS_Store
 .tmp/
+package.json.pack-backup

--- a/hindsight-integrations/openclaw/README.md
+++ b/hindsight-integrations/openclaw/README.md
@@ -202,6 +202,19 @@ Retained documents use stable session-scoped IDs derived from the OpenClaw `sess
 
 `retainContext` is sent separately from the transcript content and gives Hindsight's extraction LLM interpretation guidance for the retained document. The default is designed for OpenClaw transcripts: it explains that sender/channel/provider metadata is operational routing data, that assistant-role first-person statements belong to the AI assistant, and that bank IDs or tags should not be treated as the discussed project. Sender/channel/provider stay in retain request metadata/context and are not prepended into retained transcript content.
 
+## OpenClaw compatibility
+
+Version 0.12.0 and later work with **OpenClaw 2026.7.x through 2026.9.x**. The plugin reads both the old and the new conversation-metadata labels, so plugin and OpenClaw versions do not need to match.
+
+**On OpenClaw 2026.8.1 or later, use 0.12.0 or later.** 2026.8.1 changed how OpenClaw labels the metadata it attaches to each message; earlier plugin versions no longer recognised it, so turns were skipped with `missing stable sender identity`, routing IDs were stored as conversation content, and automatic recall could search using that metadata instead of your message.
+
+Two expected (non-error) messages on 2026.8.1+:
+
+- Install prints `Exclusive slot "memory" switched from "memory-core" to "hindsight-openclaw"` — correct; Hindsight replaces OpenClaw's built-in memory.
+- `openclaw plugins doctor` then reports `memory-core` is not selected for the memory slot — that is OpenClaw noting its built-in memory stepped aside.
+
+Upgrading from 0.11.1 or earlier: installs could fail with `npm error Cannot read properties of null (reading 'edgesOut')`. That was a packaging problem in the plugin, fixed in 0.12.0 — retry with the new version.
+
 ## Documentation
 
 For full documentation, configuration options, troubleshooting, and development guide, see:

--- a/hindsight-integrations/openclaw/package.json
+++ b/hindsight-integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectorize-io/hindsight-openclaw",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Hindsight memory plugin for OpenClaw - biomimetic long-term memory with fact extraction",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -38,6 +38,8 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
+    "prepack": "node scripts/pack-manifest.mjs strip",
+    "postpack": "node scripts/pack-manifest.mjs restore",
     "backfill:help": "node dist/backfill.js --help",
     "test": "vitest run src",
     "test:watch": "vitest src",

--- a/hindsight-integrations/openclaw/scripts/pack-manifest.mjs
+++ b/hindsight-integrations/openclaw/scripts/pack-manifest.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Keep devDependencies out of the published package.json.
+ *
+ * OpenClaw installs a plugin by running a full `npm install` inside the
+ * extracted package directory, so the plugin's own devDependencies are
+ * resolved on the user's machine — unlike an ordinary npm dependency, where
+ * they are ignored. That makes our test toolchain part of every user's
+ * install graph, and npm 10's arborist crashes resolving vitest's optional
+ * peer set ("Cannot read properties of null (reading 'edgesOut')") now that
+ * vitest 5 is published. `--omit=dev` does not help: arborist builds the full
+ * ideal tree before pruning. Shipping a manifest with no devDependencies does.
+ *
+ * Runs as prepack (strip) / postpack (restore) so the working tree is only
+ * ever modified for the duration of `npm pack` / `npm publish`.
+ */
+import { copyFileSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const manifestPath = join(packageDir, "package.json");
+const backupPath = join(packageDir, "package.json.pack-backup");
+
+/** Fields that only matter while developing this package. */
+const DEV_ONLY_FIELDS = ["devDependencies", "overrides"];
+
+function strip() {
+  if (existsSync(backupPath)) {
+    throw new Error(
+      `${backupPath} already exists — a previous pack did not restore package.json. ` +
+        `Restore it manually before packing again.`
+    );
+  }
+  const original = readFileSync(manifestPath, "utf8");
+  const manifest = JSON.parse(original);
+  const removed = DEV_ONLY_FIELDS.filter((field) => field in manifest);
+  if (removed.length === 0) return;
+  copyFileSync(manifestPath, backupPath);
+  for (const field of removed) delete manifest[field];
+  // Trailing newline keeps the file prettier-clean if a restore ever fails.
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`[pack-manifest] stripped from published manifest: ${removed.join(", ")}`);
+}
+
+function restore() {
+  if (!existsSync(backupPath)) return;
+  copyFileSync(backupPath, manifestPath);
+  rmSync(backupPath);
+  console.log("[pack-manifest] restored package.json");
+}
+
+const mode = process.argv[2];
+if (mode === "strip") strip();
+else if (mode === "restore") restore();
+else {
+  console.error("usage: pack-manifest.mjs strip|restore");
+  process.exit(1);
+}

--- a/hindsight-integrations/openclaw/scripts/smoke-test.sh
+++ b/hindsight-integrations/openclaw/scripts/smoke-test.sh
@@ -102,11 +102,24 @@ run_setup_mode() {
   # `openclaw plugins doctor` can print diagnostics for UNRELATED bundled
   # plugins (e.g. ollama double-registration in clean CI envs). Only fail if
   # doctor surfaces something that specifically names hindsight, or if the
-  # command itself exits non-zero.
-  local doctor_out
-  if ! doctor_out="$(openclaw plugins doctor 2>&1)"; then
-    printf '%s\n' "$doctor_out" >&2
-    fail "openclaw plugins doctor exited non-zero after: $label"
+  # command itself exits non-zero for a reason we do not expect.
+  #
+  # Since openclaw 2026.8.1 the memory "kind" is an exclusive slot: installing
+  # this plugin deselects the bundled `memory-core`, and doctor reports that
+  # deselection as a diagnostic — which makes it exit non-zero even though the
+  # state is exactly the one we want (`plugins.slots.memory = hindsight-openclaw`).
+  # Tolerate a non-zero exit only when every diagnostic line is that notice.
+  local doctor_out doctor_rc=0 unexpected
+  doctor_out="$(openclaw plugins doctor 2>&1)" || doctor_rc=$?
+  if [[ $doctor_rc -ne 0 ]]; then
+    unexpected="$(printf '%s\n' "$doctor_out" \
+      | grep -E '^- ' \
+      | grep -vE '^- memory-core: memory plugin not selected for the memory slot' || true)"
+    if [[ -n "$unexpected" ]]; then
+      printf '%s\n' "$doctor_out" >&2
+      fail "openclaw plugins doctor exited non-zero after: $label"
+    fi
+    warn "  doctor exit $doctor_rc is the expected memory-slot deselection notice"
   fi
   if printf '%s' "$doctor_out" | grep -iE 'hindsight.*(fail|error|not loaded)|(fail|error).*hindsight' >/dev/null; then
     printf '%s\n' "$doctor_out" >&2

--- a/hindsight-integrations/openclaw/src/index.test.ts
+++ b/hindsight-integrations/openclaw/src/index.test.ts
@@ -30,6 +30,8 @@ import {
   stripInlineRetainTags,
   stripInlineTimestampPrefix,
   stripRuntimeEnvelope,
+  stripMetadataEnvelopes,
+  extractSenderIdFromText,
   configureSenderPrefixStripping,
   getPluginConfig,
   formatHookPerf,
@@ -2219,5 +2221,71 @@ describe("senderPrefixPattern display-name stripping (#3070)", () => {
     expect(stripRuntimeEnvelope("UserName: today weather?")).toBe("UserName: today weather?");
 
     expect(getPluginConfig(makeApi({})).senderPrefixPattern).toBeUndefined();
+  });
+});
+
+// OpenClaw 2026.8.1 replaced the "(untrusted metadata)" label on every injected
+// inbound context header with a `⟦openclaw:ctx⟧` provenance marker. Both forms
+// have to keep working: hosts on either side of that change are in the field.
+describe("inbound metadata blocks (marker and legacy forms)", () => {
+  const MARKER = "⟦openclaw:ctx⟧";
+  const markerBlock = (label: string, json: string) =>
+    `${label} ${MARKER}\n\`\`\`json\n${json}\n\`\`\``;
+  const legacyBlock = (label: string, json: string) =>
+    `${label} (untrusted metadata):\n\`\`\`json\n${json}\n\`\`\``;
+
+  it("extracts sender_id from a marker-form Conversation info block", () => {
+    const text = `${markerBlock("Conversation info:", '{"message_id":"om_abc","sender_id":"ou_xyz"}')}\n\nwhat did I say about postgres?`;
+    expect(extractSenderIdFromText(text)).toBe("ou_xyz");
+  });
+
+  it("extracts sender_id from a marker-form Sender block", () => {
+    const text = `${markerBlock("Sender:", '{"id":"ou_sender_only"}')}\n\nhello`;
+    expect(extractSenderIdFromText(text)).toBe("ou_sender_only");
+  });
+
+  it("still extracts sender_id from the legacy label", () => {
+    const text = `${legacyBlock("Conversation info", '{"sender_id":"ou_legacy"}')}\n\nhello`;
+    expect(extractSenderIdFromText(text)).toBe("ou_legacy");
+  });
+
+  it("strips a marker-form block from retained content", () => {
+    const text = `${markerBlock("Conversation info:", '{"sender_id":"ou_xyz"}')}\n\nremember I use pnpm`;
+    expect(stripMetadataEnvelopes(text)).toBe("remember I use pnpm");
+  });
+
+  it("strips a marker-form block that has no json fence", () => {
+    const text = `Chat history since last reply: ${MARKER}\nalice: hi\nbob: hey\n\nremember I use pnpm`;
+    expect(stripMetadataEnvelopes(text)).toBe("remember I use pnpm");
+  });
+
+  it("strips several marker-form blocks and keeps the user text", () => {
+    const text = [
+      markerBlock("Conversation info:", '{"sender_id":"ou_xyz"}'),
+      "",
+      markerBlock("Location:", '{"city":"Milan"}'),
+      "",
+      "what is the plan?",
+    ].join("\n");
+    expect(stripMetadataEnvelopes(text)).toBe("what is the plan?");
+  });
+
+  it("still strips the legacy label form", () => {
+    const text = `${legacyBlock("Conversation info", '{"sender_id":"ou_legacy"}')}\n\nremember I use pnpm`;
+    expect(stripMetadataEnvelopes(text)).toBe("remember I use pnpm");
+  });
+
+  it("leaves ordinary user text untouched", () => {
+    expect(stripMetadataEnvelopes("just a normal message")).toBe("just a normal message");
+  });
+
+  it("rejects a marker-only prompt as a recall query", () => {
+    const text = markerBlock("Conversation info:", '{"sender_id":"ou_xyz"}');
+    expect(extractRecallQuery(text, undefined)).toBeNull();
+  });
+
+  it("recovers the user query from a marker-wrapped prompt", () => {
+    const text = `${markerBlock("Conversation info:", '{"sender_id":"ou_xyz"}')}\n\nwhat did I say about postgres?`;
+    expect(extractRecallQuery(undefined, text)).toBe("what did I say about postgres?");
   });
 });

--- a/hindsight-integrations/openclaw/src/index.ts
+++ b/hindsight-integrations/openclaw/src/index.ts
@@ -671,22 +671,95 @@ export function stripInlineTimestampPrefix(content: string): string {
 }
 
 /**
+ * Provenance marker OpenClaw appends to every injected inbound context header
+ * since 2026.8.1 — e.g. `Conversation info: ⟦openclaw:ctx⟧`. Older hosts label
+ * the same blocks `Conversation info (untrusted metadata):` instead. Both forms
+ * are recognised: the plugin has to keep working against hosts on either side
+ * of that change.
+ */
+const INBOUND_CONTEXT_MARKER = "⟦openclaw:ctx⟧";
+
+/** Matches a header line in either the marker (2026.8.1+) or legacy form. */
+const INBOUND_META_HEADER_RE = new RegExp(
+  `^[^\\n]*(?:${INBOUND_CONTEXT_MARKER}|\\(untrusted metadata\\))[^\\n]*$`
+);
+
+/** True when `line` opens an OpenClaw-injected inbound metadata block. */
+function isInboundMetaHeaderLine(line: string): boolean {
+  return INBOUND_META_HEADER_RE.test(line.trim());
+}
+
+interface InboundMetaBlock {
+  /** Index of the header line's first character. */
+  start: number;
+  /** Index just past the block (header + body), i.e. where normal text resumes. */
+  end: number;
+  /** Parsed body when the block is a ```json fence, otherwise undefined. */
+  json?: unknown;
+}
+
+/**
+ * Locate every OpenClaw-injected inbound metadata block in `text`.
+ *
+ * Mirrors the host's own stripper: a header line is followed either by a
+ * ```json fence (block ends at the closing fence) or by free-form lines that
+ * end at the first blank line. Keying on the header rather than on a fenced
+ * payload is what makes marker-form blocks like `Chat history since last
+ * reply: ⟦openclaw:ctx⟧` strippable too.
+ */
+function findInboundMetaBlocks(text: string): InboundMetaBlock[] {
+  if (!text) return [];
+  const lines = text.split("\n");
+  // Byte offset of the start of each line, plus a terminator past the end.
+  const offsets: number[] = [];
+  let cursor = 0;
+  for (const line of lines) {
+    offsets.push(cursor);
+    cursor += line.length + 1;
+  }
+  offsets.push(cursor);
+
+  const blocks: InboundMetaBlock[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!isInboundMetaHeaderLine(lines[i])) continue;
+    const start = offsets[i];
+    let end: number;
+    let json: unknown;
+    if (lines[i + 1]?.trim() === "```json") {
+      let close = i + 2;
+      while (close < lines.length && lines[close].trim() !== "```") close++;
+      if (close < lines.length) {
+        try {
+          json = JSON.parse(lines.slice(i + 2, close).join("\n"));
+        } catch {
+          // Leave `json` undefined; the block is still stripped.
+        }
+      }
+      end = offsets[Math.min(close + 1, lines.length)];
+      i = close;
+    } else {
+      let blank = i + 1;
+      while (blank < lines.length && lines[blank].trim() !== "") blank++;
+      end = offsets[Math.min(blank + 1, lines.length)];
+      i = blank;
+    }
+    blocks.push({ start, end, json });
+  }
+  return blocks;
+}
+
+/**
  * Extract sender_id from OpenClaw's injected inbound metadata blocks.
- * Checks both "Conversation info (untrusted metadata)" and "Sender (untrusted metadata)" blocks.
+ * Reads both "Conversation info" and "Sender" blocks, in either the 2026.8.1+
+ * `⟦openclaw:ctx⟧` marker form or the legacy "(untrusted metadata)" form.
  * Returns the first sender_id / id string found, or undefined if none.
  */
 export function extractSenderIdFromText(text: string): string | undefined {
   if (!text) return undefined;
-  const metaBlockRe = /[\w\s]+\(untrusted metadata\)[^\n]*\n```json\n([\s\S]*?)\n```/gi;
-  let match: RegExpExecArray | null;
-  while ((match = metaBlockRe.exec(text)) !== null) {
-    try {
-      const obj = JSON.parse(match[1]);
-      const id = obj?.sender_id ?? obj?.id;
-      if (id && typeof id === "string") return id;
-    } catch {
-      // continue to next block
-    }
+  for (const block of findInboundMetaBlocks(text)) {
+    const obj = block.json as { sender_id?: unknown; id?: unknown } | undefined;
+    const id = obj?.sender_id ?? obj?.id;
+    if (typeof id === "string" && id) return id;
   }
   return undefined;
 }
@@ -696,12 +769,20 @@ export function extractSenderIdFromText(text: string): string | undefined {
  * These blocks are injected by OpenClaw but are noise for memory storage and recall.
  */
 export function stripMetadataEnvelopes(content: string): string {
-  // Strip: ---\n<Label> (untrusted metadata):\n```json\n{...}\n```\n<message>\n---
-  content = content
-    .replace(/^---\n[\w\s]+\(untrusted metadata\)[^\n]*\n```json[\s\S]*?```\n\n?/im, "")
-    .replace(/\n---$/, "");
-  // Strip: <Label> (untrusted metadata):\n```json\n{...}\n```  (without --- wrapper)
-  content = content.replace(/[\w\s]+\(untrusted metadata\)[^\n]*\n```json[\s\S]*?```\n?/gim, "");
+  if (!content) return content;
+  const blocks = findInboundMetaBlocks(content);
+  if (blocks.length > 0) {
+    const parts: string[] = [];
+    let cursor = 0;
+    for (const block of blocks) {
+      parts.push(content.slice(cursor, Math.max(cursor, block.start)));
+      cursor = Math.max(cursor, block.end);
+    }
+    parts.push(content.slice(cursor));
+    content = parts.join("");
+  }
+  // Drop the `---` fences that wrapped the legacy envelope form.
+  content = content.replace(/^---\n/, "").replace(/\n---$/, "");
   return stripRuntimeEnvelope(content).trim();
 }
 
@@ -778,7 +859,10 @@ export function extractRecallQuery(
     /^\s*\(untrusted metadata\)/i,
     /^\s*system:/i,
   ];
-  const isMetadata = (s: string) => METADATA_PATTERNS.some((p) => p.test(s));
+  const isMetadata = (s: string) =>
+    METADATA_PATTERNS.some((p) => p.test(s)) ||
+    // 2026.8.1+ marker form: a leftover header line is metadata, not a query.
+    isInboundMetaHeaderLine(s.split("\n")[0] ?? "");
 
   let recallQuery = rawMessage;
   // Strip sender metadata envelope before any checks

--- a/hindsight-integrations/openclaw/src/packaging.test.ts
+++ b/hindsight-integrations/openclaw/src/packaging.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(__dirname, "..");
+const manifest = JSON.parse(readFileSync(resolve(packageDir, "package.json"), "utf-8"));
+const packScript = readFileSync(resolve(packageDir, "scripts", "pack-manifest.mjs"), "utf-8");
+
+/** The field names `pack-manifest.mjs` strips, read from the script itself. */
+function strippedFields(): Set<string> {
+  const list = packScript.match(/const DEV_ONLY_FIELDS = \[([^\]]*)\]/);
+  if (!list) throw new Error("Could not locate DEV_ONLY_FIELDS in pack-manifest.mjs");
+  return new Set([...list[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]));
+}
+
+// OpenClaw installs a plugin by running a full `npm install` inside the
+// extracted package directory, so anything left in the published manifest is
+// resolved on the user's machine. Shipping devDependencies broke every install
+// on npm 10 once vitest 5 was published ("Cannot read properties of null
+// (reading 'edgesOut')"). These assertions are the cheap guard; the real
+// end-to-end proof is the `smoke-openclaw-install` CI job.
+describe("published manifest", () => {
+  it("wires the prepack/postpack pair that strips dev-only fields", () => {
+    expect(manifest.scripts.prepack).toBe("node scripts/pack-manifest.mjs strip");
+    expect(manifest.scripts.postpack).toBe("node scripts/pack-manifest.mjs restore");
+  });
+
+  it("strips every dev-only field the package actually declares", () => {
+    // A new dev-only top-level field added to package.json without being added
+    // to DEV_ONLY_FIELDS would ship to users and be installed by OpenClaw.
+    const devOnlyPresent = ["devDependencies", "overrides"].filter((f) => f in manifest);
+    const stripped = strippedFields();
+    const unstripped = devOnlyPresent.filter((f) => !stripped.has(f));
+    expect(unstripped, "dev-only package.json fields that would ship to users").toEqual([]);
+  });
+
+  it("keeps the runtime dependencies the plugin needs at runtime", () => {
+    // The counterpart risk: stripping too much. These four are imported by
+    // dist/ and must survive into the published manifest.
+    const stripped = strippedFields();
+    expect(stripped.has("dependencies")).toBe(false);
+    expect(Object.keys(manifest.dependencies).sort()).toEqual([
+      "@clack/prompts",
+      "@vectorize-io/hindsight-agent-sdk",
+      "@vectorize-io/hindsight-all",
+      "@vectorize-io/hindsight-client",
+    ]);
+  });
+});

--- a/skills/hindsight-docs/references/sdks/integrations/openclaw.md
+++ b/skills/hindsight-docs/references/sdks/integrations/openclaw.md
@@ -399,6 +399,41 @@ uvx hindsight-embed@latest -p openclaw memory list openclaw --limit 10
 uvx hindsight-embed@latest -p openclaw ui
 ```
 
+## OpenClaw compatibility
+
+The plugin is tested against the current OpenClaw release and against older ones.
+Version 0.12.0 and later work with **OpenClaw 2026.7.x through 2026.9.x**.
+
+**If you are on OpenClaw 2026.8.1 or later, upgrade to plugin 0.12.0.** OpenClaw
+2026.8.1 changed how it labels the conversation metadata it attaches to each
+message. Earlier plugin versions no longer recognised those labels, which caused
+three problems on affected setups:
+
+- Turns were skipped instead of being remembered, with
+  `missing stable sender identity` in the gateway log.
+- OpenClaw's internal routing details (sender and channel IDs) were stored as if
+  they were part of the conversation, so they could surface in later recalls.
+- Automatic recall sometimes searched using that metadata instead of what you
+  actually said, returning irrelevant memories.
+
+0.12.0 reads both the old and new labels, so it is safe on any supported OpenClaw
+version — you do not need to match plugin and OpenClaw versions.
+
+Two things to expect after installing on OpenClaw 2026.8.1 or later:
+
+- Install prints
+  `Exclusive slot "memory" switched from "memory-core" to "hindsight-openclaw"`.
+  This is correct: Hindsight replaces OpenClaw's built-in memory.
+- `openclaw plugins doctor` then reports that `memory-core` is not selected for
+  the memory slot. This is expected and not an error — it is OpenClaw noting that
+  its built-in memory stepped aside.
+
+> **📝 Upgrading from 0.11.1 or earlier**
+>
+Installing 0.11.x could fail with
+`npm error Cannot read properties of null (reading 'edgesOut')`. That was a
+packaging problem in the plugin, triggered by a change in the npm registry, and
+it is fixed in 0.12.0 — retry the install with the new version.
 ## Troubleshooting
 
 ### Plugin not loading


### PR DESCRIPTION
## Summary

The OpenClaw plugin is broken against current OpenClaw. Three separate breakages, all reproduced locally against `openclaw@2026.9.2` with node 22.22.3 / npm 10.9.8 (the same toolchain CI uses).

### 1. `openclaw plugins install` fails for every user on npm 10

OpenClaw installs a plugin by running a full `npm install` inside the extracted package directory, so the plugin's **own devDependencies** are resolved on the user's machine — unlike an ordinary npm dependency, where they are ignored. Since `vitest@5.0.0` was published (2026-09-03), npm 10's arborist crashes walking vitest 4.x's optional peer set:

```
Installing plugin dependencies…
npm install failed: npm error Cannot read properties of null (reading 'edgesOut')
```

This is **not** CI-only and **not** the runner image: a bare `npm install` of our own `package.json` in an empty directory reproduces it, and so does a real `openclaw plugins install` of the 0.11.1 tarball on macOS.

- `npm@11` resolves the same manifest fine; `npm@10.9.8` (what node 22 ships) does not.
- `--omit=dev` does **not** help — arborist builds the full ideal tree before pruning.
- `overrides` pinning the `@vitest/browser-*` peers does not help either.

Fix: a `prepack`/`postpack` pair strips `devDependencies` and the dev-only `overrides` from the published manifest, and restores the working tree afterwards. Verified: the packed tarball now carries only the four runtime deps, and `package.json` is byte-identical after `npm pack`.

### 2. Sender identity and metadata stripping broke on OpenClaw 2026.8.1

2026.8.1 replaced the `(untrusted metadata)` label on every injected inbound context header with a `⟦openclaw:ctx⟧` provenance marker:

```
Conversation info: ⟦openclaw:ctx⟧          ← 2026.8.1+ (2026-08-31)
Conversation info (untrusted metadata):    ← up to 2026.7.x
```

Every parser in the plugin keyed on the old label, so on any host from 2026.8.1 onward:

- `sender_id` was never recovered from the prompt → turns skipped with `missing stable sender identity` (this is the real, much broader cause behind #4144, which reported it only for Dashboard sessions);
- routing metadata was no longer stripped → injected `sender_id` / `channel_id` JSON got **retained as memory content**;
- the metadata-only guard stopped firing → metadata blocks were used as recall queries.

Block detection now keys on the header line in either form and follows the host's own framing rules — a ` ```json ` fence ends at its closing fence, anything else ends at the first blank line — which also makes non-JSON blocks such as `Chat history since last reply:` strippable. Legacy-form hosts keep working; both forms are covered by tests.

### 3. The install smoke test failed on a benign diagnostic

The memory `kind` is now an exclusive slot. Installing this plugin correctly takes it:

```
Exclusive slot "memory" switched from "memory-core" to "hindsight-openclaw".
```

but `plugins doctor` then reports the resulting `memory-core` deselection as a diagnostic and exits non-zero — even though that state is exactly the one we want. The smoke test tolerates a non-zero exit only when *every* diagnostic line is that notice, and still fails on anything else.

## Verification

- `npm test` — 335 passed (10 new, covering both header forms).
- `npx tsc --noEmit` — clean.
- `./scripts/hooks/lint.sh` — clean.
- `./scripts/smoke-test.sh` against a real `openclaw@2026.9.2` in an isolated `HOME` — **all phases pass**, including the tarball install, dependency resolution from the registry, and all seven setup modes.

## Notes

- Version bumped to **0.12.0**.
- Unblocks #4145 and #4149, both of which are currently red only on `smoke-openclaw-install`.
- Closes the root cause of #4144 for all channels; #4149 remains worth merging for the separate `agent:<id>:dashboard:<uuid>` agent-id parsing gap.

Fixes #4144
