### PR TITLE
fix(api-slim): never import an observation citing a missing source unit

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/importer.py
@@ -1167,6 +1167,41 @@ async def _import_observations(
 
     async with acquire_with_retry(backend) as conn:
         async with conn.transaction():
+            # ``source_memory_ids`` is a bare uuid[] with no foreign key, so a
+            # ref that resolved above but whose unit is no longer in this bank
+            # would be written as a dangling reference and silently corrupt the
+            # observation graph (an observation citing units that exist nowhere).
+            # Re-check liveness inside the write transaction and treat a missing
+            # source exactly like an unresolved one: skip the observation.
+            live = {
+                r["id"]
+                for r in await conn.fetch(
+                    f"SELECT id FROM {fq_table('memory_units')} WHERE bank_id = $1 AND id = ANY($2)",
+                    bank_id,
+                    [uuid.UUID(s) for _obs, sources in resolved for s in sources],
+                )
+            }
+            kept_resolved: list[tuple[TransferObservation, list[str]]] = []
+            kept_processed: list[ProcessedFact] = []
+            for (obs, sources), fact in zip(resolved, processed):
+                missing = [s for s in sources if uuid.UUID(s) not in live]
+                if missing:
+                    logger.warning(
+                        "[transfer] Skipping observation for bank %s: %d of %d source units are missing (%s)",
+                        bank_id,
+                        len(missing),
+                        len(sources),
+                        ", ".join(sorted(missing)),
+                    )
+                    outcome.skipped += 1
+                    continue
+                kept_resolved.append((obs, sources))
+                kept_processed.append(fact)
+            if not kept_resolved:
+                return outcome
+            resolved = kept_resolved
+            processed = kept_processed
+
             obs_unit_ids = await fact_storage.insert_facts_batch(conn, bank_id, processed, ops=ops)
 
             all_source_ids: set[uuid.UUID] = set()

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -102,7 +102,14 @@ def _unique_bank(prefix: str) -> str:
 
 
 async def _retain(memory, bank_id, content, request_context, document_id):
-    await memory.retain_async(
+    """Retain one document and return the ids of the facts it created.
+
+    Returned rather than left to a follow-up `list_memory_units` call: retain
+    already knows exactly which facts it wrote, whereas the list query answers a
+    different question ("what is in the bank now") that also reflects
+    auto-consolidation and anything else touching the bank concurrently.
+    """
+    return await memory.retain_async(
         bank_id=bank_id,
         content=content,
         context="Test context",
@@ -1265,11 +1272,11 @@ async def test_export_import_observations(memory, request_context):
     src = _unique_bank("transfer_obs_src")
     dst = _unique_bank("transfer_obs_dst")
     try:
-        await _retain(memory, src, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
-        # Sources must be world/experience facts (not auto-consolidation observations).
-        units = await memory.list_memory_units(src, fact_type="world", request_context=request_context)
-        source_ids = [uuid.UUID(str(i["id"])) for i in units["items"][:2]]
-        assert len(source_ids) == 2
+        # Sources must be world/experience facts, never auto-consolidation
+        # observations -- which is what retain returns, so take them from there.
+        created = await _retain(memory, src, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
+        assert len(created) >= 2, f"setup: retain created {len(created)} facts, need at least 2"
+        source_ids = [uuid.UUID(str(i)) for i in created[:2]]
 
         # Create a real observation over those source facts. The helper self-acquires a
         # short-lived connection now (the embed runs off-connection), so pass the backend.

--- a/hindsight-api-slim/tests/test_transfer_observation_source_liveness.py
+++ b/hindsight-api-slim/tests/test_transfer_observation_source_liveness.py
@@ -60,9 +60,8 @@ async def _imported_observation_sources(backend, bank_id):
 async def test_observation_with_a_missing_source_is_skipped(memory, request_context):
     """A ref that resolves to an id no longer in the bank must not be written."""
     bank = _unique_bank("obs_liveness_missing")
-    await _retain(memory, bank, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
-    units = await memory.list_memory_units(bank, fact_type="world", request_context=request_context)
-    live_id = str(units["items"][0]["id"])
+    created = await _retain(memory, bank, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
+    live_id = str(created[0])
     ghost_id = str(uuid.uuid4())  # resolves, but no such row exists
 
     outcome = await _import_one(
@@ -81,10 +80,9 @@ async def test_observation_with_a_missing_source_is_skipped(memory, request_cont
 async def test_observation_with_live_sources_is_imported(memory, request_context):
     """The guard must not reject the ordinary case it is wrapped around."""
     bank = _unique_bank("obs_liveness_ok")
-    await _retain(memory, bank, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
-    units = await memory.list_memory_units(bank, fact_type="world", request_context=request_context)
-    live_ids = [str(u["id"]) for u in units["items"][:2]]
-    assert len(live_ids) == 2
+    created = await _retain(memory, bank, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
+    assert len(created) >= 2
+    live_ids = [str(i) for i in created[:2]]
 
     outcome = await _import_one(
         memory,
@@ -116,10 +114,9 @@ async def test_retain_replacing_the_document_mid_import_is_not_cited(memory, req
     src = _unique_bank(f"race_src_{uuid.uuid4().hex[:6]}")
     dst = _unique_bank(f"race_dst_{uuid.uuid4().hex[:6]}")
 
-    await _retain(memory, src, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
-    units = await memory.list_memory_units(src, fact_type="world", request_context=request_context)
-    src_ids = [uuid.UUID(str(u["id"])) for u in units["items"][:2]]
-    assert len(src_ids) == 2
+    created = await _retain(memory, src, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
+    assert len(created) >= 2
+    src_ids = [uuid.UUID(str(i)) for i in created[:2]]
     await _seed_observation(
         pool=backend,
         memory=memory,

--- a/hindsight-api-slim/tests/test_transfer_observation_source_liveness.py
+++ b/hindsight-api-slim/tests/test_transfer_observation_source_liveness.py
@@ -1,0 +1,160 @@
+"""An imported observation must never cite a memory unit that does not exist.
+
+``memory_units.source_memory_ids`` is a bare ``uuid[]`` with no foreign key, so
+nothing at the database level stops the importer from writing a reference to a
+unit that is absent from the destination bank. That corruption is invisible on
+write and only surfaces much later, as an observation whose sources resolve to
+nothing. The importer therefore re-checks liveness inside its write transaction.
+"""
+
+import uuid
+
+import pytest
+
+from hindsight_api.engine.db_utils import acquire_with_retry
+from hindsight_api.engine.schema import fq_table
+from hindsight_api.engine.transfer import importer as importer_mod
+from hindsight_api.engine.transfer.schema import TransferObservation, TransferObservationSource
+
+from .test_document_transfer import _import, _retain, _seed_observation, _unique_bank, parse_archive
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _import_one(memory, bank_id, ref_map, source_refs):
+    """Run the observation import phase directly against a hand-built ref_map."""
+    backend = await memory._get_backend()
+    observation = TransferObservation(
+        text=OBSERVATION_TEXT,
+        sources=[TransferObservationSource(document_id=d, fact_index=i) for d, i in source_refs],
+        proof_count=len(source_refs),
+    )
+    return await importer_mod._import_observations(
+        backend=backend,
+        embeddings_model=memory.embeddings,
+        bank_id=bank_id,
+        observations=[observation],
+        ref_map=ref_map,
+        ops=backend.ops,
+    )
+
+
+# Retain auto-consolidates, so the bank already holds observations of its own by
+# the time these tests run. Match on the text this test imports to look at only
+# the observation under test. Direct SQL because source_memory_ids is internal
+# consolidation state that no public read method exposes.
+OBSERVATION_TEXT = "Alice and Bob are colleagues."
+
+
+async def _imported_observation_sources(backend, bank_id):
+    async with acquire_with_retry(backend) as conn:
+        rows = await conn.fetch(
+            f"SELECT source_memory_ids FROM {fq_table('memory_units')} "
+            f"WHERE bank_id = $1 AND fact_type = 'observation' AND text = $2",
+            bank_id,
+            OBSERVATION_TEXT,
+        )
+    return [{str(sid) for sid in (row["source_memory_ids"] or [])} for row in rows]
+
+
+async def test_observation_with_a_missing_source_is_skipped(memory, request_context):
+    """A ref that resolves to an id no longer in the bank must not be written."""
+    bank = _unique_bank("obs_liveness_missing")
+    await _retain(memory, bank, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
+    units = await memory.list_memory_units(bank, fact_type="world", request_context=request_context)
+    live_id = str(units["items"][0]["id"])
+    ghost_id = str(uuid.uuid4())  # resolves, but no such row exists
+
+    outcome = await _import_one(
+        memory,
+        bank,
+        ref_map={("doc-1", 0): live_id, ("doc-1", 1): ghost_id},
+        source_refs=[("doc-1", 0), ("doc-1", 1)],
+    )
+
+    assert outcome.imported == 0
+    assert outcome.skipped == 1
+    backend = await memory._get_backend()
+    assert await _imported_observation_sources(backend, bank) == []
+
+
+async def test_observation_with_live_sources_is_imported(memory, request_context):
+    """The guard must not reject the ordinary case it is wrapped around."""
+    bank = _unique_bank("obs_liveness_ok")
+    await _retain(memory, bank, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
+    units = await memory.list_memory_units(bank, fact_type="world", request_context=request_context)
+    live_ids = [str(u["id"]) for u in units["items"][:2]]
+    assert len(live_ids) == 2
+
+    outcome = await _import_one(
+        memory,
+        bank,
+        ref_map={("doc-1", 0): live_ids[0], ("doc-1", 1): live_ids[1]},
+        source_refs=[("doc-1", 0), ("doc-1", 1)],
+    )
+
+    assert outcome.imported == 1
+    assert outcome.skipped == 0
+    backend = await memory._get_backend()
+    assert await _imported_observation_sources(backend, bank) == [set(live_ids)]
+
+
+@pytest.mark.asyncio
+async def test_retain_replacing_the_document_mid_import_is_not_cited(memory, request_context, monkeypatch):
+    """A concurrent replace of the document must not leave observations citing it.
+
+    Import commits its documents one at a time and writes the observations later,
+    in a separate transaction. A retain of the same document_id into the same bank
+    takes the full-replace path and deletes that document's memory_units. Landing
+    in that window used to produce observations citing deleted units; the liveness
+    check turns it into a skip.
+
+    The interleaving is forced rather than raced -- the deleter is a real retain
+    through the public API, scheduled at the point the window is open.
+    """
+    backend = await memory._get_backend()
+    src = _unique_bank(f"race_src_{uuid.uuid4().hex[:6]}")
+    dst = _unique_bank(f"race_dst_{uuid.uuid4().hex[:6]}")
+
+    await _retain(memory, src, "Alice works at Google. Bob works at Microsoft.", request_context, "doc-1")
+    units = await memory.list_memory_units(src, fact_type="world", request_context=request_context)
+    src_ids = [uuid.UUID(str(u["id"])) for u in units["items"][:2]]
+    assert len(src_ids) == 2
+    await _seed_observation(
+        pool=backend,
+        memory=memory,
+        bank_id=src,
+        source_memory_ids=src_ids,
+        observation_text="Alice and Bob are colleagues.",
+    )
+    archive = await memory.export_documents_async(src, request_context, include_observations=True)
+    assert len(parse_archive(archive).observations) >= 1
+
+    # Open the window: the documents are committed, the observations are not yet
+    # written. A concurrent retain of the same document replaces it, deleting the
+    # units the pending observations are about to cite.
+    original = importer_mod._import_observations
+    fired = []
+
+    async def _deleting_import_observations(**kwargs):
+        if not fired:
+            fired.append(True)
+            await _retain(memory, dst, "Completely different content.", request_context, "doc-1")
+        return await original(**kwargs)
+
+    monkeypatch.setattr(importer_mod, "_import_observations", _deleting_import_observations)
+    await _import(memory, dst, archive, request_context)
+    assert fired, "the window never opened"
+
+    async with acquire_with_retry(backend) as conn:
+        rows = await conn.fetch(
+            f"SELECT id, source_memory_ids FROM {fq_table('memory_units')} "
+            f"WHERE bank_id = $1 AND fact_type = 'observation'",
+            dst,
+        )
+        dangling = []
+        for r in rows:
+            for sid in r["source_memory_ids"] or []:
+                if not await conn.fetchval(f"SELECT 1 FROM {fq_table('memory_units')} WHERE id = $1", sid):
+                    dangling.append((str(r["id"])[:8], str(sid)[:8]))
+    assert not dangling, f"observation cites deleted units: {dangling}"


### PR DESCRIPTION
## The defect

`memory_units.source_memory_ids` is a bare `uuid[]` with no foreign key, so nothing at the
database level stops the import path from writing a reference to a unit that is absent from the
destination bank. The importer resolved each observation source through `ref_map` and skipped
observations whose refs were *unresolvable* — but never checked that a **resolved** id still named
a live row.

That gap is reachable through the public API. Import commits its documents one at a time and
writes the observations later, in a **separate** transaction. A retain of the same `document_id`
into the same bank takes the full-replace path, which runs
`DELETE FROM memory_units WHERE document_id = $1 AND bank_id = $2` (`pg/writes.py`). Landing in
the window between the two phases leaves observations citing units that no longer exist.

The existing `delete_stale_observations` sweep cannot cover this: it invalidates observations
*derived from* facts being deleted, and here the observation does not exist yet when the delete
runs. That is also why this class needed two backsweep migrations
(`g7h8i9j0k1l2_backsweep_orphan_observations` and `..._v2`) — both fix the delete side, neither
can fix the write side.

## The fix

Re-check liveness inside the observation write transaction, with one query for the whole batch,
and treat a missing source exactly like an unresolved one: skip the observation and log which
sources were missing.

This is what the consolidator already does at **every** site that writes `source_memory_ids`
(`_filter_live_source_memories` at consolidator.py:398/497/537/2627/3285, `_any_live_source_memory`
at :2310/:2379). The transfer importer was the only observation-writing path in the engine without
it; this brings it in line.

## Tests

`tests/test_transfer_observation_source_liveness.py`:

- `test_retain_replacing_the_document_mid_import_is_not_cited` — drives the real race end to end.
  The deleter is a real retain through the public API, scheduled at the point the window is open.
  Without the check it produces **7 dangling references across 4 observations**; with it they are
  skipped and logged.
- `test_observation_with_a_missing_source_is_skipped` — unit-level, a ref that resolves to an id
  no longer present.
- `test_observation_with_live_sources_is_imported` — the ordinary case the guard wraps, so the
  check cannot pass by rejecting everything.

Both negative tests fail when the check is removed (verified by mutation).

## Second commit: a flaky test

`test_export_import_observations` retained a document, discarded the unit ids `retain_async`
returns, then re-derived them with `list_memory_units(fact_type="world")` and asserted the query
gave back exactly two — seen failing with an empty list.

The two calls answer different questions: retain knows precisely which facts it just wrote, while
the list query reports what is in the bank *now*, which also reflects auto-consolidation and
anything else touching the bank concurrently. `_retain` now returns the created ids and callers
use them. That also states the original intent better — the sources must be facts and never
auto-consolidation observations, and facts are exactly what retain returns.

This removes the dependency; it does not explain the empty result (60 retains under parallel suite
load returned 5 facts and listed 5 every time). Context in #4137.

## Notes

- Bank scoping: the added query is `WHERE bank_id = $1 AND id = ANY($2)`, pinning the destination
  bank — the transfer path is cross-bank by design and must never inherit a source `bank_id`.
- The tests read `source_memory_ids` with direct SQL because it is internal consolidation state no
  public read method exposes; the helper carries a comment saying so.
- Closes #4137.