### PR TITLE
fix(api-slim): read the opencode-go retry assertion off LLMCallResult.content

### DIFF
--- a/hindsight-api-slim/tests/test_opencode_go_session_header.py
+++ b/hindsight-api-slim/tests/test_opencode_go_session_header.py
@@ -107,7 +107,7 @@ async def test_session_id_is_stable_across_provider_retries():
             initial_backoff=0,
         )
 
-    assert result.ok is True
+    assert result.content.ok is True
     first, second = _sent_session_ids(create)
     assert first and second
     assert first == second, "retries of one operation must reuse the session id"


### PR DESCRIPTION
## main is red

`tests/test_opencode_go_session_header.py:110` asserts `result.ok` on the value returned by
`OpenAICompatibleLLM.call`. That method returns `LLMCallResult` since #4122, and `ok` is a field
of the parsed payload, not of the result wrapper:

```
AttributeError: 'LLMCallResult' object has no attribute 'ok'
```

**This is not a regression from any open PR** — it is on `main`, and every PR inherits it.
#4122 merged at 13:14 and #4084 at 13:24 the same day. #4084's CI ran against a base predating
the new contract; merging does not re-run it, and pushes to `main` do not run `test-api`, so the
mismatch landed without ever being executed.

It fails three jobs: `test-api (3/3)` and `test-api (free-threaded 3.14)` on the AttributeError
itself, and `test-api (2/3)` on `test_named_result_stubs`, the guard that exists to catch exactly
this class and correctly flagged the same line.

## Fix

Read the payload through `.content`, which is what the guard asks for:

```python
assert result.content.ok is True
```

Verified locally: `tests/test_opencode_go_session_header.py` + `tests/test_named_result_stubs.py`
= **538 passed**.

Unrelated and not addressed here: `test-api (1/3)` also failed on
`test_bank_stats_cache_distributed::test_result_is_written_and_served_from_table`
(`assert 2 == 1`), which looks like a flake.