### PR TITLE
fix(embeddings): bound embedding input by the model's context, prefix included

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -362,10 +362,12 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_ONNX_TOKENIZER_NAME_OR_PATH=/models/multilingual-e5-small
 # Optional for China network / restricted HF access:
 # HF_ENDPOINT=https://hf-mirror.com
-# Applies to any provider: cap each input at this many tokens before
-# embedding, so oversized content is truncated instead of failing the embed call
-# permanently (e.g. Bedrock Titan V2's 8192, or a llama.cpp server's context). Off
-# by default. (Deprecated alias: HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS)
+# Applies to any provider: cap each input at this many tokens before embedding, so
+# oversized content is truncated instead of failing the embed call permanently.
+# Defaults to 8192, the input limit of essentially every remote embedding model
+# (OpenAI text-embedding-3-*, Bedrock Titan V2, Cohere v3, a stock llama.cpp
+# context); raise or lower it to match your model, or set 0 to send text uncapped.
+# (Deprecated alias: HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS)
 # HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS=8192
 # Asymmetric models (E5, google/embeddinggemma-300m, ...) expect a different instruction
 # in front of a search than in front of stored text. Providers that only accept plain text

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -1367,11 +1367,14 @@ DEFAULT_RERANKER_LITELLM_MAX_TOKENS_PER_DOC: int | None = None
 # LiteLLM SDK defaults
 DEFAULT_EMBEDDINGS_LITELLM_SDK_MODEL = "cohere/embed-english-v3.0"
 DEFAULT_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT = "float"
-# Opt-in per-text input truncation (tokens, see ENV_TOKENIZER_ENCODING). Off by default;
-# set to the embedding model's real input limit (e.g. 8192 for Bedrock Titan V2, or a
-# llama.cpp server's context) to keep oversized content from permanently failing the
-# embed call. Applies to every embeddings provider. See #2501.
-DEFAULT_EMBEDDINGS_MAX_INPUT_TOKENS: int | None = None
+# Per-text input truncation (tokens, see ENV_TOKENIZER_ENCODING), applied to every
+# embeddings provider before the text leaves the process. 8192 is the input limit of
+# essentially every remote embedding model in use (OpenAI text-embedding-3-*, Bedrock
+# Titan V2, Cohere v3, a stock llama.cpp context), and those reject an oversized input
+# with a permanent 400 instead of truncating it server-side the way SentenceTransformers
+# does — which failed the owning task for good (#2501, #4165). Set the env var to the
+# model's real limit if it differs, or to 0 to send text uncapped.
+DEFAULT_EMBEDDINGS_MAX_INPUT_TOKENS: int | None = 8192
 DEFAULT_RERANKER_LITELLM_SDK_MODEL = "cohere/rerank-english-v3.0"
 
 # Vocabulary used for every token count and chunk boundary in the engine. Server-level:
@@ -3879,7 +3882,9 @@ class HindsightConfig:
             # Embeddings
             embeddings_provider=os.getenv(ENV_EMBEDDINGS_PROVIDER, DEFAULT_EMBEDDINGS_PROVIDER),
             # Generic name, falling back to the deprecated LiteLLM-SDK-specific alias.
-            embeddings_max_input_tokens=int(v)
+            # 0 (or any non-positive value) means "no cap" — the only way to opt out
+            # now that the default is a real limit rather than None.
+            embeddings_max_input_tokens=(int(v) if int(v) > 0 else None)
             if (
                 v := os.getenv(ENV_EMBEDDINGS_MAX_INPUT_TOKENS)
                 or os.getenv(ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS)

--- a/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
@@ -8,7 +8,7 @@ import logging
 from typing import Literal, Protocol
 
 from ...config import ENV_EMBEDDINGS_MAX_INPUT_TOKENS, get_config
-from ..token_encoding import truncate_many_to_tokens
+from ..token_encoding import count_tokens, truncate_many_to_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,26 @@ class EmbeddingsBackend(Protocol):
     def encode_documents(self, texts: list[str]) -> list[list[float]]: ...
 
 
-def _truncate_inputs(texts: list[str], max_input_tokens: int, backend: EmbeddingsBackend) -> list[str]:
+def _prefix_tokens(backend: EmbeddingsBackend, input_type: EmbeddingInputType) -> int:
+    """Tokens the backend will prepend to every text after this cap is applied.
+
+    Asymmetric models (E5, embeddinggemma, ...) carry their instruction as a literal
+    prefix that `Embeddings._encode_prefixed` glues on *after* truncation, so a text cut
+    to exactly the model's limit still arrives a few tokens over it. Charge the prefix
+    against the budget here. Providers with a native mechanism (SentenceTransformers'
+    prompts, ZeroEntropy's input_type) carry no prefix and cost nothing.
+    """
+    # `EmbeddingsBackend` is a duck-typed Protocol and does not declare the prefixes —
+    # they are an optional capability of the concrete `Embeddings` ABC — so getattr can
+    # hand back anything at all. Only a real, non-empty string costs budget.
+    attr = "query_prefix" if input_type == "query" else "passage_prefix"
+    prefix = getattr(backend, attr, "")
+    return count_tokens(prefix) if isinstance(prefix, str) and prefix else 0
+
+
+def _truncate_inputs(
+    texts: list[str], max_input_tokens: int, backend: EmbeddingsBackend, input_type: EmbeddingInputType
+) -> list[str]:
     """Cap each input at ``max_input_tokens`` tokens before it reaches the provider.
 
     Remote providers with a fixed input-token limit (e.g. Bedrock Titan V2's hard 8192
@@ -35,18 +54,25 @@ def _truncate_inputs(texts: list[str], max_input_tokens: int, backend: Embedding
     permanent 4xx rather than truncating server-side the way SentenceTransformers does.
     One oversized memory then fails the whole retain/recall batch. This is provider-
     agnostic on purpose: the cap is applied here, once, before any backend's `encode()`.
+
+    The budget covers the *whole* string that will go over the wire, not just the
+    caller's payload: an asymmetric model's prefix is subtracted up front (see
+    :func:`_prefix_tokens`), and callers that decorate their text — a knowledge page
+    embeds ``f"{name} {content}"`` — pass the joined string, so the join is inside the
+    cap rather than one token past it (#4165).
     """
-    results = truncate_many_to_tokens(texts, max_input_tokens)
+    budget = max(max_input_tokens - _prefix_tokens(backend, input_type), 0)
+    results = truncate_many_to_tokens(texts, budget)
     truncated = [result.text for result in results]
-    original_token_counts = [r.original_tokens for r in results if r.original_tokens > max_input_tokens]
+    original_token_counts = [r.original_tokens for r in results if r.original_tokens > budget]
     if original_token_counts:
         logger.warning(
             "Embeddings: truncated %d of %d input(s) to %d tokens for provider %s "
-            "(largest was ~%d tokens); embedded content is incomplete. Raise or unset "
+            "(largest was ~%d tokens); embedded content is incomplete. Raise or disable "
             "%s if this is unexpected.",
             len(original_token_counts),
             len(texts),
-            max_input_tokens,
+            budget,
             getattr(backend, "provider_name", "?"),
             max(original_token_counts),
             ENV_EMBEDDINGS_MAX_INPUT_TOKENS,
@@ -93,7 +119,7 @@ async def generate_embeddings_batch(
     # recall queries, consolidation, import) gets identical, model-agnostic truncation.
     max_input_tokens = get_config().embeddings_max_input_tokens
     if max_input_tokens is not None and texts:
-        texts = _truncate_inputs(texts, max_input_tokens, embeddings_backend)
+        texts = _truncate_inputs(texts, max_input_tokens, embeddings_backend, input_type)
 
     try:
         loop = asyncio.get_event_loop()

--- a/hindsight-api-slim/tests/test_embeddings_max_input_tokens.py
+++ b/hindsight-api-slim/tests/test_embeddings_max_input_tokens.py
@@ -6,7 +6,10 @@ identical, model-agnostic truncation before any backend's `encode()` runs.
 
 Config is exposed as the generic `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS`, with the
 old LiteLLM-SDK-specific `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS` kept as
-a deprecated alias for backward compatibility.
+a deprecated alias for backward compatibility. It defaults to 8192 — the input limit of
+essentially every remote embedding model — because leaving it off let a knowledge page
+sized to its own 8192-token generation budget fail its refresh permanently (#4165); 0
+opts out.
 """
 
 import logging
@@ -28,6 +31,8 @@ class _FakeBackend:
     """Records the texts each `encode_*` call actually receives."""
 
     provider_name = "fake"
+    query_prefix = ""
+    passage_prefix = ""
 
     def __init__(self, dimension: int = 3) -> None:
         self._dimension = dimension
@@ -58,7 +63,7 @@ class TestTruncateInputs:
         backend = _FakeBackend()
         long_text = "word " * 500  # far more than 50 tokens
         with caplog.at_level(logging.WARNING):
-            result = embedding_utils._truncate_inputs([long_text], 50, backend)
+            result = embedding_utils._truncate_inputs([long_text], 50, backend, "document")
 
         assert count_tokens(result[0]) <= 50
         assert result[0] != long_text
@@ -72,7 +77,7 @@ class TestTruncateInputs:
     def test_short_input_untouched_no_warning(self, caplog):
         backend = _FakeBackend()
         with caplog.at_level(logging.WARNING):
-            result = embedding_utils._truncate_inputs(["short text"], 50, backend)
+            result = embedding_utils._truncate_inputs(["short text"], 50, backend, "document")
 
         assert result == ["short text"]
         assert not any("truncated" in r.message for r in caplog.records)
@@ -115,7 +120,55 @@ class TestConfigWiring:
         monkeypatch.setenv(ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS, "4096")
         assert HindsightConfig.from_env().embeddings_max_input_tokens == 8192
 
-    def test_default_is_disabled(self, monkeypatch):
+    def test_default_is_the_common_model_limit(self, monkeypatch):
         monkeypatch.delenv(ENV_EMBEDDINGS_MAX_INPUT_TOKENS, raising=False)
         monkeypatch.delenv(ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS, raising=False)
+        assert HindsightConfig.from_env().embeddings_max_input_tokens == 8192
+
+    def test_zero_opts_out(self, monkeypatch):
+        """0 is the only way to send text uncapped now that the default is a real limit."""
+        monkeypatch.setenv(ENV_EMBEDDINGS_MAX_INPUT_TOKENS, "0")
+        monkeypatch.delenv(ENV_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS, raising=False)
         assert HindsightConfig.from_env().embeddings_max_input_tokens is None
+
+
+class _PrefixedBackend(_FakeBackend):
+    """An asymmetric model whose instruction `Embeddings._encode_prefixed` glues on
+    AFTER the cap has been applied."""
+
+    query_prefix = "query: "
+    passage_prefix = "passage: "
+
+    def encode_documents(self, texts: list[str]) -> list[list[float]]:
+        return super().encode_documents([f"{self.passage_prefix}{t}" for t in texts])
+
+    def encode_query(self, texts: list[str]) -> list[list[float]]:
+        return super().encode_documents([f"{self.query_prefix}{t}" for t in texts])
+
+
+@pytest.mark.asyncio
+class TestFinalPayloadFitsTheCap:
+    """What must fit the model's limit is the string that goes over the wire."""
+
+    @pytest.mark.parametrize("input_type", ["document", "query"])
+    async def test_prefix_is_charged_against_the_budget(self, input_type):
+        backend = _PrefixedBackend()
+        with _patch_cap(50):
+            await embedding_utils.generate_embeddings_batch(backend, ["word " * 500], input_type=input_type)
+
+        # backend.received holds the prefixed text, i.e. the actual provider payload.
+        assert count_tokens(backend.received[0]) <= 50
+
+    async def test_page_name_plus_content_fits(self):
+        """#4165: a knowledge page embeds `f"{name} {content}"`. Content sized to the
+        cap plus the name used to arrive exactly one token over."""
+        backend = _FakeBackend()
+        content = "consolidated " * 9000
+        while count_tokens(content) > 8192:
+            content = content[: -len("consolidated ")]
+        assert count_tokens(content) == 8192
+
+        with _patch_cap(8192):
+            await embedding_utils.generate_embeddings_batch(backend, [f"User working preferences {content}"])
+
+        assert count_tokens(backend.received[0]) <= 8192

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -733,7 +733,7 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `onnx`, `tei`, `openai`, `openai-codex`, `openrouter`, `requesty`, `cohere`, `google`, `zeroentropy`, `litellm`, or `litellm-sdk` | `local` |
-| `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS` | Applies to **every** provider. If set, truncate each text to this many tokens (counted with `HINDSIGHT_API_TOKENIZER_ENCODING`, approximate) before embedding. Set it to the model's real input limit (e.g. `8192` for Bedrock Titan V2, or a llama.cpp server's context, with a little headroom) so oversized content is truncated instead of failing the embed call permanently. Off by default. (Deprecated alias: `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS`.) | - |
+| `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS` | Applies to **every** provider: truncate each text to this many tokens (counted with `HINDSIGHT_API_TOKENIZER_ENCODING`, approximate) before embedding, so oversized content is truncated instead of failing the embed call permanently. The budget covers the whole payload, including any client-side prefix an asymmetric model needs. The default matches the input limit of essentially every remote embedding model (OpenAI `text-embedding-3-*`, Bedrock Titan V2, Cohere v3, a stock llama.cpp context) — set it to your model's real limit if it differs, or to `0` to send text uncapped. (Deprecated alias: `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS`.) | `8192` |
 | `HINDSIGHT_API_EMBEDDINGS_QUERY_PREFIX` | Text prepended to every search before it is embedded. Set it when your endpoint serves an asymmetric model that expects a search instruction — e.g. `task: search result \| query: ` for `google/embeddinggemma-300m`, or `query: ` for E5. Applies to the providers that only accept plain text (`tei`, `openai`, `openai-codex`, `openrouter`, `requesty`, `litellm`, `litellm-sdk`); see the note below for the ones that don't need it. Trailing spaces are kept as written. | - (no prefix) |
 | `HINDSIGHT_API_EMBEDDINGS_PASSAGE_PREFIX` | Text prepended to every stored memory/document before it is embedded — e.g. `title: none \| text: ` for `google/embeddinggemma-300m`, or `passage: ` for E5. Same providers as above. Trailing spaces are kept as written. | - (no prefix) |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider. Models that ship their own search-text and stored-text instructions (e.g. the Qwen3-Embedding family) have them applied automatically — see the note below. | `BAAI/bge-small-en-v1.5` |
@@ -1019,8 +1019,8 @@ export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY=your-provider-api-key
 export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL=cohere/embed-english-v3.0
 # Optional: request a specific output dimension when the provider supports it
 # export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS=768
-# Optional (any provider): truncate oversized inputs to the model's input-token limit
-# (e.g. Bedrock Titan V2, or a llama.cpp server's context)
+# Optional (any provider): the input-token limit inputs are truncated to.
+# Defaults to 8192; set it to your model's real limit, or 0 to send text uncapped
 # export HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS=8192
 
 # Supported LiteLLM SDK embedding providers:

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -362,10 +362,12 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_EMBEDDINGS_ONNX_TOKENIZER_NAME_OR_PATH=/models/multilingual-e5-small
 # Optional for China network / restricted HF access:
 # HF_ENDPOINT=https://hf-mirror.com
-# Applies to any provider: cap each input at this many tokens before
-# embedding, so oversized content is truncated instead of failing the embed call
-# permanently (e.g. Bedrock Titan V2's 8192, or a llama.cpp server's context). Off
-# by default. (Deprecated alias: HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS)
+# Applies to any provider: cap each input at this many tokens before embedding, so
+# oversized content is truncated instead of failing the embed call permanently.
+# Defaults to 8192, the input limit of essentially every remote embedding model
+# (OpenAI text-embedding-3-*, Bedrock Titan V2, Cohere v3, a stock llama.cpp
+# context); raise or lower it to match your model, or set 0 to send text uncapped.
+# (Deprecated alias: HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS)
 # HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS=8192
 # Asymmetric models (E5, google/embeddinggemma-300m, ...) expect a different instruction
 # in front of a search than in front of stored text. Providers that only accept plain text

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -733,7 +733,7 @@ server-level only (not overridable per tenant/bank) and a change requires a rest
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_EMBEDDINGS_PROVIDER` | Provider: `local`, `onnx`, `tei`, `openai`, `openai-codex`, `openrouter`, `requesty`, `cohere`, `google`, `zeroentropy`, `litellm`, or `litellm-sdk` | `local` |
-| `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS` | Applies to **every** provider. If set, truncate each text to this many tokens (counted with `HINDSIGHT_API_TOKENIZER_ENCODING`, approximate) before embedding. Set it to the model's real input limit (e.g. `8192` for Bedrock Titan V2, or a llama.cpp server's context, with a little headroom) so oversized content is truncated instead of failing the embed call permanently. Off by default. (Deprecated alias: `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS`.) | - |
+| `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS` | Applies to **every** provider: truncate each text to this many tokens (counted with `HINDSIGHT_API_TOKENIZER_ENCODING`, approximate) before embedding, so oversized content is truncated instead of failing the embed call permanently. The budget covers the whole payload, including any client-side prefix an asymmetric model needs. The default matches the input limit of essentially every remote embedding model (OpenAI `text-embedding-3-*`, Bedrock Titan V2, Cohere v3, a stock llama.cpp context) — set it to your model's real limit if it differs, or to `0` to send text uncapped. (Deprecated alias: `HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MAX_INPUT_TOKENS`.) | `8192` |
 | `HINDSIGHT_API_EMBEDDINGS_QUERY_PREFIX` | Text prepended to every search before it is embedded. Set it when your endpoint serves an asymmetric model that expects a search instruction — e.g. `task: search result \| query: ` for `google/embeddinggemma-300m`, or `query: ` for E5. Applies to the providers that only accept plain text (`tei`, `openai`, `openai-codex`, `openrouter`, `requesty`, `litellm`, `litellm-sdk`); see the note below for the ones that don't need it. Trailing spaces are kept as written. | - (no prefix) |
 | `HINDSIGHT_API_EMBEDDINGS_PASSAGE_PREFIX` | Text prepended to every stored memory/document before it is embedded — e.g. `title: none \| text: ` for `google/embeddinggemma-300m`, or `passage: ` for E5. Same providers as above. Trailing spaces are kept as written. | - (no prefix) |
 | `HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL` | Model for local provider. Models that ship their own search-text and stored-text instructions (e.g. the Qwen3-Embedding family) have them applied automatically — see the note below. | `BAAI/bge-small-en-v1.5` |
@@ -1019,8 +1019,8 @@ export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY=your-provider-api-key
 export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL=cohere/embed-english-v3.0
 # Optional: request a specific output dimension when the provider supports it
 # export HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS=768
-# Optional (any provider): truncate oversized inputs to the model's input-token limit
-# (e.g. Bedrock Titan V2, or a llama.cpp server's context)
+# Optional (any provider): the input-token limit inputs are truncated to.
+# Defaults to 8192; set it to your model's real limit, or 0 to send text uncapped
 # export HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS=8192
 
 # Supported LiteLLM SDK embedding providers:


### PR DESCRIPTION
Fixes #4165.

## What was happening

A knowledge page / mental model is embedded as `f"{name} {content}"` (`memory_engine.py:14560`), and its content is generated against the page's own `max_tokens` budget — which the API accepts up to **8192**, the same number as the embedding model's input limit. The name and the joining space are added *after* that budget is spent, so a page sized to the cap reached the provider at 8193 tokens: a hard 400, `refresh_mental_model` failing permanently once its 3 retries are gone, and the mental model silently stuck on stale content.

The reported off-by-one is real but it isn't in a batcher — **nothing was bounding the input at all**. The only cap, `_truncate_inputs`, was opt-in behind `HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS`, whose default was `None`. Local SentenceTransformers truncates server-side, which is why this only shows up against a remote provider.

## Fix

- **Default the cap to 8192** — the input limit of essentially every remote embedding model (OpenAI `text-embedding-3-*`, Bedrock Titan V2, Cohere v3, a stock llama.cpp context), all of which reject an oversized input rather than truncating it. `0` now means "no cap", since leaving the variable unset no longer does.
- **Make the budget cover the whole payload.** `Embeddings._encode_prefixed` (`embeddings.py:457`) glues an asymmetric model's `passage: ` / `query: ` instruction on **after** truncation ran, so a text cut to exactly the limit still went over by the prefix — the same defect one layer down. `_prefix_tokens` charges it against the budget up front.

## Behaviour change

A deployment embedding >8192-token texts against a model with a *larger* window (e.g. voyage-3 at 32k) now gets truncation plus a warning where it previously sent full text; the fix is to set the variable to that model's real limit. Worth a changelog line at release.

## Tests

`tests/test_embeddings_max_input_tokens.py`: new `TestFinalPayloadFitsTheCap` covers the prefixed-provider case for both input types and the exact #4165 shape (content at the cap + a page name); the default-is-`None` test becomes default-is-8192 plus a `0`-opts-out test. 12 passed, `ty check` clean, lints clean.

## Not covered

`_encode_batched` (`embeddings.py:400`) still slices batches by item count only, so a server that charges the whole request array could overshoot with many individually-in-limit texts. That is not what this issue hit (a single 8193-token input) and is left out to keep the fix minimal.