### PR TITLE
fix(consolidation): teach the prompt to name delete targets, and count discarded batch responses

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/consolidator.py
@@ -30,9 +30,10 @@ from itertools import combinations
 from typing import TYPE_CHECKING, Any, Literal
 
 import asyncpg
-from pydantic import BaseModel, ValidationError, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from ...config import get_config
+from ...metrics import get_metrics_collector
 from ...worker.stage import set_stage
 from ..db import DatabaseBackend
 from ..db_utils import acquire_with_retry
@@ -827,7 +828,24 @@ class _UpdateAction(BaseModel):
 
 
 class _DeleteAction(BaseModel):
-    observation_id: str  # UUID of the observation to remove
+    """One DELETE from an LLM response.
+
+    ``observation_id`` stays required — a delete naming no target has no defensible
+    fallback, and guessing one would remove the wrong observation. But rejecting the
+    entry rejects the ENTIRE ``_ConsolidationBatchResponse``, taking the batch's
+    perfectly good creates and updates with it (#4152), so a near-miss is worth
+    absorbing rather than paying a bisected re-run for: models that copy the
+    observation's own field name emit ``id``, which is unambiguous here because a
+    delete entry has exactly one identifier. ``populate_by_name`` keeps the
+    canonical name working for in-process construction, and the generated JSON
+    schema still advertises ``observation_id`` alone (pydantic emits the first
+    of the ``AliasChoices``), so what a grammar-constrained provider is told to
+    emit does not change — this only widens what a free-form one gets away with.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    observation_id: str = Field(validation_alias=AliasChoices("observation_id", "id"))
     reason: str = ""  # LLM's one-sentence justification (diagnostic only)
 
 
@@ -886,6 +904,10 @@ class _BatchLLMResult:
     obs_count: int = 0
     prompt_chars: int = 0
     failed: bool = False
+    #: How many attempts inside this batch call raised. Non-zero even when a later
+    #: attempt succeeded, so the run summary can report calls that were retried out
+    #: of existence — `failed` alone hides them (#4151).
+    failed_attempts: int = 0
 
 
 @dataclass
@@ -1080,6 +1102,7 @@ class ConsolidationPerfLog:
         self.llm_calls: int = 0
         self.total_obs_in_context: int = 0
         self.total_prompt_chars: int = 0
+        self.llm_batch_failures: int = 0
 
     def log(self, message: str) -> None:
         """Add a log line."""
@@ -1099,6 +1122,10 @@ class ConsolidationPerfLog:
         self.llm_calls += 1
         self.total_obs_in_context += obs_count
         self.total_prompt_chars += prompt_chars
+
+    def record_llm_batch_failures(self, count: int) -> None:
+        """Record LLM batch attempts that raised, whether or not a retry rescued them."""
+        self.llm_batch_failures += count
 
     def merge_from(self, other: "ConsolidationPerfLog") -> None:
         """Merge a per-batch perf log into this (job-level) one.
@@ -1120,6 +1147,7 @@ class ConsolidationPerfLog:
         self.llm_calls += other.llm_calls
         self.total_obs_in_context += other.total_obs_in_context
         self.total_prompt_chars += other.total_prompt_chars
+        self.llm_batch_failures += other.llm_batch_failures
 
     def flush(self) -> None:
         """Flush all log lines to the logger."""
@@ -1455,6 +1483,11 @@ async def _run_consolidation_job(
         "actions_executed": 0,
         "skipped": 0,
         "memories_failed": 0,
+        # LLM batch attempts that raised, including those a retry or the adaptive bisection
+        # later rescued. `memories_failed` counts only facts left stuck, so it reads 0 for
+        # a run that discarded every response it got (#4151, #4152). One batch call can
+        # contribute several attempts, so this is not bounded by the batch count.
+        "llm_batch_failures": 0,
     }
 
     # Track all unique tags from consolidated memories for mental model refresh filtering
@@ -1957,6 +1990,22 @@ async def _run_consolidation_job(
     if timing_parts:
         perf.log(f"[4] Timing breakdown: {', '.join(timing_parts)}")
 
+    # A run whose LLM calls kept failing schema validation looks exactly like a clean one
+    # from the counters above: adaptive bisection rescues the facts, so nothing is left
+    # carrying `consolidation_failed_at`, while everything those responses would have done
+    # -- notably their deletes -- was thrown away (#4151, #4152). Say so, loudly, and only
+    # when it happened, so a healthy summary is unchanged.
+    stats["llm_batch_failures"] = perf.llm_batch_failures
+    if perf.llm_batch_failures:
+        # Attempts, not batches: one batch call can burn up to `consolidation_max_attempts`
+        # of them, so this can exceed the batch count above rather than being a share of it.
+        perf.log(
+            f"[5] WARNING: {perf.llm_batch_failures} LLM batch attempt(s) failed and their responses were "
+            f"discarded (creates, updates AND deletes alike). Facts the retry/bisection path rescued are NOT "
+            f"reflected in failed_consolidation; see hindsight.consolidation.batch_failures for the "
+            f"per-class breakdown."
+        )
+
     # Trigger mental-model refreshes once, when the chain has fully drained. On a
     # round-limited round we skip and carry the affected tags forward (above); the
     # final round flushes the accumulated union, so a model whose memories were
@@ -2234,6 +2283,7 @@ async def _process_memory_batch(
     if perf:
         perf.record_timing("llm", time.time() - t0)
         perf.record_llm_call(llm_result.obs_count, llm_result.prompt_chars)
+        perf.record_llm_batch_failures(llm_result.failed_attempts)
 
     # 4. Prepare every action connection-free, then apply them all in ONE transaction.
     #
@@ -3154,6 +3204,7 @@ async def _consolidate_batch_with_llm(
     inner_max_retries = config.consolidation_llm_max_retries
     last_exc: Exception | None = None
     attempts_made = 0
+    failed_attempts = 0
     # Pre-compute a stable identifier set for the batch so failure logs name the
     # exact memories whose consolidation is failing — without this, an opaque
     # "LLM batch call failed" line gives operators no way to find the offending
@@ -3209,9 +3260,19 @@ async def _consolidate_batch_with_llm(
                 deletes=response.deletes,
                 obs_count=len(union_observations),
                 prompt_chars=len(system_prompt) + len(user_content),
+                failed_attempts=failed_attempts,
             )
         except Exception as exc:
             failure_class = _classify_batch_failure(exc)
+            # Count every failed call, including the ones adaptive bisection goes on to
+            # rescue. `failed_consolidation` cannot show those — it is a gauge over rows
+            # still carrying `consolidation_failed_at` when the run ends — so without this
+            # a run that burned N schema-invalid calls and dropped every delete they
+            # carried reads exactly like a clean one (#4151, #4152). Exception path only.
+            get_metrics_collector().record_consolidation_batch_failure(
+                failure_class=str(failure_class), error_type=type(exc).__name__
+            )
+            failed_attempts += 1
             if failure_class is _BatchFailureClass.PROPAGATE:
                 logger.warning(
                     f"[CONSOLIDATION] LLM batch call for {batch_label} raised a non-batch failure "
@@ -3241,7 +3302,10 @@ async def _consolidate_batch_with_llm(
         f"{batch_label}, skipping batch (the caller will bisect it). Last error: {last_exc}"
     )
     return _BatchLLMResult(
-        obs_count=len(union_observations), prompt_chars=len(system_prompt) + len(user_content), failed=True
+        obs_count=len(union_observations),
+        prompt_chars=len(system_prompt) + len(user_content),
+        failed=True,
+        failed_attempts=failed_attempts,
     )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py
+++ b/hindsight-api-slim/hindsight_api/engine/consolidation/prompts.py
@@ -140,6 +140,20 @@ Expected output (UPDATE for the state change; CREATE for the unrelated work-hour
   "updates": [{{"text": "Alice owned a 2019 Honda Civic; sold it on March 15, 2025.", "observation_id": "22222222-2222-2222-2222-222222222222", "source_fact_ids": ["c3d4e5f6-a7b8-9012-cdef-123456789012"], "reason": "State change to the existing Honda Civic observation 2222 — UPDATE, not a new sibling."}}],
   "deletes": []}}
 
+### Example 3 — A superseded observation is deleted (note the `observation_id`)
+
+Input facts:
+  [e5f6a7b8-c9d0-1234-efab-345678901234] Bob confirmed the beta waitlist was shut down and replaced by open signup. (occurred_start=2025-06-02, mentioned_at=2025-06-02)
+
+Existing observation:
+  {{"id": "33333333-3333-3333-3333-333333333333", "text": "Bob is on the beta waitlist.", "proof_count": 1}}
+
+Expected output (the waitlist observation is no longer true of anyone and records no significant event, so DELETE it and CREATE the replacement):
+
+{{"creates": [{{"text": "Bob uses the product through open signup; the beta waitlist was shut down.", "source_fact_ids": ["e5f6a7b8-c9d0-1234-efab-345678901234"], "reason": "The waitlist observation is superseded outright rather than amended, so CREATE the replacement and DELETE the old one."}}],
+  "updates": [],
+  "deletes": [{{"observation_id": "33333333-3333-3333-3333-333333333333", "reason": "The waitlist no longer exists — this observation is superseded, not merely out of date."}}]}}
+
 ### Observation text rules
 
 - Write clean prose — NEVER copy raw fact lines or their metadata (temporal fields, "Involving:", "When:" labels, UUIDs).
@@ -152,7 +166,7 @@ Expected output (UPDATE for the state change; CREATE for the unrelated work-hour
 - `observation_id`: copy the EXACT `id` UUID string from existing observations.
 - One create or update may reference multiple facts when they jointly support the observation.
 - **AT MOST ONE UPDATE PER `observation_id`**: if several new facts all update the same existing observation, emit a single `updates` entry that lists all contributing `source_fact_ids` and a single consolidated `text`. Never emit two `updates` entries with the same `observation_id` in one response — they would silently overwrite each other.
-- `deletes`: only when an observation is directly superseded or contradicted by new facts.
+- `deletes`: only when an observation is directly superseded or contradicted by new facts. Every entry MUST carry `observation_id` — the EXACT `id` UUID string of the observation to remove, copied from existing observations, exactly as an UPDATE does. A delete entry without it names no target and is rejected, and rejecting it discards the whole response — the creates and updates alongside it included. Naming the observation in `reason` prose is NOT enough. If you cannot supply the id, emit no delete.
 - `reason`: REQUIRED on every create/update/delete — one sentence explaining the choice. For a CREATE, state which existing observation(s) you considered and why none matched (a near-identical existing observation means you should UPDATE, not CREATE). This is audited to catch duplicate creates.
 - Do NOT include `tags` — handled automatically.
 - Return `{{"creates": [], "updates": [], "deletes": []}}` if nothing durable is found."""

--- a/hindsight-api-slim/hindsight_api/metrics.py
+++ b/hindsight-api-slim/hindsight_api/metrics.py
@@ -320,6 +320,18 @@ class MetricsCollectorBase:
         """Record a detected event-loop stall (blocked longer than the watchdog threshold)."""
         raise NotImplementedError
 
+    def record_consolidation_batch_failure(self, failure_class: str, error_type: str):
+        """Record one consolidation LLM batch call that failed.
+
+        `failed_consolidation` is a gauge over rows carrying `consolidation_failed_at`,
+        so it reports facts left STUCK — never a call that failed and whose facts the
+        caller's adaptive bisection then rescued. A run can burn dozens of schema-invalid
+        calls, drop every delete they carried, and still end with that gauge at 0 and
+        `observations_deleted` at 0, indistinguishable from a healthy run (#4151, #4152).
+        This counter is the missing signal: it counts calls, not stuck rows.
+        """
+        raise NotImplementedError
+
     def set_db_pool(self, pool: "asyncpg.Pool"):
         """Set the database pool for metrics collection."""
         pass
@@ -392,6 +404,10 @@ class NoOpMetricsCollector(MetricsCollectorBase):
 
     def record_loop_stall(self, stall_seconds: float):
         """No-op loop-stall recording."""
+        pass
+
+    def record_consolidation_batch_failure(self, failure_class: str, error_type: str):
+        """No-op consolidation batch-failure recording."""
         pass
 
 
@@ -545,6 +561,19 @@ class MetricsCollector(MetricsCollectorBase):
         self.recall_phase_calls = self.meter.create_counter(
             name="hindsight.recall.phase.calls",
             description="Number of times a recall phase ran",
+            unit="calls",
+        )
+        # Consolidation batch calls that failed. Labelled by failure class so the two
+        # populations stay separable: `retry` is transport-shaped and usually self-heals,
+        # while `fail_fast` is the model emitting something the response schema rejects —
+        # the case that silently drains the delete path (#4152). Neither reaches
+        # `failed_consolidation`, which only counts facts bisection could not rescue.
+        self.consolidation_batch_failures = self.meter.create_counter(
+            name="hindsight.consolidation.batch_failures",
+            description=(
+                "Consolidation LLM batch calls that failed, by failure class -- "
+                "including those whose facts adaptive bisection later rescued"
+            ),
             unit="calls",
         )
         self.event_loop_stalls = self.meter.create_counter(
@@ -828,6 +857,17 @@ class MetricsCollector(MetricsCollectorBase):
         """Record a detected event-loop stall. Called from the watchdog thread."""
         self.event_loop_stalls.add(1)
         self.event_loop_stall_duration.record(stall_seconds)
+
+    def record_consolidation_batch_failure(self, failure_class: str, error_type: str):
+        """Record one failed consolidation LLM batch call.
+
+        Called only on the exception path, so the successful batch costs nothing.
+        `error_type` is the exception class name — `ValidationError` is the #4152
+        signature — and is bounded by the exception types the LLM layer can raise.
+        """
+        self.consolidation_batch_failures.add(
+            1, {"failure_class": failure_class, "error_type": error_type, "tenant": _get_tenant()}
+        )
 
     def _setup_process_metrics(self):
         """Set up observable gauges for process metrics."""

--- a/hindsight-api-slim/tests/test_consolidation_batch_failure_visibility.py
+++ b/hindsight-api-slim/tests/test_consolidation_batch_failure_visibility.py
@@ -1,0 +1,297 @@
+"""Failed consolidation batch calls are visible at run level (#4151).
+
+``failed_consolidation`` is a gauge over rows still carrying
+``consolidation_failed_at``, so it counts facts left STUCK. It cannot count a
+batch call that failed and whose facts the adaptive bisection then rescued —
+and that is the common case for a schema-invalid response, which is classified
+FAIL_FAST, fails the batch, and gets bisected into calls small enough to
+validate. A run can therefore burn dozens of failed calls, discard every action
+those responses carried, and end with ``failed_consolidation`` at 0 and
+``observations_deleted`` at 0: indistinguishable from a clean run.
+
+Two counters close that: ``llm_batch_failures`` in the job's own stats, and the
+``hindsight.consolidation.batch_failures`` metric, labelled by failure class so
+transport-shaped retries stay separable from schema rejections.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.consolidation import consolidator as consolidator_module
+from hindsight_api.engine.consolidation.consolidator import (
+    _BatchFailureClass,
+    _classify_batch_failure,
+    _ConsolidationBatchResponse,
+    _CreateAction,
+    run_consolidation_job,
+)
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.providers.mock_llm import MockLLM
+from hindsight_api.metrics import NoOpMetricsCollector
+
+
+@pytest.fixture(autouse=True)
+def enable_observations():
+    config = _get_raw_config()
+    original = config.enable_observations
+    config.enable_observations = True
+    yield
+    config.enable_observations = original
+
+
+def _override_config(memory: MemoryEngine, **overrides):
+    raw = _get_raw_config()
+    fake = type(raw)(**{**{f: getattr(raw, f) for f in raw.__dataclass_fields__}, **overrides})
+    return patch.object(memory._config_resolver, "resolve_full_config", return_value=fake)
+
+
+def _schema_validation_error() -> ValidationError:
+    """A real pydantic ValidationError, the shape a model emitting non-conforming
+    JSON produces on the way out of the LLM layer."""
+
+    class _Probe(BaseModel):
+        creates: list[_CreateAction]
+
+    try:
+        _Probe.model_validate({"creates": "not-a-list"})
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("expected a ValidationError")
+
+
+class _RecordingCollector(NoOpMetricsCollector):
+    """Captures batch-failure records; every other metric stays a no-op."""
+
+    def __init__(self):
+        self.batch_failures: list[tuple[str, str]] = []
+
+    def record_consolidation_batch_failure(self, failure_class: str, error_type: str):
+        self.batch_failures.append((failure_class, error_type))
+
+
+def test_schema_validation_failure_is_fail_fast():
+    """A re-send of the identical payload cannot fix a schema rejection, so the
+    batch fails immediately and the caller bisects instead."""
+    assert _classify_batch_failure(_schema_validation_error()) is _BatchFailureClass.FAIL_FAST
+
+
+async def _insert_memory(conn, bank_id: str, text: str, tags: list[str]) -> uuid.UUID:
+    mem_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO memory_units (id, bank_id, text, fact_type, tags, observation_scopes, created_at)
+        VALUES ($1, $2, $3, 'experience', $4, $5::jsonb, now())
+        """,
+        mem_id,
+        bank_id,
+        text,
+        tags,
+        json.dumps(None),
+    )
+    return mem_id
+
+
+def _install_llm(memory: MemoryEngine, callback):
+    mock_llm = MockLLM(provider="mock", api_key="", base_url="", model="mock-model")
+    mock_llm.set_response_callback(callback)
+    wrapper = MagicMock()
+    wrapper.with_config.return_value = mock_llm
+    memory._consolidation_llm_config = wrapper
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_failures_rescued_by_bisection_are_still_counted(memory: MemoryEngine, request_context):
+    """The reported symptom: N calls fail schema validation, bisection rescues every
+    fact, ``failed_consolidation`` reads 0 — and the run now says so anyway."""
+    bank_id = f"test-4151-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    collector = _RecordingCollector()
+    original_llm = memory._consolidation_llm_config
+    try:
+        async with memory._pool.acquire() as conn:
+            for text in ("Alice likes tea", "Alice bikes daily", "Alice reads books", "Alice runs races"):
+                await _insert_memory(conn, bank_id, text, ["user:alice"])
+
+        validation_failures = 0
+
+        def callback(messages, scope):
+            nonlocal validation_failures
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            # Stands in for a model that only emits valid strict JSON for the
+            # simplest prompts: anything with more than one fact comes back
+            # schema-invalid, and bisection is what eventually gets through.
+            if len(fact_ids) > 1:
+                validation_failures += 1
+                raise _schema_validation_error()
+            return _ConsolidationBatchResponse(
+                creates=[
+                    _CreateAction(text=f"Observation about fact {fid[:8]}", source_fact_ids=[fid]) for fid in fact_ids
+                ]
+            )
+
+        _install_llm(memory, callback)
+        with (
+            _override_config(memory, consolidation_llm_batch_size=4, consolidation_llm_parallelism=1),
+            patch.object(memory, "submit_async_consolidation"),
+            patch.object(consolidator_module, "get_metrics_collector", return_value=collector),
+        ):
+            result = await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+        # 4 -> 2+2 -> 1x4: three calls failed before anything validated.
+        assert validation_failures >= 3
+
+        # The stuck-fact gauge legitimately reads 0 — bisection rescued them all.
+        stats = await memory.get_bank_stats(bank_id, request_context=request_context)
+        assert stats["failed_consolidation"] == 0
+        assert stats["pending_consolidation"] == 0
+
+        # The run-level counter reports what the gauge structurally cannot.
+        assert result["llm_batch_failures"] == validation_failures
+
+        # And so does the metric, labelled so schema rejections stay separable
+        # from transport-shaped retries.
+        assert len(collector.batch_failures) == validation_failures
+        assert set(collector.batch_failures) == {(str(_BatchFailureClass.FAIL_FAST), "ValidationError")}
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_a_clean_run_reports_no_batch_failures(memory: MemoryEngine, request_context):
+    """The counter must stay 0 on a healthy run, or it is noise rather than signal."""
+    bank_id = f"test-4151-clean-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    collector = _RecordingCollector()
+    original_llm = memory._consolidation_llm_config
+    try:
+        async with memory._pool.acquire() as conn:
+            for text in ("Dave likes tea", "Dave bikes daily"):
+                await _insert_memory(conn, bank_id, text, ["user:dave"])
+
+        def callback(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+            fact_ids = re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+            return _ConsolidationBatchResponse(
+                creates=[
+                    _CreateAction(text=f"Observation about fact {fid[:8]}", source_fact_ids=[fid]) for fid in fact_ids
+                ]
+            )
+
+        _install_llm(memory, callback)
+        with (
+            _override_config(memory, consolidation_llm_batch_size=2, consolidation_llm_parallelism=1),
+            patch.object(memory, "submit_async_consolidation"),
+            patch.object(consolidator_module, "get_metrics_collector", return_value=collector),
+        ):
+            result = await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+        assert result["llm_batch_failures"] == 0
+        assert collector.batch_failures == []
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_retried_attempts_each_count(memory: MemoryEngine, request_context):
+    """One batch call can burn several attempts, and each is a discarded response.
+
+    A transport-shaped failure is RETRY, so the outer ladder re-sends up to
+    ``consolidation_max_attempts`` times. The counter must total attempts rather
+    than batch calls — a call retried three times cost three generations.
+    """
+    bank_id = f"test-4151-retry-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    collector = _RecordingCollector()
+    original_llm = memory._consolidation_llm_config
+    try:
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Erin likes tea", ["user:erin"])
+
+        def callback(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            # Not JSONDecodeError/ValidationError/OutputTooLong, so it classifies RETRY
+            # and the outer ladder re-sends instead of failing the batch immediately.
+            raise RuntimeError("connection reset by peer")
+
+        _install_llm(memory, callback)
+        with (
+            _override_config(
+                memory,
+                consolidation_llm_batch_size=1,
+                consolidation_llm_parallelism=1,
+                consolidation_max_attempts=3,
+            ),
+            patch.object(memory, "submit_async_consolidation"),
+            patch.object(consolidator_module, "get_metrics_collector", return_value=collector),
+            patch.object(consolidator_module, "_OUTER_RETRY_INITIAL_BACKOFF", 0),
+        ):
+            result = await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+        # One fact, one batch call, three attempts — all three counted.
+        assert result["llm_batch_failures"] == 3
+        assert collector.batch_failures == [(str(_BatchFailureClass.RETRY), "RuntimeError")] * 3
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_facts_bisection_cannot_rescue_are_counted_in_both_places(memory: MemoryEngine, request_context):
+    """Contrast: when even a single-fact call fails, the fact IS stuck and both the
+    gauge and the new counter report it — they measure different things, not the
+    same thing twice."""
+    bank_id = f"test-4151-stuck-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    collector = _RecordingCollector()
+    original_llm = memory._consolidation_llm_config
+    try:
+        async with memory._pool.acquire() as conn:
+            for text in ("Bob likes tea", "Bob bikes daily"):
+                await _insert_memory(conn, bank_id, text, ["user:bob"])
+
+        def callback(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            raise _schema_validation_error()
+
+        _install_llm(memory, callback)
+        with (
+            _override_config(
+                memory,
+                consolidation_llm_batch_size=2,
+                consolidation_llm_parallelism=1,
+                consolidation_max_attempts=1,
+            ),
+            patch.object(memory, "submit_async_consolidation"),
+            patch.object(consolidator_module, "get_metrics_collector", return_value=collector),
+        ):
+            result = await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+        stats = await memory.get_bank_stats(bank_id, request_context=request_context)
+        assert stats["failed_consolidation"] == 2
+        # One call for the pair plus one per bisected half.
+        assert result["llm_batch_failures"] == 3
+        assert len(collector.batch_failures) == 3
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-api-slim/tests/test_consolidation_delete_prompt_llm.py
+++ b/hindsight-api-slim/tests/test_consolidation_delete_prompt_llm.py
@@ -1,0 +1,103 @@
+"""The consolidation prompt gets a real model to emit a well-formed DELETE (#4152).
+
+``deletes[].observation_id`` is required, and before this the prompt never showed
+the shape of a delete entry: both worked examples ended in ``"deletes": []`` and the
+`deletes` field rule said only *when* to delete. A model that answered with a
+reason-only delete had its whole response rejected — creates and updates included.
+
+Whether a given model omits the field is exactly the kind of prompt-following
+behaviour MockLLM cannot simulate, so this runs the real batch call. Note what it
+can and cannot pin: that a delete is *emitted at all* is a model judgement (rule 7
+tells it to be conservative), so the strict assertion is conditional — every delete
+that IS emitted must carry a real observation id. The unconditional part is that
+the response validated at all, which is the failure #4152 reported.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from hindsight_api import LLMConfig
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.consolidation.consolidator import _consolidate_batch_with_llm
+from hindsight_api.engine.response_models import MemoryFact
+from tests.llm_judge import assert_meets_criteria
+
+pytestmark = pytest.mark.hs_llm_core
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+@pytest.mark.asyncio
+async def test_real_model_emits_a_delete_that_names_its_target():
+    """A fact that outright supersedes an existing observation."""
+    # MemoryFact carries its id and timestamps as plain strings (they come off a
+    # JSON row), so build them as strings rather than UUID/datetime objects.
+    stale_obs_id = str(uuid.uuid4())
+    fact_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+
+    observation = MemoryFact(
+        id=stale_obs_id,
+        text="Bob is on the beta waitlist, waiting for an invite.",
+        fact_type="observation",
+        mentioned_at=now.isoformat(),
+    )
+    memories = [
+        {
+            "id": fact_id,
+            "text": (
+                "The beta waitlist was deleted entirely and replaced with open signup; "
+                "nobody is on a waitlist any more and the waitlist page now 404s."
+            ),
+            "tags": [],
+            "occurred_start": None,
+            "occurred_end": None,
+            "mentioned_at": now,
+        }
+    ]
+
+    # The real batch call: it RAISES on a response that fails schema validation,
+    # so reaching the asserts at all is the #4152 regression check.
+    result = await _consolidate_batch_with_llm(
+        llm_config=LLMConfig.from_env(),
+        memories=memories,
+        union_observations=[observation],
+        union_source_facts={},
+        config=_get_raw_config(),
+    )
+
+    assert result.failed is False, "the consolidation batch call failed outright"
+
+    # Conditional by design — see the module docstring. What must never happen is a
+    # delete that names nothing, or one pointing at an id the prompt never showed.
+    for delete in result.deletes:
+        assert _UUID_RE.match(delete.observation_id), (
+            f"delete carries a malformed observation_id: {delete.observation_id!r}"
+        )
+        assert delete.observation_id == stale_obs_id, (
+            f"delete targets an id that was not in the prompt: {delete.observation_id!r}"
+        )
+
+    actions_summary = "\n".join(
+        [f"- CREATE: {c.text}" for c in result.creates]
+        + [f"- UPDATE {u.observation_id}: {u.text}" for u in result.updates]
+        + [f"- DELETE {d.observation_id}: {d.reason}" for d in result.deletes]
+    )
+    await assert_meets_criteria(
+        response=actions_summary or "(no actions)",
+        criteria=(
+            "The actions do not leave the claim 'Bob is on the beta waitlist' standing as a "
+            "current fact: the waitlist observation is either deleted or rewritten to say the "
+            "waitlist no longer exists. Any DELETE names an observation id."
+        ),
+        context=(
+            "A consolidation model was given one existing observation, 'Bob is on the beta "
+            f"waitlist, waiting for an invite.' (id {stale_obs_id}), and one new fact saying the "
+            "beta waitlist was deleted entirely and replaced with open signup."
+        ),
+    )

--- a/hindsight-api-slim/tests/test_consolidation_delete_schema.py
+++ b/hindsight-api-slim/tests/test_consolidation_delete_schema.py
@@ -1,0 +1,302 @@
+"""The consolidation DELETE contract (#4152).
+
+``deletes[].observation_id`` names the observation to remove. It has no defensible
+fallback — a delete with no target cannot be guessed at without risking the wrong
+row — so it stays required and a delete that omits it still fails closed.
+
+What made that expensive is that rejecting one delete entry rejects the ENTIRE
+``_ConsolidationBatchResponse``: the batch's good creates and updates go with it,
+the batch is reported failed, and the caller bisects. A model that reliably omits
+the field therefore drains the whole supersession path while every run-level
+counter still reads healthy.
+
+Two things narrow it, and these tests pin both:
+
+1. The prompt now shows the shape of a delete entry — a worked example with a
+   populated ``deletes`` array, and a field rule that says the id is mandatory.
+   Before this, both examples ended in ``"deletes": []`` and the ``deletes`` rule
+   only said *when* to delete.
+2. ``_DeleteAction`` accepts ``id`` as an alias, the name a model copying the
+   observation's own field emits. Unambiguous — a delete entry carries exactly one
+   identifier — and it keeps a near-miss from discarding the creates beside it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from hindsight_api.config import _get_raw_config
+from hindsight_api.engine.consolidation.consolidator import (
+    _ConsolidationBatchResponse,
+    _CreateAction,
+    _DeleteAction,
+    run_consolidation_job,
+)
+from hindsight_api.engine.consolidation.prompts import build_consolidation_system_prompt
+from hindsight_api.engine.memory_engine import MemoryEngine
+from hindsight_api.engine.providers.mock_llm import MockLLM
+
+
+@pytest.fixture(autouse=True)
+def enable_observations():
+    config = _get_raw_config()
+    original = config.enable_observations
+    config.enable_observations = True
+    yield
+    config.enable_observations = original
+
+
+def _override_config(memory: MemoryEngine, **overrides):
+    raw = _get_raw_config()
+    fake = type(raw)(**{**{f: getattr(raw, f) for f in raw.__dataclass_fields__}, **overrides})
+    return patch.object(memory._config_resolver, "resolve_full_config", return_value=fake)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_delete_accepts_the_id_alias():
+    """``id`` is what a model copying the observation's own field name emits."""
+    obs_id = str(uuid.uuid4())
+    response = _ConsolidationBatchResponse.model_validate(
+        {"deletes": [{"id": obs_id, "reason": "superseded by the new fact"}]}
+    )
+    assert [d.observation_id for d in response.deletes] == [obs_id]
+
+
+def test_delete_still_accepts_the_canonical_name():
+    obs_id = str(uuid.uuid4())
+    response = _ConsolidationBatchResponse.model_validate(
+        {"deletes": [{"observation_id": obs_id, "reason": "superseded"}]}
+    )
+    assert [d.observation_id for d in response.deletes] == [obs_id]
+    # populate_by_name keeps in-process construction working too.
+    assert _DeleteAction(observation_id=obs_id).observation_id == obs_id
+
+
+def test_delete_naming_no_target_still_fails_closed():
+    """A delete that identifies nothing is rejected — the alias widens what counts
+    as an identifier, it does not invent one from ``reason`` prose."""
+    with pytest.raises(ValidationError) as exc_info:
+        _ConsolidationBatchResponse.model_validate({"deletes": [{"reason": "the Civic observation is superseded"}]})
+
+    errors = exc_info.value.errors()
+    assert [e["type"] for e in errors] == ["missing"]
+
+
+def test_alias_saves_the_creates_and_updates_in_the_same_response():
+    """The point of the alias: one near-miss delete no longer discards the batch.
+
+    Everything in a rejected response is lost, not just its deletes — so an
+    ``id``-shaped delete used to cost the good creates beside it as well.
+    """
+    obs_id = str(uuid.uuid4())
+    payload = {
+        "creates": [{"text": "Alice works nights.", "source_fact_ids": [str(uuid.uuid4())], "reason": "new facet"}],
+        "updates": [],
+        "deletes": [{"id": obs_id, "reason": "superseded"}],
+    }
+    response = _ConsolidationBatchResponse.model_validate(payload)
+    assert len(response.creates) == 1
+    assert response.deletes[0].observation_id == obs_id
+
+
+def test_json_schema_still_advertises_only_the_canonical_name():
+    """The alias must not change what a grammar-constrained provider is told to
+    emit — it only widens what a free-form one gets away with."""
+    schema = _ConsolidationBatchResponse.model_json_schema()["$defs"]["_DeleteAction"]
+    assert schema["required"] == ["observation_id"]
+    assert set(schema["properties"]) == {"observation_id", "reason"}
+
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_states_that_deletes_need_an_observation_id():
+    prompt = build_consolidation_system_prompt()
+    deletes_rule = next(line for line in prompt.splitlines() if line.startswith("- `deletes`"))
+    assert "observation_id" in deletes_rule
+
+
+def test_prompt_shows_a_worked_example_of_a_populated_deletes_array():
+    """Both prior examples ended in ``"deletes": []``, so the model had never been
+    shown the shape of a delete entry."""
+    prompt = build_consolidation_system_prompt()
+    match = re.search(r'"deletes": \[\{[^}]*\}\]', prompt)
+    assert match is not None, "no worked example with a populated deletes array"
+    assert "observation_id" in match.group(0)
+
+
+# ---------------------------------------------------------------------------
+# End to end
+# ---------------------------------------------------------------------------
+
+
+async def _insert_memory(conn, bank_id: str, text: str, tags: list[str]) -> uuid.UUID:
+    mem_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO memory_units (id, bank_id, text, fact_type, tags, observation_scopes, created_at)
+        VALUES ($1, $2, $3, 'experience', $4, $5::jsonb, now())
+        """,
+        mem_id,
+        bank_id,
+        text,
+        tags,
+        json.dumps(None),
+    )
+    return mem_id
+
+
+async def _observations(memory: MemoryEngine, bank_id: str, request_context) -> list[dict]:
+    return (
+        await memory.list_memory_units(bank_id, fact_type="observation", limit=1000, request_context=request_context)
+    )["items"]
+
+
+def _install_llm(memory: MemoryEngine, callback):
+    mock_llm = MockLLM(provider="mock", api_key="", base_url="", model="mock-model")
+    mock_llm.set_response_callback(callback)
+    wrapper = MagicMock()
+    wrapper.with_config.return_value = mock_llm
+    memory._consolidation_llm_config = wrapper
+
+
+def _fact_ids(messages) -> list[str]:
+    prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+    return re.findall(r"\[([0-9a-f-]{36})\]", prompt)
+
+
+async def _seed_one_observation(memory: MemoryEngine, bank_id: str, request_context, text: str, tags: list[str]) -> str:
+    """Consolidate one fact into one observation with a well-behaved model."""
+    async with memory._pool.acquire() as conn:
+        await _insert_memory(conn, bank_id, text, tags)
+
+    def seed_callback(messages, scope):
+        if scope != "consolidation":
+            return _ConsolidationBatchResponse()
+        return _ConsolidationBatchResponse(
+            creates=[_CreateAction(text=text, source_fact_ids=[fid]) for fid in _fact_ids(messages)]
+        )
+
+    _install_llm(memory, seed_callback)
+    with (
+        _override_config(memory, consolidation_llm_batch_size=4, consolidation_llm_parallelism=1),
+        patch.object(memory, "submit_async_consolidation"),
+    ):
+        await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+    seeded = await _observations(memory, bank_id, request_context)
+    assert len(seeded) == 1
+    return str(seeded[0]["id"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+@pytest.mark.parametrize("id_field", ["observation_id", "id"])
+async def test_supersession_delete_lands_under_either_field_name(memory: MemoryEngine, request_context, id_field: str):
+    """End to end, an ``id``-shaped delete removes the superseded observation just
+    as the canonical one does — and the run reports it."""
+    bank_id = f"test-del-{id_field}-{uuid.uuid4().hex[:8]}"
+    tags = [f"user:{uuid.uuid4().hex[:6]}"]
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    original_llm = memory._consolidation_llm_config
+    try:
+        stale_id = await _seed_one_observation(memory, bank_id, request_context, "Bob is on the beta waitlist.", tags)
+
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "The beta waitlist was shut down", tags)
+
+        def deleting_callback(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            return _ConsolidationBatchResponse.model_validate(
+                {
+                    "creates": [
+                        {
+                            "text": "Bob uses the product through open signup.",
+                            "source_fact_ids": [fid],
+                            "reason": "replacement for the superseded waitlist observation",
+                        }
+                        for fid in _fact_ids(messages)
+                    ],
+                    "deletes": [{id_field: stale_id, "reason": "the waitlist no longer exists"}],
+                }
+            )
+
+        _install_llm(memory, deleting_callback)
+        with (
+            _override_config(memory, consolidation_llm_batch_size=4, consolidation_llm_parallelism=1),
+            patch.object(memory, "submit_async_consolidation"),
+        ):
+            result = await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+        assert result["observations_deleted"] == 1
+        assert result["llm_batch_failures"] == 0
+        surviving = {str(o["id"]) for o in await _observations(memory, bank_id, request_context)}
+        assert stale_id not in surviving
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.memory_backend_incompatible
+async def test_delete_with_no_identifier_fails_the_batch_and_is_reported(memory: MemoryEngine, request_context):
+    """Fail-closed is still the behaviour for a delete naming nothing — but the run
+    now says the responses were discarded instead of reading as healthy (#4151)."""
+    bank_id = f"test-del-none-{uuid.uuid4().hex[:8]}"
+    tags = ["user:carol"]
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+    original_llm = memory._consolidation_llm_config
+    try:
+        stale_id = await _seed_one_observation(memory, bank_id, request_context, "Carol owns a 2019 Honda Civic.", tags)
+
+        async with memory._pool.acquire() as conn:
+            await _insert_memory(conn, bank_id, "Carol sold the Civic in March 2025", tags)
+            await _insert_memory(conn, bank_id, "Carol now drives a leased EV", tags)
+
+        def malformed_callback(messages, scope):
+            if scope != "consolidation":
+                return _ConsolidationBatchResponse()
+            ids = _fact_ids(messages)
+            creates = [_CreateAction(text=f"Observation about {fid[:8]}", source_fact_ids=[fid]) for fid in ids]
+            if len(ids) > 1:
+                # Names the observation in prose only — no identifier at all.
+                return _ConsolidationBatchResponse.model_validate(
+                    {
+                        "creates": [c.model_dump() for c in creates],
+                        "deletes": [{"reason": "the Civic observation is superseded — Carol sold it"}],
+                    }
+                )
+            return _ConsolidationBatchResponse(creates=creates)
+
+        _install_llm(memory, malformed_callback)
+        with (
+            _override_config(memory, consolidation_llm_batch_size=2, consolidation_llm_parallelism=1),
+            patch.object(memory, "submit_async_consolidation"),
+        ):
+            result = await run_consolidation_job(memory_engine=memory, bank_id=bank_id, request_context=request_context)
+
+        # Bisection rescued the facts, so the stuck-fact gauge stays 0 ...
+        stats = await memory.get_bank_stats(bank_id, request_context=request_context)
+        assert stats["failed_consolidation"] == 0
+        # ... and the delete never landed, as fail-closed requires.
+        assert result["observations_deleted"] == 0
+        surviving = {str(o["id"]) for o in await _observations(memory, bank_id, request_context)}
+        assert stale_id in surviving
+        # But the run no longer looks clean: the discarded responses are counted.
+        assert result["llm_batch_failures"] > 0
+    finally:
+        memory._consolidation_llm_config = original_llm
+        await memory.delete_bank(bank_id, request_context=request_context)

--- a/hindsight-docs/docs/developer/monitoring.md
+++ b/hindsight-docs/docs/developer/monitoring.md
@@ -161,6 +161,40 @@ sum(rate(hindsight_retain_documents_total{outcome="no_facts"}[15m]))
 - `success`: Whether the call succeeded (`true`, `false`)
 - `token_bucket`: Token count bucket for cardinality control (`0-100`, `100-500`, `500-1k`, `1k-5k`, `5k-10k`, `10k-50k`, `50k+`)
 
+### Consolidation Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `hindsight.consolidation.batch_failures` | Counter | failure_class, error_type | Consolidation LLM batch calls that failed, including those whose facts were later recovered |
+
+**Labels:**
+- `failure_class`: How the call was treated (`fail_fast` — the model returned something the response schema rejects, so a re-send of the same payload cannot help; `retry` — transport-shaped, an unchanged re-send may succeed; `propagate` — not a batch failure, re-raised to the task handler)
+- `error_type`: Exception class name (e.g. `ValidationError`, `JSONDecodeError`)
+
+This is not the same signal as the `failed_consolidation` field in bank stats. That
+field counts *facts* still waiting to be consolidated after a failure; when a batch
+call fails, consolidation halves the batch and retries, so a call that failed at
+batch size 8 and succeeded at size 1 leaves `failed_consolidation` at 0. Everything
+the failed response asked for is dropped, though — including any observations it
+wanted to delete — so a bank can look completely healthy while its
+supersession cleanup does nothing.
+
+Alert on the schema-rejection rate, which no other metric exposes:
+
+```promql
+sum(rate(hindsight_consolidation_batch_failures_total{failure_class="fail_fast"}[15m]))
+```
+
+A sustained non-zero rate usually means the consolidation model does not reliably
+emit valid JSON for the response schema. Switching to a model with stronger
+structured output, or enabling `HINDSIGHT_API_LLM_STRICT_SCHEMA_CONSOLIDATION` if
+the provider supports grammar-enforced schemas, is the usual fix.
+
+The same count is reported per run as `llm_batch_failures` in the consolidation
+operation's result, and the consolidation log summary prints a warning line
+whenever it is non-zero. Both count *attempts* — one batch call retried three times
+contributes three — so they are not bounded by the number of batches in the run.
+
 ### HTTP Request Metrics
 
 | Metric | Type | Labels | Description |

--- a/skills/hindsight-docs/references/developer/monitoring.md
+++ b/skills/hindsight-docs/references/developer/monitoring.md
@@ -161,6 +161,40 @@ sum(rate(hindsight_retain_documents_total{outcome="no_facts"}[15m]))
 - `success`: Whether the call succeeded (`true`, `false`)
 - `token_bucket`: Token count bucket for cardinality control (`0-100`, `100-500`, `500-1k`, `1k-5k`, `5k-10k`, `10k-50k`, `50k+`)
 
+### Consolidation Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `hindsight.consolidation.batch_failures` | Counter | failure_class, error_type | Consolidation LLM batch calls that failed, including those whose facts were later recovered |
+
+**Labels:**
+- `failure_class`: How the call was treated (`fail_fast` — the model returned something the response schema rejects, so a re-send of the same payload cannot help; `retry` — transport-shaped, an unchanged re-send may succeed; `propagate` — not a batch failure, re-raised to the task handler)
+- `error_type`: Exception class name (e.g. `ValidationError`, `JSONDecodeError`)
+
+This is not the same signal as the `failed_consolidation` field in bank stats. That
+field counts *facts* still waiting to be consolidated after a failure; when a batch
+call fails, consolidation halves the batch and retries, so a call that failed at
+batch size 8 and succeeded at size 1 leaves `failed_consolidation` at 0. Everything
+the failed response asked for is dropped, though — including any observations it
+wanted to delete — so a bank can look completely healthy while its
+supersession cleanup does nothing.
+
+Alert on the schema-rejection rate, which no other metric exposes:
+
+```promql
+sum(rate(hindsight_consolidation_batch_failures_total{failure_class="fail_fast"}[15m]))
+```
+
+A sustained non-zero rate usually means the consolidation model does not reliably
+emit valid JSON for the response schema. Switching to a model with stronger
+structured output, or enabling `HINDSIGHT_API_LLM_STRICT_SCHEMA_CONSOLIDATION` if
+the provider supports grammar-enforced schemas, is the usual fix.
+
+The same count is reported per run as `llm_batch_failures` in the consolidation
+operation's result, and the consolidation log summary prints a warning line
+whenever it is non-zero. Both count *attempts* — one batch call retried three times
+contributes three — so they are not bounded by the number of batches in the run.
+
 ### HTTP Request Metrics
 
 | Metric | Type | Labels | Description |


### PR DESCRIPTION
Fixes #4152, fixes #4151.

## The shared mechanism

A consolidation response that fails `_ConsolidationBatchResponse` validation is classified `FAIL_FAST` (`consolidator.py:3061`), so the batch is reported failed without an identical re-send, and the caller bisects it (`consolidator.py:1652`). When the halves then validate, every fact consolidates and nothing is left carrying `consolidation_failed_at`.

`failed_consolidation` is a gauge over rows with that column set, so it reads 0 — and the run looks exactly like a clean one, even though everything those responses asked for was discarded. That is #4151.

#4152 is the concrete instance. `deletes[].observation_id` is required, but nothing told the model so: both worked examples in the prompt ended in `"deletes": []`, and the one `deletes` field rule said only *when* to delete. A model answering with a reason-only delete had its **whole response** rejected — the good creates and updates alongside it included — and the supersession-cleanup path silently did nothing for a whole backlog drain, with `observations_deleted` stuck at 0.

## Changes

**Prompt** (`prompts.py`) — a worked Example 3 with a populated `deletes` array, and a field rule stating that every entry must carry the exact `observation_id`, that naming the observation in `reason` prose is not enough, and that a bad entry costs the entire response.

**Schema tolerance** (`consolidator.py`) — `_DeleteAction` accepts `id` as an alias, the name a model copying the observation's own field emits. Unambiguous, because a delete entry carries exactly one identifier.

The field stays **required**: a delete naming no target has no defensible fallback, and guessing one would remove the wrong observation. The generated JSON schema still advertises `observation_id` alone (pydantic emits the first of the `AliasChoices`), so what a grammar-constrained provider is told to emit does not change — this only widens what a free-form one gets away with, and stops a near-miss from discarding the batch.

**Visibility** (`metrics.py`, `consolidator.py`) — three surfaces, since `failed_consolidation` structurally cannot report a failure bisection recovered from:

- `hindsight.consolidation.batch_failures`, a counter labelled by `failure_class` (`fail_fast` / `retry` / `propagate`) and `error_type`, so schema rejections stay separable from transport-shaped retries.
- `llm_batch_failures` in the consolidation job's stats dict.
- A warning line in the run's log summary, emitted only when non-zero, so a healthy summary is unchanged.

Both counts are **attempts**, not batch calls — one call retried three times contributes three — and recording happens on the exception path only, so a successful batch costs nothing.

## Tests

`test_consolidation_delete_schema.py` (10) — the `id` alias; the canonical name still working; a delete naming nothing still failing closed; the JSON schema unchanged; both prompt rules; and end to end, a supersession delete landing under either field name, plus a no-identifier delete failing closed while the run now reports it.

`test_consolidation_batch_failure_visibility.py` (5) — the reported symptom (3 validation failures, `failed_consolidation == 0`, counter reports 3); retried attempts each counted; a clean run still reporting zero; and the contrast case where bisection cannot rescue, so gauge and counter both fire.

`test_consolidation_delete_prompt_llm.py` — `hs_llm_core` prompt-following check against a real model.

## Notes for review

- **Two judgement calls worth a look.** Example 3 shows a delete, and processing rule 7 tells the model to be conservative about deletes — worth a second opinion on whether the example shifts the delete rate. And the real-LLM test's strict assertion is conditional by design: *whether* a delete is emitted is a model judgement, so it asserts that every delete emitted names a real observation id, plus (unconditionally) that the response validated at all — which is the #4152 failure.
- The system prompt is the Gemini context-cache prefix; adding Example 3 busts that cache once, then it re-warms.
- `_DeleteAction`'s `id` alias is *not* wired into the OpenAPI surface — it's an internal LLM response model, so no client regeneration.
