### PR TITLE
fix(coding-agents): scope knowledge pages to the bank, not the session's cwd (#4146)

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/bank-project-name.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank-project-name.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Same seam as bank.test.ts: state what the repository layout probe says, assert what is derived.
+vi.mock("./git-layout", () => ({ probeGitLayout: vi.fn() }));
+
+import { bankProjectName, deriveBankId } from "./bank";
+import { probeGitLayout } from "./git-layout";
+import { pagesFor } from "./missions";
+
+const mockProbe = vi.mocked(probeGitLayout);
+const inRepo = (commonDir: string, bare = false) =>
+  ({ status: "resolved", commonDir, bare }) as const;
+
+/**
+ * #4146: the seeded knowledge pages carry a scope sentence naming the repository they are about,
+ * and that sentence is PATCHed onto pages that outlive the session. Deriving it from the session's
+ * cwd made it a property of whoever ran last: on a bank several repositories share, every session
+ * start rewrote all five pages to its own repo and the previous repo's synthesis was thrown away.
+ *
+ * The name may therefore only be answered when the BANK and the REPOSITORY are the same unit.
+ */
+describe("bankProjectName", () => {
+  beforeEach(() => {
+    mockProbe.mockReturnValue({ status: "absent" }); // default: not in a git repo
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("a bank the repository owns", () => {
+    it("names the repo under the default template, matching the bank id's own {gitProject}", () => {
+      mockProbe.mockReturnValue(inRepo("/home/me/dev/myrepo/.git"));
+      expect(bankProjectName({}, "/home/me/dev/myrepo")).toBe("myrepo");
+      expect(deriveBankId({}, "/home/me/dev/myrepo")).toBe("coding-agent::myrepo");
+    });
+
+    it("gives every linked worktree the same name, as the shared bank id does", () => {
+      mockProbe.mockReturnValue(inRepo("/home/me/dev/myrepo/.git"));
+      const main = bankProjectName({}, "/home/me/dev/myrepo");
+      const worktree = bankProjectName({}, "/home/me/dev/.worktrees/myrepo-233");
+      expect(worktree).toBe(main);
+      expect(worktree).toBe("myrepo");
+    });
+
+    it("answers for a custom template that still keys on {gitProject}", () => {
+      mockProbe.mockReturnValue(inRepo("/home/me/dev/myrepo/.git"));
+      const cfg = { bankIdTemplate: "{harness}-{gitProject}" };
+      expect(bankProjectName(cfg, "/home/me/dev/myrepo")).toBe("myrepo");
+    });
+
+    it("honours resolveWorktrees:false — the SAME call the bank id makes, not a second one", () => {
+      mockProbe.mockReturnValue(inRepo("/home/me/dev/myrepo/.git"));
+      const cfg = { resolveWorktrees: false };
+      // The bank is per-WORKTREE here, so the page scope must be too, or a bank named after the
+      // worktree would carry a sentence naming the main repo.
+      expect(bankProjectName(cfg, "/home/me/dev/myrepo-wt")).toBe("myrepo-wt");
+      expect(deriveBankId(cfg, "/home/me/dev/myrepo-wt")).toBe("coding-agent::myrepo-wt");
+      expect(mockProbe).not.toHaveBeenCalled();
+    });
+
+    it("names the session's starting directory outside a repository, as the bank id does", () => {
+      expect(bankProjectName({}, "/home/me/scratch")).toBe("scratch");
+    });
+  });
+
+  describe("a bank no single repository owns", () => {
+    it("declines for a static bankId — the reported configuration", () => {
+      mockProbe.mockReturnValue(inRepo("/work/one-repo/.git"));
+      expect(bankProjectName({ bankId: "shared_bank_id" }, "/work/one-repo")).toBeUndefined();
+    });
+
+    it("declines for dynamicBankId:false", () => {
+      mockProbe.mockReturnValue(inRepo("/work/one-repo/.git"));
+      const cfg = { bankId: "shared_bank_id", dynamicBankId: false };
+      expect(bankProjectName(cfg, "/work/one-repo")).toBeUndefined();
+    });
+
+    it("declines for a mapPathToBank destination, which many paths may share", () => {
+      mockProbe.mockReturnValue(inRepo("/work/one-repo/.git"));
+      const cfg = { mapPathToBank: { "/work": "workspace" } };
+      expect(bankProjectName(cfg, "/work/one-repo")).toBeUndefined();
+      expect(deriveBankId(cfg, "/work/one-repo")).toBe("workspace");
+    });
+
+    it("declines for a template that does not key on the repository", () => {
+      mockProbe.mockReturnValue(inRepo("/work/one-repo/.git"));
+      // {project} is the live directory basename — it names a subdirectory as readily as a repo.
+      expect(bankProjectName({ bankIdTemplate: "{project}" }, "/work/one-repo")).toBeUndefined();
+      expect(bankProjectName({ bankIdTemplate: "{user}-{channel}" }, "/work/x")).toBeUndefined();
+    });
+  });
+
+  it("returns undefined rather than throwing when the probe cannot name the repository", () => {
+    mockProbe.mockReturnValue({ status: "failed", reason: "EAGAIN" });
+    // deriveBankId refuses to guess here (#3950) because a wrong bank id is permanent; a page
+    // scope name is not identity, so the caller falls back to the bank id instead of crashing.
+    expect(bankProjectName({}, "/home/me/dev/myrepo-wt1")).toBeUndefined();
+    expect(() => deriveBankId({}, "/home/me/dev/myrepo-wt1")).toThrow();
+  });
+
+  it("keeps the seeded page queries identical across repos on a shared bank (#4146 repro)", () => {
+    const cfg = { bankId: "shared_bank_id" };
+    const BANK = "shared_bank_id";
+
+    mockProbe.mockReturnValue(inRepo("/work/one-repo/.git"));
+    const fromRepoA = pagesFor(bankProjectName(cfg, "/work/.worktrees/one-repo-233") ?? BANK);
+
+    mockProbe.mockReturnValue({ status: "absent" });
+    const fromWorkspaceRoot = pagesFor(bankProjectName(cfg, "/work") ?? BANK);
+
+    // Same text => `seedPages()` sees no source drift => no PATCH, no page regeneration.
+    expect(fromWorkspaceRoot).toEqual(fromRepoA);
+    for (const page of fromRepoA) expect(page.source_query).toContain("shared_bank_id");
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/bank.ts
+++ b/hindsight-integrations/coding-agents/src/core/bank.ts
@@ -268,6 +268,20 @@ export function isOptedIn(config: BankConfig, directory: string): boolean {
   return Boolean(pathMap && directories.some((candidate) => mapLookup(pathMap, candidate)));
 }
 
+/** The `mapPathToBank` destination for a directory, if any — resolution step 1, shared by
+ *  `deriveBankId` and `bankProjectName` so the two cannot disagree about which step applied. */
+function mappedBank(
+  config: BankConfig,
+  directory: string,
+  sessionRoot?: string
+): string | undefined {
+  const pathMap = config.mapPathToBank;
+  if (!directory || !pathMap) return undefined;
+  return lookupDirectories(config, directory, sessionRoot)
+    .map((candidate) => mapLookup(pathMap, candidate))
+    .find((bank) => bank !== undefined);
+}
+
 /** Derive the bank id for a working directory (see module doc for the resolution order). */
 export function deriveBankId(
   config: BankConfig,
@@ -279,13 +293,7 @@ export function deriveBankId(
    *  entry this directory inherits (lookupDirectories). */
   sessionRoot?: string
 ): string {
-  const pathMap = config.mapPathToBank;
-  const mapped =
-    directory && pathMap
-      ? lookupDirectories(config, directory, sessionRoot)
-          .map((candidate) => mapLookup(pathMap, candidate))
-          .find((bank) => bank !== undefined)
-      : undefined;
+  const mapped = mappedBank(config, directory, sessionRoot);
   if (mapped) return mapped;
 
   // dynamic by default — but an explicit bankId (without dynamicBankId: true) means "static".
@@ -300,6 +308,48 @@ export function deriveBankId(
     user: () => process.env.HINDSIGHT_USER_ID || "anonymous",
   };
   return applyTemplate(config.bankIdTemplate || DEFAULT_TEMPLATE, resolvers, "bankIdTemplate");
+}
+
+/**
+ * The repository a BANK is about, or undefined when no single repository is.
+ *
+ * Distinct from `deriveBankId`'s `{gitProject}` in what it is a property OF. Both read the session's
+ * working directory, but a bank id derived from `{gitProject}` moves with the directory in lockstep
+ * with this name, so the two can never disagree; a bank id that does NOT come from the directory —
+ * a static `bankId`, a `mapPathToBank` destination, a template keyed on `{channel}` — can collect
+ * several repositories, and naming one of them after whichever session happened to run last is how
+ * the seeded knowledge pages ended up flipping their scope sentence between repos on every session
+ * start (#4146). Callers write this into per-BANK state, so it may only be answered when the bank
+ * and the repository are the same unit; `undefined` means "this bank is not one repo's" and leaves
+ * the caller to name it some other way.
+ *
+ * Deliberately failure-tolerant where `deriveBankId` refuses to guess: a probe that cannot name the
+ * repository yields `undefined` rather than throwing, because the strict rule protects bank
+ * IDENTITY (#3950) and nothing here decides which bank is written to.
+ */
+export function bankProjectName(
+  config: BankConfig,
+  directory: string,
+  sessionRoot?: string
+): string | undefined {
+  if (mappedBank(config, directory, sessionRoot)) return undefined;
+
+  const dynamic = config.dynamicBankId ?? !config.bankId;
+  if (!dynamic) return undefined;
+
+  // Only `{gitProject}` ties the id to the repository. `{project}` is the live directory basename
+  // and names a subdirectory as readily as a repo, so it does not qualify.
+  const template = config.bankIdTemplate || DEFAULT_TEMPLATE;
+  if (!template.includes("{gitProject}")) return undefined;
+
+  try {
+    // The IDENTICAL call `deriveBankId` makes for the placeholder, `resolveWorktrees` and
+    // `sessionRoot` included — a second, subtly different derivation is the bug being fixed.
+    return gitProjectName(directory, config.resolveWorktrees ?? true, sessionRoot);
+  } catch (error) {
+    if (error instanceof BankResolutionError) return undefined;
+    throw error;
+  }
 }
 
 /**

--- a/hindsight-integrations/coding-agents/src/core/hindsight.ts
+++ b/hindsight-integrations/coding-agents/src/core/hindsight.ts
@@ -93,8 +93,10 @@ export interface ClientOpts {
   apiToken?: string;
   bank: string;
   /** Repository this bank is about, named in every seeded page's query (`pageScopeRule`). Only
-   *  `seedPages()` reads it; it falls back to the bank id, which carries the repo name in the
-   *  default `coding-agent::{gitProject}` template. */
+   *  `seedPages()` reads it. Undefined when no single repository is (a shared static bank, a path
+   *  map, a bank several repos are renamed onto) — the query then names the BANK, which is the
+   *  only stable subject such a bank has. Must be a property of the bank and never of the calling
+   *  session's cwd: see `bankProjectName` (#4146). */
   project?: string;
   log?: (msg: string) => void;
   /** Cap on concurrent retain-related requests (drain op polls, deepen pools). Default 10. */
@@ -623,6 +625,9 @@ export class HindsightClient {
    * which is how `pageScopeRule`'s repo name reaches banks seeded by an earlier version.
    */
   async seedPages(pageTrigger: PageTrigger = buildPageTrigger()): Promise<void> {
+    // The bank id is the fallback subject, not a degraded one: for a bank no single repository
+    // owns it is the only name that stays put across sessions, and under the default
+    // `coding-agent::{gitProject}` template `project` is always set, so it never applies there.
     const pages = pagesFor(this.project ?? this.bank);
     const existing = new Map<string, KnowledgeNode>();
     let roots: KnowledgeNode[];
@@ -695,7 +700,8 @@ export class HindsightClient {
       }
     }
     this.log(
-      `[bank] knowledge pages seeded on ${this.bank}: ${created} created, ${updated} re-synced, ` +
+      `[bank] knowledge pages seeded on ${this.bank} (scoped to ${this.project ?? this.bank}): ` +
+        `${created} created, ${updated} re-synced, ` +
         `${pages.length - created - updated} unchanged`
     );
   }

--- a/hindsight-integrations/coding-agents/src/core/missions.ts
+++ b/hindsight-integrations/coding-agents/src/core/missions.ts
@@ -194,7 +194,12 @@ export interface KnowledgePage {
 }
 
 /**
- * The subject-scoping clause every seeded page's query carries, naming the repository it is about.
+ * The subject-scoping clause every seeded page's query carries, naming the subject it is about.
+ *
+ * `project` is the repository when the bank is one repository's, and the BANK otherwise — a bank
+ * several repos share has no repo to name, and naming whichever one seeded last made the sentence
+ * flip on every session start (#4146). Either way it must be stable for the bank, because the
+ * clause is PATCHed onto pages that outlive the session.
  *
  * A bank collects everything said IN a repository, which is NOT the same as everything said ABOUT
  * it: a repo that reads its dependency's source, drafts its upstream issues, or documents how it
@@ -269,10 +274,11 @@ const PAGE_TAXONOMY: readonly KnowledgePage[] = [
 ];
 
 /**
- * The seeded pages for one repository: the taxonomy above with `project` named in every query.
+ * The seeded pages for one subject: the taxonomy above with `project` named in every query.
  *
- * A pure function of `project`, so the query text is STABLE for a given repo and `seedPages()`
- * PATCHes once (on the upgrade that introduces the clause) rather than on every deepen run.
+ * A pure function of `project`, so the query text is STABLE for a given subject and `seedPages()`
+ * PATCHes once (on the upgrade that introduces the clause) rather than on every deepen run — which
+ * holds only while the caller's `project` is itself stable per bank (see `bankProjectName`).
  */
 export function pagesFor(project: string): KnowledgePage[] {
   const scope = pageScopeRule(project);

--- a/hindsight-integrations/coding-agents/src/deepen.ts
+++ b/hindsight-integrations/coding-agents/src/deepen.ts
@@ -23,7 +23,7 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { deriveBankIdOrSkip } from "./core/bank";
+import { bankProjectName, deriveBankIdOrSkip } from "./core/bank";
 import { ingestChats } from "./core/chat";
 import { applyBankConfig, loadConfig } from "./core/config";
 import { commitsSince, repoNameOf, retainCommit, syncGitLog } from "./core/git";
@@ -63,6 +63,10 @@ if (cfg.disabled) {
   process.exit(0);
 }
 const HARNESS = arg("harness") ?? cfg0.harness;
+// The repository name the seeded knowledge pages are scoped to — see the `project` option below.
+// `resolved0.bankId !== BANK` means a `banks.<id>.bank` rename redirected this run, and several
+// repos may be renamed onto one destination, so the repo cannot claim to name it.
+const PAGE_PROJECT = REPO && resolved0.bankId === BANK ? bankProjectName(cfg, REPO) : undefined;
 const API_URL = arg("api-url") ?? cfg.apiUrl;
 const API_TOKEN = arg("api-token") ?? cfg.apiToken;
 const CONV = arg("conversations");
@@ -137,9 +141,14 @@ async function main() {
       apiToken: API_TOKEN,
       bank: FINAL_BANK!,
       // Names the repository in every seeded page's query, so page synthesis can tell this
-      // project's decisions from those of a dependency it merely discusses (#3476). Same
-      // worktree-aware name the gitlog document id uses, so all worktrees agree on it.
-      project: repoNameOf(REPO!),
+      // project's decisions from those of a dependency it merely discusses (#3476).
+      //
+      // A property of the BANK, not of this run's cwd: the query is PATCHed onto pages that
+      // outlive the session, so a bank several repos share must not be told it is whichever one
+      // ran last (#4146). `bankProjectName` answers only when the bank IS this repo's; the
+      // `banks.<id>.bank` rename below it can point many repos at one destination, so a renamed
+      // bank is not this repo's either. Undefined leaves the client to fall back to the bank id.
+      project: PAGE_PROJECT,
       maxParallelRetains: cfg.maxParallelRetains,
       observationScopes: cfg.observationScopes,
       log,


### PR DESCRIPTION
Fixes #4146.

## The bug

Each seeded taxonomy page's `source_query` ends with a scoping sentence naming the repository it is about — "Scope this page to `<repo>` ITSELF … leave out dependencies" (#3476) — and `seedPages()` PATCHes that text onto the live page whenever it drifts.

`deepen.ts` built the name with `repoNameOf(REPO)`: the repo of the session that happened to run. But the pages it writes to belong to the **bank**. When the bank is one repository's, the two agree by construction. When it isn't — a static `bankId`, a `mapPathToBank` destination — they don't, and the reporter's setup (22 repos, one bank) rewrote all five pages to whichever repo started a session:

```
23:10  session in .worktrees/one-repo-233   -> "Scope this page to one-repo ITSELF"    5 re-synced
23:28  session in the workspace root        -> "Scope this page to parent-dir ITSELF"  5 re-synced
```

Every flip regenerates five pages, and in between they describe one sub-repo and drop the other twenty-one. `node dist/deepen.js --repo <A>` then `--repo <B>` reproduces it: the second run logs `5 re-synced`.

Nothing was wrong with worktree resolution — `resolveWorktrees` mapped the linked worktree to `one-repo` correctly, and that correct answer is precisely what disagreed with the next session's equally correct `parent-dir`.

## The fix

`bankProjectName()` answers the repo name only when the bank **is** that repository's — i.e. its id came from `{gitProject}` — and `undefined` otherwise, letting `seedPages()`'s existing `?? this.bank` fallback name the bank. That fallback was already there and already correct; it was simply unreachable, because `repoNameOf` always returns a name.

|  | scope name |
|---|---|
| default `coding-agent::{gitProject}` | the repo — unchanged |
| custom template containing `{gitProject}` | the repo |
| static `bankId` / `dynamicBankId: false` | the bank id |
| `mapPathToBank` destination | the bank id |
| template without `{gitProject}` (`{project}`, `{channel}`) | the bank id |
| `banks.<id>.bank` rename | the bank id |

It calls the **identical** `gitProjectName(directory, config.resolveWorktrees ?? true, sessionRoot)` that `deriveBankId` uses for the placeholder. `repoNameOf` honoured neither `resolveWorktrees` nor `sessionRoot`, so a `resolveWorktrees: false` setup was already getting a bank named after the worktree and a page sentence naming the main repo — a second, quieter instance of the same class of bug, fixed here too.

Where `deriveBankId` refuses to guess on a failed probe (#3950), this returns `undefined`: that rule protects bank *identity*, and a page's scope name decides nothing about which bank is written to.

## Blast radius

None for the default configuration. The bank id's `{gitProject}` and this name move together, so the query text is byte-identical and no existing page is PATCHed. Shared-bank users get one PATCH to the bank-scoped wording on their next deepen run, then stability.

I did **not** add the `pageProject` setting the issue proposes — the name is derivable from configuration that already exists, so a new knob would be a second source of truth for the same fact.

## Also

The seed log now names the resolved scope, because the flip was invisible in `plugin.log` and only diagnosable by `GET`ting a page:

```
[bank] knowledge pages seeded on shared_bank_id (scoped to shared_bank_id): 0 created, 0 re-synced, 5 unchanged
```

## Tests

`src/core/bank-project-name.test.ts` — 11 cases: the owned-bank paths (default template, worktree agreement, custom `{gitProject}` template, `resolveWorktrees: false`, outside a repo), each not-owned path, probe failure, and the issue's repro asserting the seeded queries are identical from two different repos on a shared bank.
