### PR TITLE
fix(ci): unbreak test-api — the call envelope and the temporal golden corpus

### DIFF
--- a/hindsight-api-slim/tests/test_opencode_go_session_header.py
+++ b/hindsight-api-slim/tests/test_opencode_go_session_header.py
@@ -107,7 +107,7 @@ async def test_session_id_is_stable_across_provider_retries():
             initial_backoff=0,
         )
 
-    assert result.ok is True
+    assert result.content.ok is True
     first, second = _sent_session_ids(create)
     assert first and second
     assert first == second, "retries of one operation must reuse the session id"


### PR DESCRIPTION
## Problem

`test-api` is red on every branch off `main`. Two unrelated PR-crossings, three failing jobs (shards 2/3 and 3/3, plus free-threaded 3.14):

```
FAILED tests/test_opencode_go_session_header.py::test_session_id_is_stable_across_provider_retries
  - AttributeError: 'LLMCallResult' object has no attribute 'ok'
FAILED tests/test_named_result_stubs.py::test_a_call_result_binding_is_only_read_through_its_fields
  - AssertionError: tests/test_opencode_go_session_header.py:110 uses 'result'
    (bound from await ....call() at line 103) as the payload — read .content
FAILED tests/test_temporal_extraction.py::test_golden_corpus_unchanged
  - AssertionError: 10 behavioural changes
```

Both breaks share a shape: a PR that was green on its own base, merged after another PR moved the ground under it. Neither could have been caught by its own CI, and both merged cleanly because the conflict is semantic, not textual.

### 1. The call envelope (#4122 × #4084)

#4122 changed `LLMInterface.call` to return a named `LLMCallResult` (`content` + `usage`) instead of the bare parsed response. #4084 was written against the old shape and merged after it, so its retry test still read `result.ok` — the field belongs to the `SimpleJsonResponse` the provider parsed, which now lives at `result.content`.

The second failure is not a separate defect: it is the structural guard #4122 added for exactly this — a name bound from `await ....call()` read as if it were the payload. The guard was right, and it goes green with the same one-line fix.

### 2. The temporal golden corpus (#4076)

#4076 deliberately changed what "last weekend" resolves to when the reference date is itself a weekend day: asked on a Sunday it now means the previous weekend, not the Saturday-plus-today window in progress. It added the direct coverage in `test_query_analyzer.py` but left `tests/data/query_analyzer_golden.json` recording the old answers — and that file is the compatibility oracle `test_golden_corpus_unchanged` reads, whose whole job is to fail when any answer changes.

This one is datable to the minute: the test passed at 08:54 UTC today and failed at 09:24, with #4076 merging at 09:04 in between.

## Fix

- Read the parsed model through `.content`, as every other caller does.
- Re-snapshot the golden corpus with `HS_REGEN_GOLDEN=1`.

Only the Sunday reference date (`2026-08-09`) moves in the corpus, and only its ten "last weekend" spellings across the seven supported languages — English, Spanish, French, German, Italian, Russian and Chinese. Every other reference date is byte-identical, which is precisely what #4076 predicted for Monday through Saturday.

## Tests

- `tests/test_opencode_go_session_header.py` + `tests/test_named_result_stubs.py` — 537 passed.
- `tests/test_temporal_extraction.py::test_golden_corpus_unchanged` + `tests/test_query_analyzer.py` — 486 passed.

Both previously-failing tests included.
