### PR TITLE
fix(api): 404 bank-scoped reads for a bank that does not exist (#4175)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -7298,7 +7298,6 @@ def _register_routes(app: FastAPI):
         operation_id="get_bank_profile",
         tags=["Banks"],
         deprecated=True,
-        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_get_bank_profile(bank_id: str, request_context: RequestContext = Depends(get_request_context)):
         """Removed bank-profile read — always 410, pointing at the bank config API."""

--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -252,6 +252,12 @@ def _internal_error(exc: Exception, where: str) -> HTTPException:
 # 499 is the de facto reverse-proxy status for "client closed request".
 _CLIENT_CLOSED_REQUEST_STATUS_CODE = 499
 
+# Declared on every bank-scoped read so a generated client can tell "this bank
+# does not exist" apart from "this bank is empty" (#4175). Without it the spec
+# advertises only 200/422 and a consumer has no documented missing-bank case.
+_BANK_NOT_FOUND_RESPONSES: dict[int | str, dict[str, Any]] = {404: {"description": "The bank does not exist."}}
+
+
 _T = TypeVar("_T")
 
 
@@ -4901,6 +4907,7 @@ def _register_routes(app: FastAPI):
         description="Retrieve graph data for visualization, optionally filtered by type (world/experience/observation).",
         operation_id="get_graph",
         tags=["Memory"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_graph(
         bank_id: str,
@@ -4941,6 +4948,7 @@ def _register_routes(app: FastAPI):
         description="List memory units with pagination and optional full-text search. Supports filtering by type, source document, and linked entity ID. Results are sorted by most recent first (mentioned_at DESC, then created_at DESC).",
         operation_id="list_memories",
         tags=["Memory"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list(
         bank_id: str,
@@ -5607,6 +5615,7 @@ def _register_routes(app: FastAPI):
         description="Get statistics about nodes and links for a specific agent",
         operation_id="get_agent_stats",
         tags=["Banks"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_stats(
         bank_id: str,
@@ -5699,6 +5708,7 @@ def _register_routes(app: FastAPI):
         description="Memories ingested over a period, bucketed by time and broken down by fact type.",
         operation_id="get_memories_timeseries",
         tags=["Banks"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_memories_timeseries(
         bank_id: str,
@@ -5733,6 +5743,7 @@ def _register_routes(app: FastAPI):
         description="List all entities (people, organizations, etc.) known by the bank, ordered by mention count. Supports pagination.",
         operation_id="list_entities",
         tags=["Entities"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list_entities(
         bank_id: str,
@@ -5765,6 +5776,7 @@ def _register_routes(app: FastAPI):
         description="Return a graph of entities (nodes) and their co-occurrences (edges) for visualization.",
         operation_id="get_entity_graph",
         tags=["Entities"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_entity_graph(
         bank_id: str,
@@ -5855,6 +5867,7 @@ def _register_routes(app: FastAPI):
         description="List user-curated living documents that stay current.",
         operation_id="list_mental_models",
         tags=["Mental Models"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list_mental_models(
         bank_id: str,
@@ -6219,6 +6232,7 @@ def _register_routes(app: FastAPI):
         description="Return the knowledge base as a nested tree of folders and pages.",
         operation_id="get_knowledge_base_tree",
         tags=["Knowledge Base"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_knowledge_base_tree(
         bank_id: str,
@@ -6329,6 +6343,7 @@ def _register_routes(app: FastAPI):
         description="Return a portable markdown bundle: a nested index.md, one <id>.md per page, and history logs.",
         operation_id="export_knowledge_base",
         tags=["Knowledge Base"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_export_knowledge_base(
         bank_id: str,
@@ -6374,6 +6389,7 @@ def _register_routes(app: FastAPI):
         ),
         operation_id="search_knowledge_base",
         tags=["Knowledge Base"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_search_knowledge_base(
         bank_id: str,
@@ -6532,6 +6548,7 @@ def _register_routes(app: FastAPI):
         description="List directive definitions. Unlike reflect, an omitted tag filter returns all directives.",
         operation_id="list_directives",
         tags=["Directives"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list_directives(
         bank_id: str,
@@ -6712,6 +6729,7 @@ def _register_routes(app: FastAPI):
         description="List documents with pagination and optional search, most recently written first (`updated_at` descending). Documents are the source content from which memory units are extracted.",
         operation_id="list_documents",
         tags=["Documents"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list_documents(
         bank_id: str,
@@ -6890,6 +6908,7 @@ def _register_routes(app: FastAPI):
         "Use `source=mental_models` to list tags used on mental models instead of memories.",
         operation_id="list_tags",
         tags=["Memory"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list_tags(
         bank_id: str,
@@ -7077,6 +7096,7 @@ def _register_routes(app: FastAPI):
         description="Get a list of async operations for a specific agent, with optional filtering by status and operation type. Results are sorted by most recent first.",
         operation_id="list_operations",
         tags=["Operations"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list_operations(
         bank_id: str,
@@ -7278,6 +7298,7 @@ def _register_routes(app: FastAPI):
         operation_id="get_bank_profile",
         tags=["Banks"],
         deprecated=True,
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_get_bank_profile(bank_id: str, request_context: RequestContext = Depends(get_request_context)):
         """Removed bank-profile read — always 410, pointing at the bank config API."""
@@ -7527,6 +7548,7 @@ def _register_routes(app: FastAPI):
         "The exported manifest can be imported into another bank to replicate the setup.",
         operation_id="export_bank_template",
         tags=["Bank Templates"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_export_bank_template(
         bank_id: str,
@@ -7904,6 +7926,7 @@ def _register_routes(app: FastAPI):
         ),
         operation_id="list_observation_scopes",
         tags=["Memory"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list_observation_scopes(
         bank_id: str,
@@ -7988,6 +8011,7 @@ def _register_routes(app: FastAPI):
         "Always available: HINDSIGHT_API_ENABLE_BANK_CONFIG_API gates only the write operations on this resource.",
         operation_id="get_bank_config",
         tags=["Banks"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_get_bank_config(bank_id: str, request_context: RequestContext = Depends(get_request_context)):
         """Get configuration for a bank with all hierarchical overrides applied.
@@ -8202,6 +8226,7 @@ def _register_routes(app: FastAPI):
         "Paged: `total` reports every webhook on the bank.",
         operation_id="list_webhooks",
         tags=["Webhooks"],
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list_webhooks(
         bank_id: str,
@@ -8881,6 +8906,7 @@ def _register_routes(app: FastAPI):
         operation_id="list_audit_logs",
         tags=["Audit"],
         response_model=AuditLogListResponse,
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list_audit_logs(
         bank_id: str,
@@ -8921,6 +8947,7 @@ def _register_routes(app: FastAPI):
         operation_id="audit_log_stats",
         tags=["Audit"],
         response_model=AuditLogStatsResponse,
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_audit_log_stats(
         bank_id: str,
@@ -8954,6 +8981,7 @@ def _register_routes(app: FastAPI):
         operation_id="list_llm_requests",
         tags=["LLM Traces"],
         response_model=LLMRequestListResponse,
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_list_llm_requests(
         bank_id: str,
@@ -9010,6 +9038,7 @@ def _register_routes(app: FastAPI):
         operation_id="llm_request_stats",
         tags=["LLM Traces"],
         response_model=LLMRequestStatsResponse,
+        responses=_BANK_NOT_FOUND_RESPONSES,
     )
     async def api_llm_request_stats(
         bank_id: str,

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -10418,6 +10418,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.LIST_OBSERVATION_SCOPES, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         backend = await self._get_backend()
         from .memories import get_memories
 
@@ -11193,6 +11194,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.GET_GRAPH_DATA, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         from .memories import get_memories
 
         store = get_memories()
@@ -11629,6 +11631,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.LIST_MEMORY_UNITS, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         from .memories import get_memories
 
         backend = await self._get_backend()
@@ -11737,6 +11740,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.LIST_DOCUMENTS, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
 
         # A store that owns its document metadata keeps no rows in the SQL `documents` table, so the
         # query below would return an empty page for it. List from the store's own registry instead.
@@ -12853,6 +12857,26 @@ class MemoryEngine(MemoryEngineInterface):
             "mission": resolved.mission,
         }
 
+    async def _require_bank_exists(self, bank_id: str) -> None:
+        """Raise a 404 when a bank-scoped read targets a bank that was never created.
+
+        Read endpoints must not answer for a bank nobody created. A 200 with
+        empty counters is indistinguishable from a healthy, empty bank, so a
+        typo'd, renamed or deleted ``bank_id`` silently passes any monitor built
+        on ``/stats`` or ``/memories/list`` (#4175). Callers invoke this after
+        their own authentication and read authorization, so the check neither
+        widens what a request is allowed to see nor creates the bank.
+
+        The profile row is cached per process (see ``bank_info_cache``), so on an
+        existing bank this costs no query; a missing bank is never cached, so it
+        stays one cheap read.
+        """
+        backend = await self._get_backend()
+        if await bank_utils.get_bank_profile_if_exists(backend, bank_id) is None:
+            from hindsight_api.extensions import OperationValidationError
+
+            raise OperationValidationError(f"Bank '{bank_id}' not found", status_code=404)
+
     async def _ensure_bank_exists(
         self,
         bank_id: str,
@@ -12983,6 +13007,7 @@ class MemoryEngine(MemoryEngineInterface):
                 request_context=request_context,
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(context))
+        await self._require_bank_exists(bank_id)
         return await self._get_bank_config_authenticated(bank_id, request_context)
 
     async def update_bank_config(
@@ -14217,6 +14242,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.LIST_ENTITIES, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         from .memories import get_memories
 
         backend = await self._get_backend()
@@ -14254,6 +14280,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.GET_ENTITY_GRAPH, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
 
         # A store that owns its entities keeps no rows in the SQL entity_cooccurrences/entities
         # tables, so the query below would return an empty graph. Read the store's own aggregate.
@@ -14419,6 +14446,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.LIST_TAGS, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         # Tags live with the memories, so the store owns the histogram and applies
         # the wildcard filter, ordering (count desc, tag asc) and paging — on the
         # SQL stores that is one paged query, never the whole histogram over the wire.
@@ -14455,6 +14483,7 @@ class MemoryEngine(MemoryEngineInterface):
                 request_context=request_context,
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         return await self._list_tags_from_table(
             table="mental_models",
             bank_id=bank_id,
@@ -14591,6 +14620,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.GET_BANK_STATS, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
 
         return await self._cached_bank_stats(bank_id, force_refresh=force_refresh)
 
@@ -14845,6 +14875,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.GET_MEMORIES_TIMESERIES, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
 
         cfg = _MEMORIES_TIMESERIES_PERIODS.get(period) or _MEMORIES_TIMESERIES_PERIODS["7d"]
         if period not in _MEMORIES_TIMESERIES_PERIODS:
@@ -15049,6 +15080,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.LIST_MENTAL_MODELS, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         backend = await self._get_backend()
 
         async with acquire_with_retry(backend) as conn:
@@ -17807,6 +17839,7 @@ class MemoryEngine(MemoryEngineInterface):
                 request_context=request_context,
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             rows = await conn.fetch(
@@ -17926,6 +17959,7 @@ class MemoryEngine(MemoryEngineInterface):
                 request_context=request_context,
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         query = (query or "").strip()
         if not query:
             return []
@@ -18377,6 +18411,7 @@ class MemoryEngine(MemoryEngineInterface):
                 request_context=request_context,
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
 
         with _authorize_nested_operations():
             nodes = await self.list_knowledge_nodes(bank_id=bank_id, request_context=request_context)
@@ -18741,6 +18776,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.LIST_DIRECTIVES, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         backend = await self._get_backend()
 
         async with acquire_with_retry(backend) as conn:
@@ -19094,6 +19130,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.LIST_OPERATIONS, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
         backend = await self._get_backend()
 
         async with acquire_with_retry(backend) as conn:
@@ -19839,6 +19876,7 @@ class MemoryEngine(MemoryEngineInterface):
                 bank_id=bank_id, operation=BankReadOperation.LIST_WEBHOOKS, request_context=request_context
             )
             await self._validate_operation(self._operation_validator.validate_bank_read(ctx))
+        await self._require_bank_exists(bank_id)
 
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:

--- a/hindsight-api-slim/tests/test_bank_scoped_read_404.py
+++ b/hindsight-api-slim/tests/test_bank_scoped_read_404.py
@@ -9,6 +9,10 @@ a typo in ``bank_id`` was never surfaced at all.
 The check runs after each endpoint's own read authorization, so it widens nothing:
 a caller that may not read the bank still gets its usual authorization error, not
 a 404 that would leak the bank's existence.
+
+The endpoint list is derived from the app's own routing table rather than written
+out by hand, so a bank-scoped collection GET added later is covered the day it
+lands instead of the day someone remembers to extend this file.
 """
 
 import uuid
@@ -16,67 +20,99 @@ import uuid
 import httpx
 import pytest
 import pytest_asyncio
+from fastapi.routing import APIRoute
 
 from hindsight_api import RequestContext
 from hindsight_api.api import create_app
 
+_BANK_PREFIX = "/v1/default/banks/{bank_id}"
+
+# Query params without which a route is a 422 before it ever reaches the handler.
+_REQUIRED_PARAMS: dict[str, dict[str, str]] = {
+    "/knowledge-base/search": {"q": "anything"},
+}
+
+# Bank-scoped GETs deliberately outside this contract.
+_EXEMPT: dict[str, str] = {
+    # Serves the bank's own stored files by storage key; a missing bank has no
+    # keys, so the 404 already comes from the file lookup.
+    "/files/{storage_key:path}": "404s on the missing file",
+    # Withdrawn endpoints: 410 Gone for every bank, existing or not, pointing at
+    # their replacements. There is nothing left to distinguish.
+    "/document-transfer": "410 Gone regardless of the bank",
+    "/profile": "410 Gone regardless of the bank",
+}
+
+
+def _bank_scoped_read_paths(app) -> list[str]:
+    """Every GET under /banks/{bank_id} whose answer is a collection or aggregate.
+
+    Sub-resource GETs (``/memories/{memory_id}``, ``/webhooks/{id}/deliveries``, …)
+    are excluded: they already 404 on the missing child, so a missing bank was
+    never mistaken for an empty one there. They are identified by carrying a
+    second path parameter.
+    """
+    paths = []
+    for route in app.routes:
+        if not isinstance(route, APIRoute) or "GET" not in route.methods:
+            continue
+        if not route.path.startswith(_BANK_PREFIX):
+            continue
+        suffix = route.path[len(_BANK_PREFIX) :]
+        if "{" in suffix or suffix in _EXEMPT:
+            continue
+        paths.append(suffix)
+    return sorted(set(paths))
+
+
+@pytest.fixture
+def app(memory):
+    return create_app(memory, initialize_memory=False)
+
 
 @pytest_asyncio.fixture
-async def api_client(memory):
-    app = create_app(memory, initialize_memory=False)
+async def api_client(app):
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
 
 
-# Every bank-scoped GET that aggregates or lists, i.e. the ones whose empty
-# answer is indistinguishable from "bank exists and is empty". Sub-resource GETs
-# (``/memories/{id}``, ``/mental-models/{id}``, ...) already 404 on the missing
-# child and are not listed here.
-READ_ENDPOINTS = [
-    ("graph", {}),
-    ("memories/list", {"limit": 1}),
-    ("stats", {}),
-    ("stats/memories-timeseries", {}),
-    ("entities", {}),
-    ("entities/graph", {}),
-    ("mental-models", {}),
-    ("knowledge-base/tree", {}),
-    ("knowledge-base/export", {}),
-    ("knowledge-base/search", {"q": "anything"}),
-    ("directives", {}),
-    ("documents", {}),
-    ("tags", {}),
-    ("operations", {}),
-    ("observations/scopes", {}),
-    ("config", {}),
-    ("webhooks", {}),
-]
+@pytest.fixture
+def read_paths(app):
+    return _bank_scoped_read_paths(app)
 
 
-def _url(bank_id: str, suffix: str) -> str:
-    return f"/v1/default/banks/{bank_id}/{suffix}"
+def test_the_route_scan_finds_the_endpoints_from_the_issue(read_paths):
+    # Guards the scan itself: if a refactor moved these routes or changed the
+    # prefix, every other test here would pass vacuously over an empty list.
+    assert "/stats" in read_paths
+    assert "/memories/list" in read_paths
+    assert len(read_paths) >= 15
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("suffix,params", READ_ENDPOINTS, ids=[s for s, _ in READ_ENDPOINTS])
-async def test_missing_bank_returns_404(api_client, suffix, params):
+async def test_missing_bank_returns_404(api_client, read_paths):
     bank_id = f"nosuch-{uuid.uuid4().hex[:8]}"
-    resp = await api_client.get(_url(bank_id, suffix), params=params)
-    assert resp.status_code == 404, resp.text
-    assert bank_id in resp.json()["detail"]
+    for suffix in read_paths:
+        resp = await api_client.get(
+            f"{_BANK_PREFIX.format(bank_id=bank_id)}{suffix}", params=_REQUIRED_PARAMS.get(suffix)
+        )
+        assert resp.status_code == 404, f"{suffix}: {resp.status_code} {resp.text}"
+        assert bank_id in resp.json()["detail"], suffix
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("suffix,params", READ_ENDPOINTS, ids=[s for s, _ in READ_ENDPOINTS])
-async def test_existing_empty_bank_still_returns_200(api_client, memory, suffix, params):
+async def test_existing_empty_bank_still_returns_200(api_client, memory, read_paths):
     # Positive control: an empty bank that DOES exist must keep answering 200,
-    # so the 404 above distinguishes "missing" from "empty" rather than
-    # replacing one indistinguishable answer with another.
+    # so the 404 above distinguishes "missing" from "empty" rather than replacing
+    # one indistinguishable answer with another.
     bank_id = f"empty-{uuid.uuid4().hex[:8]}"
     await memory.get_bank_profile(bank_id=bank_id, request_context=RequestContext())
-    resp = await api_client.get(_url(bank_id, suffix), params=params)
-    assert resp.status_code == 200, resp.text
+    for suffix in read_paths:
+        resp = await api_client.get(
+            f"{_BANK_PREFIX.format(bank_id=bank_id)}{suffix}", params=_REQUIRED_PARAMS.get(suffix)
+        )
+        assert resp.status_code == 200, f"{suffix}: {resp.status_code} {resp.text}"
 
 
 @pytest.mark.asyncio
@@ -84,6 +120,6 @@ async def test_read_does_not_create_the_bank(api_client, memory):
     # The 404 must come from a read-only existence check: a client polling a
     # stale bank_id must not silently materialise that bank.
     bank_id = f"nosuch-{uuid.uuid4().hex[:8]}"
-    assert (await api_client.get(_url(bank_id, "stats"))).status_code == 404
+    assert (await api_client.get(f"{_BANK_PREFIX.format(bank_id=bank_id)}/stats")).status_code == 404
     profile = await memory.get_bank_profile(bank_id, request_context=RequestContext(), create_if_missing=False)
     assert profile is None

--- a/hindsight-api-slim/tests/test_bank_scoped_read_404.py
+++ b/hindsight-api-slim/tests/test_bank_scoped_read_404.py
@@ -1,0 +1,89 @@
+"""Regression (#4175): bank-scoped read endpoints must 404 for a bank that does not exist.
+
+They used to answer 200 with an empty payload — zeroed counters from ``/stats``,
+an empty page from ``/memories/list`` — which is byte-identical to a healthy,
+freshly-created bank. Any monitor built on those endpoints therefore kept passing
+after the bank it watched was renamed, deleted or recreated under another id, and
+a typo in ``bank_id`` was never surfaced at all.
+
+The check runs after each endpoint's own read authorization, so it widens nothing:
+a caller that may not read the bank still gets its usual authorization error, not
+a 404 that would leak the bank's existence.
+"""
+
+import uuid
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from hindsight_api import RequestContext
+from hindsight_api.api import create_app
+
+
+@pytest_asyncio.fixture
+async def api_client(memory):
+    app = create_app(memory, initialize_memory=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+# Every bank-scoped GET that aggregates or lists, i.e. the ones whose empty
+# answer is indistinguishable from "bank exists and is empty". Sub-resource GETs
+# (``/memories/{id}``, ``/mental-models/{id}``, ...) already 404 on the missing
+# child and are not listed here.
+READ_ENDPOINTS = [
+    ("graph", {}),
+    ("memories/list", {"limit": 1}),
+    ("stats", {}),
+    ("stats/memories-timeseries", {}),
+    ("entities", {}),
+    ("entities/graph", {}),
+    ("mental-models", {}),
+    ("knowledge-base/tree", {}),
+    ("knowledge-base/export", {}),
+    ("knowledge-base/search", {"q": "anything"}),
+    ("directives", {}),
+    ("documents", {}),
+    ("tags", {}),
+    ("operations", {}),
+    ("observations/scopes", {}),
+    ("config", {}),
+    ("webhooks", {}),
+]
+
+
+def _url(bank_id: str, suffix: str) -> str:
+    return f"/v1/default/banks/{bank_id}/{suffix}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suffix,params", READ_ENDPOINTS, ids=[s for s, _ in READ_ENDPOINTS])
+async def test_missing_bank_returns_404(api_client, suffix, params):
+    bank_id = f"nosuch-{uuid.uuid4().hex[:8]}"
+    resp = await api_client.get(_url(bank_id, suffix), params=params)
+    assert resp.status_code == 404, resp.text
+    assert bank_id in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suffix,params", READ_ENDPOINTS, ids=[s for s, _ in READ_ENDPOINTS])
+async def test_existing_empty_bank_still_returns_200(api_client, memory, suffix, params):
+    # Positive control: an empty bank that DOES exist must keep answering 200,
+    # so the 404 above distinguishes "missing" from "empty" rather than
+    # replacing one indistinguishable answer with another.
+    bank_id = f"empty-{uuid.uuid4().hex[:8]}"
+    await memory.get_bank_profile(bank_id=bank_id, request_context=RequestContext())
+    resp = await api_client.get(_url(bank_id, suffix), params=params)
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_read_does_not_create_the_bank(api_client, memory):
+    # The 404 must come from a read-only existence check: a client polling a
+    # stale bank_id must not silently materialise that bank.
+    bank_id = f"nosuch-{uuid.uuid4().hex[:8]}"
+    assert (await api_client.get(_url(bank_id, "stats"))).status_code == 404
+    profile = await memory.get_bank_profile(bank_id, request_context=RequestContext(), create_if_missing=False)
+    assert profile is None

--- a/hindsight-api-slim/tests/test_bank_stats.py
+++ b/hindsight-api-slim/tests/test_bank_stats.py
@@ -13,6 +13,7 @@ import httpx
 import pytest
 import pytest_asyncio
 
+from hindsight_api import RequestContext
 from hindsight_api.api import create_app
 
 
@@ -24,9 +25,14 @@ async def api_client(memory):
         yield client
 
 
-@pytest.fixture
-def test_bank_id():
-    return f"stats_test_{datetime.now().timestamp()}"
+@pytest_asyncio.fixture
+async def test_bank_id(memory):
+    bank_id = f"stats_test_{datetime.now().timestamp()}"
+    # Create the bank. Bank-scoped reads 404 for a bank nobody created (#4175),
+    # so a stats test that only invents an id would exercise that path instead of
+    # the empty-bank one it is about.
+    await memory.get_bank_profile(bank_id, request_context=RequestContext())
+    return bank_id
 
 
 async def _insert_memory(memory, bank_id: str, text: str, *, failed: bool = False) -> str:

--- a/hindsight-api-slim/tests/test_knowledge_search_text_search_disabled.py
+++ b/hindsight-api-slim/tests/test_knowledge_search_text_search_disabled.py
@@ -59,8 +59,16 @@ def search(monkeypatch):
     async def fake_get_bank_config(bank_id, context=None):
         return resolved
 
+    async def fake_require_bank_exists(bank_id):
+        # The search 404s for a bank nobody created (#4175). That check reads the
+        # bank row through a real pool, which this engine — stubbed down to the one
+        # method under test — does not have. The SQL asserted below is emitted only
+        # for a bank that exists, so the stub says it does.
+        return None
+
     engine._authenticate_tenant = fake_authenticate
     engine._get_backend = fake_get_backend
+    engine._require_bank_exists = fake_require_bank_exists
     engine._config_resolver = SimpleNamespace(get_bank_config=fake_get_bank_config)
 
     @asynccontextmanager

--- a/hindsight-api-slim/tests/test_memories_extension.py
+++ b/hindsight-api-slim/tests/test_memories_extension.py
@@ -886,6 +886,11 @@ async def test_engine_list_tags_routes_through_the_installed_store(memory, reque
 
     await store.insert_facts(conn=None, ops=None, bank_id="seam-bank", facts=[_Fact()], document_id="d")
 
+    # The read 404s for a bank nobody created (#4175). A store owns the facts, never the bank row
+    # itself, so a real deployment always has this row — a retain writes it before the store sees
+    # anything. Only the stub reaches an engine read without one.
+    await memory.get_bank_profile("seam-bank", request_context=request_context)
+
     result = await memory.list_tags("seam-bank", request_context=request_context)
 
     assert result["items"] == [{"tag": "only-in-the-store", "count": 1}]
@@ -1103,6 +1108,7 @@ async def test_engine_list_memory_units_routes_through_store(memory, request_con
     store = InMemoryMemories({})
     set_memories(store)
     await _seed(store, "seam-bank", text="only in the store", fact_type="world")
+    await memory.get_bank_profile("seam-bank", request_context=request_context)  # see #4175 above
     res = await memory.list_memory_units("seam-bank", request_context=request_context)
     assert "list_memory_units" in store.calls
     assert res["total"] == 1  # the row exists only in the stub, so it can only have come from it
@@ -1144,6 +1150,7 @@ async def test_apply_edit_is_told_the_pre_edit_fact_type(memory, request_context
 async def test_engine_list_entities_routes_through_store(memory, request_context, restore_default_store):
     store = InMemoryMemories({})
     set_memories(store)
+    await memory.get_bank_profile("seam-bank", request_context=request_context)  # see #4175 above
     await memory.list_entities("seam-bank", request_context=request_context)
     assert "list_entities" in store.calls
 

--- a/hindsight-api-slim/tests/test_schema_isolation.py
+++ b/hindsight-api-slim/tests/test_schema_isolation.py
@@ -254,6 +254,17 @@ class TestSchemaIsolation:
         conn = await asyncpg.connect(pg0_db_url)
         try:
             for schema in schemas:
+                # The bank row goes in per schema too: list_memory_units 404s for a bank
+                # nobody created (#4175), and "created" is per tenant schema — which is
+                # part of what this test is about.
+                await conn.execute(
+                    f"""
+                    INSERT INTO "{schema}".banks (bank_id, name, disposition, mission, internal_id)
+                    VALUES ($1, $1, '{{"skepticism": 3, "literalism": 3, "empathy": 3}}'::jsonb, '', gen_random_uuid())
+                    ON CONFLICT (bank_id) DO NOTHING
+                    """,
+                    bank_id,
+                )
                 await conn.execute(
                     f"""
                     INSERT INTO "{schema}".memory_units (bank_id, text, event_date, fact_type)

--- a/hindsight-api-slim/tests/test_tags_visibility.py
+++ b/hindsight-api-slim/tests/test_tags_visibility.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 import pytest_asyncio
 
+from hindsight_api import RequestContext
 from hindsight_api.api import create_app
 from hindsight_api.engine.search.tags import (
     TagGroupAnd,
@@ -1414,9 +1415,11 @@ async def test_list_tags_pagination(api_client):
 
 
 @pytest.mark.asyncio
-async def test_list_tags_empty_bank(api_client):
+async def test_list_tags_empty_bank(api_client, memory):
     """Test that list_tags returns empty for bank with no tags."""
     bank_id = f"list_tags_empty_test_{datetime.now().timestamp()}"
+    # The bank has to exist: a bank nobody created is a 404, not an empty list (#4175).
+    await memory.get_bank_profile(bank_id, request_context=RequestContext())
 
     # List tags without storing anything
     response = await api_client.get(f"/v1/default/banks/{bank_id}/tags")

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -3032,8 +3032,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/BankProfileResponse'
           description: Successful Response
-        "404":
-          description: The bank does not exist.
         "422":
           content:
             application/json:

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -176,6 +176,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/GraphDataResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -308,6 +310,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListMemoryUnitsResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -715,6 +719,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/BankStatsResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -821,6 +827,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/MemoriesTimeseriesResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -883,6 +891,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/EntityListResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -944,6 +954,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/EntityGraphResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -1138,6 +1150,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/MentalModelListResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -1564,6 +1578,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/KnowledgeTreeResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -1689,6 +1705,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/KnowledgePageBundleResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -1752,6 +1770,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/KnowledgePageSearchResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -1997,6 +2017,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/DirectiveListResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -2268,6 +2290,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListDocumentsResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -2628,6 +2652,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListTagsResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -2760,6 +2786,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/OperationsListResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -3004,6 +3032,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/BankProfileResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -3316,6 +3346,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/BankTemplateManifest'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -3709,6 +3741,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ObservationScopesResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -3875,6 +3909,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/BankConfigResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -4026,6 +4062,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/WebhookListResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -4516,6 +4554,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuditLogListResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -4573,6 +4613,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuditLogStatsResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -4731,6 +4773,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/LLMRequestListResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:
@@ -4788,6 +4832,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/LLMRequestStatsResponse'
           description: Successful Response
+        "404":
+          description: The bank does not exist.
         "422":
           content:
             application/json:

--- a/hindsight-clients/python/hindsight_client_api/api/audit_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/audit_api.py
@@ -107,6 +107,7 @@ class AuditApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "AuditLogStatsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -187,6 +188,7 @@ class AuditApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "AuditLogStatsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -267,6 +269,7 @@ class AuditApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "AuditLogStatsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -435,6 +438,7 @@ class AuditApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "AuditLogListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -531,6 +535,7 @@ class AuditApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "AuditLogListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -627,6 +632,7 @@ class AuditApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "AuditLogListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/bank_templates_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/bank_templates_api.py
@@ -99,6 +99,7 @@ class BankTemplatesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankTemplateManifest",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -171,6 +172,7 @@ class BankTemplatesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankTemplateManifest",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -243,6 +245,7 @@ class BankTemplatesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankTemplateManifest",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/banks_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/banks_api.py
@@ -1863,7 +1863,6 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankProfileResponse",
-            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1937,7 +1936,6 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankProfileResponse",
-            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2011,7 +2009,6 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankProfileResponse",
-            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/banks_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/banks_api.py
@@ -1287,6 +1287,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankStatsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1363,6 +1364,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankStatsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1439,6 +1441,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankStatsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1578,6 +1581,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankConfigResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1650,6 +1654,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankConfigResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1722,6 +1727,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankConfigResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1857,6 +1863,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankProfileResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1930,6 +1937,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankProfileResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2003,6 +2011,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "BankProfileResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2145,6 +2154,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "MemoriesTimeseriesResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2225,6 +2235,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "MemoriesTimeseriesResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2305,6 +2316,7 @@ class BanksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "MemoriesTimeseriesResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/directives_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/directives_api.py
@@ -1013,6 +1013,7 @@ class DirectivesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "DirectiveListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1105,6 +1106,7 @@ class DirectivesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "DirectiveListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1197,6 +1199,7 @@ class DirectivesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "DirectiveListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/documents_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/documents_api.py
@@ -1316,6 +1316,7 @@ class DocumentsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ListDocumentsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1408,6 +1409,7 @@ class DocumentsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ListDocumentsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1500,6 +1502,7 @@ class DocumentsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ListDocumentsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/entities_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/entities_api.py
@@ -401,6 +401,7 @@ class EntitiesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "EntityGraphResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -481,6 +482,7 @@ class EntitiesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "EntityGraphResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -561,6 +563,7 @@ class EntitiesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "EntityGraphResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -713,6 +716,7 @@ class EntitiesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "EntityListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -793,6 +797,7 @@ class EntitiesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "EntityListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -873,6 +878,7 @@ class EntitiesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "EntityListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/knowledge_base_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/knowledge_base_api.py
@@ -1011,6 +1011,7 @@ class KnowledgeBaseApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "KnowledgePageBundleResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1083,6 +1084,7 @@ class KnowledgeBaseApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "KnowledgePageBundleResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1155,6 +1157,7 @@ class KnowledgeBaseApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "KnowledgePageBundleResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1289,6 +1292,7 @@ class KnowledgeBaseApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "KnowledgeTreeResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1361,6 +1365,7 @@ class KnowledgeBaseApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "KnowledgeTreeResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1433,6 +1438,7 @@ class KnowledgeBaseApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "KnowledgeTreeResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1868,6 +1874,7 @@ class KnowledgeBaseApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "KnowledgePageSearchResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1948,6 +1955,7 @@ class KnowledgeBaseApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "KnowledgePageSearchResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2028,6 +2036,7 @@ class KnowledgeBaseApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "KnowledgePageSearchResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/llm_traces_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/llm_traces_api.py
@@ -147,6 +147,7 @@ class LLMTracesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "LLMRequestListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -267,6 +268,7 @@ class LLMTracesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "LLMRequestListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -387,6 +389,7 @@ class LLMTracesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "LLMRequestListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -589,6 +592,7 @@ class LLMTracesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "LLMRequestStatsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -669,6 +673,7 @@ class LLMTracesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "LLMRequestStatsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -749,6 +754,7 @@ class LLMTracesApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "LLMRequestStatsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/memory_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/memory_api.py
@@ -1328,6 +1328,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "GraphDataResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1428,6 +1429,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "GraphDataResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1528,6 +1530,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "GraphDataResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2324,6 +2327,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ListMemoryUnitsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2436,6 +2440,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ListMemoryUnitsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2548,6 +2553,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ListMemoryUnitsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2741,6 +2747,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ObservationScopesResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2821,6 +2828,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ObservationScopesResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2901,6 +2909,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ObservationScopesResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -3061,6 +3070,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ListTagsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -3149,6 +3159,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ListTagsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -3237,6 +3248,7 @@ class MemoryApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ListTagsResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/mental_models_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/mental_models_api.py
@@ -1912,6 +1912,7 @@ class MentalModelsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "MentalModelListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2004,6 +2005,7 @@ class MentalModelsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "MentalModelListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -2096,6 +2098,7 @@ class MentalModelsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "MentalModelListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/operations_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/operations_api.py
@@ -1018,6 +1018,7 @@ class OperationsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "OperationsListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1110,6 +1111,7 @@ class OperationsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "OperationsListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1202,6 +1204,7 @@ class OperationsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "OperationsListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/python/hindsight_client_api/api/webhooks_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/webhooks_api.py
@@ -1037,6 +1037,7 @@ class WebhooksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "WebhookListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1117,6 +1118,7 @@ class WebhooksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "WebhookListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(
@@ -1197,6 +1199,7 @@ class WebhooksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "WebhookListResponse",
+            '404': None,
             '422': "HTTPValidationError",
         }
         response_data = await self.api_client.call_api(

--- a/hindsight-clients/rust/build.rs
+++ b/hindsight-clients/rust/build.rs
@@ -43,6 +43,39 @@ fn filter_multipart_endpoints(spec: &mut serde_json::Value) {
     }
 }
 
+/// Drop error responses that carry no schema (the documented 404 on bank-scoped
+/// reads, say).
+///
+/// progenitor models at most one error type per operation --
+/// `assertion failed: response_types.len() <= 1` in method.rs -- and FastAPI
+/// already gives every one of these operations a typed 422. A bodyless 404 adds
+/// a second, empty error type and panics the generator. Dropping it costs the
+/// Rust client nothing: an undeclared status still surfaces as
+/// `Error::UnexpectedResponse`, status code intact.
+fn filter_bodyless_error_responses(spec: &mut serde_json::Value) {
+    let Some(paths) = spec.get_mut("paths").and_then(|v| v.as_object_mut()) else {
+        return;
+    };
+    for (_path_name, path_item) in paths.iter_mut() {
+        let Some(operations) = path_item.as_object_mut() else {
+            continue;
+        };
+        for (_method, operation) in operations.iter_mut() {
+            let Some(responses) = operation.get_mut("responses").and_then(|v| v.as_object_mut()) else {
+                continue;
+            };
+            responses.retain(|status, response| {
+                let is_error = status
+                    .chars()
+                    .next()
+                    .map(|c| c == '4' || c == '5')
+                    .unwrap_or(false);
+                !(is_error && response.get("content").is_none())
+            });
+        }
+    }
+}
+
 /// Collapse `anyOf` whose members are all plain string types into a single
 /// `{"type": "string"}`. Without this, progenitor emits a struct like
 /// `MemoryItemTimestamp { #[serde(flatten)] subtype_0: Option<DateTime>, ... }`
@@ -186,6 +219,10 @@ fn main() {
 
     // Filter out multipart/form-data endpoints (progenitor doesn't support them)
     filter_multipart_endpoints(&mut spec_json);
+
+    // Drop schema-less error responses; progenitor allows only one error type
+    // per operation and the typed 422 is the one worth keeping.
+    filter_bodyless_error_responses(&mut spec_json);
 
     // Now parse as OpenAPI struct
     let spec: openapiv3::OpenAPI = serde_json::from_value(spec_json)

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -5905,6 +5905,10 @@ export type GetGraphData = {
 
 export type GetGraphErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -5981,6 +5985,10 @@ export type ListMemoriesData = {
 };
 
 export type ListMemoriesErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -6300,6 +6308,10 @@ export type GetAgentStatsData = {
 
 export type GetAgentStatsErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -6383,6 +6395,10 @@ export type GetMemoriesTimeseriesData = {
 
 export type GetMemoriesTimeseriesErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -6434,6 +6450,10 @@ export type ListEntitiesData = {
 
 export type ListEntitiesErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -6482,6 +6502,10 @@ export type GetEntityGraphData = {
 };
 
 export type GetEntityGraphErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -6627,6 +6651,10 @@ export type ListMentalModelsData = {
 };
 
 export type ListMentalModelsErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -6989,6 +7017,10 @@ export type GetKnowledgeBaseTreeData = {
 
 export type GetKnowledgeBaseTreeErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -7102,6 +7134,10 @@ export type ExportKnowledgeBaseData = {
 
 export type ExportKnowledgeBaseErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -7151,6 +7187,10 @@ export type SearchKnowledgeBaseData = {
 };
 
 export type SearchKnowledgeBaseErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -7334,6 +7374,10 @@ export type ListDirectivesData = {
 };
 
 export type ListDirectivesErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -7551,6 +7595,10 @@ export type ListDocumentsData = {
 };
 
 export type ListDocumentsErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -7828,6 +7876,10 @@ export type ListTagsData = {
 
 export type ListTagsErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -7930,6 +7982,10 @@ export type ListOperationsData = {
 };
 
 export type ListOperationsErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -8134,6 +8190,10 @@ export type GetBankProfileData = {
 };
 
 export type GetBankProfileErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -8398,6 +8458,10 @@ export type ExportBankTemplateData = {
 };
 
 export type ExportBankTemplateErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -8705,6 +8769,10 @@ export type ListObservationScopesData = {
 
 export type ListObservationScopesErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -8859,6 +8927,10 @@ export type GetBankConfigData = {
 
 export type GetBankConfigErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -8984,6 +9056,10 @@ export type ListWebhooksData = {
 };
 
 export type ListWebhooksErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -9345,6 +9421,10 @@ export type ListAuditLogsData = {
 
 export type ListAuditLogsErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -9393,6 +9473,10 @@ export type AuditLogStatsData = {
 };
 
 export type AuditLogStatsErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */
@@ -9503,6 +9587,10 @@ export type ListLlmRequestsData = {
 
 export type ListLlmRequestsErrors = {
   /**
+   * The bank does not exist.
+   */
+  404: unknown;
+  /**
    * Validation Error
    */
   422: HttpValidationError;
@@ -9551,6 +9639,10 @@ export type LlmRequestStatsData = {
 };
 
 export type LlmRequestStatsErrors = {
+  /**
+   * The bank does not exist.
+   */
+  404: unknown;
   /**
    * Validation Error
    */

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -8191,10 +8191,6 @@ export type GetBankProfileData = {
 
 export type GetBankProfileErrors = {
   /**
-   * The bank does not exist.
-   */
-  404: unknown;
-  /**
    * Validation Error
    */
   422: HttpValidationError;

--- a/hindsight-docs/docs/developer/api/memory-banks.mdx
+++ b/hindsight-docs/docs/developer/api/memory-banks.mdx
@@ -34,6 +34,12 @@ Banks are completely isolated from each other — memories stored in one bank ar
 
 You don't need to pre-create a bank. Hindsight will automatically create it with default settings when you first use it.
 
+Only *writes* create a bank — retaining, updating its profile, changing its config. **Reads of a
+bank that does not exist return `404`**, so a typo'd, renamed or deleted `bank_id` is reported
+rather than answered with empty results. That matters if you are monitoring a bank: `GET .../stats`
+on a missing bank fails loudly instead of returning zeroed counters that look like a healthy,
+empty bank.
+
 :::tip Prerequisites
 Make sure you've completed the [Quick Start](./quickstart) to install the client and start the server.
 :::

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -267,6 +267,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -479,6 +482,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -1058,6 +1064,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1198,6 +1207,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1283,6 +1295,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1366,6 +1381,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -1640,6 +1658,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -2262,6 +2283,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -2459,6 +2483,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -2543,6 +2570,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -2885,6 +2915,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -3292,6 +3325,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -3785,6 +3821,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -3977,6 +4016,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -4319,6 +4361,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -4780,6 +4825,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -5312,6 +5360,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -5497,6 +5548,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -5850,6 +5904,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -6465,6 +6522,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -6553,6 +6613,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -6814,6 +6877,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -6902,6 +6968,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -4362,9 +4362,6 @@
               }
             }
           },
-          "404": {
-            "description": "The bank does not exist."
-          },
           "422": {
             "description": "Validation Error",
             "content": {

--- a/skills/hindsight-docs/references/developer/api/memory-banks.md
+++ b/skills/hindsight-docs/references/developer/api/memory-banks.md
@@ -19,6 +19,12 @@ Banks are completely isolated from each other — memories stored in one bank ar
 
 You don't need to pre-create a bank. Hindsight will automatically create it with default settings when you first use it.
 
+Only *writes* create a bank — retaining, updating its profile, changing its config. **Reads of a
+bank that does not exist return `404`**, so a typo'd, renamed or deleted `bank_id` is reported
+rather than answered with empty results. That matters if you are monitoring a bank: `GET .../stats`
+on a missing bank fails loudly instead of returning zeroed counters that look like a healthy,
+empty bank.
+
 > **💡 Prerequisites**
 >
 Make sure you've completed the [Quick Start](./quickstart) to install the client and start the server.

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -267,6 +267,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -479,6 +482,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -1058,6 +1064,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1198,6 +1207,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1283,6 +1295,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1366,6 +1381,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -1640,6 +1658,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -2262,6 +2283,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -2459,6 +2483,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -2543,6 +2570,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -2885,6 +2915,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -3292,6 +3325,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -3785,6 +3821,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -3977,6 +4016,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -4319,6 +4361,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -4780,6 +4825,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -5312,6 +5360,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -5497,6 +5548,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -5850,6 +5904,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -6465,6 +6522,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -6553,6 +6613,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",
@@ -6814,6 +6877,9 @@
               }
             }
           },
+          "404": {
+            "description": "The bank does not exist."
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -6902,6 +6968,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The bank does not exist."
           },
           "422": {
             "description": "Validation Error",

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -4362,9 +4362,6 @@
               }
             }
           },
-          "404": {
-            "description": "The bank does not exist."
-          },
           "422": {
             "description": "Validation Error",
             "content": {


### PR DESCRIPTION
Fixes #4175.

## The bug

`GET /stats` and `GET /memories/list` answered **200 with zeroed counters and an empty page** for a bank nobody ever created — byte-identical to a healthy, empty bank. A monitor built on either kept passing after the bank it watched was renamed, deleted or recreated under another id, and a typo in `bank_id` was never surfaced.

## Audit: 17 endpoints, not 2

The issue names two. Every bank-scoped GET that aggregates or lists had it:

`/graph` · `/memories/list` · `/stats` · `/stats/memories-timeseries` · `/entities` · `/entities/graph` · `/mental-models` · `/knowledge-base/{tree,export,search}` · `/directives` · `/documents` · `/tags` · `/operations` · `/observations/scopes` · `/config` · `/webhooks`

Not affected, left alone: sub-resource GETs (`/memories/{id}`, `/mental-models/{id}`, `/documents/{id}`, `/webhooks/{id}/deliveries`, …) already 404 on the missing child, and `/profile`, `/export`, `/audit-logs*`, `/llm-requests*` already checked the bank.

## The fix

One `MemoryEngine._require_bank_exists`, called in each of those 18 engine reads **after** that method's own `_authenticate_tenant` and read authorization — so it cannot widen what a caller may see, and it never creates the bank. The profile row is cached per process (`bank_info_cache`), so an existing bank costs no extra query; a missing bank is never cached, so it stays one cheap read.

Writes are unchanged: retain, `PUT /banks/{id}`, `PATCH /config` still create the bank lazily.

## OpenAPI

404 is now declared on those operations plus the 6 that already returned one, so generated clients have a documented missing-bank case (the issue asked for this).

That broke the Rust client: progenitor asserts `response_types.len() <= 1` per operation and the typed 422 already occupied the single error slot. `hindsight-clients/rust/build.rs` now strips schema-less 4xx/5xx before generating — same place it already strips multipart endpoints. An undeclared status still surfaces as `Error::UnexpectedResponse` with the status intact, so the Rust client loses nothing.

## Behaviour changes worth calling out

- `GET /config` on an uncreated bank is now 404 rather than the resolved global defaults.
- MCP tools share these engine reads, so e.g. `search_knowledge_base` against a bank with nothing retained yet returns `{"error": "Bank '…' not found"}` instead of an empty result set.

Both follow from the issue's logic; flagging them because they are visible.

## Tests

- New `hindsight-api-slim/tests/test_bank_scoped_read_404.py` — 404 for each of the 17 endpoints, 200 for each on a bank that exists (the positive control that keeps "missing" distinguishable from "empty"), and a check that the read did not create the bank.
- Two existing tests asserted the old behaviour on banks they never created and were corrected: the `test_bank_stats.py` bank fixture now creates its bank, and `test_list_tags_empty_bank` creates one before asserting an empty list.
- Docs: `memory-banks.mdx` now states that only writes create a bank and reads 404; skill references and the spec regenerated.