### PR TITLE
feat(llm): route retain items to a chain member by their metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,8 +179,13 @@ HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
 # two Codex members fails over between two ChatGPT accounts instead of retrying one.
 # HINDSIGHT_API_LLM_1_PROVIDER=openai-codex
 # HINDSIGHT_API_LLM_1_CODEX_HOME=/var/lib/hindsight/codex-b
-# Strategy JSON: {"mode": "failover"} or {"mode": "round-robin"}.
+# Strategy JSON: {"mode": "failover"}, {"mode": "round-robin"}, or
+# {"mode": "metadata", "routes": [{"key": "classification", "value": "sensitive", "member": 1}]}.
 # Round-robin accepts optional positive-int "weights" (one per member, primary first).
+# Metadata mode is RETAIN ONLY: each retained item picks a member from its own
+# metadata (first matching route wins; no match uses the primary). It chooses which
+# model extracts a document, not where that document's data can end up -- recall,
+# reflect, consolidation and mental models all keep using the primary.
 # HINDSIGHT_API_LLM_STRATEGY={"mode": "failover"}
 
 # API Configuration (Optional)

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from typing import Any, Literal
 
 from dotenv import find_dotenv, load_dotenv
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from ._pg_search import normalize_pg_search_tokenizer
 from ._vector_index import validate_extension
@@ -2213,21 +2214,26 @@ LLM_STRATEGY_METADATA = "metadata"
 _VALID_LLM_STRATEGY_MODES = (LLM_STRATEGY_FAILOVER, LLM_STRATEGY_ROUND_ROBIN, LLM_STRATEGY_METADATA)
 
 
-@dataclass(frozen=True)
-class LLMMetadataRoute:
+class LLMMetadataRoute(BaseModel):
     """Send a retain item whose ``metadata[key] == value`` to member ``member``.
 
     Matching is on the string form of the item's value, because retain metadata
     is free-form JSON and a route read from an env var is always a string.
+
+    Strict and closed on purpose: this is parsed straight from operator-supplied
+    JSON, where ``{"member": true}`` is a typo rather than member 1, and a
+    misspelled key (``"membr"``) must fail loudly instead of leaving the route
+    pointed at the default member.
     """
 
-    key: str
+    model_config = ConfigDict(strict=True, extra="forbid", frozen=True)
+
+    key: str = Field(min_length=1)
     value: str
-    member: int
+    member: int = Field(ge=0)
 
 
-@dataclass
-class LLMStrategyConfig:
+class LLMStrategyConfig(BaseModel):
     """How to route a request across the members of a multi-LLM chain.
 
     ``mode`` is "failover" (try members in order), "round-robin" (rotate the
@@ -2239,20 +2245,51 @@ class LLMStrategyConfig:
     none uses the primary.
     """
 
+    model_config = ConfigDict(strict=True, extra="forbid")
+
     mode: str
     weights: list[int] | None = None
     routes: list[LLMMetadataRoute] | None = None
+
+    @field_validator("mode")
+    @classmethod
+    def _validate_mode(cls, mode: str) -> str:
+        if mode not in _VALID_LLM_STRATEGY_MODES:
+            raise ValueError(
+                f"Invalid LLM strategy mode {mode!r}. Must be one of: {', '.join(_VALID_LLM_STRATEGY_MODES)}."
+            )
+        return mode
+
+    @model_validator(mode="after")
+    def _validate_mode_specific_fields(self) -> "LLMStrategyConfig":
+        """``weights`` and ``routes`` each belong to exactly one mode.
+
+        Rejecting the wrong pairing matters more than it looks: a ``routes`` list
+        under "failover" would otherwise be accepted and never consulted, which
+        reads as the routes silently not working.
+        """
+        if self.weights is not None:
+            if self.mode != LLM_STRATEGY_ROUND_ROBIN:
+                raise ValueError(f"LLM strategy 'weights' is only valid with mode '{LLM_STRATEGY_ROUND_ROBIN}'.")
+            if not self.weights or any(weight <= 0 for weight in self.weights):
+                raise ValueError("LLM strategy 'weights' must be a non-empty list of positive integers.")
+
+        if self.mode == LLM_STRATEGY_METADATA:
+            if not self.routes:
+                raise ValueError(f"LLM strategy 'routes' must be a non-empty list with mode '{LLM_STRATEGY_METADATA}'.")
+        elif self.routes is not None:
+            raise ValueError(f"LLM strategy 'routes' is only valid with mode '{LLM_STRATEGY_METADATA}'.")
+        return self
 
 
 def _parse_llm_strategy(raw: str | None) -> LLMStrategyConfig | None:
     """Parse a multi-LLM strategy from a JSON env var.
 
-    Returns ``None`` when unset. The value must be a JSON object with a ``mode``
-    of "failover", "round-robin" or "metadata"; ``weights`` (round-robin only)
-    must be a list of positive ints, and ``routes`` (metadata only) a non-empty
-    list of ``{"key": str, "value": str, "member": non-negative int}`` objects.
-    Raises ``ValueError`` on any malformed input so misconfiguration fails fast
-    at startup rather than silently degrading.
+    Returns ``None`` when unset. Shape and per-field rules live on
+    :class:`LLMStrategyConfig` / :class:`LLMMetadataRoute`, so this only decodes
+    the JSON and restates pydantic's complaint in terms of the env var. Any
+    malformed input raises ``ValueError`` so misconfiguration fails fast at
+    startup rather than silently degrading.
     """
     text = (raw or "").strip()
     if not text:
@@ -2264,44 +2301,27 @@ def _parse_llm_strategy(raw: str | None) -> LLMStrategyConfig | None:
     if not isinstance(parsed, dict):
         raise ValueError(f"Invalid LLM strategy: expected a JSON object, got {type(parsed).__name__}")
 
-    mode = parsed.get("mode")
-    if mode not in _VALID_LLM_STRATEGY_MODES:
-        raise ValueError(f"Invalid LLM strategy mode {mode!r}. Must be one of: {', '.join(_VALID_LLM_STRATEGY_MODES)}.")
-
-    weights = parsed.get("weights")
-    if weights is not None:
-        if mode != LLM_STRATEGY_ROUND_ROBIN:
-            raise ValueError(f"LLM strategy 'weights' is only valid with mode '{LLM_STRATEGY_ROUND_ROBIN}'.")
-        if not isinstance(weights, list) or not weights or not all(isinstance(w, int) and w > 0 for w in weights):
-            raise ValueError("LLM strategy 'weights' must be a non-empty list of positive integers.")
-
-    raw_routes = parsed.get("routes")
-    routes: list[LLMMetadataRoute] | None = None
-    if mode == LLM_STRATEGY_METADATA:
-        if not isinstance(raw_routes, list) or not raw_routes:
-            raise ValueError(f"LLM strategy 'routes' must be a non-empty list with mode '{LLM_STRATEGY_METADATA}'.")
-        routes = [_parse_llm_metadata_route(index, route) for index, route in enumerate(raw_routes)]
-    elif raw_routes is not None:
-        raise ValueError(f"LLM strategy 'routes' is only valid with mode '{LLM_STRATEGY_METADATA}'.")
-
-    return LLMStrategyConfig(mode=mode, weights=weights, routes=routes)
+    try:
+        return LLMStrategyConfig.model_validate(parsed)
+    except ValidationError as e:
+        raise ValueError(f"Invalid {ENV_LLM_STRATEGY}: {_format_validation_error(e)}") from e
 
 
-def _parse_llm_metadata_route(index: int, route: object) -> LLMMetadataRoute:
-    """Validate one entry of a metadata strategy's ``routes`` list."""
-    if not isinstance(route, dict):
-        raise ValueError(f"LLM metadata route {index} must be a JSON object.")
-    key = route.get("key")
-    value = route.get("value")
-    member = route.get("member")
-    if not isinstance(key, str) or not key:
-        raise ValueError(f"LLM metadata route {index} 'key' must be a non-empty string.")
-    if not isinstance(value, str):
-        raise ValueError(f"LLM metadata route {index} 'value' must be a string.")
-    # bool is an int subclass, and {"member": true} is a typo, not member 1.
-    if not isinstance(member, int) or isinstance(member, bool) or member < 0:
-        raise ValueError(f"LLM metadata route {index} 'member' must be a non-negative integer.")
-    return LLMMetadataRoute(key=key, value=value, member=member)
+def _format_validation_error(error: ValidationError) -> str:
+    """Flatten a ``ValidationError`` into one operator-readable line.
+
+    The default rendering spans several lines and names the model, neither of
+    which helps someone reading a startup crash caused by an env var. Keep the
+    field path (``routes.0.member``) — with nested routes it is the only thing
+    that says *which* entry is wrong.
+    """
+    details = []
+    for detail in error.errors():
+        location = ".".join(str(part) for part in detail["loc"])
+        # Messages raised by our own validators arrive prefixed by pydantic.
+        message = detail["msg"].removeprefix("Value error, ")
+        details.append(f"{location}: {message}" if location else message)
+    return "; ".join(details)
 
 
 def _parse_llm_members(prefix: str) -> list[LLMMemberConfig]:

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -2209,30 +2209,50 @@ class LLMMemberConfig:
 # Valid multi-LLM strategy modes.
 LLM_STRATEGY_FAILOVER = "failover"
 LLM_STRATEGY_ROUND_ROBIN = "round-robin"
-_VALID_LLM_STRATEGY_MODES = (LLM_STRATEGY_FAILOVER, LLM_STRATEGY_ROUND_ROBIN)
+LLM_STRATEGY_METADATA = "metadata"
+_VALID_LLM_STRATEGY_MODES = (LLM_STRATEGY_FAILOVER, LLM_STRATEGY_ROUND_ROBIN, LLM_STRATEGY_METADATA)
+
+
+@dataclass(frozen=True)
+class LLMMetadataRoute:
+    """Send a retain item whose ``metadata[key] == value`` to member ``member``.
+
+    Matching is on the string form of the item's value, because retain metadata
+    is free-form JSON and a route read from an env var is always a string.
+    """
+
+    key: str
+    value: str
+    member: int
 
 
 @dataclass
 class LLMStrategyConfig:
     """How to route a request across the members of a multi-LLM chain.
 
-    ``mode`` is "failover" (try members in order) or "round-robin" (rotate the
-    starting member per request, then fall through the rest on error). ``weights``
-    is round-robin only: positive integers, one per member (primary first), giving
-    an unbalanced rotation; ``None`` means uniform.
+    ``mode`` is "failover" (try members in order), "round-robin" (rotate the
+    starting member per request, then fall through the rest on error) or
+    "metadata" (pick the member from the retained item's own metadata).
+    ``weights`` is round-robin only: positive integers, one per member (primary
+    first), giving an unbalanced rotation; ``None`` means uniform. ``routes`` is
+    metadata only: the first route matching an item wins, and an item matching
+    none uses the primary.
     """
 
     mode: str
     weights: list[int] | None = None
+    routes: list[LLMMetadataRoute] | None = None
 
 
 def _parse_llm_strategy(raw: str | None) -> LLMStrategyConfig | None:
     """Parse a multi-LLM strategy from a JSON env var.
 
     Returns ``None`` when unset. The value must be a JSON object with a ``mode``
-    of "failover" or "round-robin"; ``weights`` (round-robin only) must be a list
-    of positive ints. Raises ``ValueError`` on any malformed input so
-    misconfiguration fails fast at startup rather than silently degrading.
+    of "failover", "round-robin" or "metadata"; ``weights`` (round-robin only)
+    must be a list of positive ints, and ``routes`` (metadata only) a non-empty
+    list of ``{"key": str, "value": str, "member": non-negative int}`` objects.
+    Raises ``ValueError`` on any malformed input so misconfiguration fails fast
+    at startup rather than silently degrading.
     """
     text = (raw or "").strip()
     if not text:
@@ -2255,7 +2275,33 @@ def _parse_llm_strategy(raw: str | None) -> LLMStrategyConfig | None:
         if not isinstance(weights, list) or not weights or not all(isinstance(w, int) and w > 0 for w in weights):
             raise ValueError("LLM strategy 'weights' must be a non-empty list of positive integers.")
 
-    return LLMStrategyConfig(mode=mode, weights=weights)
+    raw_routes = parsed.get("routes")
+    routes: list[LLMMetadataRoute] | None = None
+    if mode == LLM_STRATEGY_METADATA:
+        if not isinstance(raw_routes, list) or not raw_routes:
+            raise ValueError(f"LLM strategy 'routes' must be a non-empty list with mode '{LLM_STRATEGY_METADATA}'.")
+        routes = [_parse_llm_metadata_route(index, route) for index, route in enumerate(raw_routes)]
+    elif raw_routes is not None:
+        raise ValueError(f"LLM strategy 'routes' is only valid with mode '{LLM_STRATEGY_METADATA}'.")
+
+    return LLMStrategyConfig(mode=mode, weights=weights, routes=routes)
+
+
+def _parse_llm_metadata_route(index: int, route: object) -> LLMMetadataRoute:
+    """Validate one entry of a metadata strategy's ``routes`` list."""
+    if not isinstance(route, dict):
+        raise ValueError(f"LLM metadata route {index} must be a JSON object.")
+    key = route.get("key")
+    value = route.get("value")
+    member = route.get("member")
+    if not isinstance(key, str) or not key:
+        raise ValueError(f"LLM metadata route {index} 'key' must be a non-empty string.")
+    if not isinstance(value, str):
+        raise ValueError(f"LLM metadata route {index} 'value' must be a string.")
+    # bool is an int subclass, and {"member": true} is a typo, not member 1.
+    if not isinstance(member, int) or isinstance(member, bool) or member < 0:
+        raise ValueError(f"LLM metadata route {index} 'member' must be a non-negative integer.")
+    return LLMMetadataRoute(key=key, value=value, member=member)
 
 
 def _parse_llm_members(prefix: str) -> list[LLMMemberConfig]:

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -1828,6 +1828,28 @@ class ConfiguredLLMProvider:
             _safety_settings_ctx.reset(token)
             self._reset_trace_context(trace_token)
 
+    def route_for(self, metadata: dict[str, Any] | None) -> "ConfiguredLLMProvider":
+        """Re-bind to the member a metadata-routed chain selects for *metadata*.
+
+        Returns ``self`` unless the underlying provider is a multi-LLM chain in
+        ``metadata`` mode with a route matching *metadata*. The re-bound wrapper
+        keeps this one's bank config and trace context, so a routed call is
+        attributed to the same operation and trace as its siblings — only the
+        member changes.
+        """
+        provider = object.__getattribute__(self, "_provider")
+        member_for_metadata = getattr(provider, "member_for_metadata", None)
+        if member_for_metadata is None:
+            return self
+        member = member_for_metadata(metadata)
+        if member is None:
+            return self
+        return ConfiguredLLMProvider(
+            member,
+            object.__getattribute__(self, "_gemini_safety_settings"),
+            object.__getattribute__(self, "_trace_ctx"),
+        )
+
     def trace_context(self) -> Any | None:
         """The operation-level LLM trace context (or None when untraced).
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -47,6 +47,7 @@ from ..config import (
     DEFAULT_REFLECT_SOURCE_FACTS_MAX_TOKENS,
     DEFAULT_STORE_DOCUMENT_TEXT,
     ENV_MODEL_INIT_TIMEOUT,
+    LLM_STRATEGY_METADATA,
     HindsightConfig,
     LLMMemberConfig,
     LLMStrategyConfig,
@@ -711,9 +712,23 @@ async def validate_retain_batch_support(
     capability is evaluated across ALL members, not just the primary: batch
     capacity may live on a secondary (issue #3645), and gating on the primary
     alone rejected configurations that would in fact have worked.
+
+    Metadata routing is rejected outright: the batch path submits every item of a
+    retain as ONE job to ONE member, so it cannot honour a per-item route. Rather
+    than silently sending routed items to whichever member serves the batch, make
+    the operator pick one of the two features.
     """
     if not config.retain_batch_enabled:
         return
+
+    if isinstance(retain_llm_config, MultiLLMProvider) and retain_llm_config.strategy.mode == LLM_STRATEGY_METADATA:
+        raise RuntimeError(
+            "Configuration error: HINDSIGHT_API_RETAIN_BATCH_ENABLED=true is not compatible with the "
+            "'metadata' LLM strategy. Batch retain submits every item of an operation as a single job "
+            "to a single member, so it cannot route items individually. Set "
+            "HINDSIGHT_API_RETAIN_BATCH_ENABLED=false or choose another LLM strategy."
+        )
+
     if await retain_llm_config.supports_batch_api():
         return
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -687,9 +687,28 @@ def _build_llm(
 
     ``defaults`` are the operation's resolved request defaults, applied to every
     fallback member so the whole chain shares the operation's effective settings.
+
+    Raises ``ValueError`` when a non-retain operation *explicitly* selects the
+    metadata strategy, which it has no item metadata to route on.
     """
     members: list[LLMMemberConfig] = getattr(config, f"{prefix}llm_members")
     strategy: LLMStrategyConfig | None = getattr(config, f"{prefix}llm_strategy")
+
+    # Metadata routing reads a *retained item's* metadata, so only retain has
+    # anything to route on. Setting it explicitly on another operation would
+    # otherwise be accepted and then quietly ignored (that chain pins to the
+    # primary), which looks exactly like the routes not working. Inheriting it
+    # from the global strategy stays legal and does pin those operations to the
+    # primary — that is the documented behaviour, not a mistake.
+    if prefix and prefix != "retain_" and strategy is not None and strategy.mode == LLM_STRATEGY_METADATA:
+        operation = prefix.rstrip("_")
+        raise ValueError(
+            f"The '{LLM_STRATEGY_METADATA}' LLM strategy is only supported for retain, but "
+            f"HINDSIGHT_API_{operation.upper()}_LLM_STRATEGY sets it for {operation}. Routing reads the "
+            f"metadata of the item being retained, which {operation} does not have. Remove the override to "
+            f"let {operation} use the global strategy, or give it 'failover'/'round-robin'."
+        )
+
     if prefix:
         if not members:
             members = config.llm_members

--- a/hindsight-api-slim/hindsight_api/engine/multi_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/multi_llm.py
@@ -1,4 +1,4 @@
-"""Multi-LLM routing: failover and (weighted) round-robin across N providers.
+"""Multi-LLM routing: failover, (weighted) round-robin and metadata across N providers.
 
 ``MultiLLMProvider`` wraps an ordered list of :class:`LLMProvider` members and a
 :class:`~hindsight_api.config.LLMStrategyConfig`, exposing the same public surface
@@ -14,6 +14,11 @@ Strategies:
 - ``failover``: try members in declared order ``[0..N]``.
 - ``round-robin``: rotate the starting member per request (optionally weighted),
   then fall through the remaining members on error.
+- ``metadata``: retain only. Each retained item picks its member from its own
+  ``metadata`` (see ``member_for_metadata``); an item matching no route uses the
+  primary. Selection happens per item at fact-extraction time, so nothing about
+  it is stored and no other operation is affected — see ``config.py`` and the
+  configuration docs for what this does and does not promise.
 
 Batch retain runs on the **first batch-capable member** in declared order (see
 ``batch_provider_impl``), which need not be the primary; once selected, the whole
@@ -28,7 +33,7 @@ import threading
 import uuid
 from typing import TYPE_CHECKING, Any
 
-from ..config import LLM_STRATEGY_FAILOVER, LLMStrategyConfig
+from ..config import LLM_STRATEGY_FAILOVER, LLM_STRATEGY_METADATA, LLMStrategyConfig
 from .llm_wrapper import LLMProvider, OutputTooLongError
 
 if TYPE_CHECKING:
@@ -50,6 +55,23 @@ def _should_failover(exc: BaseException) -> bool:
     if isinstance(exc, OutputTooLongError):
         return False
     return isinstance(exc, Exception)
+
+
+def _metadata_matches(actual: Any, expected: str) -> bool:
+    """Whether a retain item's metadata value matches a route's value.
+
+    Retain metadata is free-form JSON while a route value is always a string, so
+    compare on the string form. A list/tuple/set value matches when any of its
+    entries does, which is what makes ``{"labels": ["pii", "eu"]}`` routable.
+    """
+    if isinstance(actual, (list, tuple, set, frozenset)):
+        return any(_metadata_matches(entry, expected) for entry in actual)
+    if actual is None or isinstance(actual, dict):
+        return False
+    if isinstance(actual, bool):
+        # str(True) is "True"; JSON booleans should match "true"/"false".
+        return str(actual).lower() == expected.lower()
+    return str(actual) == expected
 
 
 class _WeightedRoundRobin:
@@ -81,7 +103,7 @@ class _WeightedRoundRobin:
 
 
 class MultiLLMProvider:
-    """Route LLM calls across multiple members per a failover / round-robin strategy."""
+    """Route LLM calls across multiple members per the configured strategy."""
 
     def __init__(self, members: list[LLMProvider], strategy: LLMStrategyConfig) -> None:
         if not members:
@@ -97,15 +119,46 @@ class MultiLLMProvider:
             )
         self._scheduler = _WeightedRoundRobin(weights)
 
+        if strategy.mode == LLM_STRATEGY_METADATA:
+            for route in strategy.routes or []:
+                if route.member >= len(members):
+                    raise ValueError(
+                        f"LLM metadata route {route.key}={route.value!r} selects member {route.member}, "
+                        f"but the chain has members 0..{len(members) - 1}."
+                    )
+
     # ── routing ────────────────────────────────────────────────────────────────
 
     def _member_order(self) -> list[int]:
         """Indices to try, in order, for one request."""
         n = len(self._members)
+        if self._strategy.mode == LLM_STRATEGY_METADATA:
+            # A metadata member is chosen per item by the retain path, which then
+            # calls that member directly. Anything reaching the chain itself has
+            # no item to route on, so it stays on the primary and does not fail
+            # over into another member's lane.
+            return [0]
         if self._strategy.mode == LLM_STRATEGY_FAILOVER:
             return list(range(n))
         start = self._scheduler.next()
         return [(start + i) % n for i in range(n)]
+
+    def member_for_metadata(self, metadata: dict[str, Any] | None) -> LLMProvider | None:
+        """The member selected by a retained item's metadata, or ``None``.
+
+        ``None`` means "nothing to re-bind": either the chain is not in metadata
+        mode, or no route matched and the caller's existing primary binding is
+        already the right one. The first matching route in declared order wins,
+        so overlapping routes are resolved by configuration order rather than
+        rejected — one item is one prompt, so there is never more than one item
+        to satisfy.
+        """
+        if self._strategy.mode != LLM_STRATEGY_METADATA or not metadata:
+            return None
+        for route in self._strategy.routes or []:
+            if _metadata_matches(metadata.get(route.key), route.value):
+                return self._members[route.member]
+        return None
 
     async def _dispatch(self, method_name: str, **kwargs: Any) -> Any:
         last_exc: BaseException | None = None
@@ -251,6 +304,10 @@ class MultiLLMProvider:
     @property
     def members(self) -> list[LLMProvider]:
         return self._members
+
+    @property
+    def strategy(self) -> LLMStrategyConfig:
+        return self._strategy
 
     def __getattr__(self, name: str) -> Any:
         # Anything not defined here (provider, model, api_key, base_url,

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -2240,7 +2240,8 @@ async def _extract_facts_with_auto_split(
         llm_config: LLM configuration to use
         config: Resolved HindsightConfig for this bank
         agent_name: Optional agent name (memory owner)
-        metadata: Optional document metadata key-value pairs
+        metadata: Optional document metadata key-value pairs. Also selects the
+            chain member when the retain LLM uses the "metadata" strategy.
         attachment_loader: Resolves the chunk's image placeholders back to bytes, or None
             when the caller has no images to resolve. Carried through the split
             recursion so a half-chunk keeps the images it still references.
@@ -2374,6 +2375,15 @@ async def extract_facts_from_text(
         - chunks: List of tuples (chunk_text, fact_count) for each chunk
         - usage: Aggregated token usage across all LLM calls
     """
+    # Metadata routing binds the member here rather than at the operation level:
+    # one call to this function is one retain item, so its metadata is
+    # unambiguous, and every chunk it fans out below shares that one item's
+    # classification. A chain in any other mode (or an item matching no route)
+    # returns the wrapper unchanged.
+    route_for = getattr(llm_config, "route_for", None)
+    if route_for is not None:
+        llm_config = route_for(metadata)
+
     chunks = chunk_text(
         text,
         max_chars=config.retain_chunk_size,

--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -2240,8 +2240,7 @@ async def _extract_facts_with_auto_split(
         llm_config: LLM configuration to use
         config: Resolved HindsightConfig for this bank
         agent_name: Optional agent name (memory owner)
-        metadata: Optional document metadata key-value pairs. Also selects the
-            chain member when the retain LLM uses the "metadata" strategy.
+        metadata: Optional document metadata key-value pairs
         attachment_loader: Resolves the chunk's image placeholders back to bytes, or None
             when the caller has no images to resolve. Carried through the split
             recursion so a half-chunk keeps the images it still references.
@@ -2360,7 +2359,8 @@ async def extract_facts_from_text(
         llm_config: LLM configuration to use
         config: Resolved HindsightConfig for this bank
         context: Context about the conversation/document
-        metadata: Optional document metadata key-value pairs
+        metadata: Optional document metadata key-value pairs. Also selects the
+            chain member when the retain LLM uses the "metadata" strategy.
         agent_name: Optional narrator to prime the prompt with ("Narrator: {name}").
             Retain never sets it — see the caller in retain/orchestrator.py — and the
             dry-run endpoint's field that does is deprecated in favour of ``context``.

--- a/hindsight-api-slim/tests/test_metadata_llm_routing.py
+++ b/hindsight-api-slim/tests/test_metadata_llm_routing.py
@@ -1,0 +1,249 @@
+"""Retain-only metadata routing across a multi-LLM chain.
+
+``{"mode": "metadata"}`` picks a chain member from each retained item's own
+metadata. The whole feature rests on one fact about the retain pipeline: a single
+``extract_facts_from_text`` call handles exactly one retain item, so the item's
+metadata is unambiguous at the point the member is chosen and nothing has to be
+stored, unioned across a batch, or reconciled between operations.
+
+These tests therefore pin three things: the config parses and validates, the
+selection rules (first match wins, string comparison, list values, no match ->
+primary), and that the real extraction path actually calls the selected member
+with the operation's trace context intact.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hindsight_api.config import (
+    LLM_STRATEGY_FAILOVER,
+    LLM_STRATEGY_METADATA,
+    LLM_STRATEGY_ROUND_ROBIN,
+    HindsightConfig,
+    LLMMetadataRoute,
+    LLMStrategyConfig,
+    _parse_llm_strategy,
+)
+from hindsight_api.engine.llm_wrapper import ConfiguredLLMProvider, LLMProvider
+from hindsight_api.engine.memory_engine import validate_retain_batch_support
+from hindsight_api.engine.multi_llm import MultiLLMProvider
+from hindsight_api.engine.response_models import TokenUsage
+
+
+def _routes(*specs: tuple[str, str, int]) -> list[LLMMetadataRoute]:
+    return [LLMMetadataRoute(key=k, value=v, member=m) for k, v, m in specs]
+
+
+def _chain(*specs: tuple[str, str, int], members: int = 2) -> MultiLLMProvider:
+    """A chain of ``members`` distinguishable providers under metadata routing."""
+    providers = [
+        LLMProvider(provider="mock", api_key="sk-test", base_url=None, model=f"model-{index}")
+        for index in range(members)
+    ]
+    return MultiLLMProvider(providers, LLMStrategyConfig(mode=LLM_STRATEGY_METADATA, routes=_routes(*specs)))
+
+
+# ── config parsing ────────────────────────────────────────────────────────────
+
+
+def test_parses_metadata_strategy() -> None:
+    strategy = _parse_llm_strategy(
+        '{"mode": "metadata", "routes": [{"key": "classification", "value": "sensitive", "member": 1}]}'
+    )
+    assert strategy == LLMStrategyConfig(
+        mode=LLM_STRATEGY_METADATA,
+        weights=None,
+        routes=[LLMMetadataRoute(key="classification", value="sensitive", member=1)],
+    )
+
+
+def test_metadata_mode_requires_routes() -> None:
+    with pytest.raises(ValueError, match="must be a non-empty list"):
+        _parse_llm_strategy('{"mode": "metadata"}')
+    with pytest.raises(ValueError, match="must be a non-empty list"):
+        _parse_llm_strategy('{"mode": "metadata", "routes": []}')
+
+
+@pytest.mark.parametrize("mode", [LLM_STRATEGY_FAILOVER, LLM_STRATEGY_ROUND_ROBIN])
+def test_routes_rejected_outside_metadata_mode(mode: str) -> None:
+    with pytest.raises(ValueError, match="only valid with mode 'metadata'"):
+        _parse_llm_strategy('{"mode": "%s", "routes": [{"key": "k", "value": "v", "member": 1}]}' % mode)
+
+
+@pytest.mark.parametrize(
+    "route,message",
+    [
+        ('{"key": "", "value": "v", "member": 1}', "'key' must be a non-empty string"),
+        ('{"value": "v", "member": 1}', "'key' must be a non-empty string"),
+        ('{"key": "k", "value": 3, "member": 1}', "'value' must be a string"),
+        ('{"key": "k", "value": "v"}', "'member' must be a non-negative integer"),
+        ('{"key": "k", "value": "v", "member": -1}', "'member' must be a non-negative integer"),
+        # bool is an int subclass; {"member": true} is a typo, not member 1.
+        ('{"key": "k", "value": "v", "member": true}', "'member' must be a non-negative integer"),
+        ('"not-an-object"', "must be a JSON object"),
+    ],
+)
+def test_malformed_route_fails_fast(route: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        _parse_llm_strategy('{"mode": "metadata", "routes": [%s]}' % route)
+
+
+def test_route_beyond_chain_length_fails_at_construction() -> None:
+    """A typo'd index must fail at startup, not silently at the first sensitive retain."""
+    with pytest.raises(ValueError, match="selects member 5, but the chain has members 0..1"):
+        _chain(("classification", "sensitive", 5), members=2)
+
+
+# ── member selection ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "metadata,expected_model",
+    [
+        (None, None),
+        ({}, None),
+        ({"classification": "public"}, None),
+        ({"unrelated": "sensitive"}, None),
+        ({"classification": "sensitive"}, "model-1"),
+        # Values are compared as strings: retain metadata is free-form JSON.
+        ({"classification": ["internal", "sensitive"]}, "model-1"),
+        # A dict value can never equal a route's string value.
+        ({"classification": {"level": "sensitive"}}, None),
+    ],
+)
+def test_member_for_metadata(metadata: dict[str, Any] | None, expected_model: str | None) -> None:
+    chain = _chain(("classification", "sensitive", 1))
+    member = chain.member_for_metadata(metadata)
+    if expected_model is None:
+        # None means "stay where you are" — the caller is already on the primary.
+        assert member is None
+    else:
+        assert member.model == expected_model
+
+
+def test_numeric_and_bool_metadata_match_by_string_form() -> None:
+    chain = _chain(("tier", "1", 1), ("archived", "true", 1))
+    assert chain.member_for_metadata({"tier": 1}).model == "model-1"
+    assert chain.member_for_metadata({"tier": "1"}).model == "model-1"
+    assert chain.member_for_metadata({"archived": True}).model == "model-1"
+    assert chain.member_for_metadata({"archived": False}) is None
+
+
+def test_first_matching_route_wins() -> None:
+    """Overlapping routes resolve by declaration order rather than erroring.
+
+    One item is one prompt, so there is never a second item whose classification
+    also has to be satisfied — an operator ordering their routes is enough.
+    """
+    chain = _chain(("classification", "sensitive", 1), ("region", "eu", 2), members=3)
+    both = {"classification": "sensitive", "region": "eu"}
+    assert chain.member_for_metadata(both).model == "model-1"
+
+    reversed_chain = _chain(("region", "eu", 2), ("classification", "sensitive", 1), members=3)
+    assert reversed_chain.member_for_metadata(both).model == "model-2"
+
+
+def test_non_metadata_chain_never_routes() -> None:
+    failover = MultiLLMProvider(
+        [LLMProvider(provider="mock", api_key="sk-test", base_url=None, model=f"model-{i}") for i in range(2)],
+        LLMStrategyConfig(mode=LLM_STRATEGY_FAILOVER),
+    )
+    assert failover.member_for_metadata({"classification": "sensitive"}) is None
+
+
+def test_metadata_chain_does_not_fail_over_between_lanes() -> None:
+    """A direct call has no item to route on, so it stays on the primary.
+
+    Failing over would move a request into another member's lane, which is
+    exactly the thing routing exists to prevent.
+    """
+    chain = _chain(("classification", "sensitive", 1))
+    assert chain._member_order() == [0]
+
+
+# ── re-binding the configured wrapper ─────────────────────────────────────────
+
+
+def test_route_for_rebinds_member_and_keeps_trace_context() -> None:
+    """A routed call must stay attributed to the same operation and trace."""
+    chain = _chain(("classification", "sensitive", 1))
+    trace_ctx = object()
+    configured = ConfiguredLLMProvider(chain, ["safety"], trace_ctx)
+
+    routed = configured.route_for({"classification": "sensitive"})
+    assert routed is not configured
+    assert routed.model == "model-1"
+    assert routed.trace_context() is trace_ctx
+    assert object.__getattribute__(routed, "_gemini_safety_settings") == ["safety"]
+
+    assert configured.route_for({"classification": "public"}) is configured
+
+
+def test_route_for_is_a_noop_for_a_single_provider() -> None:
+    configured = ConfiguredLLMProvider(
+        LLMProvider(provider="mock", api_key="sk-test", base_url=None, model="solo"), None, None
+    )
+    assert configured.route_for({"classification": "sensitive"}) is configured
+
+
+# ── the real extraction path ──────────────────────────────────────────────────
+
+
+async def _extract(metadata: dict[str, Any] | None, chain: MultiLLMProvider) -> ConfiguredLLMProvider:
+    """Run real fact extraction and return the wrapper the prompt was sent with."""
+    from hindsight_api.engine.retain import fact_extraction
+
+    config = HindsightConfig.from_env()
+    config.retain_extraction_mode = "facts"
+    config.retain_batch_enabled = False
+
+    seen: list[ConfiguredLLMProvider] = []
+
+    async def _capture(*, llm_config, **kwargs):
+        seen.append(llm_config)
+        return [], TokenUsage()
+
+    original = fact_extraction._extract_facts_with_auto_split
+    fact_extraction._extract_facts_with_auto_split = AsyncMock(side_effect=_capture)
+    try:
+        await fact_extraction.extract_facts_from_text(
+            text="Quarterly revenue was up.",
+            event_date=None,
+            llm_config=ConfiguredLLMProvider(chain, None, None),
+            config=config,
+            metadata=metadata,
+        )
+    finally:
+        fact_extraction._extract_facts_with_auto_split = original
+    assert seen, "extraction never reached the LLM"
+    return seen[0]
+
+
+async def test_extraction_sends_a_routed_item_to_its_member() -> None:
+    chain = _chain(("classification", "sensitive", 1))
+    assert (await _extract({"classification": "sensitive"}, chain)).model == "model-1"
+
+
+async def test_extraction_sends_an_unrouted_item_to_the_primary() -> None:
+    chain = _chain(("classification", "sensitive", 1))
+    assert (await _extract({"classification": "public"}, chain)).model == "model-0"
+    assert (await _extract(None, chain)).model == "model-0"
+
+
+# ── batch retain is incompatible ──────────────────────────────────────────────
+
+
+async def test_startup_rejects_batch_retain_with_metadata_routing() -> None:
+    """Batch submits one job per operation, so it cannot honour per-item routes."""
+    config = HindsightConfig.from_env()
+    config.retain_batch_enabled = True
+    with pytest.raises(RuntimeError, match="not compatible with the 'metadata' LLM strategy"):
+        await validate_retain_batch_support(_chain(("classification", "sensitive", 1)), config)
+
+
+async def test_metadata_routing_is_fine_when_batch_retain_is_off() -> None:
+    config = HindsightConfig.from_env()
+    config.retain_batch_enabled = False
+    await validate_retain_batch_support(_chain(("classification", "sensitive", 1)), config)

--- a/hindsight-api-slim/tests/test_metadata_llm_routing.py
+++ b/hindsight-api-slim/tests/test_metadata_llm_routing.py
@@ -75,17 +75,24 @@ def test_routes_rejected_outside_metadata_mode(mode: str) -> None:
 @pytest.mark.parametrize(
     "route,message",
     [
-        ('{"key": "", "value": "v", "member": 1}', "'key' must be a non-empty string"),
-        ('{"value": "v", "member": 1}', "'key' must be a non-empty string"),
-        ('{"key": "k", "value": 3, "member": 1}', "'value' must be a string"),
-        ('{"key": "k", "value": "v"}', "'member' must be a non-negative integer"),
-        ('{"key": "k", "value": "v", "member": -1}', "'member' must be a non-negative integer"),
-        # bool is an int subclass; {"member": true} is a typo, not member 1.
-        ('{"key": "k", "value": "v", "member": true}', "'member' must be a non-negative integer"),
-        ('"not-an-object"', "must be a JSON object"),
+        ('{"key": "", "value": "v", "member": 1}', r"routes\.0\.key: String should have at least 1 character"),
+        ('{"value": "v", "member": 1}', r"routes\.0\.key: Field required"),
+        ('{"key": "k", "value": 3, "member": 1}', r"routes\.0\.value: Input should be a valid string"),
+        ('{"key": "k", "value": "v"}', r"routes\.0\.member: Field required"),
+        (
+            '{"key": "k", "value": "v", "member": -1}',
+            r"routes\.0\.member: Input should be greater than or equal to 0",
+        ),
+        # bool is an int subclass, so only strict mode rejects {"member": true},
+        # which is a typo rather than a request for member 1.
+        ('{"key": "k", "value": "v", "member": true}', r"routes\.0\.member: Input should be a valid integer"),
+        # extra="forbid": a misspelled key must fail, not leave the route on the default member.
+        ('{"key": "k", "value": "v", "member": 1, "membr": 2}', r"routes\.0\.membr: Extra inputs are not permitted"),
+        ('"not-an-object"', r"routes\.0: Input should be a valid dictionary"),
     ],
 )
 def test_malformed_route_fails_fast(route: str, message: str) -> None:
+    """Route shape is enforced by the model, so the error names the offending field."""
     with pytest.raises(ValueError, match=message):
         _parse_llm_strategy('{"mode": "metadata", "routes": [%s]}' % route)
 

--- a/hindsight-api-slim/tests/test_metadata_llm_routing.py
+++ b/hindsight-api-slim/tests/test_metadata_llm_routing.py
@@ -247,3 +247,65 @@ async def test_metadata_routing_is_fine_when_batch_retain_is_off() -> None:
     config = HindsightConfig.from_env()
     config.retain_batch_enabled = False
     await validate_retain_batch_support(_chain(("classification", "sensitive", 1)), config)
+
+
+# ── only retain can select this strategy ──────────────────────────────────────
+
+
+def _build_config(**overrides: Any) -> HindsightConfig:
+    from hindsight_api.config import LLMMemberConfig
+
+    config = HindsightConfig.from_env()
+    member = LLMMemberConfig(
+        provider="mock",
+        api_key="sk-test",
+        model="member-1",
+        base_url=None,
+        reasoning_effort=None,
+        extra_body=None,
+        default_headers=None,
+        bedrock_service_tier=None,
+        gemini_service_tier=None,
+    )
+    config.llm_members = [member]
+    config.llm_strategy = None
+    for prefix in ("retain_", "reflect_", "consolidation_"):
+        setattr(config, f"{prefix}llm_members", [])
+        setattr(config, f"{prefix}llm_strategy", None)
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _metadata_strategy() -> LLMStrategyConfig:
+    return LLMStrategyConfig(mode=LLM_STRATEGY_METADATA, routes=_routes(("classification", "sensitive", 1)))
+
+
+def _build(prefix: str, config: HindsightConfig) -> Any:
+    from hindsight_api.engine.memory_engine import _build_llm, _LLMCallDefaults
+
+    base = LLMProvider(provider="mock", api_key="sk-test", base_url=None, model="model-0")
+    defaults = _LLMCallDefaults(timeout=None, max_retries=1, initial_backoff=0.1, max_backoff=1.0)
+    return _build_llm(base, config, prefix, defaults)
+
+
+@pytest.mark.parametrize("prefix", ["reflect_", "consolidation_"])
+def test_explicit_metadata_strategy_is_rejected_for_non_retain_operations(prefix: str) -> None:
+    """Accepting it would pin the chain to the primary and look like broken routes."""
+    config = _build_config(**{f"{prefix}llm_strategy": _metadata_strategy()})
+    with pytest.raises(ValueError, match="only supported for retain"):
+        _build(prefix, config)
+
+
+def test_retain_may_select_metadata_explicitly() -> None:
+    config = _build_config(retain_llm_strategy=_metadata_strategy())
+    assert _build("retain_", config).strategy.mode == LLM_STRATEGY_METADATA
+
+
+def test_global_metadata_strategy_is_inherited_and_pins_other_operations_to_the_primary() -> None:
+    """The documented setup is a single global strategy; other operations keep the primary."""
+    config = _build_config(llm_strategy=_metadata_strategy())
+    for prefix in ("", "retain_", "reflect_", "consolidation_"):
+        chain = _build(prefix, config)
+        assert chain.strategy.mode == LLM_STRATEGY_METADATA
+        assert chain._member_order() == [0]

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -566,10 +566,11 @@ The unindexed `HINDSIGHT_API_LLM_*` config is the **primary** (member 1). Extra 
 | `HINDSIGHT_API_LLM_<n>_LITELLMROUTER_CONFIG` | Per-member LiteLLM Router config JSON (for a `litellmrouter` member). Falls back to the global `HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG` when unset. | - |
 | `HINDSIGHT_API_LLM_STRATEGY` | JSON routing strategy across the chain. Unset = single primary LLM (no change). | - |
 
-The strategy JSON supports two modes:
+The strategy JSON supports three modes:
 
 - `{"mode": "failover"}` — try members in order (primary first); on a member's failure (after its own retries) advance to the next.
 - `{"mode": "round-robin"}` — rotate the starting member per request to spread load, then fall through the rest on failure. Add `"weights": [3, 1, ...]` (positive ints, one per member, primary first) for an **unbalanced** rotation.
+- `{"mode": "metadata", "routes": [...]}` — **retain only**: pick the member from each retained item's own `metadata`. See [Metadata routing](#metadata-routing) below.
 
 ```bash
 # Primary OpenAI, failover to Groq then Anthropic
@@ -584,6 +585,35 @@ export HINDSIGHT_API_LLM_STRATEGY='{"mode": "failover"}'
 # Weighted round-robin: serve the primary 3x as often as member 1
 export HINDSIGHT_API_LLM_STRATEGY='{"mode": "round-robin", "weights": [3, 1]}'
 ```
+
+#### Metadata routing
+
+`{"mode": "metadata"}` sends each retained item to the chain member its own metadata selects, so one deployment can extract different documents with different models:
+
+```bash
+export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_API_KEY=sk-...
+export HINDSIGHT_API_LLM_1_PROVIDER=ollama
+export HINDSIGHT_API_LLM_1_MODEL=qwen3:8b
+export HINDSIGHT_API_LLM_STRATEGY='{
+  "mode": "metadata",
+  "routes": [{"key": "classification", "value": "sensitive", "member": 1}]
+}'
+```
+
+Retaining `{"content": "...", "metadata": {"classification": "sensitive"}}` extracts facts on the local `qwen3:8b`; everything else uses the primary.
+
+- **Routes are matched per item, in declared order — the first match wins.** An item that matches no route uses member `0` (the primary).
+- **Values are compared as strings**, because retain metadata is free-form JSON and route values come from an env var: `"member": 1` matches metadata `1` and `"1"`. A list value matches if any entry does, so `{"labels": ["pii", "eu"]}` matches a route on `labels` = `pii`.
+- **Nothing is stored.** The selection is made when the item's extraction prompt is built and is not persisted, so changing the routes changes only future retains. Reprocessing a document replays its original metadata and therefore re-routes the same way.
+- **Each retain item is one extraction prompt**, so a batch mixing differently routed items is fine — every item goes to its own member.
+
+**What this does not do.** Metadata routing chooses *which model extracts a document*. It is not a data boundary: the facts extracted from a routed document are stored in the same bank as everything else, and recall, reflect, consolidation, mental-model refresh and dry-run extraction all continue to use the primary LLM. If you need a document's content kept away from a provider entirely, use a separate bank with a per-bank LLM configuration instead.
+
+Two further limits:
+
+- **`update_mode: "append"` routes on the metadata supplied with the append call**, not the stored document's. An append re-extracts the stored body together with the new text, so resupply the same metadata to keep it on the same member.
+- **Batch retain is not supported** with this mode. `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` submits every item of an operation as a single job to a single member, which cannot honour per-item routes, so the combination is rejected at startup.
 
 **Per-operation chains.** Each operation can define its own members + strategy with the `RETAIN` / `REFLECT` / `CONSOLIDATION` prefix (e.g. `HINDSIGHT_API_RETAIN_LLM_1_PROVIDER`, `HINDSIGHT_API_RETAIN_LLM_STRATEGY`). A per-operation slot with no indexed members (or no strategy) inherits the global chain.
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -179,8 +179,13 @@ HINDSIGHT_API_LLM_MODEL=gpt-4o-mini
 # two Codex members fails over between two ChatGPT accounts instead of retrying one.
 # HINDSIGHT_API_LLM_1_PROVIDER=openai-codex
 # HINDSIGHT_API_LLM_1_CODEX_HOME=/var/lib/hindsight/codex-b
-# Strategy JSON: {"mode": "failover"} or {"mode": "round-robin"}.
+# Strategy JSON: {"mode": "failover"}, {"mode": "round-robin"}, or
+# {"mode": "metadata", "routes": [{"key": "classification", "value": "sensitive", "member": 1}]}.
 # Round-robin accepts optional positive-int "weights" (one per member, primary first).
+# Metadata mode is RETAIN ONLY: each retained item picks a member from its own
+# metadata (first matching route wins; no match uses the primary). It chooses which
+# model extracts a document, not where that document's data can end up -- recall,
+# reflect, consolidation and mental models all keep using the primary.
 # HINDSIGHT_API_LLM_STRATEGY={"mode": "failover"}
 
 # API Configuration (Optional)

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -566,10 +566,11 @@ The unindexed `HINDSIGHT_API_LLM_*` config is the **primary** (member 1). Extra 
 | `HINDSIGHT_API_LLM_<n>_LITELLMROUTER_CONFIG` | Per-member LiteLLM Router config JSON (for a `litellmrouter` member). Falls back to the global `HINDSIGHT_API_LLM_LITELLMROUTER_CONFIG` when unset. | - |
 | `HINDSIGHT_API_LLM_STRATEGY` | JSON routing strategy across the chain. Unset = single primary LLM (no change). | - |
 
-The strategy JSON supports two modes:
+The strategy JSON supports three modes:
 
 - `{"mode": "failover"}` — try members in order (primary first); on a member's failure (after its own retries) advance to the next.
 - `{"mode": "round-robin"}` — rotate the starting member per request to spread load, then fall through the rest on failure. Add `"weights": [3, 1, ...]` (positive ints, one per member, primary first) for an **unbalanced** rotation.
+- `{"mode": "metadata", "routes": [...]}` — **retain only**: pick the member from each retained item's own `metadata`. See [Metadata routing](#metadata-routing) below.
 
 ```bash
 # Primary OpenAI, failover to Groq then Anthropic
@@ -584,6 +585,35 @@ export HINDSIGHT_API_LLM_STRATEGY='{"mode": "failover"}'
 # Weighted round-robin: serve the primary 3x as often as member 1
 export HINDSIGHT_API_LLM_STRATEGY='{"mode": "round-robin", "weights": [3, 1]}'
 ```
+
+#### Metadata routing
+
+`{"mode": "metadata"}` sends each retained item to the chain member its own metadata selects, so one deployment can extract different documents with different models:
+
+```bash
+export HINDSIGHT_API_LLM_PROVIDER=openai
+export HINDSIGHT_API_LLM_API_KEY=sk-...
+export HINDSIGHT_API_LLM_1_PROVIDER=ollama
+export HINDSIGHT_API_LLM_1_MODEL=qwen3:8b
+export HINDSIGHT_API_LLM_STRATEGY='{
+  "mode": "metadata",
+  "routes": [{"key": "classification", "value": "sensitive", "member": 1}]
+}'
+```
+
+Retaining `{"content": "...", "metadata": {"classification": "sensitive"}}` extracts facts on the local `qwen3:8b`; everything else uses the primary.
+
+- **Routes are matched per item, in declared order — the first match wins.** An item that matches no route uses member `0` (the primary).
+- **Values are compared as strings**, because retain metadata is free-form JSON and route values come from an env var: `"member": 1` matches metadata `1` and `"1"`. A list value matches if any entry does, so `{"labels": ["pii", "eu"]}` matches a route on `labels` = `pii`.
+- **Nothing is stored.** The selection is made when the item's extraction prompt is built and is not persisted, so changing the routes changes only future retains. Reprocessing a document replays its original metadata and therefore re-routes the same way.
+- **Each retain item is one extraction prompt**, so a batch mixing differently routed items is fine — every item goes to its own member.
+
+**What this does not do.** Metadata routing chooses *which model extracts a document*. It is not a data boundary: the facts extracted from a routed document are stored in the same bank as everything else, and recall, reflect, consolidation, mental-model refresh and dry-run extraction all continue to use the primary LLM. If you need a document's content kept away from a provider entirely, use a separate bank with a per-bank LLM configuration instead.
+
+Two further limits:
+
+- **`update_mode: "append"` routes on the metadata supplied with the append call**, not the stored document's. An append re-extracts the stored body together with the new text, so resupply the same metadata to keep it on the same member.
+- **Batch retain is not supported** with this mode. `HINDSIGHT_API_RETAIN_BATCH_ENABLED=true` submits every item of an operation as a single job to a single member, which cannot honour per-item routes, so the combination is rejected at startup.
 
 **Per-operation chains.** Each operation can define its own members + strategy with the `RETAIN` / `REFLECT` / `CONSOLIDATION` prefix (e.g. `HINDSIGHT_API_RETAIN_LLM_1_PROVIDER`, `HINDSIGHT_API_RETAIN_LLM_STRATEGY`). A per-operation slot with no indexed members (or no strategy) inherits the global chain.
 


### PR DESCRIPTION
## Summary

Adds a third multi-LLM strategy, `{"mode": "metadata", "routes": [...]}`, that picks the chain member from each retained item's own `metadata`. One deployment can then extract different documents with different models — a local model for regulated content, a per-customer model, a cheaper model for bulk ingest.

```bash
export HINDSIGHT_API_LLM_PROVIDER=openai
export HINDSIGHT_API_LLM_API_KEY=sk-...
export HINDSIGHT_API_LLM_1_PROVIDER=ollama
export HINDSIGHT_API_LLM_1_MODEL=qwen3:8b
export HINDSIGHT_API_LLM_STRATEGY='{
  "mode": "metadata",
  "routes": [{"key": "classification", "value": "sensitive", "member": 1}]
}'
```

Retaining `{"content": "...", "metadata": {"classification": "sensitive"}}` extracts facts on the local `qwen3:8b`; everything else uses the primary.

This is an alternative implementation of #3900, which explores the same idea. Thanks to @cachanova — the config shape and the "a pinned member never fails over" rule come from that PR.

## Where the routing happens, and why that keeps it small

Selection is one hook in `extract_facts_from_text`, which handles **exactly one retain item**. That single fact is what makes the feature stateless:

- The item's metadata is unambiguous at the point the member is chosen, so nothing has to be persisted, unioned across a batch, or reconciled between operations.
- A batch mixing differently-classified items is fine — each item goes to its own member. There is no conflict to detect and no reason to reject a mixed submission.
- Every chunk the item fans out into shares that one item's classification.

`ConfiguredLLMProvider.route_for` re-binds to the selected member while keeping the operation's bank config and trace context, so a routed call is attributed to the same trace as its siblings — only the member changes.

Reprocess re-routes correctly for free: `retain_params` already carries `metadata`, and `_reprocess_document` replays it.

## Scope: deliberately retain-only

Metadata routing chooses **which model extracts a document**, not where that document's data can end up. Recall, reflect, consolidation, mental-model refresh and dry-run extraction all keep using the primary, and the facts extracted from a routed document live in the same bank as everything else.

The docs say this explicitly rather than implying a data boundary the design cannot enforce, and point at a separate bank with per-bank LLM configuration for callers who need one.

## Two configurations rejected at startup instead of silently misbehaving

- **Batch retain + metadata mode.** The batch path submits every item of an operation as one job to one member, so it cannot honour a per-item route. Making the operator pick one of the two features beats sending routed items to whichever member happens to serve the batch.
- **An explicit `HINDSIGHT_API_REFLECT_LLM_STRATEGY` / `_CONSOLIDATION_LLM_STRATEGY` in metadata mode.** Those chains have no item metadata to route on, so they would be accepted and then pin to the primary — indistinguishable from the routes not working. Inheriting the strategy from the *global* one stays legal and does pin those operations to the primary; that is the documented behaviour.

## Behaviour details

- Routes match **per item, in declared order — first match wins**. An item matching no route uses member `0`.
- Values compare as **strings** (retain metadata is free-form JSON; route values come from an env var), so `"1"` matches `1`. A list value matches if any entry does, making `{"labels": ["pii", "eu"]}` routable.
- Route indices are validated against the chain length at construction, so a typo fails at startup rather than at the first sensitive retain.
- The strategy JSON is parsed into a pydantic model at the boundary (`LLMStrategyConfig` / `LLMMetadataRoute`) rather than read with `.get()`. It is **strict** — `{"member": true}` is a typo, not member 1 — and **closed**, so a misspelled key like `"membr"` fails at startup instead of leaving the route silently pointed at the default member. Errors name the field path (`routes.0.member`).

## Test plan

- 33 new tests in `tests/test_metadata_llm_routing.py`: config parsing and every malformed-route rejection, member selection (first-match, string/list/bool values, no-match), wrapper re-binding with trace context preserved, the **real** `extract_facts_from_text` path asserting which member received the prompt, and both startup rejections.
- 90 existing multi-LLM / per-operation-LLM / batch-validation tests pass unchanged.
- `./scripts/hooks/lint.sh`, `uv run ty check hindsight_api/`, and `./scripts/hooks/check-unused.sh` clean.
- Docusaurus production build passes; docs skill regenerated with `./scripts/generate-docs-skill.sh`; `.env.example` re-copied to the embed package.

## Not included

`extract_dry_run` takes no `metadata`, so dry-run extraction always uses the primary. Documented rather than worked around, since threading metadata through it means changing the endpoint, request model, OpenAPI spec and clients.
