### PR TITLE
chore(docker): move the image Node runtime from EOL 20 to Active LTS 24

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,4 @@ Thumbs.db
 **/coverage
 **/.pytest_cache
 **/.mypy_cache
+**/.next-*

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -81,7 +81,7 @@ RUN if [ "$INCLUDE_LOCAL_MODELS" = "true" ]; then \
 # =============================================================================
 # Stage: SDK Builder (needed for Control Plane)
 # =============================================================================
-FROM node:20-slim AS sdk-builder
+FROM node:24-slim AS sdk-builder
 
 ARG INCLUDE_CP
 RUN if [ "$INCLUDE_CP" != "true" ]; then echo "Skipping SDK build" && exit 0; fi
@@ -99,7 +99,7 @@ RUN npm run build -w @vectorize-io/hindsight-client
 # =============================================================================
 # Stage: Control Plane Builder
 # =============================================================================
-FROM node:20-slim AS cp-builder
+FROM node:24-slim AS cp-builder
 
 ARG INCLUDE_CP
 RUN if [ "$INCLUDE_CP" != "true" ]; then echo "Skipping CP build" && exit 0; fi
@@ -253,7 +253,7 @@ CMD ["/app/start-all.sh"]
 # =============================================================================
 # Stage: Final Image - Control Plane Only
 # =============================================================================
-FROM node:20-alpine AS cp-only
+FROM node:24-alpine AS cp-only
 
 WORKDIR /app
 
@@ -331,7 +331,7 @@ RUN apt-get update && apt-get upgrade -y \
     libgssapi-krb5-2 \
     libossp-uuid16 \
     && (apt-get install -y libicu72 2>/dev/null || apt-get install -y libicu74 2>/dev/null || apt-get install -y libicu76 2>/dev/null || true) \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs \
     && [ -e /usr/lib/node_modules/npm ] \
     && rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx \


### PR DESCRIPTION
## Why

Node 20 reached end-of-life on **2026-04-30** ([nodejs/Release `schedule.json`](https://raw.githubusercontent.com/nodejs/Release/main/schedule.json)) — four months ago. Three places still pin it: the `sdk-builder` and `cp-builder` stages, the `cp-only` runtime base, and the NodeSource package installed into the `standalone` runtime.

Node 24 is the current Active LTS (maintenance 2026-10-20, end 2028-04-30) and satisfies `next@16.2.11`'s `engines: {"node": ">=20.9.0"}`.

## What this does NOT do

It does not reduce the vulnerability count. I measured, because the obvious assumption is that a newer Node clears findings, and it doesn't:

| image | Node 20 | Node 24 |
| --- | --- | --- |
| `standalone` (slim), Trivy 0.74.0 HIGH+CRITICAL | 3C / 82H | **3C / 82H** |
| `cp-only` replica (after `apk upgrade` + npm removal) | 0C / 0H | 0C / 0H |

Byte-identical. `nodejs` **is** inventoried in the standalone image (`dpkg -l nodejs` → `20.20.2-1nodesource1`), and Trivy reports zero findings against it — NodeSource ships the newest 20.x patch and it carries no open CVEs. All 82 High are Debian base packages: `perl-base` (8), the `util-linux` family (~32), and `curl`/`libcurl4t64` (8 — which is what #4057 removes).

Two related data points, since "bump Node" keeps coming up as a security lever:

- The raw `node:*-alpine` bases differ a lot (20-alpine 1C/23H → 24-alpine 0C/6H), but every one of those findings lives in npm's bundled dependency tree (`tar`, `pacote`, `sigstore`, `brace-expansion`, `minimatch`, `glob`, `cross-spawn`, `ip-address`). `cp-only` already deletes npm and runs `apk upgrade`, which is why it sits at 0C/0H on all of 20, 22 and 24.
- Under #4057's scheme — copying the bare `node` binary out of `cp-builder` — the scan is identical for Node 20 and 24 because a stray binary carries no package metadata, so Trivy stops inventorying Node entirely. Worth knowing: part of #4057's reported improvement is the scanner losing sight of Node, not Node getting safer. That makes staying on a supported Node line *more* important after #4057, not less, since no scanner will flag it.

So the case here is purely forward-looking: the next Node CVE gets a fix on 24 and never gets one on 20.

## Changes

- `sdk-builder`, `cp-builder`: `node:20-slim` → `node:24-slim`
- `cp-only`: `node:20-alpine` → `node:24-alpine`
- `standalone`: NodeSource `setup_20.x` → `setup_24.x`, in the same commit so the Next standalone bundle isn't built on 24 and then executed on 20. The `[ -e /usr/lib/node_modules/npm ]` guard — deliberately written to fail the build if a base bump relocates that path — still holds on 24, and `command -v npm` confirms npm is absent from the built image.
- `.dockerignore`: add `**/.next-*`. Unrelated to Node but it blocked verifying this PR, so it's here rather than in a follow-up. The existing `**/.next` doesn't match the `.next-<port>` scratch directories the control-plane dev server leaves behind; they were copied into the build context and failed `next build` with `TS2307` against routes deleted long ago. CI never hits this because it checks out clean — every local image build does.

## Verification

Built locally (arm64):

- `cp-only` on Node 24 builds, and `./docker/test-image.sh hindsight-cp-node24:test cp-only` **passes** (Next.js 16.3.4 boots, health endpoint responds).
- `standalone` (slim) on Node 24 builds; `node --version` → `v24.20.0` in the final image, npm absent.
- Baseline `standalone` built from `origin/main` for the scan comparison above.

The `standalone` smoke test needs LLM credentials, so it wasn't run locally — that's CI's `Build Docker (standalone-slim)` leg. Note that leg is gated on `has_secrets == 'true'`, so it does not run on fork PRs; this branch is in-repo and will exercise all of it.