### PR TITLE
ci: build the control plane on Node 24, matching the image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
         cache-dependency-path: package-lock.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1343,7 +1343,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
         cache-dependency-path: package-lock.json
 


### PR DESCRIPTION
## Why

#4193 moved the Docker `cp-builder` stage to `node:24-slim`, but the two CI jobs that build the control plane **directly on the runner** still provisioned Node 20, which went EOL on 2026-04-30.

That leaves two problems, not one:

1. **EOL toolchain** — same reason as #4193.
2. **Version skew** — CI would test and publish a control-plane build produced on a different Node major than the one the shipped image is built with. The point of #4193 was to stop building on one major and running on another; this closes the same gap on the runner side.

## Changes

| workflow | job | what it does |
| --- | --- | --- |
| `test.yml` | `build-control-plane` | CP unit tests, i18n parity check, `next build`, standalone verification, server smoke test |
| `release.yml` | `release-control-plane` | builds and publishes `@vectorize-io/hindsight-control-plane` to npm |

Both `'20'` → `'24'`. Neither `hindsight-control-plane` nor `hindsight-clients/typescript` declares an `engines` floor, and `next@16.2.11` requires `>=20.9.0`, so 24 clears both.

## Deliberately not changed

The remaining Node 20 jobs are `build-typescript-client`, `test-typescript-client{,-oracle,-deno}`, `test-hindsight-all`, `test-doc-examples`, `build-docs`, `deploy-docs`, `check-unused-code` and `verify-generated-files`.

The SDK-facing ones matter: they exercise the **published** client, where pinning an older major reads as deliberate lower-bound coverage rather than an oversight. Bumping them would quietly drop the oldest Node version the SDK is proven against, which is a product decision and not mine to make in a CI cleanup. The docs and tooling jobs are simply out of scope here. Happy to do either as a follow-up.

## Verification

This PR touches `.github/workflows/**`, which sets `detect-changes.outputs.ci`, so `build-control-plane` runs on this PR — on Node 24. That job is the verification: it runs the CP test suite, the i18n check, the production build and the server smoke test.

The Docker side is already proven — #4193's `Build Docker (control-plane)` and `(standalone-slim)` legs passed, and the `cp-only` image was smoke tested locally on Node 24 via `docker/test-image.sh`.