### PR TITLE
perf(api-slim): stop the mental-model staleness check walking the bank (#4169)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -1544,6 +1544,29 @@ class MemoriesExtension(Extension, ABC):
             for scope in scopes
         }
 
+    async def latest_memory_write_at(self, *, conn, fq_table, bank_id: str) -> datetime | None:
+        """The newest ``updated_at`` across the bank's memories, or None if it has none.
+
+        The bank-wide counterpart of :meth:`any_memory_updated_since`, and the
+        shortcut in front of it: a mental model whose watermark is at or past this
+        cannot be stale whatever its scope, so every staleness surface asks this
+        once and only then asks the scoped question for the models it cannot rule
+        out. That is worth a method of its own because the scoped check is the
+        expensive one — it is bounded by the writes since a model's watermark, and
+        a model whose own scope has been quiet pays for all of them.
+
+        None means the bank has no memories, never "unknown": a store that cannot
+        answer cheaply should leave the default in place rather than return None,
+        which callers read as an empty bank and act on.
+
+        The default is the value ``consolidation_freshness`` already computes, so a
+        store works without implementing this; override it when the aggregate costs
+        more than the single value does (Postgres reads it off the
+        ``(bank_id, updated_at)`` index instead of scanning to count).
+        """
+        fresh = await self.consolidation_freshness(conn=conn, fq_table=fq_table, bank_id=bank_id)
+        return fresh.get("last_memory_write_at")
+
     async def live_memory_ids(self, *, conn, fq_table, bank_id: str, unit_ids: list[Any]) -> set[str]:
         """Which of ``unit_ids`` still exist among the bank's live memories.
 

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/reads.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/reads.py
@@ -536,6 +536,27 @@ async def any_memory_updated_since(
     return row is not None
 
 
+async def latest_memory_write_at(
+    *,
+    conn,
+    fq_table: Callable[[str], str],
+    bank_id: str,
+) -> datetime | None:
+    """The newest ``updated_at`` across ``bank_id``'s memories, or None if it has none.
+
+    The bank-wide half of the staleness question, and the cheap one: ``MAX`` over
+    the leading column of ``idx_memory_units_bank_updated_at`` is a single backward
+    index probe, whatever the bank's size. A mental model that has read the
+    memories at or past this cannot be stale however its scope is drawn, which is
+    what lets the staleness surfaces skip the scoped scan entirely on a bank whose
+    writes have not moved since.
+    """
+    return await conn.fetchval(
+        f"SELECT MAX(updated_at) FROM {fq_table('memory_units')} WHERE bank_id = $1",
+        bank_id,
+    )
+
+
 async def any_memory_updated_since_batch(
     *,
     conn,
@@ -547,11 +568,9 @@ async def any_memory_updated_since_batch(
 
     The knowledge tree and the mental-model list ask this for every model in the
     bank on a poll, and one round-trip each is what made the exact answer look
-    expensive — the scans themselves are microseconds once
-    ``idx_memory_units_bank_updated_at`` exists. Scopes are grouped by the tag
-    clause they generate (a bank's pages almost always share one), each group is
-    joined against its scope set as JSON, and every group is a single prepared
-    plan however many pages it covers.
+    expensive. Scopes are grouped by the tag clause they generate (a bank's pages
+    almost always share one), each group is joined against its scope set as JSON,
+    and every group is a single prepared plan however many pages it covers.
 
     Two details in the SQL are load-bearing:
 
@@ -560,7 +579,14 @@ async def any_memory_updated_since_batch(
       estimates the ``LIMIT 1`` will be satisfied early, picks a sequential scan,
       and the whole point is lost (measured: 13 ms per scope instead of 0.03 ms).
       The ORDER BY makes the ``(bank_id, updated_at DESC)`` index the obvious way
-      to run the join, which is also the cheapest.
+      to run the join, which is also the cheapest **when the scope has a match**.
+      When it does not, that index is walked to the end: ``LIMIT 1`` can only stop
+      at a hit, so a scope whose own tags have been quiet rejects, one row at a
+      time, every memory written since its watermark (measured on a real bank:
+      247 ms for one scope over 123k rows, #4169). Callers therefore rule out what
+      they can against the bank-wide watermark before asking — see
+      ``MemoryEngine.compute_mental_models_are_stale`` — and what reaches here is
+      the set that genuinely has to be scoped.
     * ``LEFT JOIN LATERAL`` rather than a correlated ``EXISTS``. A scalar subquery
       over a function scan gets no useful row estimate and falls back to a
       sequential scan for the same reason.
@@ -705,6 +731,7 @@ __all__ = [
     "count_memories",
     "find_unconsolidated",
     "get_memories",
+    "latest_memory_write_at",
     "list_tags",
     "live_memory_ids",
     "mark_consolidated",

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/reads.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/reads.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import uuid
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -35,6 +36,7 @@ from ...search.tags import (
     build_tag_groups_where_clause,
     build_tags_where_clause,
     build_tags_where_clause_simple,
+    tag_clause_is_index_only,
 )
 from ..base import MemoryScopeWatermark, ScanPage, StoredMemory
 
@@ -499,15 +501,55 @@ async def any_memory_updated_since(
 ) -> bool:
     """Whether any memory in ``bank_id``'s scope was written after ``since``.
 
-    Backs the mental-model staleness check, so it is a bounded existence test —
-    ``LIMIT 1``, never a COUNT: the answer is "is there one", and the planner can
-    stop at the first hit. The scope is the mental model's: its flat tags (or the
-    compound ``tag_groups``) plus an optional ``fact_types`` restriction. This is
-    where the staleness query's WHERE lives, so the same scope that gates a
-    refresh decides whether one is due.
+    Backs the mental-model staleness check. Two shapes, because which index can
+    answer it depends on the scope, and the wrong one walks the bank (#4169):
+
+    * **Tag-indexable scopes** — the ``_strict`` modes and ``exact``, whose clause
+      is a bare ``tags @>``/``&&`` (see
+      :func:`~...search.tags.tag_clause_is_index_only`) — ask ``bool_or(updated_at
+      > since)`` with the *tag predicate alone* in the WHERE. Leaving
+      ``updated_at`` out of the WHERE is the whole point: it makes ``tags`` the
+      only index-eligible filter, so the planner reaches
+      ``idx_memory_units_tags`` and reads just the scope's own rows. Put the time
+      predicate back and it prefers a scan (measured: a seq scan of the bank).
+      Cost is then the size of the scope, not the size of the bank. ``bank_id``
+      stays in the WHERE and is still enforced, but as a recheck on the heap rather
+      than an index condition — that index is not bank-scoped, so a tag many banks
+      share costs their rows too. Bounded by the tag, and still far below a walk of
+      every write since the watermark.
+    * **Everything else** — ``any``/``all`` (whose ``OR tags IS NULL`` disjunct no
+      index can serve), an untagged scope, and compound ``tag_groups`` — keep the
+      bounded ``LIMIT 1`` existence test on ``(bank_id, updated_at)``. It stops at
+      the first hit, which is fast whenever the answer is "stale"; when it is not,
+      it walks every memory written since ``since``, and the caller's bank-wide
+      watermark check is what keeps it off that path (see
+      ``MemoryEngine.compute_mental_model_is_stale``).
+
+    Measured on 100k rows, one quiet scope: 16-21ms on the ``LIMIT 1`` shape
+    against 0.6-0.9ms on the aggregate; for a hot scope the aggregate costs
+    1.9-3.1ms against 1.1-1.6ms, which is the trade — bounded by the scope
+    instead of by the bank.
+
+    The scope is the mental model's: its flat tags (or the compound
+    ``tag_groups``) plus an optional ``fact_types`` restriction. This is where the
+    staleness query's WHERE lives, so the same scope that gates a refresh decides
+    whether one is due.
     """
+    # `since` is bound as $2 either way: in the WHERE for the LIMIT 1 shape, in the
+    # aggregate's own expression for the indexable one.
+    #
+    # Postgres only. The aggregate shape exists to reach a GIN index that Oracle has
+    # no counterpart for — its rewriter turns `tags @>` / `&&` into JSON_TABLE
+    # existence predicates, which no index serves either way — and `bool_or` is not
+    # an Oracle aggregate at all, so on Oracle this would be a syntax error rather
+    # than a slower plan. Oracle keeps the LIMIT 1 shape, which rewrites cleanly.
+    indexable = (
+        getattr(conn, "backend_type", "postgresql") == "postgresql"
+        and not tag_groups
+        and tag_clause_is_index_only(tags, tags_match)
+    )
     params: list[Any] = [bank_id, since]
-    where = ["bank_id = $1", "updated_at > $2"]
+    where = ["bank_id = $1"] if indexable else ["bank_id = $1", "updated_at > $2"]
 
     built = build_tags_where_clause(tags, param_offset=len(params) + 1, match=tags_match)
     tag_clause = built.sql
@@ -528,6 +570,15 @@ async def any_memory_updated_since(
     if fact_types:
         params.append(list(fact_types))
         where.append(f"fact_type = ANY(${len(params)}::text[])")
+
+    if indexable:
+        # bool_or over an empty match set is NULL, which is "no in-scope memory at
+        # all" — not stale, same as the LIMIT 1 shape returning no row.
+        hit = await conn.fetchval(
+            f"SELECT bool_or(updated_at > $2) FROM {fq_table('memory_units')} WHERE {' AND '.join(where)}",
+            *params,
+        )
+        return bool(hit)
 
     row = await conn.fetchval(
         f"SELECT 1 FROM {fq_table('memory_units')} WHERE {' AND '.join(where)} LIMIT 1",
@@ -557,6 +608,21 @@ async def latest_memory_write_at(
     )
 
 
+@dataclass(frozen=True)
+class _ScopeGroupKey:
+    """What makes two staleness scopes answerable by one query.
+
+    Scopes with the same tag clause *and* the same query shape share a prepared
+    plan, so they are asked together; anything else needs its own statement.
+    """
+
+    tag_clause: str
+    """The generated tag predicate, phrased over the joined scope's `s.tags`."""
+
+    indexable: bool
+    """Whether that predicate can be answered from the GIN index on ``tags`` alone."""
+
+
 async def any_memory_updated_since_batch(
     *,
     conn,
@@ -568,25 +634,32 @@ async def any_memory_updated_since_batch(
 
     The knowledge tree and the mental-model list ask this for every model in the
     bank on a poll, and one round-trip each is what made the exact answer look
-    expensive. Scopes are grouped by the tag clause they generate (a bank's pages
-    almost always share one), each group is joined against its scope set as JSON,
-    and every group is a single prepared plan however many pages it covers.
+    expensive. Scopes are grouped by the tag clause they generate and the query
+    shape it implies (a bank's pages almost always share both), each group is
+    joined against its scope set as JSON, and every group is a single prepared
+    plan however many pages it covers.
 
-    Two details in the SQL are load-bearing:
+    Which of the two shapes a group gets is :func:`any_memory_updated_since`'s
+    decision, made per group here — the aggregate over the tag index for scopes
+    whose clause that index can serve, the time-ordered ``LIMIT 1`` for the rest.
+    Read that docstring first; what follows is what the *batched* form adds.
 
-    * ``ORDER BY mu.updated_at DESC`` inside the LATERAL. It does not change the
-      answer — we only ask whether a row exists — but without it the planner
-      estimates the ``LIMIT 1`` will be satisfied early, picks a sequential scan,
-      and the whole point is lost (measured: 13 ms per scope instead of 0.03 ms).
-      The ORDER BY makes the ``(bank_id, updated_at DESC)`` index the obvious way
-      to run the join, which is also the cheapest **when the scope has a match**.
-      When it does not, that index is walked to the end: ``LIMIT 1`` can only stop
-      at a hit, so a scope whose own tags have been quiet rejects, one row at a
-      time, every memory written since its watermark (measured on a real bank:
-      247 ms for one scope over 123k rows, #4169). Callers therefore rule out what
-      they can against the bank-wide watermark before asking — see
-      ``MemoryEngine.compute_mental_models_are_stale`` — and what reaches here is
-      the set that genuinely has to be scoped.
+    Three details in the SQL are load-bearing:
+
+    * ``ORDER BY mu.updated_at DESC`` inside the ``LIMIT 1`` LATERAL. It does not
+      change the answer — we only ask whether a row exists — but without it the
+      planner estimates the ``LIMIT 1`` will be satisfied early, picks a sequential
+      scan, and the whole point is lost (measured: 13 ms per scope instead of
+      0.03 ms). It makes the ``(bank_id, updated_at DESC)`` index the obvious way
+      to run the join, which is the cheapest **when the scope has a match** — and
+      a walk to the end of the index when it does not. That is the cost the other
+      shape exists to avoid, and for the modes still on this one it is the
+      caller's bank-wide watermark check that keeps them off it.
+    * ``COALESCE(h.hit, false)`` in the aggregate shape against
+      ``(h.hit IS NOT NULL)`` in the other. A ``LIMIT 1`` LATERAL yields no row for
+      a scope with no match; ``bool_or`` yields one row holding NULL. Projecting
+      either as "not stale" is the same answer, but only if each is spelled for its
+      own shape — read the wrong way round, every quiet scope reports stale.
     * ``LEFT JOIN LATERAL`` rather than a correlated ``EXISTS``. A scalar subquery
       over a function scan gets no useful row estimate and falls back to a
       sequential scan for the same reason.
@@ -597,9 +670,8 @@ async def any_memory_updated_since_batch(
 
     Postgres only. This module backs both SQL dialects, and Oracle reaches it
     through a regex rewriter that does not model ``jsonb_to_recordset`` or
-    ``LATERAL``, so an Oracle connection takes the same per-scope path. It is the
-    round-trips that are saved here, not the scans — the scans are cheap on both
-    dialects once the ``(bank_id, updated_at)`` index exists.
+    ``LATERAL``, so an Oracle connection takes the same per-scope path — which is
+    :func:`any_memory_updated_since`, and therefore picks up the same two shapes.
     """
     if not scopes:
         return {}
@@ -622,8 +694,9 @@ async def any_memory_updated_since_batch(
     table = fq_table("memory_units")
     results: dict[str, bool] = {}
 
-    # Group by the generated clause: same clause, same query text, one plan.
-    by_clause: dict[str, list[MemoryScopeWatermark]] = {}
+    # Group by the generated clause and the shape it implies: same key, same query
+    # text, one plan.
+    by_clause: dict[_ScopeGroupKey, list[MemoryScopeWatermark]] = {}
     for scope in scopes:
         if scope.tag_groups:
             results[scope.key] = await any_memory_updated_since(
@@ -642,10 +715,14 @@ async def any_memory_updated_since_batch(
         # cosmetic: both sides of the join expose a `tags` column, and an unqualified
         # one would resolve by scoping rules rather than by intent.
         built = build_tags_where_clause(scope.tags, table_alias="mu.", match=scope.tags_match, value_expr="s.tags")
-        tag_clause = built.sql
-        by_clause.setdefault(tag_clause, []).append(scope)
+        # The shape is part of the group key, not just the clause: the two forms are
+        # different SQL, and a mode that can use the tag index must not be folded in
+        # with one that cannot.
+        indexable = tag_clause_is_index_only(scope.tags, scope.tags_match)
+        by_clause.setdefault(_ScopeGroupKey(built.sql, indexable), []).append(scope)
 
-    for tag_clause, group in by_clause.items():
+    for key, group in by_clause.items():
+        tag_clause = key.tag_clause
         payload = [
             {
                 "scope_key": scope.key,
@@ -657,28 +734,47 @@ async def any_memory_updated_since_batch(
             }
             for scope in group
         ]
-        rows = await conn.fetch(
-            f"""
+        # `tags` must be varchar[], matching memory_units.tags: there is no
+        # `varchar[] @> text[]` operator, so a text[] column here fails to resolve
+        # the containment operators the tag clauses are built from.
+        scope_set = (
+            "FROM jsonb_to_recordset($2::jsonb)\n"
+            "     AS s(scope_key text, since timestamptz, tags varchar[], fact_types text[])"
+        )
+        fact_type_clause = "AND (s.fact_types IS NULL OR mu.fact_type = ANY(s.fact_types))"
+        if key.indexable:
+            # The tag predicate is the only index-eligible filter, deliberately: the
+            # time comparison rides inside the aggregate so the planner reaches the
+            # GIN index on `tags` and touches only the scope's own rows. `bool_or`
+            # over an empty set is NULL, hence the COALESCE — unlike `LIMIT 1`,
+            # which simply yields no row.
+            sql = f"""
+            SELECT s.scope_key, COALESCE(h.hit, false) AS stale
+            {scope_set}
+            LEFT JOIN LATERAL (
+                SELECT bool_or(mu.updated_at > s.since) AS hit
+                FROM {table} mu
+                WHERE mu.bank_id = $1
+                  {tag_clause}
+                  {fact_type_clause}
+            ) h ON TRUE
+            """
+        else:
+            sql = f"""
             SELECT s.scope_key, (h.hit IS NOT NULL) AS stale
-            FROM jsonb_to_recordset($2::jsonb)
-                 -- `tags` must be varchar[], matching memory_units.tags: there is no
-                 -- `varchar[] @> text[]` operator, so a text[] column here fails to
-                 -- resolve the containment operators the tag clauses are built from.
-                 AS s(scope_key text, since timestamptz, tags varchar[], fact_types text[])
+            {scope_set}
             LEFT JOIN LATERAL (
                 SELECT 1 AS hit
                 FROM {table} mu
                 WHERE mu.bank_id = $1
                   AND mu.updated_at > s.since
                   {tag_clause}
-                  AND (s.fact_types IS NULL OR mu.fact_type = ANY(s.fact_types))
+                  {fact_type_clause}
                 ORDER BY mu.updated_at DESC
                 LIMIT 1
             ) h ON TRUE
-            """,
-            bank_id,
-            json.dumps(payload),
-        )
+            """
+        rows = await conn.fetch(sql, bank_id, json.dumps(payload))
         results.update({row["scope_key"]: row["stale"] for row in rows})
 
     return results

--- a/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/postgres.py
@@ -429,6 +429,9 @@ class PostgresMemories(MemoriesExtension):
     ) -> dict[str, bool]:
         return await reads.any_memory_updated_since_batch(conn=conn, fq_table=fq_table, bank_id=bank_id, scopes=scopes)
 
+    async def latest_memory_write_at(self, *, conn, fq_table, bank_id: str) -> datetime | None:
+        return await reads.latest_memory_write_at(conn=conn, fq_table=fq_table, bank_id=bank_id)
+
     async def live_memory_ids(self, *, conn, fq_table, bank_id: str, unit_ids: list[Any]) -> set[str]:
         return await reads.live_memory_ids(conn=conn, fq_table=fq_table, bank_id=bank_id, unit_ids=unit_ids)
 

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -1587,9 +1587,11 @@ def _may_need_refresh(last_refreshed_at: datetime | None, watermark: datetime | 
     model's tags, so it is a signal to go and ask
     (:func:`_mental_model_stale_scope` plus the store's scoped check), never an
     answer to report. Surfaces used to report it as "may need refresh" because
-    asking per model was expensive; ``idx_memory_units_bank_updated_at`` made the
-    scoped answer microseconds, so they now ask (#3291) and this stays what it
-    always was — a free way to skip the question.
+    asking per model was expensive; they now ask the scoped question instead
+    (#3291), and this stays what it always was — a free way to skip it. Every
+    staleness caller runs it first (#4169): the scoped check is bounded by the
+    writes since the model's own watermark, so a model this settles is exactly the
+    one that would have paid the most to be asked.
     """
     if last_refreshed_at is None:
         return True  # Never refreshed — nothing to be current with.
@@ -17858,10 +17860,12 @@ class MemoryEngine(MemoryEngineInterface):
         polls. On a bank whose writes spread across scopes the approximation
         saturated: pages stayed flagged for as long as their own scope stayed
         quiet, since only an in-scope write can move their watermark, and the tree
-        contradicted the gate that refused to refresh them (#3291). With
-        ``idx_memory_units_bank_updated_at`` the exact answer is one query for the
-        whole tree, so the tree asks it outright — no watermark, and so no
-        dependence on how fresh the cached one happens to be.
+        contradicted the gate that refused to refresh them (#3291). The answer here
+        is the exact scoped one, in one round-trip for the whole tree; the bank
+        watermark is back only as :meth:`compute_mental_models_are_stale`'s own
+        shortcut in front of it, read live there rather than taken from a cache, so
+        it rules pages *out* of the scoped query without ever standing in for its
+        answer.
         """
         await self._authenticate_tenant(request_context)
         if self._operation_validator and not _nested_operation_authorized.get():
@@ -18479,6 +18483,25 @@ class MemoryEngine(MemoryEngineInterface):
                 )
         return KnowledgeBaseExport(nodes=nodes, pages=pages)
 
+    async def _bank_write_watermark(self, conn, bank_id: str) -> datetime | None:
+        """The bank's newest memory write, read live, for the staleness shortcut.
+
+        One index probe (see the store's ``latest_memory_write_at``) in front of a
+        scoped check that costs a walk of every memory written since the model's
+        own watermark. It must be read here, on the same connection and
+        immediately before the scoped question, rather than taken from anything
+        cached: :func:`_may_need_refresh` reports "not stale" from it, and a
+        watermark older than the bank's real newest write would prove a freshness
+        that is not there. A write landing after this read is the same race the
+        scoped query already has, and resolves the same way — the next poll sees it.
+
+        None means an empty bank, which is a real answer (nothing has been written,
+        so nothing in any scope has).
+        """
+        from .memories import get_memories
+
+        return await get_memories().latest_memory_write_at(conn=conn, fq_table=fq_table, bank_id=bank_id)
+
     async def compute_mental_model_is_stale(
         self,
         conn,
@@ -18508,19 +18531,25 @@ class MemoryEngine(MemoryEngineInterface):
         # The scoped existence check belongs to the store: it is a query over the
         # memories, and the mental model's scope (tags, tag_groups, fact_types) is
         # exactly what decides whether one of them changed since the last refresh.
+        # It is also the expensive half, so the bank-wide watermark is asked first
+        # and settles it outright whenever nothing has been written since this
+        # model read the memories — the same shortcut the batch variant takes, and
+        # the reason the cron loop and the consolidation flush, which come through
+        # here one model at a time, do not each pay for a scan.
         from .memories import get_memories
 
-        if await get_memories().any_memory_updated_since(
-            conn=conn,
-            fq_table=fq_table,
-            bank_id=bank_id,
-            since=scope.since,
-            fact_types=scope.fact_types,
-            tags=scope.tags,
-            tags_match=scope.tags_match,
-            tag_groups=scope.tag_groups,
-        ):
-            return True
+        if _may_need_refresh(scope.since, await self._bank_write_watermark(conn, bank_id)):
+            if await get_memories().any_memory_updated_since(
+                conn=conn,
+                fq_table=fq_table,
+                bank_id=bank_id,
+                since=scope.since,
+                fact_types=scope.fact_types,
+                tags=scope.tags,
+                tags_match=scope.tags_match,
+                tag_groups=scope.tag_groups,
+            ):
+                return True
 
         # A memory that was *removed* raises no watermark — the row is simply not
         # there — so the check above can never see one. That is why a page could
@@ -18671,29 +18700,38 @@ class MemoryEngine(MemoryEngineInterface):
         against its own scope, in one round-trip for the whole set (see the store's
         ``any_memory_updated_since_batch``).
 
-        ``watermark`` is an optional shortcut, not part of the answer: a model that
-        has read the memories at or past the bank's newest write cannot be stale,
-        whatever its scope, so it can be settled without asking. Pass one **only if
-        it is live** — :meth:`get_bank_freshness` reads it fresh. A cached
-        watermark — the ``last_memory_write_at`` in the 60s-cached stats payload,
-        say — can be older than a model's own last read, and would then prove a
-        freshness that is not there. Omit it and every model is simply asked, which
-        at roughly 30µs each is what the surfaces that poll do.
+        The bank's newest write settles most of the set for free: a model that has
+        read the memories at or past it cannot be stale whatever its scope. That is
+        read here (:meth:`_bank_write_watermark`, one index probe) rather than left
+        to the caller, so every surface gets it — the mental-model list, the
+        knowledge tree and its MCP twin used to ask the scoped question for every
+        model on every poll, and the scoped question is only cheap when the model
+        *is* stale: a scope whose own tags have been quiet pays a walk of every
+        memory written since its watermark (#4169).
+
+        ``watermark`` stays an optional argument for a caller that already holds a
+        **live** one — reflect resolves it once per invocation — and passing it
+        skips the read here. Pass one only if it is live: a cached watermark, the
+        ``last_memory_write_at`` in the 60s-cached stats payload say, can be older
+        than a model's own last read and would then prove a freshness that is not
+        there.
         """
         from .memories import get_memories
 
         answers: dict[str, bool] = {}
         pending: list[MemoryScopeWatermark] = []
+        # Read once for the whole set, and only if some model could still be settled
+        # by it — a set of models that have never been stamped needs no watermark.
+        if watermark is None and any(scope is not None for scope in scopes.values()):
+            watermark = await self._bank_write_watermark(conn, bank_id)
         for key, scope in scopes.items():
             if scope is None:
                 answers[key] = True
                 continue
-            # `watermark is None` means the caller passed none, not that the bank is
-            # empty — without one there is nothing to shortcut against and every
-            # model is asked.
-            if watermark is not None and not _may_need_refresh(scope.since, watermark):
-                # Exact, and free: nothing in the bank has been written since this
-                # model read the memories, so nothing in its scope has either.
+            if not _may_need_refresh(scope.since, watermark):
+                # Exact, and one index probe for the whole set: nothing in the bank
+                # has been written since this model read the memories, so nothing in
+                # its scope has either.
                 answers[key] = False
                 continue
             pending.append(scope)

--- a/hindsight-api-slim/hindsight_api/engine/search/tags.py
+++ b/hindsight-api-slim/hindsight_api/engine/search/tags.py
@@ -89,6 +89,29 @@ def _parse_tags_match(match: TagsMatch) -> TagMatchSemantics:
         return TagMatchSemantics("&&", include_untagged=True)
 
 
+def tag_clause_is_index_only(tags: list[str] | None, match: TagsMatch) -> bool:
+    """Whether this mode's clause is a bare, GIN-indexable predicate on ``tags``.
+
+    True for the ``_strict`` modes and ``exact`` with a non-empty scope: their
+    clause is `tags @> v` / `tags && v` (plus the untagged exclusions, which are
+    rechecks), so Postgres can answer it from ``idx_memory_units_tags`` alone.
+    False for ``any``/``all``, whose clause is a disjunction —
+    ``tags IS NULL OR tags = '{}' OR tags <op> v`` — that no index can serve, and
+    for an empty scope, which is not a tag filter at all.
+
+    The staleness check reads this to decide which shape of existence test to
+    issue: a scope that can be answered from the tag index is asked with the tag
+    predicate *alone* so the planner reaches that index, while one that cannot is
+    left on the time-ordered walk that at least terminates at the first match.
+    See ``any_memory_updated_since`` for what that buys (#4169).
+    """
+    if not tags:
+        return False
+    if match == "exact":
+        return True
+    return not _parse_tags_match(match).include_untagged
+
+
 def build_tags_where_clause(
     tags: list[str] | None,
     param_offset: int = 1,

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -6,6 +6,7 @@ They are stored in the 'directives' table.
 
 import urllib.parse
 import uuid
+from datetime import datetime, timezone
 
 import pytest
 
@@ -16,6 +17,7 @@ from hindsight_api.engine.memory_engine import (
     _mental_model_stale_scope_from_row,
     fq_table,
 )
+from hindsight_api.engine.memories import MemoryScopeWatermark
 from hindsight_api.engine.retain import embedding_utils
 from tests.llm_judge import assert_meets_criteria, evaluate
 
@@ -1623,6 +1625,132 @@ class TestMentalModelStaleness:
         by_id = {m["id"]: m for m in result["mental_models"]}
         assert by_id[fresh["id"]]["is_stale"] is False
         assert by_id[stale["id"]]["is_stale"] is True
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.memory_backend_incompatible
+    @pytest.mark.parametrize(
+        "tags_match,expected_before,expected_after",
+        [
+            # Phase 1 (recent writes: one other tag, one untagged): the strict modes
+            # and `exact` see only tagged rows, so they stay fresh; `any`/`all`
+            # include untagged rows, so the untagged write alone makes them stale.
+            # Phase 2 adds a recent ["user_a", "extra"] — a superset of the scope.
+            # Containment and overlap both match it; set equality does not, which is
+            # the one case that separates `exact` from `all_strict`.
+            ("all_strict", False, True),
+            ("any_strict", False, True),
+            ("exact", False, False),
+            ("any", True, True),
+            ("all", True, True),
+        ],
+    )
+    async def test_both_query_shapes_agree_in_every_tag_mode(
+        self, memory: MemoryEngine, request_context, tags_match, expected_before, expected_after
+    ):
+        """The tag-indexable shape must answer exactly as the LIMIT 1 shape does (#4169).
+
+        Only the modes whose clause the GIN index on ``tags`` can serve take the
+        aggregate; the rest stay on the time-ordered walk. Both are asked here, on
+        the same data, and pinned against the answer the scope's own semantics
+        require — a shape that quietly disagreed with the refresh gate would flag
+        pages the gate then refuses to refresh, which is the failure #3291 was.
+        """
+        from hindsight_api.engine.memories import get_memories
+
+        bank_id = f"test-mm-shapes-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        since = datetime.now(timezone.utc)
+        # Recent, but none of it on this scope's own tag.
+        await self._insert_memory(memory, bank_id, tags=["other"])
+        await self._insert_memory(memory, bank_id, tags=[])
+
+        store = get_memories()
+        pool = await memory._get_pool()
+
+        async def ask() -> bool:
+            async with pool.acquire() as conn:
+                single = await store.any_memory_updated_since(
+                    conn=conn,
+                    fq_table=fq_table,
+                    bank_id=bank_id,
+                    since=since,
+                    tags=["user_a"],
+                    tags_match=tags_match,
+                )
+                batch = await store.any_memory_updated_since_batch(
+                    conn=conn,
+                    fq_table=fq_table,
+                    bank_id=bank_id,
+                    scopes=[
+                        MemoryScopeWatermark(
+                            key="k", since=since, tags=["user_a"], tags_match=tags_match, fact_types=None
+                        )
+                    ],
+                )
+            assert single == batch["k"], f"{tags_match}: single-scope and batched shapes disagree"
+            return single
+
+        assert await ask() is expected_before
+        # A superset of the scope: matched by containment and overlap, not by set
+        # equality.
+        await self._insert_memory(memory, bank_id, tags=["user_a", "extra"])
+        assert await ask() is expected_after
+        # The scope's own tag, exactly: every mode must now report stale.
+        await self._insert_memory(memory, bank_id, tags=["user_a"])
+        assert await ask() is True
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.memory_backend_incompatible
+    async def test_both_query_shapes_agree_with_fact_types_and_tag_groups(self, memory: MemoryEngine, request_context):
+        """The two extra scope dimensions still narrow the answer in both shapes.
+
+        ``fact_types`` rides in the same WHERE as the tag clause, and compound
+        ``tag_groups`` are the case neither shape can express against a joined row —
+        they fall back to the single-scope path. Both are checked here because the
+        aggregate rewrite touches the WHERE they live in.
+        """
+        from hindsight_api.engine.memories import get_memories
+        from hindsight_api.engine.search.tags import TagGroupLeaf
+
+        bank_id = f"test-mm-shapes2-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        since = datetime.now(timezone.utc)
+        await self._insert_memory(memory, bank_id, tags=["user_a"], fact_type="world")
+
+        store = get_memories()
+        pool = await memory._get_pool()
+
+        async def ask(**kwargs) -> bool:
+            async with pool.acquire() as conn:
+                single = await store.any_memory_updated_since(
+                    conn=conn, fq_table=fq_table, bank_id=bank_id, since=since, **kwargs
+                )
+                batch = await store.any_memory_updated_since_batch(
+                    conn=conn,
+                    fq_table=fq_table,
+                    bank_id=bank_id,
+                    scopes=[
+                        MemoryScopeWatermark(
+                            key="k",
+                            since=since,
+                            tags=kwargs.get("tags"),
+                            tags_match=kwargs.get("tags_match", "any"),
+                            fact_types=kwargs.get("fact_types"),
+                            tag_groups=kwargs.get("tag_groups"),
+                        )
+                    ],
+                )
+            assert single == batch["k"], "single-scope and batched shapes disagree"
+            return single
+
+        assert await ask(tags=["user_a"], tags_match="all_strict", fact_types=["world"]) is True
+        assert await ask(tags=["user_a"], tags_match="all_strict", fact_types=["experience"]) is False
+        # Compound scope: the write carries user_a, so the group it satisfies is stale
+        # and the one it does not is fresh.
+        assert await ask(tag_groups=[TagGroupLeaf(tags=["user_a"])]) is True
+        assert await ask(tag_groups=[TagGroupLeaf(tags=["user_b"])]) is False
 
         await memory.delete_bank(bank_id, request_context=request_context)
 

--- a/hindsight-api-slim/tests/test_mental_models.py
+++ b/hindsight-api-slim/tests/test_mental_models.py
@@ -1627,6 +1627,92 @@ class TestMentalModelStaleness:
         await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.memory_backend_incompatible
+    async def test_polling_surfaces_skip_the_scoped_scan_on_a_quiet_bank(self, memory: MemoryEngine, request_context):
+        """Every staleness surface resolves the watermark itself, not just reflect (#4169).
+
+        The scoped check is only cheap when the model *is* stale: it walks every
+        memory written since the model's watermark and can stop early only at a
+        match, so a model whose own tags have been quiet pays for the whole walk to
+        be told "no". The list and the single-model read used to pay that on every
+        poll; both now rule the model out against the bank's newest write first,
+        and only ask about what that cannot settle.
+        """
+        bank_id = f"test-mm-quiet-{uuid.uuid4().hex[:8]}"
+        await memory.get_bank_profile(bank_id, request_context=request_context)
+        # Written first, so the model ends up refreshed *after* the newest write.
+        await self._insert_memory(memory, bank_id, tags=["user_a"])
+        model = await memory.create_mental_model(
+            bank_id=bank_id,
+            name="quiet MM",
+            source_query="q",
+            content="quiet",
+            tags=["user_a"],
+            request_context=request_context,
+        )
+
+        from hindsight_api.engine.memories import get_memories
+
+        store = get_memories()
+        asked: list[str] = []
+        original_single = store.any_memory_updated_since
+        original_batch = store.any_memory_updated_since_batch
+
+        async def counting_single(*args, **kwargs):
+            asked.append("single")
+            return await original_single(*args, **kwargs)
+
+        async def counting_batch(*args, scopes, **kwargs):
+            asked.extend("batch" for _ in scopes)
+            return await original_batch(*args, scopes=scopes, **kwargs)
+
+        store.any_memory_updated_since = counting_single
+        store.any_memory_updated_since_batch = counting_batch
+        try:
+            listed = await memory.list_mental_models(
+                bank_id=bank_id, with_staleness=True, request_context=request_context
+            )
+            assert [m["is_stale"] for m in listed.items] == [False]
+            single = await memory.get_mental_model(bank_id, model["id"], request_context=request_context)
+            assert single["is_stale"] is False
+            assert asked == [], "nothing written since the model read: no scoped query from either surface"
+
+            # A write inside the scope moves the watermark past the model, and the
+            # scoped question is asked for real — the shortcut skips work, never
+            # the answer.
+            await self._insert_memory(memory, bank_id, tags=["user_a"])
+            listed = await memory.list_mental_models(
+                bank_id=bank_id, with_staleness=True, request_context=request_context
+            )
+            assert [m["is_stale"] for m in listed.items] == [True]
+            single = await memory.get_mental_model(bank_id, model["id"], request_context=request_context)
+            assert single["is_stale"] is True
+            assert asked == ["batch", "single"]
+
+            # A write outside the scope moves the watermark too, so the shortcut
+            # cannot settle it — and the scoped answer is still "not stale".
+            # Stamp the model current directly: a real refresh would need an LLM,
+            # and what is under test is the query it is asked, not its content.
+            pool = await memory._get_pool()
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    f"UPDATE {fq_table('mental_models')} SET last_memory_seen_at = now() "
+                    f"WHERE bank_id = $1 AND id = $2",
+                    bank_id,
+                    model["id"],
+                )
+            asked.clear()
+            await self._insert_memory(memory, bank_id, tags=["user_b"])
+            listed = await memory.list_mental_models(
+                bank_id=bank_id, with_staleness=True, request_context=request_context
+            )
+            assert [m["is_stale"] for m in listed.items] == [False]
+            assert asked == ["batch"], "behind the watermark, out of scope: asked, and answered fresh"
+        finally:
+            store.any_memory_updated_since = original_single
+            store.any_memory_updated_since_batch = original_batch
+            await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.memory_backend_incompatible
     async def test_tool_search_mental_models_skips_the_scan_below_the_watermark(
         self, memory: MemoryEngine, request_context
     ):


### PR DESCRIPTION
Fixes #4169.

## The bug

`any_memory_updated_since_batch` forces the `LIMIT 1` existence test onto
`idx_memory_units_bank_updated_at` (`ORDER BY mu.updated_at DESC`, deliberately —
without it the planner picks a seq scan). That is optimal when the scope *has* a
recent write and pathological when it does not: `LIMIT 1` can only stop at a hit,
so a model whose own tags have been quiet since its watermark rejects, one row at
a time, every memory written since. The issue measures 247ms for a single scope
over 123k rows, and #3589's benchmark only ever covered the positive case.

Then it is asked once per model, on every poll:

| Surface | Scopes per request | Had the shortcut? |
|---|---|---|
| `GET .../mental-models` | up to `limit` = 1000 | no |
| `GET .../knowledge-base/tree` | every page in the bank | no |
| MCP `get_knowledge_base_tree` | every page in the bank | no |
| `GET .../mental-models/{id}` | 1 | no |
| cron mental-model refresh | 1 per model, serial | no |
| consolidation refresh flush | 1 per candidate, serial | no |
| reflect's `search_mental_models` | result set | **yes** |

A batch of 214 quiet scopes is how the reporter reached a 15s gateway timeout.

## The fix

Two changes, in the order the request hits them.

### 1. Rule out what the bank watermark already answers

A model that has read the memories at or past the bank's newest write cannot be
stale whatever its scope, and `_may_need_refresh` has always been that rule —
reflect was simply the only caller resolving a watermark. Resolve it inside the two
staleness methods instead, so every surface in the table gets it with no call-site
change: `compute_mental_models_are_stale` reads it once for the whole set, and
`compute_mental_model_is_stale` before the scoped query, which is the path the cron
loop and the consolidation flush walk one model at a time. `watermark` stays an
argument for a caller that already holds a live one.

It is one backward probe of the leading column of `idx_memory_units_bank_updated_at`
— a new store read `latest_memory_write_at`, defaulting on `MemoriesExtension` to the
value `consolidation_freshness` already computes, so an external store keeps working.
It must be read live, on the same connection: `_may_need_refresh` reports "not stale"
from it, so a cached watermark would prove a freshness that is not there.

This settles a bank that is quiet. It cannot settle the reported case, where writes
are ongoing and every model is behind the bank watermark — hence the second change.

### 2. Ask the tag index for the scopes it can answer

For the modes whose tag clause is a bare `tags @>` / `&&` — the two `_strict` modes
and `exact` — ask `bool_or(updated_at > since)` with the tag predicate **alone** in
the `WHERE`. That makes `tags` the only index-eligible filter, so the planner reaches
the existing `idx_memory_units_tags` and reads the scope's own rows rather than the
bank's.

Leaving `updated_at` out of the `WHERE` is load-bearing, not tidiness: put it back
and the planner prefers a sequential scan (`Rows Removed by Filter: 100214`). That is
also why a composite `btree_gin (bank_id, tags, updated_at)` is **not** proposed here
— it does not rescue the `LIMIT 1` form either (3439ms), so the lever is the query
shape. No new index, no new extension.

Everything else keeps the `LIMIT 1` walk: `any`/`all`, whose clause carries an
`OR tags IS NULL` disjunct no index can serve and which the aggregate does not speed
up; untagged scopes; compound `tag_groups`; and every scope on Oracle, whose rewriter
has no `bool_or` and turns the tag operators into `JSON_TABLE` predicates.

`bank_id` stays in the `WHERE` and is still enforced, but as a heap recheck rather
than an index condition — that index is not bank-scoped, so a tag many banks share
costs their rows too. Bounded by the tag, and far below a walk of every write since
the watermark.

## Measured

Synthetic reproduction of the reporter's shape on local PG: 100k rows written
recently under tags no model is scoped to, 214 `all_strict` models whose own scopes
have been quiet, `GET /mental-models` with `limit=1000`. Median of 3–5 runs, answers
asserted identical throughout.

| | before | after |
|---|---|---|
| `GET /mental-models`, active bank (**the incident**) | 3502ms | **6.1ms** |
| `GET /mental-models`, bank quiet since every watermark | 3.5ms | **0.4ms** |
| one scope, single-model read | 16–21ms | **0.6–0.9ms** |

While measuring the "before" case the pool raised `TimeoutError` from
`asyncpg/protocol.pyx` on this query — the same failure the report shows in
production.

The trade is a scope that is both large and stale, where `LIMIT 1` stops at the first
row: 214 such scopes cost 170ms against 3ms. Bounded by the size of the scope, where
the shape it replaces could not be bounded at all.

## Tests

`test_polling_surfaces_skip_the_scoped_scan_on_a_quiet_bank` counts the scoped store
calls the list and the single-model read actually make, across three states: quiet
bank (none), in-scope write (asked, stale), out-of-scope write (asked, fresh).

`test_both_query_shapes_agree_in_every_tag_mode` runs all five modes through both the
single-scope and the batched entry points on the same data and pins each against the
answer its own semantics require, through three phases: writes on another tag and on
no tag (strict and `exact` fresh, `any`/`all` stale), a superset of the scope
(containment and overlap match it, set equality does not), and the scope's own tag
(all five stale). A shape that quietly disagreed with the refresh gate would flag
pages the gate then refuses to refresh — the #3291 failure.

`test_both_query_shapes_agree_with_fact_types_and_tag_groups` covers the two scope
dimensions that share that `WHERE`: `fact_types` narrows the answer in both shapes,
and compound `tag_groups` stay on the single-scope path.
