### PR TITLE
fix(docker): stop installing curl into the cp-only image

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -272,8 +272,13 @@ WORKDIR /app
 COPY docker/standalone/start-all.sh /app/start-all.sh
 RUN chmod +x /app/start-all.sh
 
-# Install curl for health checks. `apk upgrade` first, for the same reason the
-# Debian stages run `apt-get upgrade` - see the comment on the api-only stage.
+# Install bash for the shared startup script. No curl: this image performs no
+# health check. start-all.sh probes only the API (gated on ENABLE_API, which
+# this stage sets to false) and the LLM under the opt-in HINDSIGHT_WAIT_FOR_DEPS,
+# which a control-plane-only container has no reason to set; the control-plane
+# branch launches `node server.js` and waits on nothing. There is no HEALTHCHECK
+# instruction either. `apk upgrade` runs first for the same reason the Debian
+# stages run `apt-get upgrade` - see the comment on the api-only stage.
 # npm is removed for the same reason the Debian stages remove pip's build
 # tooling: nothing invokes it at runtime - start-all.sh launches the pre-built
 # Next standalone bundle with `node server.js` - and dropping it leaves no
@@ -284,7 +289,7 @@ RUN chmod +x /app/start-all.sh
 # The `[ -e ]` guard is deliberate: a bare `rm -rf` on a path a future base
 # image no longer uses succeeds silently and npm quietly ships again. Fail the
 # build instead, so the path assumption has to be revisited on a base bump.
-RUN apk upgrade --no-cache && apk add --no-cache curl bash \
+RUN apk upgrade --no-cache && apk add --no-cache bash \
     && [ -e /usr/local/lib/node_modules/npm ] \
     && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
     && ! command -v npm


### PR DESCRIPTION
Closes #4197. Split out of #4057 — this is the free half of that PR's curl removal, with no probe rewrite behind it.

## Why

The comment above the `apk add` claims curl is installed "for health checks". The image performs none.

`start-all.sh` has exactly two curl call sites:

- **line 282** — the API readiness loop, gated on `ENABLE_API=true`. `cp-only` sets `HINDSIGHT_ENABLE_API=false`.
- **line 170** — `check_llm`, gated on the opt-in `HINDSIGHT_WAIT_FOR_DEPS` (default false), which a control-plane-only container has no reason to set.

The control-plane branch (line 301) launches `node server.js` and waits on nothing, and there is no `HEALTHCHECK` instruction anywhere in the Dockerfile. curl was installed and never invoked.

## What this is worth

Not the finding count — `cp-only` already scans **0 Critical / 0 High**, because `apk upgrade` plus the existing npm removal handles everything. The value is removing a standard post-exploitation tool (fetching a second stage) from a runtime container, and correcting a comment that documented behaviour the image doesn't have.

Unlike #4198, nothing needs replacing here, which is why it's separated out.

## Verification

Built locally (arm64):

- `curl` absent from the image, `bash` still present
- `./docker/test-image.sh hindsight-cp-nocurl:test cp-only` **passes** — Next.js 16.3.4 boots and the health endpoint responds

`docker/test-image.sh` probes from the host, not via `docker exec`, so it doesn't depend on curl being inside the image. CI's `Build Docker (control-plane)` leg runs that same smoke test.