### PR TITLE
fix(docker): drop the NodeSource bootstrap from the standalone image

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -305,19 +305,10 @@ FROM python:3.11-slim AS standalone
 
 WORKDIR /app
 
-# Install Node.js, curl, uv, and system dependencies
+# Install curl, uv, and system dependencies. Node arrives separately, below.
 # Note: libicu version varies by Debian version - try common versions in order
 # Runtime images use uv directly; remove pip build tooling after installation so
 # vulnerable setuptools-vendored packages and wheel are not shipped in production.
-# npm goes the same way: nothing invokes it at runtime - start-all.sh launches
-# the pre-built Next standalone bundle with `node server.js` - and dropping it
-# leaves no scannable vulnerable tar component in the stage. corepack is
-# deliberately kept: it has no node_modules tree and ships no tar package
-# metadata, so a scanner reports nothing for it. npm is not installed as a
-# separate apt package here - NodeSource's `nodejs` package ships it
-# (`dpkg -S /usr/bin/npm` resolves to `nodejs`), so `apt-get remove npm` is a
-# no-op and removal by path is the only option. The `[ -e ]` guard fails the
-# build if a base bump moves that path, rather than silently shipping npm.
 # `upgrade` before `install`: without it the image ships whatever package
 # snapshot the base image was cut with, so security updates published since
 # never reach the runtime layers - that is how 0.9.2 shipped openssl 3.5.6 with
@@ -331,14 +322,30 @@ RUN apt-get update && apt-get upgrade -y \
     libgssapi-krb5-2 \
     libossp-uuid16 \
     && (apt-get install -y libicu72 2>/dev/null || apt-get install -y libicu74 2>/dev/null || apt-get install -y libicu76 2>/dev/null || true) \
-    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y nodejs \
-    && [ -e /usr/lib/node_modules/npm ] \
-    && rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx \
-    && ! command -v npm \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir uv \
     && pip uninstall --yes setuptools wheel
+
+# This is a Python base image, but it also runs the control plane - a pre-built
+# Next standalone bundle launched with `node server.js` - so it needs a Node
+# runtime. Take cp-builder's binary rather than NodeSource's apt repo. That
+# bootstrap was a `curl | bash` from a third-party host at build time, it made
+# builds non-reproducible (the remote script and repo move under a fixed
+# Dockerfile), and it dragged ~14 packages into the runtime image that nothing
+# runs: the whole GnuPG suite, used only to verify the repo key at build time,
+# plus a second system Python (3.13, in a python:3.11 image).
+#
+# Copying the binary also means npm never arrives, so the previous removal by
+# path - and its `[ -e ]` guard against a base bump moving that path - is gone
+# with it. corepack does not come along either; nothing invoked it.
+#
+# node:24-slim and python:3.11-slim are both Debian and glibc is backward
+# compatible, so the binary runs here. `node --version` fails the build if a
+# base change on either side ever breaks that, rather than shipping an image
+# whose control plane cannot start.
+COPY --from=cp-builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=cp-builder /usr/local/LICENSE /usr/local/LICENSE
+RUN node --version && ! command -v npm
 
 RUN useradd -m -s /bin/bash hindsight
 


### PR DESCRIPTION
Closes #4196. Split out of #4057 — this is the highest-value, lowest-risk part of that PR.

## Why

`standalone` is `FROM python:3.11-slim` because it runs the Python API, but it also runs the control plane as a Next standalone bundle (`node server.js`), so it needs a Node runtime inside a Python base image. That came from NodeSource:

```dockerfile
&& curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
&& apt-get install -y nodejs \
&& [ -e /usr/lib/node_modules/npm ] \
&& rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx \
&& ! command -v npm \
```

A shell script downloaded from a third-party host and executed as root at build time, to install their signing key and apt repo.

`cp-builder` is already `node:24-slim` and has the binary sitting there, so this copies it instead:

```dockerfile
COPY --from=cp-builder /usr/local/bin/node /usr/local/bin/node
COPY --from=cp-builder /usr/local/LICENSE /usr/local/LICENSE
RUN node --version && ! command -v npm
```

## Impact

**28 packages leave the runtime image**, none of which anything runs:

```
nodejs
dirmngr gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpgconf gpgsm gpgv
libassuan9 libgcrypt20 libgpg-error0 libgpg-error-l10n libksba8 libnpth0t64 pinentry-curses
python3 python3-minimal python3.13 python3.13-minimal libpython3-stdlib
libpython3.13-minimal libpython3.13-stdlib
apt-transport-https libexpat1 media-types
```

The GnuPG suite existed only to verify NodeSource's repo key at build time and then stayed in the image forever. And the image was carrying a *second* system Python — 3.13, inside a `python:3.11` image.

Trivy 0.74.0, HIGH+CRITICAL, locally built `standalone` (slim), before and after:

```
before   3 Critical / 82 High
after    3 Critical / 60 High      -22 High, 0 new findings
```

Two things that don't show up in a scan but matter as much:

- **No more `curl | bash` from a third-party host at build time.**
- **The stage becomes reproducible.** The remote setup script and the repo behind it could change under a fixed Dockerfile; a pinned builder image can't.

npm never arrives now, so the removal-by-path and its `[ -e ]` guard — which existed to fail the build if a base bump moved that path — are gone with it. corepack doesn't come along either; nothing invoked it.

## Risk

The copied binary has to run on a different base than it was built on. `node:24-slim` and `python:3.11-slim` are both Debian and glibc is backward compatible, so it does — and `RUN node --version` fails the build if a base change on either side ever breaks that, rather than shipping an image whose control plane can't start. That guard is the load-bearing part of this change and it's deliberately kept from #4057's original.

## What this does NOT do

curl stays. `start-all.sh` still probes the API health endpoint with it, and `standalone` runs the API. Removing it needs a probe that matches `curl -sf` exactly (it does **not** follow redirects, which the obvious `urllib` replacement gets wrong) — that's #4198, deliberately not bundled here.

Also worth recording: after this, Trivy no longer inventories Node at all, because a bare binary carries no package metadata. Part of the improvement above is the scanner losing sight of Node rather than Node getting safer. That makes staying on a supported Node line more important, not less — the images are on Node 24 Active LTS as of #4193.

## Verification

Built locally (arm64), `standalone` slim:

- `node --version` → `v24.20.0`, `npm` absent
- no `gnupg*`, `python3.13*` or `nodejs` packages remain
- **the control plane actually serves traffic from the copied binary**: started the image with `HINDSIGHT_ENABLE_API=false`, and `/api/health` returned HTTP 200 within 2s
- package diff and Trivy numbers above are from these builds

The full `standalone` smoke test needs LLM credentials, so it wasn't run locally — that's CI's `Build Docker (standalone-slim)` leg, which runs on this branch.