### PR TITLE
fix(local-ml): floor torch at 2.11.0 so arm64 images run on ARMv8.0 CPUs

### DIFF
--- a/hindsight-api-slim/pyproject.toml
+++ b/hindsight-api-slim/pyproject.toml
@@ -120,7 +120,13 @@ local-ml = [
     # this cap: without it an in-place upgrade can pull tokenizers 0.23.1 and
     # break local embeddings/reranker startup. See issue #2055.
     "tokenizers>=0.22.0,<=0.23.0",
-    "torch>=2.6.0", # CVE fix for remote code execution
+    # >=2.6.0 for the remote-code-execution CVE fix. The 2.11.0 floor is for
+    # ARMv8.0 CPUs (e.g. Cortex-A57): torch 2.10.0's aarch64 wheel bundles a
+    # mimalloc whose ELF constructor runs an inline ARMv8.1 LSE atomic
+    # (`ldaddal` in `_mi_options_init`), so `import torch` dies with SIGILL at
+    # dlopen time on any CPU without LSE. 2.11.0+ keeps LSE behind the
+    # runtime-dispatched outline-atomics helpers again. See issue #4142.
+    "torch>=2.11.0",
     "einops>=0.8.2",
     "flashrank>=0.2.0",
     # Apple Silicon local inference — mlx publishes wheels only for

--- a/uv.lock
+++ b/uv.lock
@@ -1882,7 +1882,7 @@ requires-dist = [
     { name = "tokenizers", marker = "extra == 'local-ml'", specifier = ">=0.22.0,<=0.23.0" },
     { name = "tokenizers", marker = "extra == 'local-onnx'", specifier = ">=0.22.0,<=0.23.0" },
     { name = "toktok-rs", specifier = ">=0.1.3" },
-    { name = "torch", marker = "extra == 'local-ml'", specifier = ">=2.6.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", marker = "extra == 'local-ml'", specifier = ">=2.11.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "transformers", marker = "extra == 'local-ml'", specifier = ">=5.5.0" },
     { name = "transformers", marker = "extra == 'local-onnx'", specifier = ">=5.5.0" },
     { name = "typer", specifier = ">=0.9.0" },


### PR DESCRIPTION
## Problem

`import torch` dies with `SIGILL` (exit 132) on any ARMv8.0 CPU — one without the ARMv8.1 LSE atomics — taking the whole arm64 image down at startup. Reported in #4142 on a QNAP NAS with an Annapurna AL324 (Cortex-A57):

```
/app/start-all.sh: line 295:   10 Illegal instruction     hindsight-api
# container exits with code 132
```

## Root cause

Not `cryptography`, which the issue thread (and my own first reply on it) had assumed. gdb on the fault, reproduced under qemu-user `-cpu cortex-a57` inside the real `ghcr.io/vectorize-io/hindsight:0.9.2` arm64 image:

```
Program received signal SIGILL, Illegal instruction.
0x0000ffff6f660fec in _mi_options_init () from torch/lib/libc10.so
=> 0xffff6f660fec <_mi_options_init+28>:	ldaddal	x22, x22, [x0]
#0  _mi_options_init ()      from torch/lib/libc10.so
#1  _mi_auto_process_init () from torch/lib/libc10.so
#2  0x0000ffff883d4a6c in ?? () from /lib/ld-linux-aarch64.so.1
...
#12 dlopen () from /lib/aarch64-linux-gnu/libc.so.6
```

torch 2.10.0's aarch64 wheel bundles a **mimalloc** built with LSE atomics compiled in, and its init runs from an **ELF constructor** — so the illegal instruction executes at `dlopen` time, before any Python code. `OPENSSL_armcap` is irrelevant: cryptography 50.0.0 RSA keygen + sign passes cleanly on the same emulated A57.

`torch` was only floored at `>=2.6.0`, so the lock was free to drift onto 2.10.0 — which is exactly what shipped in the 0.9.x arm64 images. 0.8.2 happened to resolve 2.12.0 and runs fine on the same hardware, which is why the reporter's bisect pointed at the cryptography bump instead.

## Fix

Floor `torch>=2.11.0` in the `local-ml` extra. **Resolution is unchanged** — `uv.lock` stays on `2.13.0+cpu`; the floor just makes the one broken release unreachable, so the lock can't drift back onto it.

## Verification

Disassembled `torch/lib/libc10.so` from each aarch64 CPU wheel, and ran `import torch` under qemu-user `-cpu cortex-a57` (a CPU model with no LSE) inside the real image:

| torch | LSE instructions in libc10 | inline in `_mi_options_init` | `import torch` on A57 |
|---|---|---|---|
| 2.10.0 | 185 | 1 | ❌ SIGILL |
| 2.11.0 | 11 | 0 | ✅ |
| 2.12.0 | 11 | 0 | ✅ (this is what 0.8.2 shipped) |
| 2.13.0 | 11 | 0 | ✅ (what we lock today) |

The remaining 11 in every good version are the `__aarch64_*` outline-atomics helpers, which are behind an ifunc HWCAP check and safe on ARMv8.0.

End-to-end, upgrading torch inside the 0.9.2 image and re-running under emulated A57:

```
torch ok 2.13.0+cpu
matmul ok 42.00560760498047
sentence_transformers ok 5.2.0
```

Repro command, for anyone who wants to re-check this without ARMv8.0 hardware:

```
qemu-aarch64-static -cpu cortex-a57 /app/api/.venv/bin/python3 -c "import torch"
```

## No test

The change is a declarative dependency constraint; a test asserting the floor would just restate the specifier. The real failure mode was lock drift, and CI's `uv lock --check` plus the floor make 2.10.0 unresolvable, which covers it structurally.

Fixes #4142
