### PR TITLE
fix(coding-agents): stop promising automatic correction supersession

### DIFF
--- a/hindsight-integrations/coding-agents/skill-src/preamble.md
+++ b/hindsight-integrations/coding-agents/skill-src/preamble.md
@@ -55,6 +55,8 @@ source contradicts it), FIX THE RECORD — don't just ignore it. Call
 - **content**: (1) what memory claimed, (2) what is verifiably true now, (3) the evidence you
   checked (file/commit/output). Quote exact values verbatim.
 
-Newer facts supersede older ones in retrieval, so one clear correction permanently outranks the
-stale memory. Do this whenever you catch a wrong injected memory, a stale knowledge-page claim, or
-an outdated decision — silent disregard leaves the trap armed for the next session.
+Ingesting a correction adds evidence for future retrieval and page refreshes; it does not rewrite
+the page or guarantee that the correction outranks the old claim. The old claim can remain
+retrievable, so state the verified correction in your answer as well. Do this whenever you catch a
+wrong injected memory, a stale knowledge-page claim, or an outdated decision — silent disregard
+leaves the trap armed for the next session.

--- a/hindsight-integrations/coding-agents/skill/SKILL.md
+++ b/hindsight-integrations/coding-agents/skill/SKILL.md
@@ -58,9 +58,11 @@ source contradicts it), FIX THE RECORD — don't just ignore it. Call
 - **content**: (1) what memory claimed, (2) what is verifiably true now, (3) the evidence you
   checked (file/commit/output). Quote exact values verbatim.
 
-Newer facts supersede older ones in retrieval, so one clear correction permanently outranks the
-stale memory. Do this whenever you catch a wrong injected memory, a stale knowledge-page claim, or
-an outdated decision — silent disregard leaves the trap armed for the next session.
+Ingesting a correction adds evidence for future retrieval and page refreshes; it does not rewrite
+the page or guarantee that the correction outranks the old claim. The old claim can remain
+retrievable, so state the verified correction in your answer as well. Do this whenever you catch a
+wrong injected memory, a stale knowledge-page claim, or an outdated decision — silent disregard
+leaves the trap armed for the next session.
 
 ## Install / update
 

--- a/hindsight-integrations/coding-agents/src/core/knowledge-injection.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-injection.ts
@@ -79,8 +79,9 @@ export function buildKnowledgePreamble(pages: PageRef[], opts?: ToolGuideOpts): 
     "memory behind them). The tools below are registered, but you must actually CALL them at the right moments:\n" +
     `${toolGuide(opts)}\n` +
     "ALSO your correction tool: when you verify a Hindsight memory is wrong or stale, ingest a " +
-    '"Correction: <topic>" doc stating what memory claimed, what is true now, and the evidence — ' +
-    "newer facts supersede older ones.\n" +
+    '"Correction: <topic>" doc stating what memory claimed, what is true now, and the evidence. ' +
+    "Ingesting it does not rewrite the page or guarantee that it outranks the old claim, " +
+    "so state the correction in your answer too.\n" +
     `${body}\n` +
     "This tool guide and the page list are re-injected for you periodically as things change.\n" +
     "</hindsight_knowledge>"


### PR DESCRIPTION
## Problem

The coding-agent SessionStart preamble says that newer facts supersede older ones. Its skill promises that one correction permanently outranks the stale memory. Ingesting a correction does not establish either guarantee: it adds evidence, but does not directly rewrite the stored knowledge page or guarantee retrieval precedence. An agent can therefore leave the current answer wrong while believing that ingest alone repaired it.

## Change

- Keep the existing correction workflow: record what memory claimed, the verified correction, and its evidence with hindsight_ingest_document.
- Explicitly distinguish recording evidence from rewriting a page or guaranteeing ranking.
- Tell the agent to state the verified correction in its current answer as well.
- Regenerate skill/SKILL.md from skill-src/preamble.md using the existing generator.

Three files only: skill source, generated skill, and src/core/knowledge-injection.ts. No storage, retrieval, consolidation, API, stale-page flags, or ingestion-wait behavior changes. Independent of #4170.

## Verification

On an isolated worktree based on upstream 9e6d9e76c:

- npm ci --ignore-scripts
- npm run skill:build; node scripts/build-skill.mjs --check
- npm test: **879 tests passed across 67 files**
- npx tsc --noEmit: clean
- npm run build: success
- prettier --check on all three changed files: clean
- Executed buildKnowledgePreamble with both an empty and populated page roster. A throwaway check rejects the old supersession promise before the patch and passes afterward; both rendered outputs retain correction ingestion and tell the agent to state the correction. No permanent test added solely to pin prose.

No live LLM calls or backend behavior claims. Prepared with automated assistance; the commands above were executed against this PR's tree.
