### PR TITLE
fix(coding-agents): replay a failed retain append instead of replacing the transcript (#3989)

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { RateLimitedError, type HindsightClient } from "./hindsight";
 import { ingestChats, renderSessionJsonl, retainLiveSession, type TransportTurn } from "./chat";
-import { memoryCursorStore, type RetainCursorStore } from "./retain-cursor";
+import { PENDING_MAX_AGE_MS, memoryCursorStore, type RetainCursorStore } from "./retain-cursor";
 
 describe("renderSessionJsonl", () => {
   const turns: TransportTurn[] = [
@@ -174,14 +174,84 @@ describe("retainLiveSession — incremental write-back", () => {
     expect(retain).toHaveBeenCalledTimes(1);
   });
 
-  it("replaces the whole document after a failed write, instead of appending onto an unknown state", async () => {
+  it("buffers a failed append and replays it, instead of re-sending the whole transcript", async () => {
     const { retain, client } = stubClient();
     const cursors = memoryCursorStore();
     await write(client, turns(2), cursors);
 
     retain.mockRejectedValueOnce(new Error("timeout"));
     await expect(write(client, turns(4), cursors)).rejects.toThrow("timeout");
+    const failed = retain.mock.calls[1];
+    // Not dirty: a failed append no longer condemns the session to full replacement (#3989). Its
+    // turns are counted in the cursor because the buffer covers them.
+    expect(cursors.read("s1")?.dirty).toBeUndefined();
+    expect(cursors.read("s1")?.turns).toBe(4);
+    expect(cursors.read("s1")?.pending).toHaveLength(1);
+
+    await write(client, turns(6), cursors);
+    // The buffered slice goes out FIRST, byte-for-byte under its original operation id, so a write
+    // the server actually committed collapses into that operation instead of appending twice.
+    const replay = retain.mock.calls[2];
+    expect(replay[0]).toBe(failed[0]);
+    expect(replay[5].operationId).toBe(failed[5].operationId);
+    expect(replay[5].updateMode).toBe("append");
+    // Then only what is new. The transcript is never re-sent, and never re-extracted.
+    const tail = retain.mock.calls[3];
+    expect(tail[5].updateMode).toBe("append");
+    expect((tail[0] as string).split("\n").map((l) => JSON.parse(l) as TransportTurn)).toEqual([
+      turn(4),
+      turn(5),
+    ]);
+    expect(cursors.read("s1")).toEqual({
+      turns: 6,
+      fingerprint: expect.any(String),
+      bank: "coding-agent::repo",
+    });
+  });
+
+  it("drops a buffered append as soon as it lands, so a later failure cannot resend it", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    await write(client, turns(2), cursors);
+    retain.mockRejectedValueOnce(new Error("timeout"));
+    await expect(write(client, turns(4), cursors)).rejects.toThrow("timeout");
+
+    // The replay lands; the new tail behind it does not.
+    retain.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("timeout"));
+    await expect(write(client, turns(6), cursors)).rejects.toThrow("timeout");
+    const pending = cursors.read("s1")?.pending ?? [];
+    expect(pending).toHaveLength(1);
+    expect(pending[0].content).toBe(retain.mock.calls[3][0]);
+  });
+
+  it("replaces again after a failed replace, which needs no buffer to be idempotent", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    retain.mockRejectedValueOnce(new Error("timeout"));
+    await expect(write(client, turns(2), cursors)).rejects.toThrow("timeout");
     expect(cursors.read("s1")?.dirty).toBe(true);
+    expect(cursors.read("s1")?.pending).toBeUndefined();
+
+    await write(client, turns(4), cursors);
+    expect(retain.mock.calls[1][5].updateMode).toBeUndefined();
+    expect(retain.mock.calls[1][0]).toBe(
+      renderSessionJsonl("conversation:s1", turns(4), "2026-01-01T00:00:00Z")
+    );
+  });
+
+  it("replaces rather than replaying a buffer the server may no longer dedupe", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    await write(client, turns(2), cursors);
+    retain.mockRejectedValueOnce(new Error("timeout"));
+    await expect(write(client, turns(4), cursors)).rejects.toThrow("timeout");
+
+    const stale = cursors.read("s1");
+    const pending = (stale?.pending ?? []).map((p) => ({
+      ...p,
+      at: p.at - PENDING_MAX_AGE_MS - 1,
+    }));
+    if (stale) cursors.write("s1", { ...stale, pending });
 
     await write(client, turns(6), cursors);
     const recovery = retain.mock.calls[2];
@@ -189,11 +259,7 @@ describe("retainLiveSession — incremental write-back", () => {
     expect(recovery[0]).toBe(
       renderSessionJsonl("conversation:s1", turns(6), "2026-01-01T00:00:00Z")
     );
-    expect(cursors.read("s1")).toEqual({
-      turns: 6,
-      fingerprint: expect.any(String),
-      bank: "coding-agent::repo",
-    });
+    expect(cursors.read("s1")?.pending).toBeUndefined();
   });
 
   it("never appends against a server that ignores operation_id", async () => {

--- a/hindsight-integrations/coding-agents/src/core/chat.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.test.ts
@@ -224,6 +224,27 @@ describe("retainLiveSession — incremental write-back", () => {
     expect(pending[0].content).toBe(retain.mock.calls[3][0]);
   });
 
+  it("stops flushing rather than starting a request the host deadline cannot fit", async () => {
+    const { retain, client } = stubClient();
+    const cursors = memoryCursorStore();
+    await write(client, turns(2), cursors);
+    retain.mockRejectedValueOnce(new Error("timeout"));
+    await expect(write(client, turns(4), cursors)).rejects.toThrow("timeout");
+
+    // A budget that fits the replay and nothing after it: the new tail stays buffered for the next
+    // write-back instead of overrunning the deadline the host kills the hook at.
+    await retainLiveSession(client, "s1", turns(6), "2026-01-01T00:00:00Z", "codex", {
+      cursors,
+      retryUntil: Date.now(),
+    });
+    expect(retain).toHaveBeenCalledTimes(3);
+    expect(cursors.read("s1")?.pending).toHaveLength(1);
+
+    await write(client, turns(6), cursors);
+    expect(retain).toHaveBeenCalledTimes(4);
+    expect(cursors.read("s1")?.pending).toBeUndefined();
+  });
+
   it("replaces again after a failed replace, which needs no buffer to be idempotent", async () => {
     const { retain, client } = stubClient();
     const cursors = memoryCursorStore();

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -328,6 +328,12 @@ async function writeSession(
   // which is the one thing appending onto an unknown state could otherwise get wrong.
   cursors?.write(sessionId, { ...next, pending: queue });
   for (let i = 0; i < queue.length; i++) {
+    // One request per entry, each able to burn the full 15s abort — where this used to send exactly
+    // once. Never START one that cannot finish inside the caller's budget: a hook harness is killed
+    // by its host at `retryUntil` (retain-hook's hostDeadline), and a flush that overruns it buys
+    // nothing. The first entry always goes out, so a chronically short budget still makes progress;
+    // whatever is left is already durable, so the next write-back sends it.
+    if (i > 0 && Date.now() + REQUEST_BUDGET_MS > retryUntil) return;
     const entry = queue[i];
     await submitWithRetry(
       () => submit(entry.content, entry.operationId, true),

--- a/hindsight-integrations/coding-agents/src/core/chat.ts
+++ b/hindsight-integrations/coding-agents/src/core/chat.ts
@@ -128,8 +128,8 @@ const REQUEST_BUDGET_MS = 15_000;
  *
  * The staleness check is the important half. If another write-back has claimed the cursor since
  * ours — a newer turn, another process — then ours is superseded, and the newer one carries
- * everything we were sending (or replaces the document outright, because our failure left the
- * cursor dirty). Retrying then would spend a hook's remaining time re-sending content that is
+ * everything we were sending: it replays our buffered payload ahead of its own, or replaces the
+ * document outright. Retrying then would spend a hook's remaining time re-sending content that is
  * already on its way.
  */
 async function submitWithRetry(
@@ -173,8 +173,8 @@ function serialize(
 ): Promise<void> {
   const perSession = writeBacks.get(cursors) ?? new Map<string, Promise<void>>();
   writeBacks.set(cursors, perSession);
-  // Chain off the previous write-back whether it succeeded or failed — a failure leaves the cursor
-  // dirty, which the next call needs to see so it can replace rather than append.
+  // Chain off the previous write-back whether it succeeded or failed — a failure leaves its payload
+  // buffered on the cursor (or the cursor dirty), which the next call needs to see before it plans.
   const next = (perSession.get(sessionId) ?? Promise.resolve()).then(write, write);
   const tail = next.catch(() => {});
   perSession.set(sessionId, tail);
@@ -238,67 +238,105 @@ async function writeSession(
   /** Absolute time this write-back may keep retrying until; the caller owns its own clock. */
   retryUntil = Date.now() + DEFAULT_RETRY_WINDOW_MS
 ): Promise<void> {
+  if (!turns.length) return;
   const refId = `conversation:${sessionId}`;
   const appendSupported = Boolean(cursors) && (await supportsAppend(client));
-  const plan = planRetain(turns, cursors?.read(sessionId), { appendSupported, bank: client.bank });
-  if (plan.mode === "skip") return;
+  const cursor = cursors?.read(sessionId);
+  const plan = planRetain(turns, cursor, { appendSupported, bank: client.bank });
+  // Appends built but never confirmed. A replace rewrites the whole document from the same
+  // transcript, so it SUBSUMES them; on every other path they go out first, oldest first, before
+  // anything new — the document only ever grows in transcript order.
+  const outbox = plan.mode === "replace" ? [] : (cursor?.pending ?? []);
+  if (plan.mode === "skip" && !outbox.length) return;
 
-  const content =
-    plan.mode === "append"
-      ? turns
-          .slice(plan.fromTurn)
-          .map((t) => JSON.stringify(t))
-          .join("\n")
-      : renderSessionJsonl(refId, turns, startTs);
+  /** Identity of ONE payload: a resubmission of the same bytes is collapsed server-side into the
+   *  original operation instead of extracting (or appending) twice. */
+  const opId = (mode: string, content: string) =>
+    uuidV5(`${client.bank}\n${refId}\n${mode}\n${content}`);
+  const submit = (content: string, operationId: string, append: boolean) =>
+    client.retain(
+      content,
+      "coding agent session",
+      refId,
+      // Configured tags first, built-ins last and deduped: `source:chat` and `harness:<id>` are what
+      // the documents list filters and draws its agent logo from, so a template cannot displace them.
+      [
+        ...new Set([
+          ...(stamp?.tags ?? []),
+          "source:chat",
+          ...(harness ? [`harness:${harness}`] : []),
+        ]),
+      ],
+      "conversation",
+      {
+        timestamp: startTs,
+        updateMode: append ? "append" : undefined,
+        operationId,
+        metadata: {
+          ...stamp?.metadata, // configured first: the built-ins below win on any key collision
+          source: "chat",
+          session_id: sessionId,
+          ref_id: refId,
+          ...(harness ? { harness } : {}),
+        },
+      }
+    );
 
-  // Claim the new position BEFORE the write and mark it unconfirmed, so a client that times out on
-  // a request the server did commit replaces next time instead of appending the same turns twice.
+  // The position the cursor reaches once everything below has been applied. On a "skip" this is
+  // exactly where the cursor already is: skip means the transcript ends at cursor.turns.
   const next = {
     turns: turns.length,
     fingerprint: fingerprintTurns(turns, turns.length),
     bank: client.bank,
   };
-  cursors?.write(sessionId, { ...next, dirty: true });
+  // Still ours to retry only while the cursor holds the claim we write below.
+  const stillOurs = () => {
+    if (!cursors) return true;
+    const now = cursors.read(sessionId);
+    return now?.turns === next.turns && now?.fingerprint === next.fingerprint;
+  };
 
-  const claimed = { ...next, dirty: true };
-  await submitWithRetry(
-    () =>
-      client.retain(
-        content,
-        "coding agent session",
-        refId,
-        // Configured tags first, built-ins last and deduped: `source:chat` and `harness:<id>` are what
-        // the documents list filters and draws its agent logo from, so a template cannot displace them.
-        [
-          ...new Set([
-            ...(stamp?.tags ?? []),
-            "source:chat",
-            ...(harness ? [`harness:${harness}`] : []),
-          ]),
-        ],
-        "conversation",
-        {
-          timestamp: startTs,
-          updateMode: plan.mode === "append" ? "append" : undefined,
-          // Identity of THIS payload: a resubmission of the same bytes is collapsed server-side into
-          // the original operation instead of extracting (or appending) twice.
-          operationId: uuidV5(`${client.bank}\n${refId}\n${plan.mode}\n${content}`),
-          metadata: {
-            ...stamp?.metadata, // configured first: the built-ins below win on any key collision
-            source: "chat",
-            session_id: sessionId,
-            ref_id: refId,
-            ...(harness ? { harness } : {}),
-          },
-        }
-      ),
-    // Still ours to retry only while the cursor holds the claim we wrote above.
-    () => {
-      if (!cursors) return true;
-      const now = cursors.read(sessionId);
-      return now?.turns === claimed.turns && now?.fingerprint === claimed.fingerprint;
-    },
-    retryUntil
-  );
-  cursors?.write(sessionId, next);
+  if (plan.mode === "replace") {
+    const content = renderSessionJsonl(refId, turns, startTs);
+    // Nothing to buffer: replace is idempotent by construction, so a later one re-establishes the
+    // same truth from the same transcript. Claim the position unconfirmed so an outcome we never
+    // learn resolves to another replace rather than an append onto an unknown state.
+    cursors?.write(sessionId, { ...next, dirty: true });
+    await submitWithRetry(
+      () => submit(content, opId("replace", content), false),
+      stillOurs,
+      retryUntil
+    );
+    cursors?.write(sessionId, next);
+    return;
+  }
+
+  const queue = [...outbox];
+  if (plan.mode === "append") {
+    const content = turns
+      .slice(plan.fromTurn)
+      .map((t) => JSON.stringify(t))
+      .join("\n");
+    queue.push({ content, operationId: opId("append", content), at: Date.now() });
+  }
+
+  // Claim the position BEFORE the request, WITH the bytes: a rejected retain — or a process the
+  // host kills mid-write — leaves a replayable buffer rather than a cursor that can only be
+  // recovered by re-sending (and re-extracting) the entire transcript, forever, for the rest of the
+  // session (#3989). Replay is safe precisely because the bytes and the operation id are unchanged:
+  // a write the server DID commit collapses into that same operation instead of appending twice,
+  // which is the one thing appending onto an unknown state could otherwise get wrong.
+  cursors?.write(sessionId, { ...next, pending: queue });
+  for (let i = 0; i < queue.length; i++) {
+    const entry = queue[i];
+    await submitWithRetry(
+      () => submit(entry.content, entry.operationId, true),
+      stillOurs,
+      retryUntil
+    );
+    // Confirmed: drop it immediately, so a failure on a LATER entry cannot resubmit it as part of
+    // the next flush. Whatever is still queued when this throws is what the next flush replays.
+    const remaining = queue.slice(i + 1);
+    cursors?.write(sessionId, remaining.length ? { ...next, pending: remaining } : next);
+  }
 }

--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { TransportTurn } from "./chat";
-import { fingerprintTurns, memoryCursorStore, planRetain } from "./retain-cursor";
+import {
+  PENDING_MAX_AGE_MS,
+  PENDING_MAX_BYTES,
+  fingerprintTurns,
+  memoryCursorStore,
+  planRetain,
+  type PendingAppend,
+} from "./retain-cursor";
 
 const turn = (i: number): TransportTurn => ({ role: "user", content: `turn ${i}` });
 const turns = (n: number, from = 0): TransportTurn[] =>
@@ -16,6 +23,8 @@ const cursorFor = (all: TransportTurn[], count: number) => ({
 
 const SUPPORTED = { appendSupported: true, bank: BANK };
 
+const pendingAt = (at: number): PendingAppend => ({ content: "{}", operationId: "op", at });
+
 describe("planRetain", () => {
   it("appends only the turns added since the last write", () => {
     const all = turns(5);
@@ -26,11 +35,33 @@ describe("planRetain", () => {
     expect(planRetain(turns(3), undefined, SUPPORTED)).toEqual({ mode: "replace" });
   });
 
-  it("replaces when the previous write was never confirmed", () => {
-    // The one case that would DUPLICATE turns inside the document if we appended anyway: the
-    // server may or may not hold the last slice, and only a replace settles it.
+  it("replaces when a previous REPLACE was never confirmed", () => {
+    // Nothing is buffered for a replace — another one re-establishes the same truth.
     const all = turns(5);
     expect(planRetain(all, { ...cursorFor(all, 3), dirty: true }, SUPPORTED)).toEqual({
+      mode: "replace",
+    });
+  });
+
+  it("keeps appending over an unconfirmed APPEND, whose bytes are buffered for replay", () => {
+    const all = turns(5);
+    const cursor = { ...cursorFor(all, 3), pending: [pendingAt(Date.now())] };
+    expect(planRetain(all, cursor, SUPPORTED)).toEqual({ mode: "append", fromTurn: 3 });
+  });
+
+  it("replaces once a buffered append is too old for the server to still dedupe it", () => {
+    const all = turns(5);
+    const cursor = {
+      ...cursorFor(all, 3),
+      pending: [pendingAt(Date.now() - PENDING_MAX_AGE_MS - 1)],
+    };
+    expect(planRetain(all, cursor, SUPPORTED)).toEqual({ mode: "replace" });
+  });
+
+  it("replaces once the buffer has grown past the point where a replace is cheaper", () => {
+    const all = turns(5);
+    const big = { ...pendingAt(Date.now()), content: "x".repeat(PENDING_MAX_BYTES + 1) };
+    expect(planRetain(all, { ...cursorFor(all, 3), pending: [big] }, SUPPORTED)).toEqual({
       mode: "replace",
     });
   });

--- a/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-cursor.ts
@@ -17,19 +17,56 @@
  *                        NOT Claude Code compaction, which this used to cite: that appends a
  *                        summary record and leaves every earlier record in place (#3379), so the
  *                        prefix stays intact and the append path keeps working.
- *   - dirty              the previous retain failed, or its outcome is unknown (the client aborts at
- *                        15s while the server may well have committed it). Appending on top of an
- *                        unknown state is the one way to DUPLICATE turns inside the document, so we
- *                        rewrite the whole thing instead and let replace re-establish the truth.
+ *   - dirty              a REPLACE was started and not confirmed. There is nothing worth replaying
+ *                        (another replace re-establishes the same truth from the same transcript),
+ *                        so the next write-back simply replaces again.
  *
- * `dirty` is set BEFORE the request and cleared after it succeeds, so an overlapping retain (the
- * runtime fires them without awaiting) sees the advanced cursor and does not re-send the same slice.
+ * An APPEND that fails does NOT fall back to replace, because that fallback is what made a single
+ * outage cost a full re-extraction on every subsequent Stop for the life of the session (#3989).
+ * Its bytes are buffered in `pending` instead and replayed on the next write-back, unchanged and
+ * under their original operation id — so a write the server actually committed is collapsed into
+ * that same operation rather than appending the turns twice, which is the only thing appending onto
+ * an unknown state could otherwise get wrong. The buffer is an optimisation, never the source of
+ * truth: whenever it cannot be trusted (see `pendingReplayable`) the cursor falls back to replace.
+ *
+ * The claim (`dirty`, or `pending` plus the advanced position) is written BEFORE the request and
+ * settled after it, so an overlapping retain (the runtime fires them without awaiting) sees the
+ * advanced cursor and does not re-send the same slice.
  */
 import { createHash } from "node:crypto";
 import type { TransportTurn } from "./chat";
 
+/** One append that was built and submitted but never confirmed. */
+export interface PendingAppend {
+  /** Its EXACT bytes. Replayed unchanged — different bytes would be a different operation, and the
+   *  server's dedupe (which is what makes a replay safe at all) would not apply to them. */
+  content: string;
+  /** The operation id it went out under, replayed unchanged for the same reason. */
+  operationId: string;
+  /** When it was buffered, so a replay cannot outlive the server's operation retention. */
+  at: number;
+}
+
+/** A buffered append is only replayable while the server still holds the operation it would collapse
+ *  into. Operations are kept forever by default (`HINDSIGHT_API_OPERATION_RETENTION_DAYS=0`), but an
+ *  operator can prune them, and a replay after that prune would append the same turns a second time
+ *  — so buffered bytes expire well inside any retention an operator would plausibly configure. */
+export const PENDING_MAX_AGE_MS = 12 * 60 * 60 * 1000;
+/** Past this much buffered content a replace costs about the same as the replay and is simpler, so
+ *  the buffer stops growing and the cursor falls back to it. Also bounds the cursor file. */
+export const PENDING_MAX_BYTES = 256 * 1024;
+
+/** Whether a cursor's buffered appends can still be replayed, or the write-back must replace. */
+export function pendingReplayable(cursor: RetainCursor, now: number): boolean {
+  const pending = cursor.pending ?? [];
+  if (!pending.length) return true;
+  if (pending.some((p) => now - p.at > PENDING_MAX_AGE_MS)) return false;
+  return pending.reduce((n, p) => n + p.content.length, 0) <= PENDING_MAX_BYTES;
+}
+
 export interface RetainCursor {
-  /** Turns already written to the document (index into the normalized transcript). */
+  /** Turns the document holds once every `pending` entry has been applied — what the next append
+   *  must start from, whether those turns are already committed or still buffered. */
   turns: number;
   /** Identity of the written prefix — detects a rewritten transcript (see module doc). */
   fingerprint: string;
@@ -37,8 +74,11 @@ export interface RetainCursor {
    *  per hook invocation from that event's cwd — a session that moves between repos (#3133) keeps
    *  its id and changes bank, and the new bank holds no document to append to. */
   bank: string;
-  /** A write was started and not confirmed: the next retain must replace, not append. */
+  /** A REPLACE was started and not confirmed: the next retain must replace, not append. */
   dirty?: boolean;
+  /** Appends started and not confirmed, oldest first — replayed before anything new. Their turns
+   *  are already counted in `turns`: the cursor covers what is committed OR buffered. */
+  pending?: PendingAppend[];
 }
 
 /**
@@ -68,10 +108,13 @@ export type RetainPlan =
 export function planRetain(
   turns: TransportTurn[],
   cursor: RetainCursor | undefined,
-  opts: { appendSupported: boolean; bank: string }
+  opts: { appendSupported: boolean; bank: string; now?: number }
 ): RetainPlan {
   if (!turns.length) return { mode: "skip" };
   if (!opts.appendSupported || !cursor || cursor.dirty) return { mode: "replace" };
+  // Buffered appends we can no longer replay safely: replace subsumes them (and the caller drops
+  // them), so the document is rebuilt from the transcript rather than left with a gap.
+  if (!pendingReplayable(cursor, opts.now ?? Date.now())) return { mode: "replace" };
   // A different bank holds no document for this session: appending would store the tail alone.
   if (cursor.bank !== opts.bank) return { mode: "replace" };
   // Fewer turns than we wrote: the transcript shrank, so it was rewritten, not extended.

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
@@ -324,7 +324,7 @@ describe("buildRetain — incremental write-back across Stop hooks", () => {
     expect(JSON.parse(rewritten[1])).toMatchObject({ content: "summary of the work so far" });
   });
 
-  it("a failed write is not silently skipped by the next one — it replaces", async () => {
+  it("a failed write is not silently skipped by the next one — it is replayed", async () => {
     const { retain, client } = stubClient();
     const cursors = memoryCursorStore();
     writeFileSync(file, [line(0), line(1)].join("\n"));
@@ -333,14 +333,21 @@ describe("buildRetain — incremental write-back across Stop hooks", () => {
     retain.mockRejectedValueOnce(new Error("server unreachable"));
     writeFileSync(file, [line(0), line(1), line(2)].join("\n"));
     await stop(client, cursors); // buildRetain swallows the failure by design
+    const failed = retain.mock.calls[1];
 
     writeFileSync(file, [line(0), line(1), line(2), line(3)].join("\n"));
     await stop(client, cursors);
 
-    expect(retain).toHaveBeenCalledTimes(3);
-    expect(retain.mock.calls[2][5].updateMode).toBeUndefined();
-    // Everything the failed append would have carried is back in the replaced document.
-    expect((retain.mock.calls[2][0] as string).split("\n")).toHaveLength(5);
+    // The next Stop replays the failed slice verbatim and then appends the new one. Neither is a
+    // replace: an outage costs one retried append, not a full re-extraction per Stop (#3989).
+    expect(retain).toHaveBeenCalledTimes(4);
+    expect(retain.mock.calls[2][0]).toBe(failed[0]);
+    expect(retain.mock.calls[2][5].operationId).toBe(failed[5].operationId);
+    expect(retain.mock.calls.slice(1).map((c) => c[5].updateMode)).toEqual([
+      "append",
+      "append",
+      "append",
+    ]);
   });
 });
 

--- a/hindsight-integrations/coding-agents/src/core/session-cache.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-cache.test.ts
@@ -31,6 +31,14 @@ describe("fileCursorStore", () => {
     });
   });
 
+  it("round-trips the buffered appends a killed hook process must recover", () => {
+    // The whole point of the buffer: the bytes of an unconfirmed append outlive the process that
+    // built them, so the next Stop replays them instead of replacing the transcript (#3989).
+    const pending = [{ content: '{"role":"user"}', operationId: "op-1", at: 1_700_000_000_000 }];
+    fileCursorStore(HARNESS).write("s1", { turns: 4, fingerprint: "abc", bank: "b1", pending });
+    expect(fileCursorStore(HARNESS).read("s1")?.pending).toEqual(pending);
+  });
+
   it("keeps cursors separate per session", () => {
     const store = fileCursorStore(HARNESS);
     store.write("s1", { turns: 1, fingerprint: "a", bank: "b1" });


### PR DESCRIPTION
## Problem

A failed retain leaves the session cursor `dirty`, and a dirty cursor forces `planRetain` into `replace` mode — the whole transcript, re-sent and re-extracted. The cursor is only cleared on success, so an outage does not cost one full re-extraction; it costs one on **every subsequent Stop for the life of the session**.

The reporter measured the second half of that: across one such forced replace a document grew 212,335 → 267,311 characters while its extracted facts *fell* 197 → 131. Facts are replaced wholesale on upsert, so a forced replace does not merely re-pay for existing knowledge — it can silently discard facts the longer transcript does not re-derive.

## Fix

Buffer the append rather than falling back to replace.

`RetainCursor` now carries `pending` — the exact bytes and operation id of any append that was built but never confirmed. The next write-back replays them, oldest first, **verbatim and under their original operation id**, before anything new. `cursor.turns` therefore means "committed *or* buffered", so the following append starts after them and the document only ever grows in transcript order.

Replay is safe for precisely that reason: a write the server *did* commit is collapsed into that same operation instead of appending the turns twice — the one thing appending onto an unknown state could otherwise get wrong. So this needs no classification of *why* the request failed: every append failure buffers, including the ambiguous ones (client timeout, 5xx, connection reset) and the ones a status allowlist would miss (429 arrives as `RateLimitedError`; a refused connection has no status at all).

The claim is written *before* the request, bytes included, so a process the host kills mid-write also leaves a replayable buffer instead of a poisoned cursor. Each entry is dropped the moment it lands, so a failure later in the queue cannot resubmit one that already succeeded. A merged payload would be different bytes, a different operation and no dedupe — so the buffer and the new tail go out as separate calls; queued retains for one document fold into a single extraction server-side anyway.

`dirty` narrows to *replace* failures, which need no buffer: another replace re-establishes the same truth from the same transcript.

The buffer stays an optimisation, never the source of truth. `planRetain` falls back to replace when it can no longer be trusted:

- **`PENDING_MAX_AGE_MS` (12h)** — operations are kept forever by default, but `HINDSIGHT_API_OPERATION_RETENTION_DAYS` can prune them, and a replay after that prune would append the same turns a second time.
- **`PENDING_MAX_BYTES` (256 KB)** — past which a replace costs about the same as the replay, and the cursor file stops growing.

## Test

`npm test` — 898 passed. `npm run build`, `./scripts/hooks/lint.sh` clean.

Two existing tests encoded the old contract and now assert the new one: a failed append is replayed (same bytes, same operation id) followed by the new tail, with no replace on either the unit or the Stop-hook path. New coverage for the buffer being dropped as it lands, a failed *replace* still replacing, and both fallback bounds.

## Scope

Client-side only, `hindsight-integrations/coding-agents`. Two things this deliberately does **not** address, both worth their own issues:

- Replace still happens legitimately — first write, fingerprint drift, bank move (#3133), cursor eviction, `memoryCursorStore` lost on a host restart. This reduces how often that path is taken; it does not remove it. Reconciling against the server's stored document (exposing its turn count or a prefix fingerprint) is what would.
- That a re-extraction can *drop facts* is a server-side bug and survives this change entirely.

Fixes #3989.
