### PR TITLE
chore(deps): bump qs, @humanfs/node and postcss-selector-parser in the root lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3296,9 +3296,9 @@
       }
     },
     "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -3717,9 +3717,9 @@
       }
     },
     "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -4164,9 +4164,9 @@
       }
     },
     "node_modules/@csstools/postcss-scope-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -6432,23 +6432,36 @@
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -15673,9 +15686,9 @@
       }
     },
     "node_modules/css-blank-pseudo/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15756,9 +15769,9 @@
       }
     },
     "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -26626,9 +26639,9 @@
       }
     },
     "node_modules/postcss-attribute-case-insensitive/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -26870,9 +26883,9 @@
       }
     },
     "node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -26908,9 +26921,9 @@
       }
     },
     "node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -27036,9 +27049,9 @@
       }
     },
     "node_modules/postcss-focus-visible/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -27074,9 +27087,9 @@
       }
     },
     "node_modules/postcss-focus-within/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -27406,9 +27419,9 @@
       }
     },
     "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -27434,9 +27447,9 @@
       }
     },
     "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -27533,9 +27546,9 @@
       }
     },
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -27905,9 +27918,9 @@
       }
     },
     "node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -27998,9 +28011,9 @@
       }
     },
     "node_modules/postcss-selector-not/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+      "integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -28011,9 +28024,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -28335,12 +28348,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -30365,14 +30379,14 @@
       "license": "MIT"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -30384,13 +30398,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "./scripts/setup-hooks.sh"
   },
   "overrides": {
-    "qs": "^6.14.2",
+    "qs": ">=6.16.0 <7.0.0",
     "fast-xml-parser": ">=5.5.6",
     "serialize-javascript": "^7.0.5",
     "minimatch": "^3.1.4",
@@ -57,6 +57,28 @@
     "webpack-dev-server": ">=5.2.6 <6.0.0",
     "esbuild": ">=0.28.1 <0.29.0",
     "body-parser": ">=1.20.6 <2.0.0",
-    "browserslist": ">=4.28.7 <5.0.0"
+    "browserslist": ">=4.28.7 <5.0.0",
+    "postcss-selector-parser": ">=7.1.3 <8.0.0",
+    "postcss-calc": {
+      "postcss-selector-parser": "^6.1.3"
+    },
+    "postcss-discard-unused": {
+      "postcss-selector-parser": "^6.1.3"
+    },
+    "postcss-merge-rules": {
+      "postcss-selector-parser": "^6.1.3"
+    },
+    "postcss-minify-selectors": {
+      "postcss-selector-parser": "^6.1.3"
+    },
+    "postcss-unique-selectors": {
+      "postcss-selector-parser": "^6.1.3"
+    },
+    "stylehacks": {
+      "postcss-selector-parser": "^6.1.3"
+    },
+    "@tailwindcss/typography": {
+      "postcss-selector-parser": "6.0.10"
+    }
   }
 }


### PR DESCRIPTION
Routine dependency maintenance on the root workspace `package-lock.json`.

Closes #1440, #1442, #1441, #1421, #1420.

## What changed

| Package | Before | After | Alert |
|---|---|---|---|
| `qs` | 6.15.2 | 6.16.0 | #1442, #1441 |
| `@humanfs/node` | 0.16.7 | 0.16.8 | #1440 |
| `postcss-selector-parser` (v7 line) | 7.1.1 | 7.1.6 | #1421 |
| `postcss-selector-parser` (v6 line) | 6.1.2 | 6.1.4 | #1420 |

## Why `postcss-selector-parser` needed seven scoped overrides

This package resolves on **two major lines at once** in this tree, and each line
has its own advisory range (`>=6.1.0 <6.1.3` and `>=7.1.0 <7.1.3`).

npm `overrides` *replace* a parent's declared range rather than intersecting
with it, so the obvious single union range —
`">=6.1.3 <7.0.0 || >=7.1.3 <8.0.0"` — would have resolved every consumer to
the highest satisfying member and silently dragged six v6 consumers up onto v7,
a major bump well outside the scope of a dependency update.

Instead: a global floor for the v7 line, plus a scoped override per v6 consumer.

```
"postcss-selector-parser": ">=7.1.3 <8.0.0",     // 16 v7 consumers -> 7.1.6
"postcss-calc":             { "postcss-selector-parser": "^6.1.3" },
"postcss-discard-unused":   { "postcss-selector-parser": "^6.1.3" },
"postcss-merge-rules":      { "postcss-selector-parser": "^6.1.3" },
"postcss-minify-selectors": { "postcss-selector-parser": "^6.1.3" },
"postcss-unique-selectors": { "postcss-selector-parser": "^6.1.3" },
"stylehacks":               { "postcss-selector-parser": "^6.1.3" },
"@tailwindcss/typography":  { "postcss-selector-parser": "6.0.10" }
```

`@tailwindcss/typography` pins `6.0.10` exactly. That version sits *below* the
`>=6.1.0` advisory range and so was never affected; its scoped entry exists only
to hold it where it already was, since the global floor would otherwise have
moved it too.

`qs` had an existing `"^6.14.2"` override that still resolved onto a 6.15.x
line, so the floor was raised to `">=6.16.0 <7.0.0"`. `@humanfs/node` 0.16.8 was
already inside eslint's declared `^0.16.6`, so it needed no override at all.

## A note for reviewers on npm 10 vs npm 11

**The lockfile was regenerated with npm 11** (11.19.1, via
`npx npm@11 update qs @humanfs/node postcss-selector-parser --package-lock-only`).

This matters and is worth stating plainly, because a reviewer regenerating on
npm 10 will not reproduce this diff. npm 10.9.2 has an overrides-plus-workspaces
bug: it applies the override at the hoisted root but then **de-hoists fresh
vulnerable copies** into `hindsight-all-npm` and `hindsight-clients/typescript`,
leaving the tree in a worse state than before the change. npm 11 resolves to a
single hoisted copy.

The resulting lockfile was verified to contain **no de-hoisted vulnerable
copies** — one hoisted `qs@6.16.0`, one `@humanfs/node@0.16.8`, and
`postcss-selector-parser` only at 7.1.6 / 6.1.4 / 6.0.10.

`npm ci` under npm 10.9.2 still accepts the result (0 vulnerabilities), so this
does not raise the floor for anyone building the repo.

## Every other line in the diff

The four remaining version changes are all direct dependencies of the two
packages bumped above, pulled in automatically:

- `side-channel` 1.1.0 -> 1.1.1 and `side-channel-list` 1.0.0 -> 1.0.1 — required by `qs@6.16.0`
- `@humanfs/core` 0.19.1 -> 0.19.2 and `@humanfs/types` 0.15.0 (new) — required by `@humanfs/node@0.16.8`

No entries were pruned and nothing else in the tree moved.

## Verification

Reproducing the CI jobs that consume the root lockfile, locally:

- `npm ci --workspace=hindsight-clients/typescript` + `npm run build` — clean (build-typescript-client)
- `npm ci --workspace=hindsight-all-npm` + `npm test` + `npm run build` — 10/10 tests, clean build (build-hindsight-all-npm)
- control plane: `npm test` 198/198, `npm run build` plus the standalone build — clean (build-control-plane)

The control plane build is the one that matters most here: it is the real
consumer of the postcss selector pipeline, so it was built rather than only
tested.
