### PR TITLE
chore(deps): bump qs to 6.16.0 in the coding-agents lock

### DIFF
--- a/hindsight-integrations/coding-agents/package-lock.json
+++ b/hindsight-integrations/coding-agents/package-lock.json
@@ -3535,9 +3535,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
Routine dependency maintenance on `hindsight-integrations/coding-agents/package-lock.json`.

Closes #1439, #1438.

## What changed

`qs` 6.15.3 -> 6.16.0, and nothing else. The whole diff is three lines.

## Why no override was needed

Both declared ranges in this tree already admit 6.16.0:

- `body-parser` -> `qs@^6.15.2`
- `express` -> `qs@^6.14.0`

So this is a plain in-range resolution forward rather than an override — the
lockfile was simply held behind its own permitted range. A bounded override
would have been redundant here, so none was added.

`qs@6.16.0`'s own dependencies (`side-channel ^1.1.1`, `es-define-property
^1.0.1`) were already present at satisfying versions (1.1.1 and 1.0.1), which is
why nothing else in the lockfile moved.

Regenerated with npm 11 (`npx npm@11 update qs --package-lock-only`) for
consistency with the other lockfiles in this repo, though this particular change
is simple enough that npm 10 produces the same result.

## Verification

Reproducing the `test-coding-agents` job's steps locally:

- `npm ci` — clean, 0 vulnerabilities
- `npx tsc --noEmit` — clean
- `npm test` — 879 tests across 67 files, all passing
- `npm run build` — clean

Confirmed afterwards that `qs` appears exactly once in the tree, at 6.16.0.
