### PR TITLE
fix(ci): skip star history updates in forks

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   update:
+    if: github.repository == 'vectorize-io/hindsight'
     concurrency:
       group: star-history
       cancel-in-progress: false


### PR DESCRIPTION
Forks can inherit this scheduled workflow and commit fork-specific star data to `main`, causing conflicts when syncing from upstream.

Skip the job unless it is running in `vectorize-io/hindsight`.

Tested with `./scripts/hooks/lint.sh`.