### PR TITLE
docs: point the Slack community links at a redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Version](https://img.shields.io/pypi/v/hindsight-api?logo=python&logoColor=white&label=version&color=blue)](https://pypi.org/project/hindsight-api/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/hindsight-client?logo=pypi&logoColor=white&label=PyPI&color=blue)](https://pypi.org/project/hindsight-client/)
 [![NPM Downloads](https://img.shields.io/npm/dm/%40vectorize-io%2Fhindsight-client?logo=npm&logoColor=white&label=NPM&color=blue)](https://www.npmjs.com/package/@vectorize-io/hindsight-client)
-[![Slack Community](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg)
+[![Slack Community](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://vectorize.io/slack)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 <br/>
 
@@ -414,7 +414,7 @@ More patterns in the [Cookbook](https://hindsight.vectorize.io/cookbook) and [Be
 - [Python](https://hindsight.vectorize.io/sdks/python) · [Node.js](https://hindsight.vectorize.io/sdks/nodejs) · [Go](https://hindsight.vectorize.io/sdks/go) · [CLI](https://hindsight.vectorize.io/sdks/cli) · [REST API](https://hindsight.vectorize.io/api-reference)
 
 **Community:**
-- [Slack](https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg)
+- [Slack](https://vectorize.io/slack)
 - [GitHub Issues](https://github.com/vectorize-io/hindsight/issues)
 
 ---

--- a/hindsight-docs/blog/2026-06-09-fastest-growing-oss-ai-memory.md
+++ b/hindsight-docs/blog/2026-06-09-fastest-growing-oss-ai-memory.md
@@ -146,6 +146,6 @@ API at `http://localhost:8888`, web UI at `http://localhost:9999`. Connect it to
 
 - **Star [the repo](https://github.com/vectorize-io/hindsight)** — the real kind — and help us find out how fast the *next* milestone arrives
 - **Try [Hindsight Cloud](https://ui.hindsight.vectorize.io/signup)** — managed, scaled, usage-based pricing
-- **Join the conversation** — [GitHub Discussions](https://github.com/vectorize-io/hindsight/discussions) or [Slack](https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg)
+- **Join the conversation** — [GitHub Discussions](https://github.com/vectorize-io/hindsight/discussions) or [Slack](https://vectorize.io/slack)
 
 Seven months, two stars to sixteen thousand — every one of them earned, for the agent memory that learns. Thanks for building with us — let's see where the curve goes next.

--- a/hindsight-docs/docusaurus.config.ts
+++ b/hindsight-docs/docusaurus.config.ts
@@ -335,7 +335,7 @@ const config: Config = {
               customProps: { icon: 'lu-book-open' },
             },
             {
-              href: 'https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg',
+              href: 'https://vectorize.io/slack',
               label: 'Community',
               customProps: { icon: 'si-slack' },
             },
@@ -434,7 +434,7 @@ const config: Config = {
             },
             {
               label: 'Slack',
-              href: 'https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg',
+              href: 'https://vectorize.io/slack',
             },
             {
               label: 'Vectorize',

--- a/hindsight-docs/sidebars.ts
+++ b/hindsight-docs/sidebars.ts
@@ -369,7 +369,7 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'link',
-          href: 'https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg',
+          href: 'https://vectorize.io/slack',
           label: 'Community',
           customProps: { icon: 'si-slack', iconAfter: 'lu-arrow-up-right' },
         },

--- a/hindsight-docs/src/pages/faq.mdx
+++ b/hindsight-docs/src/pages/faq.mdx
@@ -409,4 +409,4 @@ Yes — by giving the consuming LLM better-grounded context to reason from. Thre
 
 ## Still have questions?
 
-Join our [Slack community](https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg) or report issues on [GitHub](https://github.com/vectorize-io/hindsight/issues).
+Join our [Slack community](https://vectorize.io/slack) or report issues on [GitHub](https://github.com/vectorize-io/hindsight/issues).

--- a/hindsight-docs/versioned_sidebars/version-0.6-sidebars.json
+++ b/hindsight-docs/versioned_sidebars/version-0.6-sidebars.json
@@ -423,7 +423,7 @@
         },
         {
           "type": "link",
-          "href": "https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg",
+          "href": "https://vectorize.io/slack",
           "label": "Community",
           "customProps": {
             "icon": "si-slack",

--- a/hindsight-docs/versioned_sidebars/version-0.7-sidebars.json
+++ b/hindsight-docs/versioned_sidebars/version-0.7-sidebars.json
@@ -423,7 +423,7 @@
         },
         {
           "type": "link",
-          "href": "https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg",
+          "href": "https://vectorize.io/slack",
           "label": "Community",
           "customProps": {
             "icon": "si-slack",

--- a/hindsight-docs/versioned_sidebars/version-0.8-sidebars.json
+++ b/hindsight-docs/versioned_sidebars/version-0.8-sidebars.json
@@ -454,7 +454,7 @@
         },
         {
           "type": "link",
-          "href": "https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg",
+          "href": "https://vectorize.io/slack",
           "label": "Community",
           "customProps": {
             "icon": "si-slack",

--- a/hindsight-docs/versioned_sidebars/version-0.9-sidebars.json
+++ b/hindsight-docs/versioned_sidebars/version-0.9-sidebars.json
@@ -478,7 +478,7 @@
         },
         {
           "type": "link",
-          "href": "https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg",
+          "href": "https://vectorize.io/slack",
           "label": "Community",
           "customProps": {
             "icon": "si-slack",

--- a/skills/hindsight-docs/references/faq.md
+++ b/skills/hindsight-docs/references/faq.md
@@ -429,4 +429,4 @@ Yes — by giving the consuming LLM better-grounded context to reason from. Thre
 
 ## Still have questions?
 
-Join our [Slack community](https://join.slack.com/t/hindsight-space/shared_invite/zt-3nhbm4w29-LeSJ5Ixi6j8PdiYOCPlOgg) or report issues on [GitHub](https://github.com/vectorize-io/hindsight/issues).
+Join our [Slack community](https://vectorize.io/slack) or report issues on [GitHub](https://github.com/vectorize-io/hindsight/issues).


### PR DESCRIPTION
## Why

The Slack invite token was pasted verbatim into **twelve places across ten files** in this repo. Slack shared-invite links expire — on the plan this workspace uses they are capped at 30 days, with no "never expires" option — so every one of those twelve copies had gone stale.

An expired Slack invite gives no useful signal to the person clicking it. It quietly redirects to the workspace's generic signup page, which is restricted to a company email domain and tells the visitor to contact an administrator for an invitation. It reads like the community is closed, or like a permissions bug. Two people reported it that way before anyone realised the link was simply dead.

The difference, confirmed by loading both:

| Link | Lands on |
|---|---|
| the old token | `/signup#/domain-signup` — restricted dead end |
| a live invite | `/join/shared_invite/<code>#/shared-invite/email` — real join page |

Rotating a token across twelve hardcoded copies every 30 days was never going to happen, which is exactly how it got this stale.

## What changed

All twelve now point at `https://vectorize.io/slack`, which redirects to the current invite:

- `README.md` (×2 — badge and Resources)
- `hindsight-docs/docusaurus.config.ts` (×2), `sidebars.ts`, `src/pages/faq.mdx`
- `hindsight-docs/versioned_sidebars/` — 0.6, 0.7, 0.8, 0.9
- `hindsight-docs/blog/2026-06-09-fastest-growing-oss-ai-memory.md`
- `skills/hindsight-docs/references/faq.md`

Rotating the invite is now a one-line change in the site that owns the redirect. The links here stop going stale.

The four **versioned** sidebars are updated too. They are frozen docs snapshots, so leaving them alone is defensible — but a reader on 0.6 deserves a working community link as much as anyone, and those four are precisely the copies nobody ever remembers to grep.

## Verified

- `https://vectorize.io/slack` → `307` → the live invite (the redirect is deployed and answering)
- Someone has since completed a signup through it end-to-end, so the whole chain works, not just the redirect hop
- All four versioned sidebar JSON files still parse
- Pre-commit lints pass
- No occurrence of the old token remains anywhere in the repo

Deliberately a temporary (307) redirect, not permanent: the destination changes roughly monthly, and a cached 308 would pin visitors to a dead invite.

https://claude.ai/code/session_011mnzArjiCdBxa8dh1H47Fa