### PR TITLE
fix(python-client): add the missing async twins to the convenience wrapper (#4221)

### DIFF
--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -451,7 +451,28 @@ class Hindsight:
         files_metadata: list[dict[str, Any]] | None = None,
     ) -> FileRetainResponse:
         """
-        Upload files and retain their contents as memories (sync wrapper).
+        Upload files and retain their contents as memories (sync wrapper — prefer :meth:`aretain_files` in async code).
+
+        See :meth:`aretain_files` for the full argument and return documentation.
+        """
+        return _run_async(
+            self.aretain_files(
+                bank_id=bank_id,
+                files=files,
+                context=context,
+                files_metadata=files_metadata,
+            )
+        )
+
+    async def aretain_files(
+        self,
+        bank_id: str,
+        files: list[str | Path],
+        context: str | None = None,
+        files_metadata: list[dict[str, Any]] | None = None,
+    ) -> FileRetainResponse:
+        """
+        Upload files and retain their contents as memories (async — preferred over :meth:`retain_files`).
 
         Files are automatically converted to text (PDF, DOCX, images via OCR, audio via
         transcription, and more) and ingested as memories. Processing is always asynchronous
@@ -476,10 +497,8 @@ class Hindsight:
 
         request_body = json.dumps({"files_metadata": meta})
 
-        return _run_async(
-            self._files_api.file_retain(
-                bank_id=bank_id, files=file_data, request=request_body, _request_timeout=self._timeout
-            )
+        return await self._files_api.file_retain(
+            bank_id=bank_id, files=file_data, request=request_body, _request_timeout=self._timeout
         )
 
     def recall(
@@ -654,21 +673,44 @@ class Hindsight:
         limit: int = 100,
         offset: int = 0,
     ) -> ListMemoryUnitsResponse:
-        """List memory units with pagination (sync wrapper — use ``await client.memory.list_memories(...)`` in async code).
+        """
+        List memory units with pagination (sync wrapper — prefer :meth:`alist_memories` in async code).
+
+        See :meth:`alist_memories` for the full argument and return documentation.
+        """
+        return _run_async(
+            self.alist_memories(
+                bank_id=bank_id,
+                type=type,
+                search_query=search_query,
+                entity_id=entity_id,
+                limit=limit,
+                offset=offset,
+            )
+        )
+
+    async def alist_memories(
+        self,
+        bank_id: str,
+        type: str | None = None,
+        search_query: str | None = None,
+        entity_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> ListMemoryUnitsResponse:
+        """List memory units with pagination (async — preferred over :meth:`list_memories`).
 
         entity_id: filter to memory units linked to this entity ID (stored links,
         not text/semantic match).
         """
-        return _run_async(
-            self._memory_api.list_memories(
-                bank_id=bank_id,
-                type=type,
-                q=search_query,
-                entity_id=entity_id,
-                limit=limit,
-                offset=offset,
-                _request_timeout=self._timeout,
-            )
+        return await self._memory_api.list_memories(
+            bank_id=bank_id,
+            type=type,
+            q=search_query,
+            entity_id=entity_id,
+            limit=limit,
+            offset=offset,
+            _request_timeout=self._timeout,
         )
 
     def create_bank(
@@ -1309,7 +1351,34 @@ class Hindsight:
         id: str | None = None,
     ):
         """
-        Create a mental model (sync wrapper — use ``await client.mental_models.create_mental_model(...)`` in async code).
+        Create a mental model (sync wrapper — prefer :meth:`acreate_mental_model` in async code).
+
+        See :meth:`acreate_mental_model` for the full argument and return documentation.
+        """
+        return _run_async(
+            self.acreate_mental_model(
+                bank_id=bank_id,
+                name=name,
+                source_query=source_query,
+                tags=tags,
+                max_tokens=max_tokens,
+                trigger=trigger,
+                id=id,
+            )
+        )
+
+    async def acreate_mental_model(
+        self,
+        bank_id: str,
+        name: str,
+        source_query: str,
+        tags: list[str] | None = None,
+        max_tokens: int | None = None,
+        trigger: dict[str, Any] | None = None,
+        id: str | None = None,
+    ):
+        """
+        Create a mental model (async — preferred over :meth:`create_mental_model`).
 
         Args:
             bank_id: The memory bank ID
@@ -1336,9 +1405,7 @@ class Hindsight:
             trigger=trigger_obj,
         )
 
-        return _run_async(
-            self._mental_models_api.create_mental_model(bank_id, request_obj, _request_timeout=self._timeout)
-        )
+        return await self._mental_models_api.create_mental_model(bank_id, request_obj, _request_timeout=self._timeout)
 
     def list_mental_models(
         self,
@@ -1350,7 +1417,32 @@ class Hindsight:
         offset: int | None = None,
     ):
         """
-        List all mental models in a bank (sync wrapper — use ``await client.mental_models.list_mental_models(...)`` in async code).
+        List all mental models in a bank (sync wrapper — prefer :meth:`alist_mental_models` in async code).
+
+        See :meth:`alist_mental_models` for the full argument and return documentation.
+        """
+        return _run_async(
+            self.alist_mental_models(
+                bank_id=bank_id,
+                tags=tags,
+                tags_match=tags_match,
+                detail=detail,
+                limit=limit,
+                offset=offset,
+            )
+        )
+
+    async def alist_mental_models(
+        self,
+        bank_id: str,
+        tags: list[str] | None = None,
+        tags_match: Literal["any", "all", "exact"] | None = None,
+        detail: Literal["metadata", "content", "full"] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ):
+        """
+        List all mental models in a bank (async — preferred over :meth:`list_mental_models`).
 
         Args:
             bank_id: The memory bank ID
@@ -1366,16 +1458,14 @@ class Hindsight:
         Returns:
             ListMentalModelsResponse with items
         """
-        return _run_async(
-            self._mental_models_api.list_mental_models(
-                bank_id,
-                tags=tags,
-                tags_match=tags_match,
-                detail=detail,
-                limit=limit,
-                offset=offset,
-                _request_timeout=self._timeout,
-            )
+        return await self._mental_models_api.list_mental_models(
+            bank_id,
+            tags=tags,
+            tags_match=tags_match,
+            detail=detail,
+            limit=limit,
+            offset=offset,
+            _request_timeout=self._timeout,
         )
 
     def get_mental_model(
@@ -1385,7 +1475,20 @@ class Hindsight:
         detail: Literal["metadata", "content", "full"] | None = None,
     ):
         """
-        Get a specific mental model (sync wrapper — use ``await client.mental_models.get_mental_model(...)`` in async code).
+        Get a specific mental model (sync wrapper — prefer :meth:`aget_mental_model` in async code).
+
+        See :meth:`aget_mental_model` for the full argument and return documentation.
+        """
+        return _run_async(self.aget_mental_model(bank_id=bank_id, mental_model_id=mental_model_id, detail=detail))
+
+    async def aget_mental_model(
+        self,
+        bank_id: str,
+        mental_model_id: str,
+        detail: Literal["metadata", "content", "full"] | None = None,
+    ):
+        """
+        Get a specific mental model (async — preferred over :meth:`get_mental_model`).
 
         Args:
             bank_id: The memory bank ID
@@ -1398,15 +1501,21 @@ class Hindsight:
         Returns:
             MentalModelResponse
         """
-        return _run_async(
-            self._mental_models_api.get_mental_model(
-                bank_id, mental_model_id, detail=detail, _request_timeout=self._timeout
-            )
+        return await self._mental_models_api.get_mental_model(
+            bank_id, mental_model_id, detail=detail, _request_timeout=self._timeout
         )
 
     def refresh_mental_model(self, bank_id: str, mental_model_id: str):
         """
-        Refresh a mental model (sync wrapper — use ``await client.mental_models.refresh_mental_model(...)`` in async code).
+        Refresh a mental model (sync wrapper — prefer :meth:`arefresh_mental_model` in async code).
+
+        See :meth:`arefresh_mental_model` for the full argument and return documentation.
+        """
+        return _run_async(self.arefresh_mental_model(bank_id=bank_id, mental_model_id=mental_model_id))
+
+    async def arefresh_mental_model(self, bank_id: str, mental_model_id: str):
+        """
+        Refresh a mental model (async — preferred over :meth:`refresh_mental_model`).
 
         Args:
             bank_id: The memory bank ID
@@ -1415,14 +1524,21 @@ class Hindsight:
         Returns:
             RefreshMentalModelResponse with operation_id
         """
-        return _run_async(
-            self._mental_models_api.refresh_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout)
+        return await self._mental_models_api.refresh_mental_model(
+            bank_id, mental_model_id, _request_timeout=self._timeout
         )
 
     def dry_run_refresh_mental_model(self, bank_id: str, mental_model_id: str):
         """
-        Preview a mental model refresh without changing anything (sync wrapper — use
-        ``await client.mental_models.dry_run_refresh_mental_model(...)`` in async code).
+        Preview a mental model refresh without changing anything (sync wrapper — prefer :meth:`adry_run_refresh_mental_model` in async code).
+
+        See :meth:`adry_run_refresh_mental_model` for the full argument and return documentation.
+        """
+        return _run_async(self.adry_run_refresh_mental_model(bank_id=bank_id, mental_model_id=mental_model_id))
+
+    async def adry_run_refresh_mental_model(self, bank_id: str, mental_model_id: str):
+        """
+        Preview a mental model refresh without changing anything (async — preferred over :meth:`dry_run_refresh_mental_model`).
 
         The production refresh pipeline with two writes skipped — the content and the
         watermark — so what it reports is what the next refresh will do. Reports the
@@ -1437,13 +1553,19 @@ class Hindsight:
         Returns:
             MentalModelDryRunRefreshResult
         """
-        return _run_async(
-            self._mental_models_api.dry_run_refresh_mental_model(
-                bank_id, mental_model_id, _request_timeout=self._timeout
-            )
+        return await self._mental_models_api.dry_run_refresh_mental_model(
+            bank_id, mental_model_id, _request_timeout=self._timeout
         )
 
     def clear_mental_model(self, bank_id: str, mental_model_id: str):
+        """
+        Clear a mental model's content so the next refresh performs a full re-synthesis (sync wrapper — prefer :meth:`aclear_mental_model` in async code).
+
+        See :meth:`aclear_mental_model` for the full argument and return documentation.
+        """
+        return _run_async(self.aclear_mental_model(bank_id=bank_id, mental_model_id=mental_model_id))
+
+    async def aclear_mental_model(self, bank_id: str, mental_model_id: str):
         """
         Clear a mental model's content so the next refresh performs a full re-synthesis.
 
@@ -1454,8 +1576,8 @@ class Hindsight:
         Returns:
             MentalModelResponse with cleared content
         """
-        return _run_async(
-            self._mental_models_api.clear_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout)
+        return await self._mental_models_api.clear_mental_model(
+            bank_id, mental_model_id, _request_timeout=self._timeout
         )
 
     def update_mental_model(
@@ -1469,7 +1591,34 @@ class Hindsight:
         trigger: dict[str, Any] | None = None,
     ):
         """
-        Update a mental model's metadata (sync wrapper — use ``await client.mental_models.update_mental_model(...)`` in async code).
+        Update a mental model's metadata (sync wrapper — prefer :meth:`aupdate_mental_model` in async code).
+
+        See :meth:`aupdate_mental_model` for the full argument and return documentation.
+        """
+        return _run_async(
+            self.aupdate_mental_model(
+                bank_id=bank_id,
+                mental_model_id=mental_model_id,
+                name=name,
+                source_query=source_query,
+                tags=tags,
+                max_tokens=max_tokens,
+                trigger=trigger,
+            )
+        )
+
+    async def aupdate_mental_model(
+        self,
+        bank_id: str,
+        mental_model_id: str,
+        name: str | None = None,
+        source_query: str | None = None,
+        tags: list[str] | None = None,
+        max_tokens: int | None = None,
+        trigger: dict[str, Any] | None = None,
+    ):
+        """
+        Update a mental model's metadata (async — preferred over :meth:`update_mental_model`).
 
         Args:
             bank_id: The memory bank ID
@@ -1495,27 +1644,41 @@ class Hindsight:
             trigger=trigger_obj,
         )
 
-        return _run_async(
-            self._mental_models_api.update_mental_model(
-                bank_id, mental_model_id, request_obj, _request_timeout=self._timeout
-            )
+        return await self._mental_models_api.update_mental_model(
+            bank_id, mental_model_id, request_obj, _request_timeout=self._timeout
         )
 
     def delete_mental_model(self, bank_id: str, mental_model_id: str):
         """
-        Delete a mental model (sync wrapper — use ``await client.mental_models.delete_mental_model(...)`` in async code).
+        Delete a mental model (sync wrapper — prefer :meth:`adelete_mental_model` in async code).
+
+        See :meth:`adelete_mental_model` for the full argument and return documentation.
+        """
+        return _run_async(self.adelete_mental_model(bank_id=bank_id, mental_model_id=mental_model_id))
+
+    async def adelete_mental_model(self, bank_id: str, mental_model_id: str):
+        """
+        Delete a mental model (async — preferred over :meth:`delete_mental_model`).
 
         Args:
             bank_id: The memory bank ID
             mental_model_id: The mental model ID
         """
-        return _run_async(
-            self._mental_models_api.delete_mental_model(bank_id, mental_model_id, _request_timeout=self._timeout)
+        return await self._mental_models_api.delete_mental_model(
+            bank_id, mental_model_id, _request_timeout=self._timeout
         )
 
     def get_mental_model_history(self, bank_id: str, mental_model_id: str):
         """
-        Get the content change history of a mental model (sync wrapper — use ``await client.mental_models.get_mental_model_history(...)`` in async code).
+        Get the content change history of a mental model (sync wrapper — prefer :meth:`aget_mental_model_history` in async code).
+
+        See :meth:`aget_mental_model_history` for the full argument and return documentation.
+        """
+        return _run_async(self.aget_mental_model_history(bank_id=bank_id, mental_model_id=mental_model_id))
+
+    async def aget_mental_model_history(self, bank_id: str, mental_model_id: str):
+        """
+        Get the content change history of a mental model (async — preferred over :meth:`get_mental_model_history`).
 
         Returns a list of history entries (most recent first), each with
         ``previous_content`` and ``changed_at`` fields.
@@ -1524,16 +1687,23 @@ class Hindsight:
             bank_id: The memory bank ID
             mental_model_id: The mental model ID
         """
-        return _run_async(
-            self._mental_models_api.get_mental_model_history(bank_id, mental_model_id, _request_timeout=self._timeout)
+        return await self._mental_models_api.get_mental_model_history(
+            bank_id, mental_model_id, _request_timeout=self._timeout
         )
 
     # Knowledge base methods
 
     def get_knowledge_base_tree(self, bank_id: str):
         """
-        Get the knowledge base as a nested folder/page tree (sync wrapper — use
-        ``await client.knowledge_base.get_knowledge_base_tree(...)`` in async code).
+        Get the knowledge base as a nested folder/page tree (sync wrapper — prefer :meth:`aget_knowledge_base_tree` in async code).
+
+        See :meth:`aget_knowledge_base_tree` for the full argument and return documentation.
+        """
+        return _run_async(self.aget_knowledge_base_tree(bank_id=bank_id))
+
+    async def aget_knowledge_base_tree(self, bank_id: str):
+        """
+        Get the knowledge base as a nested folder/page tree (async — preferred over :meth:`get_knowledge_base_tree`).
 
         Page bodies are not included; fetch a page with :meth:`get_knowledge_page`.
 
@@ -1543,12 +1713,19 @@ class Hindsight:
         Returns:
             KnowledgeTreeResponse with roots
         """
-        return _run_async(self._knowledge_base_api.get_knowledge_base_tree(bank_id, _request_timeout=self._timeout))
+        return await self._knowledge_base_api.get_knowledge_base_tree(bank_id, _request_timeout=self._timeout)
 
     def create_knowledge_folder(self, bank_id: str, name: str, parent_id: str | None = None):
         """
-        Create a knowledge-base folder (sync wrapper — use
-        ``await client.knowledge_base.create_knowledge_folder(...)`` in async code).
+        Create a knowledge-base folder (sync wrapper — prefer :meth:`acreate_knowledge_folder` in async code).
+
+        See :meth:`acreate_knowledge_folder` for the full argument and return documentation.
+        """
+        return _run_async(self.acreate_knowledge_folder(bank_id=bank_id, name=name, parent_id=parent_id))
+
+    async def acreate_knowledge_folder(self, bank_id: str, name: str, parent_id: str | None = None):
+        """
+        Create a knowledge-base folder (async — preferred over :meth:`create_knowledge_folder`).
 
         Args:
             bank_id: The memory bank ID
@@ -1562,8 +1739,8 @@ class Hindsight:
 
         request_obj = create_folder_request.CreateFolderRequest(name=name, parent_id=parent_id)
 
-        return _run_async(
-            self._knowledge_base_api.create_knowledge_folder(bank_id, request_obj, _request_timeout=self._timeout)
+        return await self._knowledge_base_api.create_knowledge_folder(
+            bank_id, request_obj, _request_timeout=self._timeout
         )
 
     def create_knowledge_page(
@@ -1577,8 +1754,34 @@ class Hindsight:
         trigger: dict[str, Any] | None = None,
     ):
         """
-        Create a knowledge-base page (sync wrapper — use
-        ``await client.knowledge_base.create_knowledge_page(...)`` in async code).
+        Create a knowledge-base page (sync wrapper — prefer :meth:`acreate_knowledge_page` in async code).
+
+        See :meth:`acreate_knowledge_page` for the full argument and return documentation.
+        """
+        return _run_async(
+            self.acreate_knowledge_page(
+                bank_id=bank_id,
+                name=name,
+                source_query=source_query,
+                parent_id=parent_id,
+                tags=tags,
+                max_tokens=max_tokens,
+                trigger=trigger,
+            )
+        )
+
+    async def acreate_knowledge_page(
+        self,
+        bank_id: str,
+        name: str,
+        source_query: str,
+        parent_id: str | None = None,
+        tags: list[str] | None = None,
+        max_tokens: int | None = None,
+        trigger: dict[str, Any] | None = None,
+    ):
+        """
+        Create a knowledge-base page (async — preferred over :meth:`create_knowledge_page`).
 
         Content is generated asynchronously; poll the returned ``operation_id``
         to know when the first build has finished.
@@ -1617,14 +1820,21 @@ class Hindsight:
             trigger=trigger_obj,
         )
 
-        return _run_async(
-            self._knowledge_base_api.create_knowledge_page(bank_id, request_obj, _request_timeout=self._timeout)
+        return await self._knowledge_base_api.create_knowledge_page(
+            bank_id, request_obj, _request_timeout=self._timeout
         )
 
     def get_knowledge_page(self, bank_id: str, page_id: str):
         """
-        Get a knowledge page rendered as a markdown document (sync wrapper — use
-        ``await client.knowledge_base.get_knowledge_page(...)`` in async code).
+        Get a knowledge page rendered as a markdown document (sync wrapper — prefer :meth:`aget_knowledge_page` in async code).
+
+        See :meth:`aget_knowledge_page` for the full argument and return documentation.
+        """
+        return _run_async(self.aget_knowledge_page(bank_id=bank_id, page_id=page_id))
+
+    async def aget_knowledge_page(self, bank_id: str, page_id: str):
+        """
+        Get a knowledge page rendered as a markdown document (async — preferred over :meth:`get_knowledge_page`).
 
         Args:
             bank_id: The memory bank ID
@@ -1633,14 +1843,19 @@ class Hindsight:
         Returns:
             KnowledgePageResponse with body and full markdown (frontmatter + body)
         """
-        return _run_async(
-            self._knowledge_base_api.get_knowledge_page(bank_id, page_id, _request_timeout=self._timeout)
-        )
+        return await self._knowledge_base_api.get_knowledge_page(bank_id, page_id, _request_timeout=self._timeout)
 
     def search_knowledge_base(self, bank_id: str, q: str, limit: int | None = None):
         """
-        Hybrid search over knowledge pages (sync wrapper — use
-        ``await client.knowledge_base.search_knowledge_base(...)`` in async code).
+        Hybrid search over knowledge pages (sync wrapper — prefer :meth:`asearch_knowledge_base` in async code).
+
+        See :meth:`asearch_knowledge_base` for the full argument and return documentation.
+        """
+        return _run_async(self.asearch_knowledge_base(bank_id=bank_id, q=q, limit=limit))
+
+    async def asearch_knowledge_base(self, bank_id: str, q: str, limit: int | None = None):
+        """
+        Hybrid search over knowledge pages (async — preferred over :meth:`search_knowledge_base`).
 
         Args:
             bank_id: The memory bank ID
@@ -1650,8 +1865,8 @@ class Hindsight:
         Returns:
             KnowledgePageSearchResponse with ranked results
         """
-        return _run_async(
-            self._knowledge_base_api.search_knowledge_base(bank_id, q, limit=limit, _request_timeout=self._timeout)
+        return await self._knowledge_base_api.search_knowledge_base(
+            bank_id, q, limit=limit, _request_timeout=self._timeout
         )
 
     def update_knowledge_node(
@@ -1666,8 +1881,36 @@ class Hindsight:
         trigger: dict[str, Any] | None = None,
     ):
         """
-        Rename/move a knowledge node and/or update a page's options (sync wrapper —
-        use ``await client.knowledge_base.update_knowledge_node(...)`` in async code).
+        Rename/move a knowledge node and/or update a page's options (sync wrapper — prefer :meth:`aupdate_knowledge_node` in async code).
+
+        See :meth:`aupdate_knowledge_node` for the full argument and return documentation.
+        """
+        return _run_async(
+            self.aupdate_knowledge_node(
+                bank_id=bank_id,
+                node_id=node_id,
+                name=name,
+                parent_id=parent_id,
+                source_query=source_query,
+                tags=tags,
+                max_tokens=max_tokens,
+                trigger=trigger,
+            )
+        )
+
+    async def aupdate_knowledge_node(
+        self,
+        bank_id: str,
+        node_id: str,
+        name: str | None = None,
+        parent_id: str | None = _UNSET,
+        source_query: str | None = None,
+        tags: list[str] | None = None,
+        max_tokens: int | None = None,
+        trigger: dict[str, Any] | None = None,
+    ):
+        """
+        Rename/move a knowledge node and/or update a page's options (async — preferred over :meth:`update_knowledge_node`).
 
         Only the fields you pass are applied. ``parent_id`` is only sent when
         provided, so passing ``None`` explicitly moves the node to the root.
@@ -1711,29 +1954,39 @@ class Hindsight:
 
         request_obj = update_node_request.UpdateNodeRequest(**fields)
 
-        return _run_async(
-            self._knowledge_base_api.update_knowledge_node(
-                bank_id, node_id, request_obj, _request_timeout=self._timeout
-            )
+        return await self._knowledge_base_api.update_knowledge_node(
+            bank_id, node_id, request_obj, _request_timeout=self._timeout
         )
 
     def delete_knowledge_node(self, bank_id: str, node_id: str):
         """
-        Delete a knowledge folder or page and its whole subtree (sync wrapper — use
-        ``await client.knowledge_base.delete_knowledge_node(...)`` in async code).
+        Delete a knowledge folder or page and its whole subtree (sync wrapper — prefer :meth:`adelete_knowledge_node` in async code).
+
+        See :meth:`adelete_knowledge_node` for the full argument and return documentation.
+        """
+        return _run_async(self.adelete_knowledge_node(bank_id=bank_id, node_id=node_id))
+
+    async def adelete_knowledge_node(self, bank_id: str, node_id: str):
+        """
+        Delete a knowledge folder or page and its whole subtree (async — preferred over :meth:`delete_knowledge_node`).
 
         Args:
             bank_id: The memory bank ID
             node_id: The folder or page ID
         """
-        return _run_async(
-            self._knowledge_base_api.delete_knowledge_node(bank_id, node_id, _request_timeout=self._timeout)
-        )
+        return await self._knowledge_base_api.delete_knowledge_node(bank_id, node_id, _request_timeout=self._timeout)
 
     def export_knowledge_base(self, bank_id: str):
         """
-        Export the knowledge base as a portable markdown bundle (sync wrapper — use
-        ``await client.knowledge_base.export_knowledge_base(...)`` in async code).
+        Export the knowledge base as a portable markdown bundle (sync wrapper — prefer :meth:`aexport_knowledge_base` in async code).
+
+        See :meth:`aexport_knowledge_base` for the full argument and return documentation.
+        """
+        return _run_async(self.aexport_knowledge_base(bank_id=bank_id))
+
+    async def aexport_knowledge_base(self, bank_id: str):
+        """
+        Export the knowledge base as a portable markdown bundle (async — preferred over :meth:`export_knowledge_base`).
 
         Args:
             bank_id: The memory bank ID
@@ -1741,7 +1994,7 @@ class Hindsight:
         Returns:
             KnowledgePageBundleResponse with files (index.md, one file per page, history logs)
         """
-        return _run_async(self._knowledge_base_api.export_knowledge_base(bank_id, _request_timeout=self._timeout))
+        return await self._knowledge_base_api.export_knowledge_base(bank_id, _request_timeout=self._timeout)
 
     # Document transfer (export / import between banks — no LLM re-extraction)
 
@@ -1859,7 +2112,32 @@ class Hindsight:
         tags: list[str] | None = None,
     ):
         """
-        Create a directive (sync wrapper — use ``await client.directives.create_directive(...)`` in async code).
+        Create a directive (sync wrapper — prefer :meth:`acreate_directive` in async code).
+
+        See :meth:`acreate_directive` for the full argument and return documentation.
+        """
+        return _run_async(
+            self.acreate_directive(
+                bank_id=bank_id,
+                name=name,
+                content=content,
+                priority=priority,
+                is_active=is_active,
+                tags=tags,
+            )
+        )
+
+    async def acreate_directive(
+        self,
+        bank_id: str,
+        name: str,
+        content: str,
+        priority: int = 0,
+        is_active: bool = True,
+        tags: list[str] | None = None,
+    ):
+        """
+        Create a directive (async — preferred over :meth:`create_directive`).
 
         Args:
             bank_id: The memory bank ID
@@ -1882,7 +2160,7 @@ class Hindsight:
             tags=tags,
         )
 
-        return _run_async(self._directives_api.create_directive(bank_id, request_obj, _request_timeout=self._timeout))
+        return await self._directives_api.create_directive(bank_id, request_obj, _request_timeout=self._timeout)
 
     def list_directives(
         self,
@@ -1892,7 +2170,21 @@ class Hindsight:
         offset: int | None = None,
     ):
         """
-        List all directives in a bank (sync wrapper — use ``await client.directives.list_directives(...)`` in async code).
+        List all directives in a bank (sync wrapper — prefer :meth:`alist_directives` in async code).
+
+        See :meth:`alist_directives` for the full argument and return documentation.
+        """
+        return _run_async(self.alist_directives(bank_id=bank_id, tags=tags, limit=limit, offset=offset))
+
+    async def alist_directives(
+        self,
+        bank_id: str,
+        tags: list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ):
+        """
+        List all directives in a bank (async — preferred over :meth:`list_directives`).
 
         Args:
             bank_id: The memory bank ID
@@ -1903,19 +2195,25 @@ class Hindsight:
         Returns:
             ListDirectivesResponse with items and the total matching the filter
         """
-        return _run_async(
-            self._directives_api.list_directives(
-                bank_id,
-                tags=tags,
-                limit=limit,
-                offset=offset,
-                _request_timeout=self._timeout,
-            )
+        return await self._directives_api.list_directives(
+            bank_id,
+            tags=tags,
+            limit=limit,
+            offset=offset,
+            _request_timeout=self._timeout,
         )
 
     def get_directive(self, bank_id: str, directive_id: str):
         """
-        Get a specific directive (sync wrapper — use ``await client.directives.get_directive(...)`` in async code).
+        Get a specific directive (sync wrapper — prefer :meth:`aget_directive` in async code).
+
+        See :meth:`aget_directive` for the full argument and return documentation.
+        """
+        return _run_async(self.aget_directive(bank_id=bank_id, directive_id=directive_id))
+
+    async def aget_directive(self, bank_id: str, directive_id: str):
+        """
+        Get a specific directive (async — preferred over :meth:`get_directive`).
 
         Args:
             bank_id: The memory bank ID
@@ -1924,7 +2222,7 @@ class Hindsight:
         Returns:
             DirectiveResponse
         """
-        return _run_async(self._directives_api.get_directive(bank_id, directive_id, _request_timeout=self._timeout))
+        return await self._directives_api.get_directive(bank_id, directive_id, _request_timeout=self._timeout)
 
     def update_directive(
         self,
@@ -1937,7 +2235,34 @@ class Hindsight:
         tags: list[str] | None = None,
     ):
         """
-        Update a directive (sync wrapper — use ``await client.directives.update_directive(...)`` in async code).
+        Update a directive (sync wrapper — prefer :meth:`aupdate_directive` in async code).
+
+        See :meth:`aupdate_directive` for the full argument and return documentation.
+        """
+        return _run_async(
+            self.aupdate_directive(
+                bank_id=bank_id,
+                directive_id=directive_id,
+                name=name,
+                content=content,
+                priority=priority,
+                is_active=is_active,
+                tags=tags,
+            )
+        )
+
+    async def aupdate_directive(
+        self,
+        bank_id: str,
+        directive_id: str,
+        name: str | None = None,
+        content: str | None = None,
+        priority: int | None = None,
+        is_active: bool | None = None,
+        tags: list[str] | None = None,
+    ):
+        """
+        Update a directive (async — preferred over :meth:`update_directive`).
 
         Args:
             bank_id: The memory bank ID
@@ -1961,23 +2286,39 @@ class Hindsight:
             tags=tags,
         )
 
-        return _run_async(
-            self._directives_api.update_directive(bank_id, directive_id, request_obj, _request_timeout=self._timeout)
+        return await self._directives_api.update_directive(
+            bank_id, directive_id, request_obj, _request_timeout=self._timeout
         )
 
     def delete_directive(self, bank_id: str, directive_id: str):
         """
-        Delete a directive (sync wrapper — use ``await client.directives.delete_directive(...)`` in async code).
+        Delete a directive (sync wrapper — prefer :meth:`adelete_directive` in async code).
+
+        See :meth:`adelete_directive` for the full argument and return documentation.
+        """
+        return _run_async(self.adelete_directive(bank_id=bank_id, directive_id=directive_id))
+
+    async def adelete_directive(self, bank_id: str, directive_id: str):
+        """
+        Delete a directive (async — preferred over :meth:`delete_directive`).
 
         Args:
             bank_id: The memory bank ID
             directive_id: The directive ID
         """
-        return _run_async(self._directives_api.delete_directive(bank_id, directive_id, _request_timeout=self._timeout))
+        return await self._directives_api.delete_directive(bank_id, directive_id, _request_timeout=self._timeout)
 
     def get_bank_config(self, bank_id: str) -> dict[str, Any]:
         """
-        Get the resolved configuration for a bank (sync wrapper — use ``await client.banks.get_bank_config(...)`` in async code).
+        Get the resolved configuration for a bank (sync wrapper — prefer :meth:`aget_bank_config` in async code).
+
+        See :meth:`aget_bank_config` for the full argument and return documentation.
+        """
+        return _run_async(self.aget_bank_config(bank_id=bank_id))
+
+    async def aget_bank_config(self, bank_id: str) -> dict[str, Any]:
+        """
+        Get the resolved configuration for a bank (async — preferred over :meth:`get_bank_config`).
 
         Always available: ``HINDSIGHT_API_ENABLE_BANK_CONFIG_API=false`` disables only
         the config *writes*, not this read.
@@ -1988,7 +2329,7 @@ class Hindsight:
         Returns:
             dict with ``bank_id``, ``config`` (fully resolved), and ``overrides`` (bank-level only)
         """
-        return _run_async(self._aget_bank_config(bank_id))
+        return await self._aget_bank_config(bank_id)
 
     async def _aget_bank_config(self, bank_id: str) -> dict[str, Any]:
         import aiohttp
@@ -2063,7 +2404,128 @@ class Hindsight:
         audit_log_enabled: bool | None = None,
     ) -> dict[str, Any]:
         """
-        Update configuration overrides for a bank (sync wrapper — use ``await client.banks.update_bank_config(...)`` in async code).
+        Update configuration overrides for a bank (sync wrapper — prefer :meth:`aupdate_bank_config` in async code).
+
+        See :meth:`aupdate_bank_config` for the full argument and return documentation.
+        """
+        return _run_async(
+            self.aupdate_bank_config(
+                bank_id=bank_id,
+                reflect_mission=reflect_mission,
+                reflect_source_facts_max_tokens=reflect_source_facts_max_tokens,
+                retain_mission=retain_mission,
+                retain_extraction_mode=retain_extraction_mode,
+                retain_custom_instructions=retain_custom_instructions,
+                retain_chunk_size=retain_chunk_size,
+                retain_structured_chunk_size=retain_structured_chunk_size,
+                retain_max_attachments_per_chunk=retain_max_attachments_per_chunk,
+                retain_default_strategy=retain_default_strategy,
+                retain_strategies=retain_strategies,
+                retain_chunk_batch_size=retain_chunk_batch_size,
+                store_document_text=store_document_text,
+                entity_labels=entity_labels,
+                entities_allow_free_form=entities_allow_free_form,
+                enable_observations=enable_observations,
+                observations_mission=observations_mission,
+                max_observations_per_scope=max_observations_per_scope,
+                observation_scope_limits=observation_scope_limits,
+                enable_auto_consolidation=enable_auto_consolidation,
+                consolidation_llm_parallelism=consolidation_llm_parallelism,
+                consolidation_max_memories_per_round=consolidation_max_memories_per_round,
+                mental_model_min_refresh_interval_seconds=mental_model_min_refresh_interval_seconds,
+                enable_text_search=enable_text_search,
+                enable_temporal_retrieval=enable_temporal_retrieval,
+                enable_graph_retrieval=enable_graph_retrieval,
+                enable_reranking=enable_reranking,
+                consolidation_llm_batch_size=consolidation_llm_batch_size,
+                consolidation_source_facts_max_tokens=consolidation_source_facts_max_tokens,
+                consolidation_source_facts_max_tokens_per_observation=consolidation_source_facts_max_tokens_per_observation,
+                recall_max_tokens=recall_max_tokens,
+                recall_include_chunks=recall_include_chunks,
+                recall_chunks_max_tokens=recall_chunks_max_tokens,
+                recall_budget_function=recall_budget_function,
+                recall_budget_fixed_low=recall_budget_fixed_low,
+                recall_budget_fixed_mid=recall_budget_fixed_mid,
+                recall_budget_fixed_high=recall_budget_fixed_high,
+                recall_budget_adaptive_low=recall_budget_adaptive_low,
+                recall_budget_adaptive_mid=recall_budget_adaptive_mid,
+                recall_budget_adaptive_high=recall_budget_adaptive_high,
+                recall_budget_min=recall_budget_min,
+                recall_budget_max=recall_budget_max,
+                disposition_skepticism=disposition_skepticism,
+                disposition_literalism=disposition_literalism,
+                disposition_empathy=disposition_empathy,
+                mcp_enabled_tools=mcp_enabled_tools,
+                llm_gemini_safety_settings=llm_gemini_safety_settings,
+                memory_defense=memory_defense,
+                audit_log_enabled=audit_log_enabled,
+            )
+        )
+
+    async def aupdate_bank_config(
+        self,
+        bank_id: str,
+        *,
+        # Reflect settings
+        reflect_mission: str | None = None,
+        reflect_source_facts_max_tokens: int | None = None,
+        # Retain settings
+        retain_mission: str | None = None,
+        retain_extraction_mode: str | None = None,
+        retain_custom_instructions: str | None = None,
+        retain_chunk_size: int | None = None,
+        retain_structured_chunk_size: int | None = None,
+        retain_max_attachments_per_chunk: int | None = None,
+        retain_default_strategy: str | None = None,
+        retain_strategies: dict[str, Any] | None = None,
+        retain_chunk_batch_size: int | None = None,
+        store_document_text: bool | None = None,
+        # Entity settings
+        entity_labels: list[dict[str, Any]] | None = None,
+        entities_allow_free_form: bool | None = None,
+        # Observation / consolidation settings
+        enable_observations: bool | None = None,
+        observations_mission: str | None = None,
+        max_observations_per_scope: int | None = None,
+        observation_scope_limits: list[dict[str, Any]] | None = None,
+        enable_auto_consolidation: bool | None = None,
+        consolidation_llm_parallelism: int | None = None,
+        consolidation_max_memories_per_round: int | None = None,
+        mental_model_min_refresh_interval_seconds: int | None = None,
+        enable_text_search: bool | None = None,
+        enable_temporal_retrieval: bool | None = None,
+        enable_graph_retrieval: bool | None = None,
+        enable_reranking: bool | None = None,
+        consolidation_llm_batch_size: int | None = None,
+        consolidation_source_facts_max_tokens: int | None = None,
+        consolidation_source_facts_max_tokens_per_observation: int | None = None,
+        # Recall settings
+        recall_max_tokens: int | None = None,
+        recall_include_chunks: bool | None = None,
+        recall_chunks_max_tokens: int | None = None,
+        recall_budget_function: str | None = None,
+        recall_budget_fixed_low: int | None = None,
+        recall_budget_fixed_mid: int | None = None,
+        recall_budget_fixed_high: int | None = None,
+        recall_budget_adaptive_low: float | None = None,
+        recall_budget_adaptive_mid: float | None = None,
+        recall_budget_adaptive_high: float | None = None,
+        recall_budget_min: int | None = None,
+        recall_budget_max: int | None = None,
+        # Disposition settings
+        disposition_skepticism: int | None = None,
+        disposition_literalism: int | None = None,
+        disposition_empathy: int | None = None,
+        # MCP settings
+        mcp_enabled_tools: list[str] | None = None,
+        # Gemini safety settings
+        llm_gemini_safety_settings: list[dict[str, str]] | None = None,
+        # Security / audit
+        memory_defense: dict[str, Any] | None = None,
+        audit_log_enabled: bool | None = None,
+    ) -> dict[str, Any]:
+        """
+        Update configuration overrides for a bank (async — preferred over :meth:`update_bank_config`).
 
         Can be disabled on the server by setting ``HINDSIGHT_API_ENABLE_BANK_CONFIG_API=false``.
 
@@ -2189,7 +2651,7 @@ class Hindsight:
             }.items()
             if v is not None
         }
-        return _run_async(self._aupdate_bank_config(bank_id, updates))
+        return await self._aupdate_bank_config(bank_id, updates)
 
     async def _aupdate_bank_config(self, bank_id: str, updates: dict[str, Any]) -> dict[str, Any]:
         import aiohttp
@@ -2205,7 +2667,15 @@ class Hindsight:
 
     def reset_bank_config(self, bank_id: str) -> dict[str, Any]:
         """
-        Reset all bank-level config overrides (sync wrapper — use ``await client.banks.reset_bank_config(...)`` in async code).
+        Reset all bank-level config overrides (sync wrapper — prefer :meth:`areset_bank_config` in async code).
+
+        See :meth:`areset_bank_config` for the full argument and return documentation.
+        """
+        return _run_async(self.areset_bank_config(bank_id=bank_id))
+
+    async def areset_bank_config(self, bank_id: str) -> dict[str, Any]:
+        """
+        Reset all bank-level config overrides (async — preferred over :meth:`reset_bank_config`).
 
         Can be disabled on the server by setting ``HINDSIGHT_API_ENABLE_BANK_CONFIG_API=false``.
 
@@ -2215,7 +2685,7 @@ class Hindsight:
         Returns:
             dict with ``bank_id``, ``config`` (fully resolved), and ``overrides`` (now empty)
         """
-        return _run_async(self._areset_bank_config(bank_id))
+        return await self._areset_bank_config(bank_id)
 
     async def _areset_bank_config(self, bank_id: str) -> dict[str, Any]:
         import aiohttp

--- a/hindsight-clients/python/tests/test_async_sync_parity.py
+++ b/hindsight-clients/python/tests/test_async_sync_parity.py
@@ -1,0 +1,77 @@
+"""Every public convenience method must come in a sync/async pair.
+
+The class docstring promises that ``a<name>`` exists for every convenience
+method, and it is not a nicety: the sync methods route through
+``_run_async`` -> ``loop.run_until_complete``, which raises
+``RuntimeError: This event loop is already running`` inside FastAPI/LangGraph/
+CrewAI. A sync-only method is therefore unusable from exactly the contexts the
+docstring points at (#4221). Guard the whole family so a new method cannot
+reintroduce the gap.
+"""
+
+import inspect
+
+import pytest
+
+from hindsight_client import Hindsight
+
+
+def _public_methods() -> dict[str, object]:
+    return {
+        name: attr for name, attr in vars(Hindsight).items() if not name.startswith("_") and inspect.isfunction(attr)
+    }
+
+
+def _pairs() -> list[tuple[str, str]]:
+    methods = _public_methods()
+    return sorted((name, "a" + name) for name in methods if "a" + name in methods)
+
+
+def test_every_sync_convenience_method_has_an_async_twin():
+    methods = _public_methods()
+    async_twins = {"a" + name for name in methods if "a" + name in methods}
+    missing = sorted(name for name in methods if name not in async_twins and "a" + name not in methods)
+    assert missing == [], (
+        f"public convenience methods without an a-prefixed async twin: {missing}. "
+        "Add `async def a<name>` next to each (the sync method should forward to it via _run_async)."
+    )
+
+
+def test_the_pairs_are_actually_sync_and_async():
+    assert _pairs(), "expected to find sync/async method pairs on Hindsight"
+    for sync_name, async_name in _pairs():
+        sync_fn = getattr(Hindsight, sync_name)
+        async_fn = getattr(Hindsight, async_name)
+        assert not inspect.iscoroutinefunction(sync_fn), f"{sync_name} should be sync"
+        assert inspect.iscoroutinefunction(async_fn), f"{async_name} should be a coroutine function"
+
+
+@pytest.mark.parametrize(("sync_name", "async_name"), _pairs())
+def test_pair_signatures_match(sync_name: str, async_name: str):
+    """The twins must accept the same arguments, or callers silently lose one."""
+    sync_params = inspect.signature(getattr(Hindsight, sync_name)).parameters
+    async_params = inspect.signature(getattr(Hindsight, async_name)).parameters
+    assert list(sync_params) == list(async_params), f"{sync_name} and {async_name} take different arguments"
+    for name, param in sync_params.items():
+        other = async_params[name]
+        assert param.kind == other.kind, f"{sync_name}/{async_name}: '{name}' differs in kind"
+        assert param.default == other.default, f"{sync_name}/{async_name}: '{name}' differs in default"
+
+
+async def test_async_twin_is_usable_from_a_running_event_loop(monkeypatch):
+    """The repro from #4221: sync-only methods are unreachable under a live loop."""
+    from unittest.mock import MagicMock
+
+    captured: dict[str, object] = {}
+
+    async def fake_create(bank_id, request, **kwargs):
+        captured["bank_id"] = bank_id
+        captured["request"] = request
+        return MagicMock()
+
+    client = Hindsight(base_url="http://example.invalid")
+    monkeypatch.setattr(client.mental_models, "create_mental_model", fake_create)
+
+    await client.acreate_mental_model(bank_id="alice", name="Alice housing", source_query="Where does Alice live?")
+
+    assert captured["bank_id"] == "alice"

--- a/hindsight-dev/hindsight_dev/client_coverage_check.py
+++ b/hindsight-dev/hindsight_dev/client_coverage_check.py
@@ -265,7 +265,10 @@ def extract_config_method(source: str, client_name: str) -> str:
     config method does not actually accept it.
     """
     if client_name == "python":
-        start = re.search(r"^    def update_bank_config\(", source, re.M)
+        # The async twin, not the sync one: since #4221 every convenience method's
+        # body lives on ``a<name>`` and the sync method is a thin forwarder, so the
+        # enumerated updates dict this check reads is in ``aupdate_bank_config``.
+        start = re.search(r"^    async def aupdate_bank_config\(", source, re.M)
         end_pat = r"^    (?:async )?def "
     else:
         start = re.search(r"^  async updateBankConfig\(", source, re.M)


### PR DESCRIPTION
Fixes #4221.

## The problem

`Hindsight`'s docstring says every convenience method has an `a`-prefixed
counterpart. 27 of them didn't. Because the sync methods route through
`_run_async` → `loop.run_until_complete`, calling one inside a running loop
raises `RuntimeError: This event loop is already running` — so mental models,
knowledge pages, directives and bank config were **unreachable** through the
wrapper from FastAPI / LangGraph / CrewAI, the exact contexts the docstring
tells you to prefer async in.

```python
await client.aretain(bank_id="alice", content="Alice moved to Berlin.")  # fine
client.create_mental_model(bank_id="alice", name="Alice housing", ...)   # RuntimeError
```

## The fix

Each of the 27 methods now has its implementation on `a<name>`, with the sync
method forwarding to it via `_run_async`. One body per operation instead of two
that can drift; the sync signatures and behaviour are unchanged.

Covered: `list_memories`, `retain_files`, the seven mental-model methods plus
`clear`/`history`/`dry_run_refresh`, the eight knowledge-base methods, the five
directive methods, and `get`/`update`/`reset_bank_config`.

## Why it can't happen again

`hindsight-clients/python/tests/test_async_sync_parity.py` guards the whole
family rather than the methods someone remembered to test:

- every public convenience method must have an async twin (this test fails with
  the 27 names listed on `main`);
- the twins must really be sync / coroutine functions;
- their signatures must match argument for argument, including kinds and
  defaults — a twin that quietly drops a parameter is the #2975 / #3042 failure
  mode;
- plus the issue's repro: `acreate_mental_model` awaited from inside a running
  event loop.

The TypeScript wrapper is async throughout and already had all of these, so
this closes the parity gap rather than opening one.