### PR TITLE
fix(retain): a store-owned retain must not fail on its own log line

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -918,7 +918,15 @@ class MemoriesExtension(Extension, ABC):
 
         A store that indexes everything regardless ignores them, which is what the default does —
         and what Postgres does, where the columns behind both arms are maintained by the insert
-        itself and there is nothing separable to skip."""
+        itself and there is nothing separable to skip.
+
+        Returns a **mapping** describing the commit: ``seq`` (the store's write coordinate for this
+        retain), ``unit_ids`` (the ids actually written, echoed back) and ``new_entities`` (how many
+        entities the resolve minted). Read it with ``resp["seq"]`` / ``resp.get(...)``, never as
+        attributes — this is a plain mapping, not a response object, and callers that reached for
+        ``resp.seq`` raised ``AttributeError`` from inside a log line and failed the whole write.
+        Stated here because the return value was previously undeclared, which is what let the two
+        sides disagree without either being obviously wrong."""
         raise NotImplementedError("this store does not support a store-owned retain")
 
     async def assert_writable(self, bank_id: str) -> None:

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -944,7 +944,7 @@ async def _streaming_store_owned_retain(
             doc_replace_done[0] = True
         log_buffer.append(
             f"[streaming] pg-free retain doc={effective_doc_id} units={len(unit_ids)} "
-            f"seq={resp.seq} new_entities={resp.new_entities}"
+            f"seq={resp.get('seq')} new_entities={resp.get('new_entities', 0)}"
         )
     # Mark the document tracked so the post-loop "no facts / not-yet-tracked" finalizer does NOT
     # fire. That finalizer (a) writes a Postgres documents row and (b) runs handle_document_tracking,
@@ -1108,8 +1108,8 @@ async def _delta_store_owned_write(
         )
         log_buffer.append(
             f"[delta] store-owned retain doc={effective_doc_id} units={len(unit_ids or [])} "
-            f"replaced_chunks={len(replace_chunk_ids)} seq={resp.seq} "
-            f"new_entities={resp.new_entities}"
+            f"replaced_chunks={len(replace_chunk_ids)} seq={resp.get('seq')} "
+            f"new_entities={resp.get('new_entities', 0)}"
         )
 
     log_buffer.append(f"DELTA RETAIN COMPLETE (store-owned): {len(processed_facts)} new units")

--- a/hindsight-api-slim/tests/test_retain_store_owned_no_connection.py
+++ b/hindsight-api-slim/tests/test_retain_store_owned_no_connection.py
@@ -8,6 +8,11 @@ delta re-retain — are pinned here:
 * the document bodies, the id mint and the ``retain`` RPC all run with NO connection held;
 * a delta names the chunks that moved rather than replacing the whole document;
 * a delta that loses its watermark compare-and-set writes nothing and falls back.
+
+The ``retain`` doubles below return a **mapping**, matching what the interface documents and
+what a real store-owned backend returns. They previously returned an attribute object, which is
+why a caller reaching for ``resp.seq`` passed here and raised ``AttributeError`` against a real
+store — a double that is easier to satisfy than the contract tests the double, not the code.
 """
 
 from types import SimpleNamespace
@@ -91,7 +96,7 @@ async def test_a_store_owned_batch_write_holds_no_connection(monkeypatch):
         async def retain(self, bank_id, unit_ids, facts, **kw):
             saw_open.append(tracker.open)
             retained.update(kw)
-            return SimpleNamespace(seq=3, new_entities=1)
+            return {"seq": 3, "unit_ids": list(unit_ids), "new_entities": 1}
 
     async def _insert(conn, *a, **k):
         assert conn is None, "the store write must not receive a connection"
@@ -159,7 +164,7 @@ async def test_a_store_owned_delta_holds_no_connection_and_scopes_its_replace(mo
             saw_open.append(tracker.open)
             retained.update(kw)
             retained["unit_ids"] = list(unit_ids)
-            return SimpleNamespace(seq=7, new_entities=0)
+            return {"seq": 7, "unit_ids": list(unit_ids), "new_entities": 0}
 
     async def _insert(*a, **k):
         saw_open.append(tracker.open)
@@ -221,7 +226,7 @@ async def test_a_store_owned_delta_falls_back_when_the_document_moved(monkeypatc
     class _StoreOwned:
         async def retain(self, *a, **k):
             calls.append("retain")
-            return SimpleNamespace(seq=1, new_entities=0)
+            return {"seq": 1, "unit_ids": list(unit_ids), "new_entities": 0}
 
     monkeypatch.setattr(orch, "_store_document_bodies", _store_bodies)
     monkeypatch.setattr(orch.fact_storage, "insert_facts_batch", _insert)


### PR DESCRIPTION
## The bug

`retain` on the memories seam returns a **mapping**, but both store-owned write paths formatted their log line with attribute access:

```python
f"seq={resp.seq} new_entities={resp.new_entities}"                    # streaming, orchestrator.py:947
f"replaced_chunks={len(replace_chunk_ids)} seq={resp.seq} "           # delta,     orchestrator.py:1111
```

Against a real store-owned backend that raises:

```
AttributeError: 'dict' object has no attribute 'seq'
  File "hindsight_api/engine/retain/orchestrator.py", line 1040, in _delta_store_owned_write
```

The write has already been committed when this runs, so **the caller gets a 500 for a retain that actually succeeded**. Under sustained load this shows up as a steady stream of failed retains while the data lands correctly — the worst shape of failure, because a retrying client duplicates work that was never lost.

## Why CI never caught it

`tests/test_retain_store_owned_no_connection.py` returned `SimpleNamespace(seq=3, new_entities=1)` from its fake `retain` — an attribute object, which is the one shape no real implementation produces. Both call sites ran on every CI run and neither could fail.

A double that is easier to satisfy than the contract tests the double, not the code.

## The change

- **Both log lines read the mapping** (`resp.get(...)`), so a missing key cannot fail a write either. A log line should never be able to fail the operation it is describing.
- **The doubles return the documented mapping**, which makes these tests catch the bug: reverting either call site now fails at that exact line. Verified both directions.
- **The interface pins the return value**, which was previously undeclared — no return type, and a docstring that described every argument but not the result. That is what let the two sides disagree without either looking wrong.

## Testing

```
tests/test_retain_store_owned_no_connection.py .... 3 passed
tests/test_retain.py + tests/test_memories_extension.py ... 268 passed
```

Mutation check — restoring `resp.seq` fails at both sites:

```
E  AttributeError: 'dict' object has no attribute 'seq'
   hindsight_api/engine/retain/orchestrator.py:947
E  AttributeError: 'dict' object has no attribute 'seq'
   hindsight_api/engine/retain/orchestrator.py:1111
```

The 8 remaining failures in `test_retain.py` are missing-LLM-API-key environment errors, unrelated to this change.