### PR TITLE
fix(api): expose the bank template import request body

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -7841,6 +7841,23 @@ def _register_routes(app: FastAPI):
         "Use dry_run=true to validate the manifest without applying changes.",
         operation_id="import_bank_template",
         tags=["Bank Templates"],
+        # Keep parsing and validation in the handler so malformed JSON and
+        # template errors retain the API's established 400 response format,
+        # while publishing the typed manifest schema for OpenAPI clients.
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "title": "Manifest",
+                            "description": "Bank template manifest",
+                            "$ref": "#/components/schemas/BankTemplateManifest",
+                        }
+                    }
+                },
+            }
+        },
     )
     @audited("import_bank_template", request_param=None)
     async def api_import_bank_template(
@@ -7851,7 +7868,7 @@ def _register_routes(app: FastAPI):
     ):
         """Import a bank template manifest."""
         try:
-            # Parse raw JSON and validate against the Pydantic model manually
+            # Parse and validate against the Pydantic model manually
             # so we can return clean error messages instead of raw 422s.
             raw_body = await request.json()
             from pydantic import ValidationError

--- a/hindsight-api-slim/tests/test_bank_templates.py
+++ b/hindsight-api-slim/tests/test_bank_templates.py
@@ -1,6 +1,7 @@
 """Integration tests for bank template import/export endpoints."""
 
 from datetime import datetime
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -70,6 +71,29 @@ def sample_template():
 
 class TestImportValidation:
     """Test template manifest validation."""
+
+    def test_import_openapi_declares_manifest_request_body(self):
+        """The import operation publishes its manifest body for generated SDKs."""
+        app = create_app(SimpleNamespace(audit_logger=None), initialize_memory=False)
+        operation = app.openapi()["paths"]["/v1/default/banks/{bank_id}/import"]["post"]
+        request_body = operation["requestBody"]
+        assert request_body["required"] is True
+        assert (
+            request_body["content"]["application/json"]["schema"]["$ref"] == "#/components/schemas/BankTemplateManifest"
+        )
+
+    @pytest.mark.asyncio
+    async def test_import_malformed_json_returns_bad_request(self):
+        """Malformed JSON keeps the endpoint's established 400 response."""
+        app = create_app(SimpleNamespace(audit_logger=None), initialize_memory=False)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/v1/default/banks/malformed-json/import",
+                content=b'{"bank":',
+                headers={"content-type": "application/json"},
+            )
+        assert resp.status_code == 400
 
     @pytest.mark.asyncio
     async def test_import_dry_run_valid(self, api_client, bank_id, sample_template):

--- a/hindsight-cli/.openapi-coverage.toml
+++ b/hindsight-cli/.openapi-coverage.toml
@@ -138,6 +138,15 @@ enable_reranking = "Set via `bank set-config` (hierarchical config)."
 [fields.update_bank_config]
 updates = "Flattened into per-setting flags (--llm-provider, --llm-model, etc) on `bank set-config`."
 
+# `bank import-template` takes the whole manifest as a JSON file argument rather
+# than per-field flags — a template is authored by `bank export-template` and fed
+# back in verbatim, so flattening it into flags would defeat the round trip.
+[fields.import_bank_template]
+version = "Whole manifest is passed as a JSON file to `bank import-template`."
+bank = "Whole manifest is passed as a JSON file to `bank import-template`."
+mental_models = "Whole manifest is passed as a JSON file to `bank import-template`."
+directives = "Whole manifest is passed as a JSON file to `bank import-template`."
+
 [fields.create_webhook]
 http_config = "Advanced HTTP customisation (headers/method/timeout/params) is not exposed in the CLI yet; use the JSON API if needed."
 

--- a/hindsight-cli/src/api.rs
+++ b/hindsight-cli/src/api.rs
@@ -1443,9 +1443,11 @@ impl ApiClient {
         })
     }
 
-    /// Import a bank template manifest. The OpenAPI spec does not declare a
-    /// request body for this endpoint, so the progenitor-generated client does
-    /// not expose one — we POST the manifest JSON via raw HTTP instead.
+    /// Import a bank template manifest via the JSON endpoint.
+    ///
+    /// The CLI keeps using its direct HTTP path here so it can accept the
+    /// manifest as an untyped JSON value; the generated Rust client now also
+    /// exposes the typed request body from the OpenAPI schema.
     pub fn import_bank_template(
         &self,
         bank_id: &str,

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -3349,6 +3349,12 @@ paths:
           nullable: true
           type: string
         style: simple
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BankTemplateManifest'
+        required: true
       responses:
         "200":
           content:

--- a/hindsight-clients/go/api_bank_templates.go
+++ b/hindsight-clients/go/api_bank_templates.go
@@ -248,8 +248,14 @@ type ApiImportBankTemplateRequest struct {
 	ctx context.Context
 	ApiService *BankTemplatesAPIService
 	bankId string
+	bankTemplateManifest *BankTemplateManifest
 	dryRun *bool
 	authorization *string
+}
+
+func (r ApiImportBankTemplateRequest) BankTemplateManifest(bankTemplateManifest BankTemplateManifest) ApiImportBankTemplateRequest {
+	r.bankTemplateManifest = &bankTemplateManifest
+	return r
 }
 
 // Validate only, do not apply changes
@@ -305,6 +311,9 @@ func (a *BankTemplatesAPIService) ImportBankTemplateExecute(r ApiImportBankTempl
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
+	if r.bankTemplateManifest == nil {
+		return localVarReturnValue, nil, reportError("bankTemplateManifest is required and must be specified")
+	}
 
 	if r.dryRun != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "dry_run", r.dryRun, "form", "")
@@ -313,7 +322,7 @@ func (a *BankTemplatesAPIService) ImportBankTemplateExecute(r ApiImportBankTempl
 		r.dryRun = &defaultValue
 	}
 	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{}
+	localVarHTTPContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
@@ -332,6 +341,8 @@ func (a *BankTemplatesAPIService) ImportBankTemplateExecute(r ApiImportBankTempl
 	if r.authorization != nil {
 		parameterAddToHeaderOrQuery(localVarHeaderParams, "authorization", r.authorization, "simple", "")
 	}
+	// body params
+	localVarPostBody = r.bankTemplateManifest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/hindsight-clients/python/hindsight_client_api/api/bank_templates_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/bank_templates_api.py
@@ -886,3 +886,4 @@ class BankTemplatesApi:
             _request_auth=_request_auth
         )
 
+

--- a/hindsight-clients/python/hindsight_client_api/api/bank_templates_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/bank_templates_api.py
@@ -570,6 +570,7 @@ class BankTemplatesApi:
     async def import_bank_template(
         self,
         bank_id: StrictStr,
+        bank_template_manifest: BankTemplateManifest,
         dry_run: Annotated[Optional[StrictBool], Field(description="Validate only, do not apply changes")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
@@ -591,6 +592,8 @@ class BankTemplatesApi:
 
         :param bank_id: (required)
         :type bank_id: str
+        :param bank_template_manifest: (required)
+        :type bank_template_manifest: BankTemplateManifest
         :param dry_run: Validate only, do not apply changes
         :type dry_run: bool
         :param authorization:
@@ -619,6 +622,7 @@ class BankTemplatesApi:
 
         _param = self._import_bank_template_serialize(
             bank_id=bank_id,
+            bank_template_manifest=bank_template_manifest,
             dry_run=dry_run,
             authorization=authorization,
             _request_auth=_request_auth,
@@ -646,6 +650,7 @@ class BankTemplatesApi:
     async def import_bank_template_with_http_info(
         self,
         bank_id: StrictStr,
+        bank_template_manifest: BankTemplateManifest,
         dry_run: Annotated[Optional[StrictBool], Field(description="Validate only, do not apply changes")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
@@ -667,6 +672,8 @@ class BankTemplatesApi:
 
         :param bank_id: (required)
         :type bank_id: str
+        :param bank_template_manifest: (required)
+        :type bank_template_manifest: BankTemplateManifest
         :param dry_run: Validate only, do not apply changes
         :type dry_run: bool
         :param authorization:
@@ -695,6 +702,7 @@ class BankTemplatesApi:
 
         _param = self._import_bank_template_serialize(
             bank_id=bank_id,
+            bank_template_manifest=bank_template_manifest,
             dry_run=dry_run,
             authorization=authorization,
             _request_auth=_request_auth,
@@ -722,6 +730,7 @@ class BankTemplatesApi:
     async def import_bank_template_without_preload_content(
         self,
         bank_id: StrictStr,
+        bank_template_manifest: BankTemplateManifest,
         dry_run: Annotated[Optional[StrictBool], Field(description="Validate only, do not apply changes")] = None,
         authorization: Optional[StrictStr] = None,
         _request_timeout: Union[
@@ -743,6 +752,8 @@ class BankTemplatesApi:
 
         :param bank_id: (required)
         :type bank_id: str
+        :param bank_template_manifest: (required)
+        :type bank_template_manifest: BankTemplateManifest
         :param dry_run: Validate only, do not apply changes
         :type dry_run: bool
         :param authorization:
@@ -771,6 +782,7 @@ class BankTemplatesApi:
 
         _param = self._import_bank_template_serialize(
             bank_id=bank_id,
+            bank_template_manifest=bank_template_manifest,
             dry_run=dry_run,
             authorization=authorization,
             _request_auth=_request_auth,
@@ -793,6 +805,7 @@ class BankTemplatesApi:
     def _import_bank_template_serialize(
         self,
         bank_id,
+        bank_template_manifest,
         dry_run,
         authorization,
         _request_auth,
@@ -828,6 +841,8 @@ class BankTemplatesApi:
             _header_params['authorization'] = authorization
         # process the form parameters
         # process the body parameter
+        if bank_template_manifest is not None:
+            _body_params = bank_template_manifest
 
 
         # set the HTTP header `Accept`
@@ -838,6 +853,19 @@ class BankTemplatesApi:
                 ]
             )
 
+        # set the HTTP header `Content-Type`
+        if _content_type:
+            _header_params['Content-Type'] = _content_type
+        else:
+            _default_content_type = (
+                self.api_client.select_header_content_type(
+                    [
+                        'application/json'
+                    ]
+                )
+            )
+            if _default_content_type is not None:
+                _header_params['Content-Type'] = _default_content_type
 
         # authentication setting
         _auth_settings: List[str] = [
@@ -857,5 +885,4 @@ class BankTemplatesApi:
             _host=_host,
             _request_auth=_request_auth
         )
-
 

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -1284,7 +1284,14 @@ export const importBankTemplate = <ThrowOnError extends boolean = false>(
     ImportBankTemplateResponses,
     ImportBankTemplateErrors,
     ThrowOnError
-  >({ url: "/v1/default/banks/{bank_id}/import", ...options });
+  >({
+    url: "/v1/default/banks/{bank_id}/import",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
 
 /**
  * Export bank template

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -9211,7 +9211,12 @@ export type CreateOrUpdateBankResponse =
   CreateOrUpdateBankResponses[keyof CreateOrUpdateBankResponses];
 
 export type ImportBankTemplateData = {
-  body?: never;
+  /**
+   * Manifest
+   *
+   * Bank template manifest
+   */
+  body: BankTemplateManifest;
   headers?: {
     /**
      * Authorization

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -4822,6 +4822,18 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Bank template manifest",
+                "title": "Manifest",
+                "$ref": "#/components/schemas/BankTemplateManifest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful Response",

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -4822,18 +4822,6 @@
             }
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Bank template manifest",
-                "title": "Manifest",
-                "$ref": "#/components/schemas/BankTemplateManifest"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -4852,6 +4840,18 @@
                 "schema": {
                   "$ref": "#/components/schemas/HTTPValidationError"
                 }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "title": "Manifest",
+                "description": "Bank template manifest",
+                "$ref": "#/components/schemas/BankTemplateManifest"
               }
             }
           }

--- a/skills/hindsight-docs/references/developer/extensions.md
+++ b/skills/hindsight-docs/references/developer/extensions.md
@@ -27,6 +27,14 @@ Validates [Supabase](https://supabase.com) JWTs and gives each authenticated use
 Up to 0.9.2 this extension was built in, at `hindsight_api.extensions.builtin.supabase_tenant`. That path no longer exists, so an install still pointing at it fails at startup with `ModuleNotFoundError`. Add the extension to your image and set `HINDSIGHT_API_TENANT_EXTENSION=hindsight_ext_supabase_tenant:SupabaseTenantExtension`. All `HINDSIGHT_API_TENANT_*` settings and the schema naming are unchanged.
 :::
 
+**External: StaticKeysTenantExtension**
+
+A fully self-hosted multi-user mode: users and their API keys are declared in environment variables (no external identity provider, no users table). Each user maps to their own PostgreSQL schema (`{prefix}_{user_id}`), provisioned lazily on first access, giving database-level memory isolation between users. Multiple API keys may map to the same user and schema.
+
+User IDs are case-insensitive: they are lowercased (and dashes normalized to underscores) before building the schema name, so `Rafael`, `rafael` and `RAFAEL` all resolve to the same tenant schema.
+
+It lives in the [extensions registry](https://github.com/vectorize-io/hindsight/tree/main/hindsight-extensions/static-keys-tenant), which documents its configuration and ships a Dockerfile that builds an image with it.
+
 For other multi-tenant setups with separate schemas per tenant (e.g., custom JWT-based auth), implement a custom `TenantExtension`.
 
 ---

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -4843,6 +4843,18 @@
               }
             }
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "title": "Manifest",
+                "description": "Bank template manifest",
+                "$ref": "#/components/schemas/BankTemplateManifest"
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
`POST /v1/default/banks/{bank_id}/import` reads its manifest off the raw `Request`, so FastAPI
emits no `requestBody` for the operation and every generated SDK's `import_bank_template` has no
parameter to send the manifest in. Export returns a typed `BankTemplateManifest` with nowhere to
send it; import is only reachable by dropping to raw HTTP.

The handler keeps parsing and validating the body itself — declaring `manifest: BankTemplateManifest`
as a parameter would hand validation to FastAPI and turn the endpoint's established 400 responses
into 422s. So the schema is published via `openapi_extra` instead, pointing at the same
`BankTemplateManifest` the export side already returns, and the handler is unchanged.

All three generated clients now express the body: Python gains a required `bank_template_manifest`
argument and the `Content-Type` header, Go gains `BankTemplateManifest()` with a nil guard, and the
TypeScript `ImportBankTemplateData.body` goes from `never` to `BankTemplateManifest`.

Supersedes #4238 by @0x90000, whose commit is the first one here. That PR hand-edited
`hindsight-docs/static/openapi.json`, which does not match generator output: `openapi_extra` merges
last, so a regenerated spec places `requestBody` *after* `responses`. It also left
`skills/hindsight-docs/references/openapi.json` — a copy the docs-skill generator makes — without the
request body at all. Both fail the byte comparison in `verify-generated-files`. The second commit here
is the output of the four generators run in CI's order.

That regen also picks up one unrelated file: `skills/hindsight-docs/references/developer/extensions.md`
was left stale on `main` when the StaticKeysTenantExtension section was added to the docs page without
the skill being rebuilt. It has to land here because the check regenerates everything and diffs the
whole tree.

Fixes #4232

## Verification

- `tests/test_bank_templates.py::TestImportValidation` — 14 passed. `test_import_openapi_declares_manifest_request_body`
  is a real gate: deleting the `openapi_extra` block fails it with `KeyError: 'requestBody'`.
- Ran all four generators plus `lint.sh` a second time on the committed tree — no diff, which is exactly
  what `verify-generated-files` asserts.
- `check-openapi-compatibility` against `main`: no backwards-compatibility issues.

`export_documents` also takes options and has no `requestBody`; #4232 flags it as worth confirming.
Left out of this change deliberately — it wants its own issue.
