### PR TITLE
fix(reflect): say when the structured-output extraction failed (#4230)

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -1596,6 +1596,15 @@ class ReflectResponse(BaseModel):
         default=None,
         description="Structured output parsed according to the request's response_schema. Only present when response_schema was provided in the request.",
     )
+    structured_output_error: str | None = Field(
+        default=None,
+        description=(
+            "Why structured output could not be produced. Present only when a response_schema was "
+            "given and the extraction call failed (provider error, timeout, unparseable output). "
+            "A missing structured_output *without* this field means the answer held nothing "
+            "matching the schema — the reflect itself still succeeded either way."
+        ),
+    )
     usage: TokenUsage | None = Field(
         default=None,
         description="Token usage metrics for LLM calls during reflection.",
@@ -5880,6 +5889,7 @@ def _register_routes(app: FastAPI):
                 text=core_result.text,
                 based_on=based_on_result,
                 structured_output=core_result.structured_output,
+                structured_output_error=core_result.structured_output_error,
                 usage=core_result.usage,
                 trace=trace_result,
             )

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -558,6 +558,7 @@ from .mental_model_refresh import (
 from .multi_llm import MultiLLMProvider
 from .query_analyzer import QueryAnalyzer
 from .reflect import ReflectNoAnswerError, ReflectToolExecutionError, run_reflect_agent
+from .reflect.models import StructuredOutputResult
 from .reflect.retractions import (
     RetractedGrounding,
     based_on_fact_ids,
@@ -14443,6 +14444,7 @@ class MemoryEngine(MemoryEngineInterface):
                 document=agent_result.document,
                 based_on=based_on,
                 structured_output=agent_result.structured_output,
+                structured_output_error=agent_result.structured_output_error,
                 usage=usage,
                 tool_trace=tool_trace_result,
                 llm_trace=llm_trace_result,
@@ -16940,19 +16942,18 @@ class MemoryEngine(MemoryEngineInterface):
             response_schema = (mental_model.get("trigger") or {}).get("response_schema")
             prev_structured_output = (mental_model.get("reflect_response") or {}).get("structured_output")
 
-            async def _structured_output_for(content_text: str) -> dict[str, Any] | None:
+            async def _structured_output_for(content_text: str) -> StructuredOutputResult:
                 if not response_schema or not content_text.strip():
-                    return None
+                    return StructuredOutputResult(error="no response_schema, or the content was empty")
                 from .reflect.agent import _generate_structured_output
 
-                result = await _generate_structured_output(
+                return await _generate_structured_output(
                     content_text,
                     response_schema,
                     self._reflect_llm_config,
                     f"mm-{mental_model_id[:8]}",
                     mental_model.get("max_tokens"),
                 )
-                return result.structured_output
 
             if run.outcome == "content_preserved_no_new_facts":
                 logger.info(
@@ -17040,14 +17041,17 @@ class MemoryEngine(MemoryEngineInterface):
             # previously-stored value); failing here leaves content/structured untouched,
             # so the prior content and structured_output are preserved for retry.
             if response_schema:
-                structured_output = await _structured_output_for(run.final_content)
-                if structured_output is None:
+                structured = await _structured_output_for(run.final_content)
+                if structured.structured_output is None:
                     await _preserve_and_fail(
                         reason="structured_output_failed",
                         outcome="refresh_failed_structured_output",
-                        detail="structured output extraction failed while a response_schema is configured.",
+                        detail=(
+                            "structured output extraction failed while a response_schema is configured"
+                            f" ({structured.error})."
+                        ),
                     )
-                reflect_response_payload["structured_output"] = structured_output
+                reflect_response_payload["structured_output"] = structured.structured_output
 
             # Update the mental model with new content and reflect_response.
             # Passing last_refreshed_source_query records the query used for this

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -191,8 +191,10 @@ async def _generate_structured_output(
             JSON (finish_reason=length, empty content -> issue #2431)
 
     Returns:
-        A StructuredOutputResult carrying the structured output (None if
-        generation fails) and the call's token usage.
+        A StructuredOutputResult carrying the structured output and the call's
+        token usage. On failure ``structured_output`` is None and ``error``
+        says why, so a caller can tell a broken extraction (retryable) from an
+        answer that genuinely held nothing to extract (issue #4230).
     """
     try:
         from typing import Any as TypingAny
@@ -241,7 +243,7 @@ async def _generate_structured_output(
 
         if not schema_props:
             logger.warning(f"[REFLECT {reflect_id}] No fields found in response_schema, skipping structured output")
-            return StructuredOutputResult()
+            return StructuredOutputResult(error="response_schema declares no properties")
 
         DynamicModel = _model_for(response_schema, "StructuredResponse")
 
@@ -333,7 +335,7 @@ OUTPUT:"""
 
     except Exception as e:
         logger.warning(f"[REFLECT {reflect_id}] Failed to generate structured output: {e}")
-        return StructuredOutputResult()
+        return StructuredOutputResult(error=f"{type(e).__name__}: {e}")
 
 
 def _count_messages_tokens(messages: list[dict[str, Any]]) -> int:
@@ -864,10 +866,12 @@ async def _run_reflect_agent_inner(
             )
 
         structured_output = None
+        structured_output_error = None
         # ``answer`` is non-empty past the guard above, so only the schema gates this.
         if response_schema:
             struct = await _generate_structured_output(answer, response_schema, llm_config, reflect_id, max_tokens)
             structured_output = struct.structured_output
+            structured_output_error = struct.error
             total_input_tokens += struct.input_tokens
             total_output_tokens += struct.output_tokens
             total_cached_tokens += struct.cached_tokens
@@ -877,6 +881,7 @@ async def _run_reflect_agent_inner(
         return ReflectAgentResult(
             text=answer,
             structured_output=structured_output,
+            structured_output_error=structured_output_error,
             iterations=iterations_completed,
             tools_called=total_tools_called,
             tool_trace=tool_trace,
@@ -1524,9 +1529,11 @@ async def _process_done_tool(
 
     # Generate structured output if schema provided
     structured_output = None
+    structured_output_error = None
     if response_schema and llm_config and answer:
         struct = await _generate_structured_output(answer, response_schema, llm_config, reflect_id, max_tokens)
         structured_output = struct.structured_output
+        structured_output_error = struct.error
         # Add structured output tokens to usage
         final_usage = TokenUsageSummary(
             input_tokens=final_usage.input_tokens + struct.input_tokens,
@@ -1541,6 +1548,7 @@ async def _process_done_tool(
         text=answer,
         document=document,
         structured_output=structured_output,
+        structured_output_error=structured_output_error,
         iterations=iterations,
         tools_called=total_tools_called,
         tool_trace=tool_trace,

--- a/hindsight-api-slim/hindsight_api/engine/reflect/models.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/models.py
@@ -102,6 +102,13 @@ class StructuredOutputResult(BaseModel):
     structured_output: dict[str, Any] | None = Field(
         default=None, description="Generated structured output, or None if generation failed"
     )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Why the extraction call produced no structured output, when it failed. None on success. "
+            "Callers cannot otherwise tell a failed extraction from one that had nothing to extract."
+        ),
+    )
     input_tokens: int = Field(default=0, description="Input tokens used")
     output_tokens: int = Field(default=0, description="Visible output tokens used")
     cached_tokens: int = Field(default=0, description="Cached prefix tokens. Subset of input_tokens.")
@@ -141,6 +148,14 @@ class ReflectAgentResult(BaseModel):
     )
     structured_output: dict[str, Any] | None = Field(
         default=None, description="Structured output parsed according to provided response_schema"
+    )
+    structured_output_error: str | None = Field(
+        default=None,
+        description=(
+            "Why the structured-output extraction failed, when a response_schema was given and the "
+            "extraction call errored or returned unparseable output. None when it succeeded or when "
+            "no schema was requested."
+        ),
     )
     iterations: int = Field(default=0, description="Number of iterations taken")
     tools_called: int = Field(default=0, description="Total number of tool calls made")

--- a/hindsight-api-slim/hindsight_api/engine/response_models.py
+++ b/hindsight-api-slim/hindsight_api/engine/response_models.py
@@ -550,6 +550,14 @@ class ReflectResult(BaseModel):
         default=None,
         description="Structured output parsed according to the provided response schema. Only present when response_schema was provided.",
     )
+    structured_output_error: str | None = Field(
+        default=None,
+        description=(
+            "Why structured output could not be produced, when a response_schema was provided and the "
+            "extraction call failed. Absent when extraction succeeded, so a null structured_output "
+            "without this field means the answer held nothing matching the schema."
+        ),
+    )
     usage: TokenUsage | None = Field(
         default=None,
         description="Token usage metrics for the LLM calls made during this reflect operation.",

--- a/hindsight-api-slim/tests/test_http_api_integration.py
+++ b/hindsight-api-slim/tests/test_http_api_integration.py
@@ -979,6 +979,48 @@ async def test_reflect_structured_output(api_client):
 
 
 @pytest.mark.asyncio
+async def test_reflect_structured_output_failure_is_reported(api_client, monkeypatch):
+    """A failed extraction pass still returns 200 with the text answer, but says so.
+
+    Before #4230 the failure was swallowed: the caller got structured_output: null
+    with nothing distinguishing a broken extraction call (retryable) from an answer
+    that held nothing matching the schema.
+    """
+    from hindsight_api.engine.reflect import agent as reflect_agent
+    from hindsight_api.engine.reflect.models import StructuredOutputResult
+
+    async def _failing_extraction(*args, **kwargs):
+        return StructuredOutputResult(error="RuntimeError: provider is down")
+
+    monkeypatch.setattr(reflect_agent, "_generate_structured_output", _failing_extraction)
+
+    test_bank_id = f"reflect_structured_err_test_{datetime.now().timestamp()}"
+    response = await api_client.post(
+        f"/v1/default/banks/{test_bank_id}/memories",
+        json={"items": [{"content": "Alice lives in Berlin.", "context": "team member info"}]},
+    )
+    assert response.status_code == 200
+
+    response = await api_client.post(
+        f"/v1/default/banks/{test_bank_id}/reflect",
+        json={
+            "query": "Where does Alice live?",
+            "response_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+
+    assert result["text"]
+    assert result.get("structured_output") is None
+    assert result.get("structured_output_error") == "RuntimeError: provider is down"
+
+
+@pytest.mark.asyncio
 async def test_reflect_without_structured_output(api_client):
     """Test that reflect works normally without response_schema.
 

--- a/hindsight-api-slim/tests/test_mental_model_structured_output.py
+++ b/hindsight-api-slim/tests/test_mental_model_structured_output.py
@@ -9,7 +9,6 @@ modes. These are deterministic tests: reflect_async, the delta-ops LLM call, and
 the structured-output extractor are all mocked (no real LLM).
 """
 
-import types
 import uuid
 
 import pytest
@@ -18,6 +17,7 @@ from hindsight_api import MemoryEngine, RequestContext
 from hindsight_api.engine.memory_engine import MentalModelRefreshError
 from hindsight_api.engine.reflect import agent as reflect_agent
 from hindsight_api.engine.reflect.delta_ops import DeltaOperationList
+from hindsight_api.engine.reflect.models import StructuredOutputResult
 from hindsight_api.engine.response_models import LLMCallResult, ReflectResult, TokenUsage
 from tests.conftest import stub_refresh_has_sources
 
@@ -43,18 +43,19 @@ def _canned_reflect_result(text: str, facts: list[dict] | None = None) -> Reflec
     )
 
 
-def _patch_structured_output(monkeypatch, returns: dict) -> list[str]:
-    """Patch _generate_structured_output; record the content it was asked to parse."""
+def _patch_structured_output(monkeypatch, returns: dict | None) -> list[str]:
+    """Patch _generate_structured_output; record the content it was asked to parse.
+
+    ``returns=None`` stands for a failed extraction, which carries the reason in
+    ``error`` the way the real helper does (#4230).
+    """
     calls: list[str] = []
 
     async def fake(answer, response_schema, llm_config, reflect_id, max_tokens=None):
         calls.append(answer)
-        return types.SimpleNamespace(
+        return StructuredOutputResult(
             structured_output=returns,
-            input_tokens=0,
-            output_tokens=0,
-            cached_tokens=0,
-            thoughts_tokens=0,
+            error=None if returns is not None else "RuntimeError: simulated extraction failure",
         )
 
     monkeypatch.setattr(reflect_agent, "_generate_structured_output", fake)

--- a/hindsight-api-slim/tests/test_reflect_agent.py
+++ b/hindsight-api-slim/tests/test_reflect_agent.py
@@ -147,6 +147,7 @@ class TestReflectStructuredOutput:
         )
 
         assert result.structured_output is None
+        assert result.error is not None
         call_kwargs = llm.call.await_args.kwargs
         assert call_kwargs["scope"] == "reflect_structured"
         assert call_kwargs["max_retries"] == 1
@@ -220,6 +221,52 @@ class TestReflectStructuredOutput:
         )
 
         assert llm.call.await_args.kwargs.get("max_completion_tokens") is None
+
+    @pytest.mark.asyncio
+    async def test_failed_extraction_reports_why(self):
+        """A failed extraction carries the reason, so a caller can tell it apart from
+        an answer that simply held nothing matching the schema (issue #4230)."""
+        llm = MagicMock()
+        llm.call = AsyncMock(side_effect=RuntimeError("provider is down"))
+
+        result = await _generate_structured_output(
+            answer="Alice prefers concise engineering updates.",
+            response_schema={
+                "type": "object",
+                "properties": {"summary": {"type": "string"}},
+                "required": ["summary"],
+            },
+            llm_config=llm,
+            reflect_id="test-reflect",
+        )
+
+        assert result.structured_output is None
+        assert result.error == "RuntimeError: provider is down"
+
+    @pytest.mark.asyncio
+    async def test_successful_extraction_reports_no_error(self):
+        """The success path leaves ``error`` unset, so its presence alone means failure."""
+        llm = MagicMock()
+        llm.call = AsyncMock(
+            return_value=LLMCallResult(
+                content={"summary": "Alice likes short updates."},
+                usage=TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15),
+            )
+        )
+
+        result = await _generate_structured_output(
+            answer="Alice prefers concise engineering updates.",
+            response_schema={
+                "type": "object",
+                "properties": {"summary": {"type": "string"}},
+                "required": ["summary"],
+            },
+            llm_config=llm,
+            reflect_id="test-reflect",
+        )
+
+        assert result.structured_output == {"summary": "Alice likes short updates."}
+        assert result.error is None
 
 
 class TestReflectAgentMocked:

--- a/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
+++ b/hindsight-api-slim/tests/test_refresh_outcome_metadata.py
@@ -557,14 +557,13 @@ async def test_refresh_outcome_matrix(case: _OutcomeCase, memory: MemoryEngine, 
 
         monkeypatch.setattr(structured_doc, "structured_document_from_stored", unreadable)
     if case.structured_output_fails:
-        import types
-
         from hindsight_api.engine.reflect import agent as reflect_agent
+        from hindsight_api.engine.reflect.models import StructuredOutputResult
 
         async def extraction_yields_nothing(answer, response_schema, llm_config, reflect_id, max_tokens=None):
-            return types.SimpleNamespace(
-                structured_output=None, input_tokens=0, output_tokens=0, cached_tokens=0, thoughts_tokens=0
-            )
+            # A failed extraction carries the reason (#4230); the refresh records it
+            # in the failure detail, so the fake must be the real result type.
+            return StructuredOutputResult(error="RuntimeError: simulated extraction failure")
 
         monkeypatch.setattr(reflect_agent, "_generate_structured_output", extraction_yields_nothing)
 

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -10845,6 +10845,9 @@ components:
         structured_output:
           additionalProperties: {}
           nullable: true
+        structured_output_error:
+          nullable: true
+          type: string
         usage:
           $ref: '#/components/schemas/TokenUsage'
         trace:

--- a/hindsight-clients/go/model_reflect_response.go
+++ b/hindsight-clients/go/model_reflect_response.go
@@ -25,6 +25,7 @@ type ReflectResponse struct {
 	Text string `json:"text"`
 	BasedOn NullableReflectBasedOn `json:"based_on,omitempty"`
 	StructuredOutput map[string]interface{} `json:"structured_output,omitempty"`
+	StructuredOutputError NullableString `json:"structured_output_error,omitempty"`
 	Usage NullableTokenUsage `json:"usage,omitempty"`
 	Trace NullableReflectTrace `json:"trace,omitempty"`
 }
@@ -148,6 +149,48 @@ func (o *ReflectResponse) SetStructuredOutput(v map[string]interface{}) {
 	o.StructuredOutput = v
 }
 
+// GetStructuredOutputError returns the StructuredOutputError field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *ReflectResponse) GetStructuredOutputError() string {
+	if o == nil || IsNil(o.StructuredOutputError.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.StructuredOutputError.Get()
+}
+
+// GetStructuredOutputErrorOk returns a tuple with the StructuredOutputError field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ReflectResponse) GetStructuredOutputErrorOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.StructuredOutputError.Get(), o.StructuredOutputError.IsSet()
+}
+
+// HasStructuredOutputError returns a boolean if a field has been set.
+func (o *ReflectResponse) HasStructuredOutputError() bool {
+	if o != nil && o.StructuredOutputError.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetStructuredOutputError gets a reference to the given NullableString and assigns it to the StructuredOutputError field.
+func (o *ReflectResponse) SetStructuredOutputError(v string) {
+	o.StructuredOutputError.Set(&v)
+}
+// SetStructuredOutputErrorNil sets the value for StructuredOutputError to be an explicit nil
+func (o *ReflectResponse) SetStructuredOutputErrorNil() {
+	o.StructuredOutputError.Set(nil)
+}
+
+// UnsetStructuredOutputError ensures that no value is present for StructuredOutputError, not even an explicit nil
+func (o *ReflectResponse) UnsetStructuredOutputError() {
+	o.StructuredOutputError.Unset()
+}
+
 // GetUsage returns the Usage field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *ReflectResponse) GetUsage() TokenUsage {
 	if o == nil || IsNil(o.Usage.Get()) {
@@ -248,6 +291,9 @@ func (o ReflectResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if o.StructuredOutput != nil {
 		toSerialize["structured_output"] = o.StructuredOutput
+	}
+	if o.StructuredOutputError.IsSet() {
+		toSerialize["structured_output_error"] = o.StructuredOutputError.Get()
 	}
 	if o.Usage.IsSet() {
 		toSerialize["usage"] = o.Usage.Get()

--- a/hindsight-clients/python/hindsight_client_api/models/reflect_response.py
+++ b/hindsight-clients/python/hindsight_client_api/models/reflect_response.py
@@ -32,9 +32,10 @@ class ReflectResponse(BaseModel):
     text: StrictStr = Field(description="The reflect response as well-formatted markdown (headers, lists, bold/italic, code blocks, etc.)")
     based_on: Optional[ReflectBasedOn] = None
     structured_output: Optional[Dict[str, Any]] = None
+    structured_output_error: Optional[StrictStr] = None
     usage: Optional[TokenUsage] = None
     trace: Optional[ReflectTrace] = None
-    __properties: ClassVar[List[str]] = ["text", "based_on", "structured_output", "usage", "trace"]
+    __properties: ClassVar[List[str]] = ["text", "based_on", "structured_output", "structured_output_error", "usage", "trace"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -94,6 +95,11 @@ class ReflectResponse(BaseModel):
         if self.structured_output is None and "structured_output" in self.model_fields_set:
             _dict['structured_output'] = None
 
+        # set to None if structured_output_error (nullable) is None
+        # and model_fields_set contains the field
+        if self.structured_output_error is None and "structured_output_error" in self.model_fields_set:
+            _dict['structured_output_error'] = None
+
         # set to None if usage (nullable) is None
         # and model_fields_set contains the field
         if self.usage is None and "usage" in self.model_fields_set:
@@ -119,6 +125,7 @@ class ReflectResponse(BaseModel):
             "text": obj.get("text"),
             "based_on": ReflectBasedOn.from_dict(obj["based_on"]) if obj.get("based_on") is not None else None,
             "structured_output": obj.get("structured_output"),
+            "structured_output_error": obj.get("structured_output_error"),
             "usage": TokenUsage.from_dict(obj["usage"]) if obj.get("usage") is not None else None,
             "trace": ReflectTrace.from_dict(obj["trace"]) if obj.get("trace") is not None else None
         })

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -5579,6 +5579,12 @@ export type ReflectResponse = {
     [key: string]: unknown;
   } | null;
   /**
+   * Structured Output Error
+   *
+   * Why structured output could not be produced. Present only when a response_schema was given and the extraction call failed (provider error, timeout, unparseable output). A missing structured_output *without* this field means the answer held nothing matching the schema — the reflect itself still succeeded either way.
+   */
+  structured_output_error?: string | null;
+  /**
    * Token usage metrics for LLM calls during reflection.
    */
   usage?: TokenUsage | null;

--- a/hindsight-docs/docs/developer/api/reflect.mdx
+++ b/hindsight-docs/docs/developer/api/reflect.mdx
@@ -237,6 +237,10 @@ The synthesized answer as a well-formatted markdown string. This is the primary 
 
 The LLM's response parsed according to the `response_schema` provided in the request. Only present when `response_schema` was set. `null` otherwise.
 
+### structured_output_error
+
+Why the structured view could not be produced. Present only when a `response_schema` was given and the extraction pass failed — a provider error, a timeout, or output that would not parse. The reflect itself still succeeds: you get `200` and the markdown `text`, and this field tells you the machine-readable half is missing because something broke, not because the answer held nothing matching your schema. A missing `structured_output` **without** this field is the latter, ordinary case (the endpoint omits null fields). Treat its presence as retryable, and as the signal to alert on if structured output stops working.
+
 ### based_on
 
 The sources the agent used to construct the answer. Only present when `include.facts` was enabled. Contains three fields:

--- a/hindsight-docs/docs/developer/reflect.mdx
+++ b/hindsight-docs/docs/developer/reflect.mdx
@@ -269,6 +269,11 @@ extracts that answer into JSON matching your schema. `structured_output` is ther
 faithful projection of `text` — you get the readable answer **and** a typed object to program
 against, never one instead of the other.
 
+**When extraction fails.** The reflect still returns `200` with the prose answer, no
+`structured_output`, and a `structured_output_error` field saying why (a provider error, a timeout,
+unparseable output). A missing `structured_output` *without* that field means the answer simply held
+nothing matching your schema — so you can retry the broken case without retrying the ordinary one.
+
 **Schema rules.** The schema must be an object with at least one property. Each property's `type`
 is one of `string`, `number`, `integer`, `boolean`, `array`, or `object`, and `required` lists
 property names. Invalid schemas are rejected before the call runs, so a malformed schema fails

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -16189,6 +16189,18 @@
             "title": "Structured Output",
             "description": "Structured output parsed according to the request's response_schema. Only present when response_schema was provided in the request."
           },
+          "structured_output_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Structured Output Error",
+            "description": "Why structured output could not be produced. Present only when a response_schema was given and the extraction call failed (provider error, timeout, unparseable output). A missing structured_output *without* this field means the answer held nothing matching the schema \u2014 the reflect itself still succeeded either way."
+          },
           "usage": {
             "anyOf": [
               {

--- a/skills/hindsight-docs/references/developer/api/reflect.md
+++ b/skills/hindsight-docs/references/developer/api/reflect.md
@@ -361,6 +361,10 @@ The synthesized answer as a well-formatted markdown string. This is the primary 
 
 The LLM's response parsed according to the `response_schema` provided in the request. Only present when `response_schema` was set. `null` otherwise.
 
+### structured_output_error
+
+Why the structured view could not be produced. Present only when a `response_schema` was given and the extraction pass failed — a provider error, a timeout, or output that would not parse. The reflect itself still succeeds: you get `200` and the markdown `text`, and this field tells you the machine-readable half is missing because something broke, not because the answer held nothing matching your schema. A missing `structured_output` **without** this field is the latter, ordinary case (the endpoint omits null fields). Treat its presence as retryable, and as the signal to alert on if structured output stops working.
+
 ### based_on
 
 The sources the agent used to construct the answer. Only present when `include.facts` was enabled. Contains three fields:

--- a/skills/hindsight-docs/references/developer/reflect.md
+++ b/skills/hindsight-docs/references/developer/reflect.md
@@ -272,6 +272,11 @@ extracts that answer into JSON matching your schema. `structured_output` is ther
 faithful projection of `text` — you get the readable answer **and** a typed object to program
 against, never one instead of the other.
 
+**When extraction fails.** The reflect still returns `200` with the prose answer, no
+`structured_output`, and a `structured_output_error` field saying why (a provider error, a timeout,
+unparseable output). A missing `structured_output` *without* that field means the answer simply held
+nothing matching your schema — so you can retry the broken case without retrying the ordinary one.
+
 **Schema rules.** The schema must be an object with at least one property. Each property's `type`
 is one of `string`, `number`, `integer`, `boolean`, `array`, or `object`, and `required` lists
 property names. Invalid schemas are rejected before the call runs, so a malformed schema fails

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -16189,6 +16189,18 @@
             "title": "Structured Output",
             "description": "Structured output parsed according to the request's response_schema. Only present when response_schema was provided in the request."
           },
+          "structured_output_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Structured Output Error",
+            "description": "Why structured output could not be produced. Present only when a response_schema was given and the extraction call failed (provider error, timeout, unparseable output). A missing structured_output *without* this field means the answer held nothing matching the schema \u2014 the reflect itself still succeeded either way."
+          },
           "usage": {
             "anyOf": [
               {


### PR DESCRIPTION
Fixes #4230.

## The problem

`reflect` with a `response_schema` runs a second LLM call that reshapes the prose answer into the caller's schema. When that call errored or returned unparseable output, the bare `except` swallowed it and the caller got **200** with no `structured_output` — indistinguishable from an answer that genuinely held nothing matching the schema.

That is the half a caller integrates against, and the reason they supplied a schema at all. Collapsing "provider outage / timeout / unparseable" and "nothing to extract" into the same empty result means a caller either retries every empty result or none of them, and an operator watching for "structured output stopped working" gets no signal — the request succeeded.

## The fix

Returning 200 with the text answer is still right; the missing piece was saying the structured half did not happen.

- `StructuredOutputResult` gains `error` — `_generate_structured_output`'s `except` now records `"{ExcType}: {msg}"` instead of returning an empty result.
- That reaches the API as a nullable `structured_output_error` on the reflect response (`ReflectAgentResult` → `ReflectResult` → `ReflectResponse`).

The contract, documented on the field and in the docs:

| response | meaning |
|---|---|
| `structured_output` present | extraction succeeded |
| no `structured_output`, no `structured_output_error` | the answer held nothing matching the schema — ordinary result |
| `structured_output_error` present | the extraction call broke — retryable, and the thing to alert on |

(The reflect route drops nulls, so "absent" rather than "null" is what's on the wire.)

The mental-model refresh path calls the same helper, and its `structured_output_failed` failure detail now carries the reason instead of only "extraction failed".

## Tests

- `test_reflect_agent.py` — a failed extraction reports the reason; a successful one leaves `error` unset (so its presence alone means failure).
- `test_http_api_integration.py` — regression over the endpoint: 200, text answer, no `structured_output`, and the error field set.

Docs updated in `developer/reflect.mdx` and `developer/api/reflect.mdx`; OpenAPI spec, SDK clients and the docs skill regenerated.