### PR TITLE
fix(cli): account for bank template file input

### DIFF
--- a/hindsight-cli/.openapi-coverage.toml
+++ b/hindsight-cli/.openapi-coverage.toml
@@ -138,6 +138,12 @@ enable_reranking = "Set via `bank set-config` (hierarchical config)."
 [fields.update_bank_config]
 updates = "Flattened into per-setting flags (--llm-provider, --llm-model, etc) on `bank set-config`."
 
+[fields.import_bank_template]
+version = "Supplied in the JSON manifest file passed to `bank import-template`."
+bank = "Supplied in the JSON manifest file passed to `bank import-template`."
+mental_models = "Supplied in the JSON manifest file passed to `bank import-template`."
+directives = "Supplied in the JSON manifest file passed to `bank import-template`."
+
 [fields.create_webhook]
 http_config = "Advanced HTTP customisation (headers/method/timeout/params) is not exposed in the CLI yet; use the JSON API if needed."
 


### PR DESCRIPTION
## Summary

- account for the four `BankTemplateManifest` fields discovered by the CLI coverage check
- document that `version`, `bank`, `mental_models`, and `directives` are supplied together through the JSON manifest accepted by `bank import-template`

This fixes the `check-cli-coverage` failure on #4247 without changing CLI behavior.

## Verification

- `PYTHONUTF8=1 python hindsight-dev/hindsight_dev/cli_coverage_check.py`
  - `OK: all 91 operations and 121 request params covered.`