### PR TITLE
fix(reflect): honor resolved recall token defaults

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -14160,9 +14160,9 @@ class MemoryEngine(MemoryEngineInterface):
         recall_fact_types = [ft for ft in (fact_types or ["world", "experience"]) if ft in ("world", "experience")]
         include_recall = bool(recall_fact_types)
 
-        # Defaults are bound at closure-definition time (re-evaluated on each
-        # reflect_async call), so per-bank/per-trigger overrides apply when the
-        # agent invokes recall without explicit token args.
+        # Pass the resolved defaults to the agent as well: its dispatcher always
+        # supplies token arguments, so closure defaults alone cannot honor bank
+        # and mental-model trigger configuration (#4239).
         async def recall_fn(
             q: str,
             max_tokens: int = effective_recall_max_tokens,
@@ -14260,6 +14260,8 @@ class MemoryEngine(MemoryEngineInterface):
                         include_recall=include_recall,
                         budget=effective_budget,
                         max_context_tokens=max_context_tokens,
+                        recall_max_tokens=effective_recall_max_tokens,
+                        recall_chunks_max_tokens=effective_recall_chunks_max_tokens,
                         llm_output_language=getattr(resolved_reflect_config, "llm_output_language", None),
                         cancel_check=request_context.raise_if_cancelled,
                         store_document_text=config_dict.get("store_document_text", DEFAULT_STORE_DOCUMENT_TEXT),

--- a/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/agent.py
@@ -14,7 +14,7 @@ import time
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from ...cancellation import OperationCancelledError
-from ...config import get_config
+from ...config import DEFAULT_RECALL_CHUNKS_MAX_TOKENS, DEFAULT_RECALL_MAX_TOKENS, get_config
 from ..llm_interface import LLM_TOOL_CHOICE_AUTO, LLMToolChoice
 from ..llm_trace import LLMQueueWait, reset_queue_wait_sink, set_queue_wait_sink
 from ..llm_transport import describe_llm_error
@@ -511,6 +511,8 @@ async def _run_reflect_agent_inner(
     cancel_check: Callable[[], None] | None = None,
     store_document_text: bool = True,
     answer_as_document: bool = False,
+    recall_max_tokens: int = DEFAULT_RECALL_MAX_TOKENS,
+    recall_chunks_max_tokens: int = DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
     *,
     reflect_id: str,
     provider_impl: Any,
@@ -544,6 +546,8 @@ async def _run_reflect_agent_inner(
             answer mid-word (#3365). The transport-level cost cap is a separate,
             uncapped-by-default config (``reflect_max_completion_tokens``).
         response_schema: Optional JSON Schema for structured output in final response
+        recall_max_tokens: Resolved fact-token default for recall calls that omit a limit.
+        recall_chunks_max_tokens: Resolved chunk-token default; zero remains zero.
         directives: Optional list of directive mental models to inject as hard rules
 
     Returns:
@@ -576,6 +580,8 @@ async def _run_reflect_agent_inner(
         include_expand=include_expand,
         answer_as_document=answer_as_document,
         llm_output_language=llm_output_language,
+        recall_max_tokens=recall_max_tokens,
+        recall_chunks_max_tokens=recall_chunks_max_tokens,
     )
     # Build set of enabled tool names to guard against LLM hallucinating disabled tool calls
     enabled_tools: frozenset[str] = frozenset(t["function"]["name"] for t in tools if t.get("type") == "function")
@@ -1188,6 +1194,8 @@ async def _run_reflect_agent_inner(
                     recall_fn,
                     expand_fn,
                     enabled_tools=enabled_tools,
+                    recall_max_tokens=recall_max_tokens,
+                    recall_chunks_max_tokens=recall_chunks_max_tokens,
                 )
                 for tc in other_tools
             ]
@@ -1271,7 +1279,12 @@ async def _run_reflect_agent_inner(
 
                 # Track for logging and context history
                 input_dict = {"tool": tc.name, **tc.arguments}
-                input_summary = _summarize_input(tc.name, tc.arguments)
+                input_summary = _summarize_input(
+                    tc.name,
+                    tc.arguments,
+                    recall_max_tokens=recall_max_tokens,
+                    recall_chunks_max_tokens=recall_chunks_max_tokens,
+                )
 
                 # Extract reason from tool arguments (if provided)
                 tool_reason = tc.arguments.get("reason")
@@ -1560,6 +1573,9 @@ async def _execute_tool_with_timing(
     recall_fn: Callable[[str, int, int], Awaitable[dict[str, Any]]],
     expand_fn: Callable[[list[str], str], Awaitable[dict[str, Any]]],
     enabled_tools: frozenset[str] | None = None,
+    *,
+    recall_max_tokens: int = DEFAULT_RECALL_MAX_TOKENS,
+    recall_chunks_max_tokens: int = DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
 ) -> tuple[dict[str, Any], int]:
     """Execute a tool call and return result with timing."""
     from hindsight_api.tracing import get_tracer
@@ -1594,6 +1610,8 @@ async def _execute_tool_with_timing(
                 recall_fn,
                 expand_fn,
                 enabled_tools=enabled_tools,
+                recall_max_tokens=recall_max_tokens,
+                recall_chunks_max_tokens=recall_chunks_max_tokens,
             )
 
             # Set success attributes
@@ -1634,6 +1652,9 @@ async def _execute_tool(
     recall_fn: Callable[[str, int, int], Awaitable[dict[str, Any]]],
     expand_fn: Callable[[list[str], str], Awaitable[dict[str, Any]]],
     enabled_tools: frozenset[str] | None = None,
+    *,
+    recall_max_tokens: int = DEFAULT_RECALL_MAX_TOKENS,
+    recall_chunks_max_tokens: int = DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
 ) -> dict[str, Any]:
     """Execute a single tool by name."""
     # Normalize tool name for various LLM output formats
@@ -1667,13 +1688,13 @@ async def _execute_tool(
         query = args.get("query")
         if not query:
             return {"error": "recall requires a query parameter"}
-        max_tokens, error = _parse_tool_int_arg_or_error(args, "max_tokens", default=2048, minimum=1000)
+        max_tokens, error = _parse_tool_int_arg_or_error(args, "max_tokens", default=recall_max_tokens, minimum=1000)
         if error:
             return {"error": error}
         max_chunk_tokens, error = _parse_tool_int_arg_or_error(
             args,
             "max_chunk_tokens",
-            default=1000,
+            default=recall_chunks_max_tokens,
             minimum=1000,
         )
         if error:
@@ -1696,12 +1717,13 @@ _NULLISH_TOOL_INT_STRINGS = {"", "none", "null"}
 
 def _parse_tool_int_arg(args: dict[str, Any], key: str, *, default: int, minimum: int | None = None) -> int:
     raw_value = args.get(key)
+    # The minimum constrains model-chosen values, not operator/trigger defaults.
+    # In particular, a configured zero chunk budget must not become 1000.
     if not raw_value:
-        value = default
-    elif isinstance(raw_value, str) and raw_value.strip().lower() in _NULLISH_TOOL_INT_STRINGS:
-        value = default
-    else:
-        value = int(raw_value)
+        return default
+    if isinstance(raw_value, str) and raw_value.strip().lower() in _NULLISH_TOOL_INT_STRINGS:
+        return default
+    value = int(raw_value)
     if minimum is None:
         return value
     return max(value, minimum)
@@ -1734,7 +1756,13 @@ def _summarize_tool_query(args: dict[str, Any]) -> str:
     return f"'{query[:30]}...'" if len(query) > 30 else f"'{query}'"
 
 
-def _summarize_input(tool_name: str, args: dict[str, Any]) -> str:
+def _summarize_input(
+    tool_name: str,
+    args: dict[str, Any],
+    *,
+    recall_max_tokens: int = DEFAULT_RECALL_MAX_TOKENS,
+    recall_chunks_max_tokens: int = DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
+) -> str:
     """Create a summary of tool input for logging, showing all params."""
     if tool_name == "search_mental_models":
         query_preview = _summarize_tool_query(args)
@@ -1746,8 +1774,10 @@ def _summarize_input(tool_name: str, args: dict[str, Any]) -> str:
         return f"(query={query_preview}, max_tokens={max_tokens})"
     elif tool_name == "recall":
         query_preview = _summarize_tool_query(args)
-        max_tokens = _summarize_tool_int_arg(args, "max_tokens", default=2048, minimum=1000)
-        max_chunk_tokens = _summarize_tool_int_arg(args, "max_chunk_tokens", default=1000, minimum=1000)
+        max_tokens = _summarize_tool_int_arg(args, "max_tokens", default=recall_max_tokens, minimum=1000)
+        max_chunk_tokens = _summarize_tool_int_arg(
+            args, "max_chunk_tokens", default=recall_chunks_max_tokens, minimum=1000
+        )
         return f"(query={query_preview}, max_tokens={max_tokens}, max_chunk_tokens={max_chunk_tokens})"
     elif tool_name == "expand":
         memory_ids = args.get("memory_ids", [])

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools_schema.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools_schema.py
@@ -9,6 +9,9 @@ The reflect agent uses a hierarchical retrieval strategy:
 """
 
 import copy
+from typing import Any
+
+from ...config import DEFAULT_RECALL_CHUNKS_MAX_TOKENS, DEFAULT_RECALL_MAX_TOKENS
 
 # Tool definitions in OpenAI format
 
@@ -73,7 +76,7 @@ TOOL_SEARCH_OBSERVATIONS = {
     },
 }
 
-TOOL_RECALL = {
+TOOL_RECALL: dict[str, Any] = {
     "type": "function",
     "function": {
         "name": "recall",
@@ -343,6 +346,8 @@ def get_reflect_tools(
     include_expand: bool = True,
     answer_as_document: bool = False,
     llm_output_language: str | None = None,
+    recall_max_tokens: int = DEFAULT_RECALL_MAX_TOKENS,
+    recall_chunks_max_tokens: int = DEFAULT_RECALL_CHUNKS_MAX_TOKENS,
 ) -> list[dict]:
     """
     Get the list of tools for the reflect agent.
@@ -367,6 +372,8 @@ def get_reflect_tools(
             markdown that gets persisted.
         llm_output_language: Configured output language. Swaps ``done``'s default
             answer-in-the-question's-language rule for a directive to write in it.
+        recall_max_tokens: Resolved default fact-token budget to advertise for this call.
+        recall_chunks_max_tokens: Resolved default chunk-token budget to advertise.
 
     Returns:
         List of tool definitions in OpenAI format
@@ -378,7 +385,19 @@ def get_reflect_tools(
     if include_observations:
         tools.append(TOOL_SEARCH_OBSERVATIONS)
     if include_recall:
-        tools.append(TOOL_RECALL)
+        # Each reflect has its own bank/trigger defaults. Do not mutate the shared
+        # schema, or concurrent banks can advertise each other's budgets.
+        recall_tool = copy.deepcopy(TOOL_RECALL)
+        properties = recall_tool["function"]["parameters"]["properties"]
+        properties["max_tokens"]["description"] = (
+            f"Optional limit on result size (default {recall_max_tokens}). Use higher values for broader searches."
+        )
+        properties["max_chunk_tokens"]["description"] = (
+            "Maximum tokens for raw source chunk text included alongside each memory fact "
+            f"(default {recall_chunks_max_tokens}, min 1000 for explicit limits). "
+            "Chunks provide the surrounding context the fact was extracted from. Increase for broader context."
+        )
+        tools.append(recall_tool)
 
     if include_expand:
         tools.append(TOOL_EXPAND)

--- a/hindsight-api-slim/tests/test_recall_config.py
+++ b/hindsight-api-slim/tests/test_recall_config.py
@@ -7,6 +7,7 @@ and as overrides on a mental model's `trigger` JSONB field.
 """
 
 import dataclasses
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,6 +15,126 @@ import pytest
 from hindsight_api.engine.reflect.tools import tool_recall
 from hindsight_api.engine.response_models import RecallResult as RecallResultModel
 from hindsight_api.models import RequestContext
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "configured,overrides,tool_limits,expected",
+    [
+        ({}, {}, {}, (2048, 1000)),
+        ({"recall_max_tokens": 8192, "recall_chunks_max_tokens": 3072}, {}, {}, (8192, 3072)),
+        ({"recall_max_tokens": 512, "recall_chunks_max_tokens": 0}, {}, {}, (512, 0)),
+        (
+            {"recall_max_tokens": 8192, "recall_chunks_max_tokens": 3072},
+            {"recall_max_tokens_override": 512, "recall_chunks_max_tokens_override": 0},
+            {},
+            (512, 0),
+        ),
+        (
+            {"recall_max_tokens": 512, "recall_chunks_max_tokens": 0},
+            {},
+            {"max_tokens": "None", "max_chunk_tokens": "null"},
+            (512, 0),
+        ),
+        (
+            {"recall_max_tokens": 512, "recall_chunks_max_tokens": 0},
+            {},
+            {"max_tokens": 0, "max_chunk_tokens": 0},
+            (512, 0),
+        ),
+        ({"recall_max_tokens": 512, "recall_chunks_max_tokens": 0}, {}, {"max_tokens": "4096"}, (4096, 0)),
+        ({"recall_max_tokens": 512, "recall_chunks_max_tokens": 0}, {}, {"max_chunk_tokens": 2048}, (512, 2048)),
+        (
+            {"recall_max_tokens": 512, "recall_chunks_max_tokens": 0},
+            {},
+            {"max_tokens": 100, "max_chunk_tokens": 100},
+            (1000, 1000),
+        ),
+    ],
+)
+async def test_reflect_dispatch_uses_resolved_recall_defaults(
+    configured: dict[str, int],
+    overrides: dict[str, int],
+    tool_limits: dict[str, int | str],
+    expected: tuple[int, int],
+) -> None:
+    """Exercise engine -> agent -> real recall tool, not just closure defaults (#4239)."""
+    from hindsight_api.engine.memory_engine import MemoryEngine
+    from hindsight_api.engine.response_models import LLMToolCall, LLMToolCallResult, MemoryFact
+
+    # Stub storage/LLM transport, but keep the complete reflect dispatch path. The
+    # prior trigger tests stopped before the agent replaced these settings.
+    engine = MemoryEngine.__new__(MemoryEngine)
+    engine._authenticate_tenant = AsyncMock()
+    engine._operation_validator = None
+    engine._resolve_fuzzy_tag_groups = AsyncMock(return_value=None)
+    engine._get_backend = AsyncMock()
+    engine.get_bank_profile = AsyncMock(return_value={"name": "Test", "mission": "Testing"})
+    engine.get_bank_freshness = AsyncMock(return_value={})
+    engine.list_directives = AsyncMock(return_value=SimpleNamespace(items=[]))
+    engine._config_resolver = MagicMock()
+    engine._config_resolver.get_bank_config = AsyncMock(return_value=configured)
+    engine._config_resolver.resolve_full_config = AsyncMock(return_value=SimpleNamespace(llm_output_language=None))
+    engine.recall_async = AsyncMock(
+        return_value=RecallResultModel(results=[MemoryFact(id="mem-1", text="The deploy is ready.", fact_type="world")])
+    )
+    llm = MagicMock()
+    llm._provider_impl = None
+    llm.call_with_tools = AsyncMock(
+        side_effect=[
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="1", name="recall", arguments={"query": "deploy", **tool_limits})],
+                finish_reason="tool_calls",
+            ),
+            LLMToolCallResult(
+                tool_calls=[LLMToolCall(id="2", name="done", arguments={"answer": "Ready.", "memory_ids": ["mem-1"]})],
+                finish_reason="tool_calls",
+            ),
+        ]
+    )
+    engine._reflect_llm_config = MagicMock(provider="test")
+    engine._reflect_llm_config.with_config.return_value = llm
+
+    result = await engine.reflect_async(
+        bank_id="bank-1",
+        query="Deploy status?",
+        request_context=RequestContext(internal=True),
+        fact_types=["world"],
+        exclude_mental_models=True,
+        _skip_span=True,
+        **overrides,
+    )
+
+    assert result.text == "Ready."
+    engine.recall_async.assert_awaited_once()
+    actual = engine.recall_async.await_args.kwargs
+    assert (actual["max_tokens"], actual["max_chunk_tokens"]) == expected
+    assert actual["request_context"].internal is True
+    assert result.based_on["world"][0].id == "mem-1"
+
+
+def test_recall_schema_defaults_are_scoped_to_one_reflect() -> None:
+    from hindsight_api.engine.reflect.tools_schema import TOOL_RECALL, get_reflect_tools
+
+    original = TOOL_RECALL["function"]["parameters"]["properties"]["max_tokens"]["description"]
+    custom = get_reflect_tools(recall_max_tokens=512, recall_chunks_max_tokens=0)
+    regular = get_reflect_tools()
+    custom_recall = next(t for t in custom if t["function"]["name"] == "recall")
+    regular_recall = next(t for t in regular if t["function"]["name"] == "recall")
+    custom_properties = custom_recall["function"]["parameters"]["properties"]
+    assert "default 512" in custom_properties["max_tokens"]["description"]
+    assert "default 0" in custom_properties["max_chunk_tokens"]["description"]
+    assert regular_recall["function"]["parameters"]["properties"]["max_tokens"]["description"] == original
+    assert TOOL_RECALL["function"]["parameters"]["properties"]["max_tokens"]["description"] == original
+
+
+def test_recall_trace_summary_uses_the_dispatch_defaults() -> None:
+    from hindsight_api.engine.reflect.agent import _summarize_input
+
+    assert (
+        _summarize_input("recall", {"query": "deploy"}, recall_max_tokens=512, recall_chunks_max_tokens=0)
+        == "(query='deploy', max_tokens=512, max_chunk_tokens=0)"
+    )
 
 
 def _make_mock_engine():


### PR DESCRIPTION
Reflect always passed hardcoded 2048/1000 token limits to its recall callback, bypassing the defaults resolved from environment, bank configuration, and mental-model triggers. Thread those resolved defaults through dispatch, schema descriptions, and trace summaries. A configured 512-token fact budget and zero chunk budget now reach retrieval unchanged when the model omits the corresponding limits; explicit model limits retain their existing normalization.

Refs #4239. This fixes the ignored-defaults portion only. Full serialized-payload accounting, mental-model result caps, and per-iteration context ceilings remain outside this change.

Validation:
- 121 deterministic tests passed across recall configuration, reflect tools/agent, Anthropic tool-result ordering, and tool schemas (real-LLM cases excluded).
- On unmodified main, the new dispatch regression has 7 failures and 2 passes; all 9 pass with this change.
- `./scripts/hooks/lint.sh` passed, including Python type checks and JavaScript lints. `git diff --check` passed.
