### PR TITLE
fix(retain): prevent cross-bank chunk ID collisions

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/chunk_id.py
+++ b/hindsight-api-slim/hindsight_api/engine/chunk_id.py
@@ -1,0 +1,50 @@
+"""Construction and parsing for self-describing chunk identifiers."""
+
+from dataclasses import dataclass
+
+_VERSION_PREFIX = "v2:"
+
+
+@dataclass(frozen=True)
+class ChunkAddress:
+    bank_id: str
+    document_id: str
+    chunk_index: int
+
+
+def build_chunk_id(bank_id: str, document_id: str, chunk_index: int) -> str:
+    """Build an unambiguous identifier for a chunk within a bank and document."""
+    return f"{_VERSION_PREFIX}{len(bank_id)}:{len(document_id)}:{bank_id}{document_id}_{chunk_index}"
+
+
+def parse_chunk_id(chunk_id: str | None) -> ChunkAddress | None:
+    """Parse current length-prefixed IDs and legacy underscore-delimited IDs."""
+    if not chunk_id:
+        return None
+
+    if chunk_id.startswith(_VERSION_PREFIX):
+        try:
+            bank_length_text, document_length_text, payload = chunk_id[len(_VERSION_PREFIX) :].split(":", 2)
+            bank_length = int(bank_length_text)
+            document_length = int(document_length_text)
+            components, separator, chunk_index_text = payload.rpartition("_")
+            if bank_length >= 0 and document_length >= 0:
+                if separator and len(components) == bank_length + document_length:
+                    return ChunkAddress(
+                        bank_id=components[:bank_length],
+                        document_id=components[bank_length:],
+                        chunk_index=int(chunk_index_text),
+                    )
+        except ValueError:
+            pass
+
+    head, separator, chunk_index_text = chunk_id.rpartition("_")
+    if not head or not separator or not chunk_index_text:
+        return None
+    bank_id, separator, document_id = head.rpartition("_")
+    if not bank_id or not separator or not document_id:
+        return None
+    try:
+        return ChunkAddress(bank_id=bank_id, document_id=document_id, chunk_index=int(chunk_index_text))
+    except ValueError:
+        return None

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -59,6 +59,7 @@ from ..worker.exceptions import DeferOperation, RetryTaskAt, format_task_error
 from ..worker.stage import set_stage
 from .audit import AuditLogger, audit_context
 from .bank_stats_cache import BankStatsCache, DistributedBankStatsCache
+from .chunk_id import build_chunk_id, parse_chunk_id
 from .db import DatabaseBackend, DatabaseConnection, ResultRow, create_database_backend
 from .db.ops_postgresql import pg_search_vector_expr
 from .db.postgresql import PostgreSQLBackend
@@ -211,32 +212,6 @@ def _bind_bank_id(
 def count_tokens(text: str) -> int:
     """Count tokens in text under the configured encoding (see engine/token_encoding.py)."""
     return _token_encoding_count(text)
-
-
-def _parse_chunk_id(chunk_id: str | None) -> "tuple[str, str, int] | None":
-    """Split a ``{bank_id}_{document_id}_{index}`` chunk_id into its parts.
-
-    Retain builds chunk ids in exactly this shape (see ``retain/chunk_storage.py``), which makes
-    them self-describing — the addressed chunk route has no bank in its path and normally recovers
-    it from the SQL row, but a store that owns the document store has no such row. Both splits are
-    from the RIGHT: the index is the final segment, and the document id before it is a UUID, which
-    contains no underscore. A bank id containing underscores is therefore still parsed correctly.
-
-    Returns ``None`` when the id is not in that shape, so the caller falls through to the SQL
-    lookup rather than guessing.
-    """
-    if not chunk_id:
-        return None
-    head, _, idx_s = chunk_id.rpartition("_")
-    if not head or not idx_s:
-        return None
-    bank_id, _, document_id = head.rpartition("_")
-    if not bank_id or not document_id:
-        return None
-    try:
-        return bank_id, document_id, int(idx_s)
-    except ValueError:
-        return None
 
 
 def _epoch_ms_to_datetime(value: Any) -> datetime | None:
@@ -5902,7 +5877,7 @@ class MemoryEngine(MemoryEngineInterface):
             # sliced into several sub-batches that all share one document_id and
             # run sequentially, each sub-batch must continue the document's
             # chunk_index sequence rather than restart at 0 — otherwise the
-            # derived chunk_id ({bank}_{doc}_{index}) collides and later
+            # derived chunk IDs collide and later
             # sub-batches overwrite earlier chunks, leaving only one sub-batch's
             # worth of chunks/memories (issue #1888). The counts come from the
             # splitter, which cut the slices on those very chunk boundaries.
@@ -8486,26 +8461,22 @@ class MemoryEngine(MemoryEngineInterface):
                     if _owns_docs and not chunks_rows:
                         # A store that owns the document store AND wrote no SQL chunks row (PG-free
                         # retain) leaves the chunks table empty, so the query above found nothing.
-                        # Synthesize the metadata from the chunk_ids themselves — a chunk_id is
-                        # ``{bank_id}_{document_id}_{chunk_index}`` and bank_id is known, so the last
-                        # ``_``-segment is the index and everything between is the document_id — then
-                        # let the overlay below fill in the text from the store. Independent of the
+                        # Synthesize the metadata from the self-describing chunk_ids, then let the
+                        # overlay below fill in the text from the store. Independent of the
                         # per-request capability flags: it fires whenever docs are owned and SQL is
                         # empty, which is exactly the PG-free case.
-                        _pfx = f"{bank_id}_"
                         chunks_rows = []
                         for _cid in chunk_ids_ordered:
-                            if not _cid.startswith(_pfx):
-                                continue
-                            _doc, _, _idx_s = _cid[len(_pfx) :].rpartition("_")
-                            if not _doc:
-                                continue
-                            try:
-                                _idx = int(_idx_s)
-                            except ValueError:
+                            address = parse_chunk_id(_cid)
+                            if address is None or address.bank_id != bank_id:
                                 continue
                             chunks_rows.append(
-                                {"chunk_id": _cid, "chunk_text": "", "chunk_index": _idx, "document_id": _doc}
+                                {
+                                    "chunk_id": _cid,
+                                    "chunk_text": "",
+                                    "chunk_index": address.chunk_index,
+                                    "document_id": address.document_id,
+                                }
                             )
 
                     if _owns_docs:
@@ -12274,7 +12245,7 @@ class MemoryEngine(MemoryEngineInterface):
         Get a specific chunk by its ID.
 
         Args:
-            chunk_id: Chunk ID (format: bank_id_document_id_chunk_index)
+            chunk_id: Self-describing chunk ID returned by the retain or document APIs
             request_context: Request context for authentication.
 
         Returns:
@@ -12283,12 +12254,14 @@ class MemoryEngine(MemoryEngineInterface):
         await self._authenticate_tenant(request_context)
 
         # A store that owns the document store keeps no SQL `chunks` row to look this id up in.
-        # The id is self-describing — retain builds it as `{bank_id}_{document_id}_{index}` — so
+        # The id is self-describing, so
         # the bank and document are recoverable from it without a row. Attempted before touching
         # SQL because for such a bank the SELECT below can only ever miss.
-        _parsed = _parse_chunk_id(chunk_id)
+        _parsed = parse_chunk_id(chunk_id)
         if _parsed is not None:
-            _cbank, _cdoc, _cidx = _parsed
+            _cbank = _parsed.bank_id
+            _cdoc = _parsed.document_id
+            _cidx = _parsed.chunk_index
             from .memories import get_memories
 
             _chunk_store = get_memories()
@@ -12410,10 +12383,9 @@ class MemoryEngine(MemoryEngineInterface):
             return {
                 "items": [
                     {
-                        # Rebuilt to the same shape retain writes
-                        # (chunk_storage.py: f"{bank_id}_{document_id}_{index}") so an id from
+                        # Rebuilt to the same shape retain writes, so an id from
                         # this route is accepted by the addressed chunk route.
-                        "chunk_id": f"{bank_id}_{document_id}_{idx}",
+                        "chunk_id": build_chunk_id(bank_id, document_id, idx),
                         "document_id": document_id,
                         "bank_id": bank_id,
                         "chunk_index": idx,

--- a/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
+++ b/hindsight-api-slim/hindsight_api/engine/reflect/tools.py
@@ -14,6 +14,8 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from ..chunk_id import parse_chunk_id
+
 if TYPE_CHECKING:
     from asyncpg import Connection
 
@@ -498,10 +500,8 @@ async def tool_expand(
     _docs_in_store = _store.store_owned_for(bank_id)
     chunk_map: dict[str, Any] = {}
     if chunk_ids and _docs_in_store:
-        # The store addresses a chunk by (document_id, index), and `chunk_id` is
-        # `{bank_id}_{document_id}_{index}` by construction — so the index is what remains once
-        # that known prefix is removed. Built from the ids in hand rather than by splitting on
-        # "_", which a bank or document id containing one would break.
+        # The store addresses a chunk by (document_id, index), while memories carry an opaque,
+        # self-describing chunk id. Parse it once and verify it still belongs to this bank/document.
         # Deduped by chunk_id: co-located memories share one chunk, and the SQL branch collapses
         # them through `= ANY($1)`. Without this the store is asked for the same chunk once per
         # memory sitting in it.
@@ -514,12 +514,12 @@ async def tool_expand(
                 continue
             if cid in _seen_chunks:
                 continue
-            suffix = cid.removeprefix(f"{bank_id}_{did}_")
-            if suffix == cid or not suffix.isdigit():
+            address = parse_chunk_id(cid)
+            if address is None or address.bank_id != bank_id or address.document_id != did:
                 continue
             _seen_chunks.add(cid)
-            refs.append((did, int(suffix)))
-            ref_owner.append({"chunk_id": cid, "document_id": did, "chunk_index": int(suffix)})
+            refs.append((did, address.chunk_index))
+            ref_owner.append({"chunk_id": cid, "document_id": did, "chunk_index": address.chunk_index})
         if refs:
             texts = await _store.get_chunk_texts(bank_id=bank_id, refs=refs)
             for owner, text in zip(ref_owner, texts):

--- a/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/chunk_storage.py
@@ -9,6 +9,7 @@ import logging
 from dataclasses import dataclass
 
 from ...config import _get_raw_config
+from ..chunk_id import build_chunk_id
 from ..memory_engine import fq_table
 from .types import ChunkMetadata
 
@@ -286,7 +287,7 @@ async def store_chunks_batch(
     chunk_id_map = {}
 
     for chunk in chunks:
-        chunk_id = f"{bank_id}_{document_id}_{chunk.chunk_index}"
+        chunk_id = build_chunk_id(bank_id, document_id, chunk.chunk_index)
         chunk_ids.append(chunk_id)
         chunk_texts.append(chunk.chunk_text if store_text else "")
         chunk_indices.append(chunk.chunk_index)

--- a/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/orchestrator.py
@@ -25,6 +25,7 @@ from ...extensions.memory_defense import (
 )
 from ...metrics import get_metrics_collector
 from ...worker.stage import set_stage
+from ..chunk_id import build_chunk_id
 from ..db_utils import acquire_with_retry
 from ..memory_engine import count_tokens, fq_table
 
@@ -754,7 +755,7 @@ async def _streaming_session_retain(
     chunk_id_by_index = {}
     if batch_chunk_meta:
         chunk_id_by_index = {
-            cm.chunk_index: f"{bank_id}_{effective_doc_id}_{cm.chunk_index}" for cm in batch_chunk_meta
+            cm.chunk_index: build_chunk_id(bank_id, effective_doc_id, cm.chunk_index) for cm in batch_chunk_meta
         }
     for fact, processed_fact in zip(batch_extracted, batch_processed, strict=True):
         processed_fact.document_id = effective_doc_id
@@ -869,7 +870,7 @@ async def _streaming_store_owned_retain(
     chunk_id_by_index = {}
     if batch_chunk_meta:
         chunk_id_by_index = {
-            cm.chunk_index: f"{bank_id}_{effective_doc_id}_{cm.chunk_index}" for cm in batch_chunk_meta
+            cm.chunk_index: build_chunk_id(bank_id, effective_doc_id, cm.chunk_index) for cm in batch_chunk_meta
         }
     for fact, processed_fact in zip(batch_extracted, batch_processed):
         processed_fact.document_id = effective_doc_id
@@ -1029,7 +1030,7 @@ async def _delta_store_owned_write(
     # Deterministic chunk ids for the new/changed chunks, after the delta remap, so a fact's
     # chunk_id matches the chunk that carries it.
     chunk_id_by_index = {
-        cm.chunk_index: f"{bank_id}_{effective_doc_id}_{cm.chunk_index}" for cm in (new_chunk_metadata or [])
+        cm.chunk_index: build_chunk_id(bank_id, effective_doc_id, cm.chunk_index) for cm in (new_chunk_metadata or [])
     }
     for ef, pf in zip(extracted_facts, processed_facts):
         pf.document_id = effective_doc_id
@@ -1300,8 +1301,7 @@ async def retain_batch(
     only re-processes chunks whose content has changed. Unchanged chunks keep
     their existing facts, entities, and links.
 
-    ``chunk_index_offset`` shifts the chunk_index (and therefore the derived
-    ``chunk_id = {bank}_{doc}_{index}``) of every chunk this call stores. The
+    ``chunk_index_offset`` shifts the chunk_index encoded in every chunk ID this call stores. The
     in-process splitter slices an oversized single item into several
     sub-batches that all share one document_id and run sequentially; without
     a per-document offset each sub-batch would restart chunk_index at 0, so
@@ -2783,8 +2783,8 @@ async def _streaming_retain_batch(
         for global_idx, content, extracted, processed, chunk_meta, usage in batch:
             content_idx_in_batch = len(batch_contents)
             # Adjust chunk indices to use the original global position (global_idx)
-            # so that chunk_id = {bank}_{doc}_{chunk_index} is deterministic regardless
-            # of task completion order. content_index is batch-relative for result grouping.
+            # so that the chunk ID is deterministic regardless of task completion order.
+            # content_index is batch-relative for result grouping.
             #
             # chunk_index_offset continues the document's chunk_index sequence
             # when this call is one of several sequential sub-batches sliced
@@ -3598,8 +3598,8 @@ async def _try_delta_retain(
     # between this read and the write. The write TXN verifies the hash hasn't
     # changed; if it has, we fall back to streaming (which has full protection).
     if _store_owned_delta:
-        # The same two reads, asked of the store that actually holds them. A chunk_id is
-        # `{bank_id}_{document_id}_{index}` by construction, so the records carry no separate id,
+        # The same two reads, asked of the store that actually holds them. Chunk ids are
+        # deterministic from bank, document, and index, so the records carry no separate id,
         # and the hash is recomputed with the same function that wrote it — the comparison below
         # is against like. ONE record read, not two: it carries the content hash, the text when
         # asked for it, and the watermark the write below compare-and-sets against. All three come
@@ -3631,7 +3631,7 @@ async def _try_delta_retain(
         # arrive at a value the first read already had.
         existing_chunks = [
             chunk_storage.ExistingChunk(
-                chunk_id=f"{bank_id}_{effective_doc_id}_{index}",
+                chunk_id=build_chunk_id(bank_id, effective_doc_id, index),
                 chunk_index=index,
                 content_hash=chunk_hash,
             )

--- a/hindsight-api-slim/hindsight_api/engine/transfer/export.py
+++ b/hindsight-api-slim/hindsight_api/engine/transfer/export.py
@@ -23,6 +23,7 @@ from uuid import UUID
 import anyio.to_thread
 
 from ..causal_links import CAUSAL_LINK_TYPES
+from ..chunk_id import parse_chunk_id
 from ..db_utils import acquire_with_retry
 from ..metadata_utils import as_string_metadata
 from ..schema import fq_table
@@ -170,17 +171,9 @@ def _as_jsonb(value: Any) -> Any:
 
 
 def _chunk_index_from_chunk_id(chunk_id: str | None) -> int | None:
-    """Recover the chunk ordinal from a ``{bank_id}_{document_id}_{index}`` chunk_id.
-
-    The index is always the final underscore-delimited segment, so rsplit is
-    correct even when bank/document ids themselves contain underscores.
-    """
-    if not chunk_id:
-        return None
-    try:
-        return int(chunk_id.rsplit("_", 1)[1])
-    except (IndexError, ValueError):
-        return None
+    """Recover the chunk ordinal from a current or legacy chunk id."""
+    address = parse_chunk_id(chunk_id)
+    return address.chunk_index if address is not None else None
 
 
 def _resolve_memories(memories: Any) -> Any:

--- a/hindsight-api-slim/tests/test_chunk_id_bank_isolation.py
+++ b/hindsight-api-slim/tests/test_chunk_id_bank_isolation.py
@@ -1,0 +1,45 @@
+"""Regression coverage for cross-bank chunk identifier collisions."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_retain_keeps_chunks_isolated_when_bank_and_document_boundaries_overlap(memory, request_context):
+    first_bank = "a"
+    first_document = "b_c"
+    second_bank = "a_b"
+    second_document = "c"
+
+    try:
+        await memory.retain_async(
+            bank_id=first_bank,
+            content="FIRST_BANK_CONTENT Alice works at Acme.",
+            document_id=first_document,
+            request_context=request_context,
+        )
+        await memory.retain_async(
+            bank_id=second_bank,
+            content="SECOND_BANK_CONTENT Bob works at Beta.",
+            document_id=second_document,
+            request_context=request_context,
+        )
+
+        first_chunks = await memory.list_document_chunks(
+            first_bank,
+            first_document,
+            request_context=request_context,
+        )
+        second_chunks = await memory.list_document_chunks(
+            second_bank,
+            second_document,
+            request_context=request_context,
+        )
+
+        assert first_chunks["total"] == 1
+        assert second_chunks["total"] == 1
+        assert first_chunks["items"][0]["chunk_text"].startswith("FIRST_BANK_CONTENT")
+        assert second_chunks["items"][0]["chunk_text"].startswith("SECOND_BANK_CONTENT")
+        assert first_chunks["items"][0]["chunk_id"] != second_chunks["items"][0]["chunk_id"]
+    finally:
+        await memory.delete_bank(first_bank, request_context=request_context)
+        await memory.delete_bank(second_bank, request_context=request_context)

--- a/hindsight-api-slim/tests/test_document_transfer.py
+++ b/hindsight-api-slim/tests/test_document_transfer.py
@@ -197,6 +197,7 @@ async def test_import_filters_degenerate_fact_without_shifting_archive_ordinals(
 
         chunks = await memory.list_document_chunks(dst, document_id, limit=10, request_context=request_context)
         assert sorted(chunk["chunk_index"] for chunk in chunks["items"]) == [0, 1, 2, 3]
+        chunk_id_by_index = {chunk["chunk_index"]: chunk["chunk_id"] for chunk in chunks["items"]}
 
         backend = await memory._get_backend()
         async with acquire_with_retry(backend) as conn:
@@ -217,9 +218,9 @@ async def test_import_filters_degenerate_fact_without_shifting_archive_ordinals(
 
         units_by_text = {unit["text"]: unit for unit in units}
         assert "..." not in units_by_text
-        assert units_by_text[initial_text]["chunk_id"] == f"{dst}_{document_id}_0"
-        assert units_by_text[middle_text]["chunk_id"] == f"{dst}_{document_id}_2"
-        assert units_by_text[later_text]["chunk_id"] == f"{dst}_{document_id}_3"
+        assert units_by_text[initial_text]["chunk_id"] == chunk_id_by_index[0]
+        assert units_by_text[middle_text]["chunk_id"] == chunk_id_by_index[2]
+        assert units_by_text[later_text]["chunk_id"] == chunk_id_by_index[3]
         assert {str(source_id) for source_id in units_by_text[observation_text]["source_memory_ids"]} == {
             str(units_by_text[later_text]["id"])
         }


### PR DESCRIPTION
## Summary

- replace ambiguous underscore-joined chunk IDs with versioned, length-prefixed IDs
- centralize chunk ID construction/parsing and retain legacy ID parsing for existing data
- update store-owned and transfer paths to treat chunk IDs consistently
- add a public-API regression test for the `(a, b_c)` / `(a_b, c)` collision

## Testing

- `ruff check` on all changed Python files
- `ty check` on all changed production Python files
- `pytest -q -n 0 tests/test_reflect_tools.py` (18 passed)
- `python -m compileall -q hindsight_api`

The new PostgreSQL-backed regression test was collected successfully but could not run to completion on this Windows host because local pg0 loopback connections timed out after the server reported ready.

Fixes #4244
