### PR TITLE
refactor(config): make HindsightConfig the only parser of HINDSIGHT_API_* env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -542,8 +542,45 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS=1000
 
 # -----------------------------------------------------------------------------
+# Operations (Optional)
+# -----------------------------------------------------------------------------
+
+# Where `--daemon` redirects the server's stdout/stderr. Set this per profile when
+# several daemons share a machine, so their output does not interleave.
+# HINDSIGHT_API_DAEMON_LOG=~/.hindsight/daemon.log
+
+# Periodic CPU profile, as JSON. Absent = profiling off.
+# HINDSIGHT_API_PROFILE={"every": 60, "top": 20, "mode": "cprofile"}
+
+# How long a task the store shed for backpressure is held before being retried.
+# Deferrals do not count against HINDSIGHT_API_WORKER_MAX_RETRIES.
+# HINDSIGHT_API_BACKPRESSURE_DEFER_SECONDS=120
+
+# Legacy MCP bearer token, checked before the TenantExtension's own auth.
+# HINDSIGHT_API_MCP_AUTH_TOKEN=your-mcp-token
+
+# -----------------------------------------------------------------------------
+# SuperGrok OAuth provider (Optional; HINDSIGHT_API_LLM_PROVIDER=xai-oauth)
+# -----------------------------------------------------------------------------
+
+# All optional — the defaults match the vendor's own client. Log in once with
+# `python -m hindsight_api.engine.providers.xai_oauth_auth login`.
+# HINDSIGHT_API_XAI_OAUTH_TOKEN_PATH=~/.hindsight/xai_oauth.json
+# HINDSIGHT_API_XAI_OAUTH_BASE_URL=https://api.x.ai/v1
+# HINDSIGHT_API_XAI_OAUTH_CLIENT_ID=your-oauth-client-id
+# HINDSIGHT_API_XAI_OAUTH_SCOPE=openid profile email offline_access
+# HINDSIGHT_API_XAI_OAUTH_REFRESH_SKEW_SECONDS=60
+# HINDSIGHT_API_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS=20
+# Debug-only: logs an allowlist of response headers on a non-2xx reply.
+# HINDSIGHT_API_XAI_OAUTH_DEBUG_HEADERS=false
+
+# -----------------------------------------------------------------------------
 # Extensions (Optional)
 # -----------------------------------------------------------------------------
+
+# Your own FileStorage implementation, used instead of the built-in backends.
+# Every other HINDSIGHT_API_FILE_STORAGE_* variable is passed to it as config.
+# HINDSIGHT_API_FILE_STORAGE_EXTENSION=my_package.storage:MyStorage
 
 # Request headers copied into RequestContext.extra_headers so a custom
 # TenantExtension / OperationValidatorExtension can read them. Comma-separated,

--- a/hindsight-api-slim/hindsight_api/_vector_index.py
+++ b/hindsight-api-slim/hindsight_api/_vector_index.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
@@ -163,13 +162,17 @@ _INSTALL_HINTS = {
 def configured_vector_extension() -> str:
     """Return the user-configured vector backend extension.
 
-    Reads ``HINDSIGHT_API_VECTOR_EXTENSION`` (default ``"pgvector"``) and
-    validates it via :func:`validate_extension`. This is the single source of
-    truth for runtime code that needs to dispatch behaviour by vector backend;
-    callers should prefer this over reading the env var directly, so the
-    default value and the lookup mechanism live in one place.
+    Reads ``vector_extension`` off the resolved config, which is where
+    ``HINDSIGHT_API_VECTOR_EXTENSION`` and its default are parsed. This is the single
+    source of truth for runtime code that needs to dispatch behaviour by vector
+    backend; callers should prefer this over reading the env var directly.
+
+    The config import is deferred because ``config.py`` imports this module for
+    :func:`validate_extension` — at module scope the two would form a cycle.
     """
-    return validate_extension(os.getenv("HINDSIGHT_API_VECTOR_EXTENSION", "pgvector"))
+    from .config import get_config
+
+    return validate_extension(get_config().vector_extension)
 
 
 def validate_extension(name: str) -> str:

--- a/hindsight-api-slim/hindsight_api/alembic/_owned.py
+++ b/hindsight-api-slim/hindsight_api/alembic/_owned.py
@@ -48,10 +48,15 @@ from alembic import op
 
 logger = logging.getLogger(__name__)
 
+
 ENV_EXTERNALLY_OWNED_ROUTINES = "HINDSIGHT_API_EXTERNALLY_OWNED_ROUTINES"
 
 
 def _owned() -> frozenset[str]:
+    # Read from the environment, not HindsightConfig, and deliberately so: migrations
+    # run under standalone Alembic, in a process that may have no application config —
+    # and this is read at call time, so a value set after start-up still applies.
+    # Exempted in tests/test_config_is_the_only_env_reader.py, with alembic/env.py.
     raw = os.environ.get(ENV_EXTERNALLY_OWNED_ROUTINES, "")
     return frozenset(part.strip() for part in raw.split(",") if part.strip())
 

--- a/hindsight-api-slim/hindsight_api/api/mcp.py
+++ b/hindsight-api-slim/hindsight_api/api/mcp.py
@@ -10,15 +10,20 @@ from fastmcp import FastMCP
 from hindsight_api import MemoryEngine
 from hindsight_api import __version__ as HINDSIGHT_VERSION
 from hindsight_api.api.passthrough_headers import collect_passthrough_headers
-from hindsight_api.config import DEFAULT_MCP_RECALL_DESCRIPTION, DEFAULT_MCP_RETAIN_DESCRIPTION, _get_raw_config
+from hindsight_api.config import (
+    DEFAULT_MCP_RECALL_DESCRIPTION,
+    DEFAULT_MCP_RETAIN_DESCRIPTION,
+    _get_raw_config,
+    get_config,
+)
 from hindsight_api.engine.memory_engine import _current_schema
 from hindsight_api.extensions import MCPExtension, load_extension
 from hindsight_api.extensions.tenant import AuthenticationError
 from hindsight_api.mcp_tools import _ALL_TOOLS, MCPToolsConfig, register_mcp_tools
 from hindsight_api.models import RequestContext
 
-# Configure logging from HINDSIGHT_API_LOG_LEVEL environment variable
-_log_level_str = os.environ.get("HINDSIGHT_API_LOG_LEVEL", "info").lower()
+# Configure logging from the resolved config (HINDSIGHT_API_LOG_LEVEL).
+_log_level_str = get_config().log_level.lower()
 _log_level_map = {
     "critical": logging.CRITICAL,
     "error": logging.ERROR,
@@ -38,7 +43,7 @@ DEFAULT_BANK_ID = os.environ.get("HINDSIGHT_MCP_BANK_ID", "default")
 
 # Legacy MCP authentication token (for backwards compatibility)
 # If set, this token is checked first before TenantExtension auth
-MCP_AUTH_TOKEN = os.environ.get("HINDSIGHT_API_MCP_AUTH_TOKEN")
+MCP_AUTH_TOKEN = get_config().mcp_auth_token
 
 # Context variable to hold the current bank_id
 _current_bank_id: ContextVar[str | None] = ContextVar("current_bank_id", default=None)

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -333,6 +333,22 @@ def _parse_boolean_env(env_name: str, default: bool) -> bool:
     raise ValueError(f"Invalid {env_name} value {raw!r}: expected true, false, 1, or 0")
 
 
+def _parse_float_env(env_name: str, default: float) -> float:
+    """Parse a float environment variable, falling back on an unusable value.
+
+    Deliberately lenient: these tune a refresh loop, and a typo that halted start-up
+    would be a worse outcome than one that runs on the documented default and says so.
+    """
+    raw = os.getenv(env_name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Ignoring non-numeric %s; using %s", env_name, default)
+        return default
+
+
 def _parse_tristate_bool(env_name: str, raw: str | None) -> bool | None:
     """Parse a boolean env var whose *absence* is meaningful, not just a default.
 
@@ -615,10 +631,16 @@ ENV_LOG_FORMAT = "HINDSIGHT_API_LOG_FORMAT"
 ENV_LOG_JSON_FIELDS = "HINDSIGHT_API_LOG_JSON_FIELDS"
 ENV_WORKERS = "HINDSIGHT_API_WORKERS"
 ENV_ACCESS_LOG = "HINDSIGHT_API_ACCESS_LOG"
+# Path the daemon redirects its stdio to. Set per-profile by hindsight-embed so
+# concurrent profiles do not interleave into one log.
+ENV_DAEMON_LOG = "HINDSIGHT_API_DAEMON_LOG"
+# JSON: {"every": <seconds>, "top": <frames>, "mode": "cprofile"}. Absent = profiling off.
+ENV_PROFILE = "HINDSIGHT_API_PROFILE"
 ENV_MCP_ENABLED = "HINDSIGHT_API_MCP_ENABLED"
 ENV_MCP_ENABLED_TOOLS = "HINDSIGHT_API_MCP_ENABLED_TOOLS"
 ENV_MCP_STATELESS = "HINDSIGHT_API_MCP_STATELESS"
 ENV_MCP_INSTRUCTIONS = "HINDSIGHT_API_MCP_INSTRUCTIONS"
+ENV_MCP_AUTH_TOKEN = "HINDSIGHT_API_MCP_AUTH_TOKEN"
 ENV_ENABLE_BANK_CONFIG_API = "HINDSIGHT_API_ENABLE_BANK_CONFIG_API"
 ENV_ENABLE_BANK_LLM_HEALTH = "HINDSIGHT_API_ENABLE_BANK_LLM_HEALTH"
 ENV_ENABLE_DRY_RUN_EXTRACT = "HINDSIGHT_API_ENABLE_DRY_RUN_EXTRACT"
@@ -627,7 +649,6 @@ ENV_GRAPH_RETRIEVER = "HINDSIGHT_API_GRAPH_RETRIEVER"
 ENV_RECALL_MAX_CONCURRENT = "HINDSIGHT_API_RECALL_MAX_CONCURRENT"
 ENV_RECALL_CONNECTION_BUDGET = "HINDSIGHT_API_RECALL_CONNECTION_BUDGET"
 ENV_RECALL_MAX_QUERY_TOKENS = "HINDSIGHT_API_RECALL_MAX_QUERY_TOKENS"
-ENV_MENTAL_MODEL_REFRESH_CONCURRENCY = "HINDSIGHT_API_MENTAL_MODEL_REFRESH_CONCURRENCY"
 ENV_LINK_EXPANSION_PER_ENTITY_LIMIT = "HINDSIGHT_API_LINK_EXPANSION_PER_ENTITY_LIMIT"
 ENV_LINK_EXPANSION_TIMEOUT = "HINDSIGHT_API_LINK_EXPANSION_TIMEOUT"
 ENV_RETAIN_BATCH_DOCUMENT_WRITES = "HINDSIGHT_API_RETAIN_BATCH_DOCUMENT_WRITES"
@@ -661,6 +682,16 @@ ENV_DB_ACQUIRE_WARN_THRESHOLD_MS = "HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS"
 # CODEX_HOME for the primary LLM; indexed members set their own
 # (HINDSIGHT_API_<OP>LLM_<n>_CODEX_HOME) so a chain can span two profiles.
 ENV_LLM_CODEX_HOME = "HINDSIGHT_API_LLM_CODEX_HOME"
+
+# xai-oauth provider. The token store is written by the `login` entrypoint and read on
+# every call; the rest exist so a deployment can point at a different OAuth app.
+ENV_XAI_OAUTH_TOKEN_PATH = "HINDSIGHT_API_XAI_OAUTH_TOKEN_PATH"
+ENV_XAI_OAUTH_CLIENT_ID = "HINDSIGHT_API_XAI_OAUTH_CLIENT_ID"
+ENV_XAI_OAUTH_SCOPE = "HINDSIGHT_API_XAI_OAUTH_SCOPE"
+ENV_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS = "HINDSIGHT_API_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS"
+ENV_XAI_OAUTH_REFRESH_SKEW_SECONDS = "HINDSIGHT_API_XAI_OAUTH_REFRESH_SKEW_SECONDS"
+ENV_XAI_OAUTH_BASE_URL = "HINDSIGHT_API_XAI_OAUTH_BASE_URL"
+ENV_XAI_OAUTH_DEBUG_HEADERS = "HINDSIGHT_API_XAI_OAUTH_DEBUG_HEADERS"
 
 # Vertex AI configuration
 ENV_LLM_VERTEXAI_PROJECT_ID = "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID"
@@ -714,6 +745,10 @@ ENV_RETAIN_MAX_ATTACHMENTS_PER_CHUNK = "HINDSIGHT_API_RETAIN_MAX_ATTACHMENTS_PER
 
 # File storage configuration
 ENV_FILE_STORAGE_TYPE = "HINDSIGHT_API_FILE_STORAGE_TYPE"
+# "module.path:ClassName" naming a FileStorage implementation. Every other
+# HINDSIGHT_API_FILE_STORAGE_* variable is handed to it as a lowercased config dict,
+# so those stay dynamic and are read from the environment by the storage factory.
+ENV_FILE_STORAGE_EXTENSION = "HINDSIGHT_API_FILE_STORAGE_EXTENSION"
 ENV_FILE_STORAGE_S3_BUCKET = "HINDSIGHT_API_FILE_STORAGE_S3_BUCKET"
 ENV_FILE_STORAGE_S3_REGION = "HINDSIGHT_API_FILE_STORAGE_S3_REGION"
 ENV_FILE_STORAGE_S3_ENDPOINT = "HINDSIGHT_API_FILE_STORAGE_S3_ENDPOINT"
@@ -774,7 +809,6 @@ ENV_MENTAL_MODEL_MIN_REFRESH_INTERVAL_SECONDS = "HINDSIGHT_API_MENTAL_MODEL_MIN_
 ENV_WEBHOOK_URL = "HINDSIGHT_API_WEBHOOK_URL"
 ENV_WEBHOOK_SECRET = "HINDSIGHT_API_WEBHOOK_SECRET"
 ENV_WEBHOOK_EVENT_TYPES = "HINDSIGHT_API_WEBHOOK_EVENT_TYPES"
-ENV_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS = "HINDSIGHT_API_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS"
 # SSRF hardening for outbound webhook delivery. Private/loopback/link-local
 # destinations are blocked by default; list hosts or IP/CIDRs here to re-permit
 # them (e.g. "127.0.0.1" for local testing, or an internal receiver).
@@ -828,6 +862,8 @@ ENV_WORKER_MAX_RETRIES = "HINDSIGHT_API_WORKER_MAX_RETRIES"
 ENV_WORKER_TASK_RETRY_BACKOFF_SECONDS = "HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS"
 ENV_WORKER_HTTP_PORT = "HINDSIGHT_API_WORKER_HTTP_PORT"
 ENV_WORKER_MAX_SLOTS = "HINDSIGHT_API_WORKER_MAX_SLOTS"
+# How long a task shed for store backpressure is held before it is retried.
+ENV_BACKPRESSURE_DEFER_SECONDS = "HINDSIGHT_API_BACKPRESSURE_DEFER_SECONDS"
 ENV_OPERATION_RETENTION_DAYS = "HINDSIGHT_API_OPERATION_RETENTION_DAYS"
 ENV_OPERATION_CLEANUP_BATCH_SIZE = "HINDSIGHT_API_OPERATION_CLEANUP_BATCH_SIZE"
 
@@ -1391,6 +1427,16 @@ DEFAULT_LOG_LEVEL = "info"
 DEFAULT_LOG_FORMAT = "text"  # Options: "text", "json"
 DEFAULT_WORKERS = 1
 DEFAULT_ACCESS_LOG = False
+DEFAULT_XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+DEFAULT_XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access"
+DEFAULT_XAI_OAUTH_REFRESH_SKEW_SECONDS = 60.0
+DEFAULT_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS = 20.0
+DEFAULT_XAI_OAUTH_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_XAI_OAUTH_DEBUG_HEADERS = False
+# Long enough that a fold has a real chance to drain the backlog — retrying into a
+# still-full store just sheds again and burns the claim — and short enough that a
+# cleared backlog is not left waiting. Deferrals do not count against max_retries.
+DEFAULT_BACKPRESSURE_DEFER_SECONDS = 120
 DEFAULT_MCP_ENABLED = True
 DEFAULT_MCP_ENABLED_TOOLS: list[str] | None = None  # None = all tools enabled
 DEFAULT_MCP_STATELESS = False  # False = stateful (supports SSE/GET); True = stateless (POST-only)
@@ -1408,7 +1454,6 @@ DEFAULT_GRAPH_RETRIEVER = "link_expansion"
 DEFAULT_RECALL_MAX_CONCURRENT = 32  # Max concurrent recall operations per worker
 DEFAULT_RECALL_CONNECTION_BUDGET = 4  # Max concurrent DB connections per recall operation
 DEFAULT_RECALL_MAX_QUERY_TOKENS = 500  # Maximum tokens allowed in recall query
-DEFAULT_MENTAL_MODEL_REFRESH_CONCURRENCY = 8  # Max concurrent mental model refreshes
 DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT = 200  # Max target units per entity in graph expansion
 DEFAULT_LINK_EXPANSION_TIMEOUT = 10.0  # Timeout (seconds) for entity expansion query
 # The bank's own row (name/disposition/mission) and its config, cached per process so a
@@ -1850,7 +1895,6 @@ EMBEDDING_DIMENSION = DEFAULT_EMBEDDING_DIMENSION
 DEFAULT_WEBHOOK_URL = None  # None = no global webhook configured
 DEFAULT_WEBHOOK_SECRET = None  # None = no signing
 DEFAULT_WEBHOOK_EVENT_TYPES = "consolidation.completed"  # Comma-separated; default = all supported events
-DEFAULT_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS = 30  # How often to poll for pending deliveries
 DEFAULT_WEBHOOK_ALLOWED_HOSTS: list[str] = []  # Empty = public destinations only (private ranges blocked)
 DEFAULT_WEBHOOK_EXPOSE_RESPONSE_BODY = False  # Don't return raw upstream bodies to API callers
 
@@ -2330,7 +2374,7 @@ def _parse_llm_members(prefix: str) -> list[LLMMemberConfig]:
     stops at the first index whose ``_PROVIDER`` is unset (so indices must be
     contiguous from 1). ``MODEL`` defaults to the provider's default model.
     """
-    from .engine.llm_wrapper import requires_api_key
+    from .engine.provider_auth import requires_api_key
 
     members: list[LLMMemberConfig] = []
     index = 1
@@ -2836,6 +2880,8 @@ class HindsightConfig:
     embeddings_onnx_batch_size: int
     embeddings_onnx_cpu_mem_arena: bool
     embeddings_tei_url: str | None
+    embeddings_openai_api_key: str | None
+    embeddings_openai_model: str
     embeddings_openai_base_url: str | None
     embeddings_cohere_api_key: str | None
     embeddings_cohere_model: str
@@ -2931,10 +2977,29 @@ class HindsightConfig:
     reranker_google_timeout: float
 
     # Server
-    host: str
+    # None when unset. The bind default is applied by the CLI, which also needs to
+    # tell "operator chose a host" from "took the default" — daemon mode narrows an
+    # unstated host to loopback but must honour one the operator actually set.
+    host: str | None
     port: int
     base_path: str
     log_level: str
+    workers: int
+    access_log: bool
+    daemon_log: str | None  # None = ~/.hindsight/daemon.log
+    profile: str | None  # Raw JSON; parsed by hindsight_api.profiling
+    mcp_auth_token: str | None
+    file_storage_extension: str | None  # "module.path:ClassName"
+    backpressure_defer_seconds: int
+    xai_oauth_token_path: str | None  # None = ~/.hindsight/xai_oauth.json
+    xai_oauth_client_id: str
+    xai_oauth_scope: str
+    xai_oauth_refresh_timeout_seconds: float
+    xai_oauth_refresh_skew_seconds: float
+    # None when unset: the provider only treats this as a deployment-wide override of the
+    # caller's base_url when the operator actually set it.
+    xai_oauth_base_url: str | None
+    xai_oauth_debug_headers: bool
     log_format: str
     log_json_fields: list[str] | None  # None = all fields; explicit list = allowlist
     mcp_enabled: bool
@@ -2956,7 +3021,6 @@ class HindsightConfig:
     recall_max_concurrent: int
     recall_connection_budget: int
     recall_max_query_tokens: int
-    mental_model_refresh_concurrency: int
     link_expansion_per_entity_limit: int
     link_expansion_timeout: float
     retain_batch_document_writes: bool
@@ -3133,7 +3197,10 @@ class HindsightConfig:
     otel_traces_enabled: bool
     otel_exporter_otlp_endpoint: str | None
     otel_exporter_otlp_headers: str | None
-    otel_service_name: str
+    # None when unset, so a caller can tell "operator chose a name" from "nobody said".
+    # The API default is applied at the point of use (see tracing.initialize_tracing_from_config),
+    # which is also where a per-process default like "hindsight-worker" gets its chance.
+    otel_service_name: str | None
     otel_deployment_environment: str
     metrics_include_bank_id: bool
     metrics_backlog_enabled: bool
@@ -3182,7 +3249,6 @@ class HindsightConfig:
     webhook_url: str | None  # Global webhook URL (None = disabled)
     webhook_secret: str | None  # HMAC signing secret (None = unsigned)
     webhook_event_types: list[str]  # Event types to deliver globally
-    webhook_delivery_poll_interval_seconds: int  # How often the delivery worker polls
 
     # Defaulted fields (source-compatible additions — existing direct constructor callers keep working).
     # Keep at the end of the dataclass; Python forbids non-default fields after default fields.
@@ -3302,6 +3368,7 @@ class HindsightConfig:
         "reranker_google_service_account_key",
         # Embeddings API keys
         "embeddings_gemini_api_key",
+        "embeddings_openai_api_key",
         "embeddings_zeroentropy_api_key",
         # File storage credentials
         "file_storage_s3_access_key_id",
@@ -3313,6 +3380,13 @@ class HindsightConfig:
         "file_parser_markitdown_ocr_base_url",
         "file_parser_iris_token",
         "file_parser_llama_parse_api_key",
+        # Legacy MCP bearer token, checked ahead of the tenant extension's own auth.
+        "mcp_auth_token",
+        # xai-oauth: the client id and the token-store path both describe how this
+        # deployment authenticates, and the store path points at a file holding a grant.
+        "xai_oauth_client_id",
+        "xai_oauth_token_path",
+        "xai_oauth_base_url",
     }
 
     # CONFIGURABLE_FIELDS: Safe behavioral settings that can be customized per-tenant/bank
@@ -4004,6 +4078,10 @@ class HindsightConfig:
             ).lower()
             == "true",
             embeddings_tei_url=os.getenv(ENV_EMBEDDINGS_TEI_URL),
+            # Falls back to the shared LLM key, the way every other OpenAI-compatible
+            # embeddings provider here does: one key configured once covers both.
+            embeddings_openai_api_key=(os.getenv(ENV_EMBEDDINGS_OPENAI_API_KEY) or os.getenv(ENV_LLM_API_KEY)),
+            embeddings_openai_model=os.getenv(ENV_EMBEDDINGS_OPENAI_MODEL, DEFAULT_EMBEDDINGS_OPENAI_MODEL),
             embeddings_openai_base_url=os.getenv(ENV_EMBEDDINGS_OPENAI_BASE_URL) or None,
             embeddings_openai_batch_size=_parse_positive_int(
                 ENV_EMBEDDINGS_OPENAI_BATCH_SIZE,
@@ -4306,10 +4384,33 @@ class HindsightConfig:
             reranker_google_timeout=float(os.getenv(ENV_RERANKER_GOOGLE_TIMEOUT, str(DEFAULT_RERANKER_GOOGLE_TIMEOUT))),
             reranker_members=_parse_reranker_members(),
             # Server
-            host=os.getenv(ENV_HOST, DEFAULT_HOST),
+            host=os.getenv(ENV_HOST) or None,
             port=int(os.getenv(ENV_PORT, DEFAULT_PORT)),
             base_path=os.getenv(ENV_BASE_PATH, DEFAULT_BASE_PATH),
             log_level=os.getenv(ENV_LOG_LEVEL, DEFAULT_LOG_LEVEL),
+            workers=int(os.getenv(ENV_WORKERS, str(DEFAULT_WORKERS))),
+            # "yes"/"on" have always been accepted here; keep the vocabulary rather than
+            # turn a working deployment's value into a start-up error.
+            access_log=os.getenv(ENV_ACCESS_LOG, "").lower() in ("1", "true", "yes", "on") or DEFAULT_ACCESS_LOG,
+            daemon_log=os.getenv(ENV_DAEMON_LOG) or None,
+            profile=os.getenv(ENV_PROFILE, "").strip() or None,
+            mcp_auth_token=os.getenv(ENV_MCP_AUTH_TOKEN) or None,
+            file_storage_extension=os.getenv(ENV_FILE_STORAGE_EXTENSION) or None,
+            backpressure_defer_seconds=int(
+                os.getenv(ENV_BACKPRESSURE_DEFER_SECONDS, str(DEFAULT_BACKPRESSURE_DEFER_SECONDS))
+            ),
+            xai_oauth_token_path=os.getenv(ENV_XAI_OAUTH_TOKEN_PATH, "").strip() or None,
+            xai_oauth_client_id=os.getenv(ENV_XAI_OAUTH_CLIENT_ID, "").strip() or DEFAULT_XAI_OAUTH_CLIENT_ID,
+            xai_oauth_scope=os.getenv(ENV_XAI_OAUTH_SCOPE, "").strip() or DEFAULT_XAI_OAUTH_SCOPE,
+            xai_oauth_refresh_timeout_seconds=_parse_float_env(
+                ENV_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS, DEFAULT_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS
+            ),
+            xai_oauth_refresh_skew_seconds=_parse_float_env(
+                ENV_XAI_OAUTH_REFRESH_SKEW_SECONDS, DEFAULT_XAI_OAUTH_REFRESH_SKEW_SECONDS
+            ),
+            xai_oauth_base_url=(os.getenv(ENV_XAI_OAUTH_BASE_URL, "").strip() or None),
+            xai_oauth_debug_headers=os.getenv(ENV_XAI_OAUTH_DEBUG_HEADERS, str(DEFAULT_XAI_OAUTH_DEBUG_HEADERS)).lower()
+            == "true",
             log_format=os.getenv(ENV_LOG_FORMAT, DEFAULT_LOG_FORMAT).lower(),
             log_json_fields=_parse_str_list(os.getenv(ENV_LOG_JSON_FIELDS, "")) or None,
             mcp_enabled=os.getenv(ENV_MCP_ENABLED, str(DEFAULT_MCP_ENABLED)).lower() == "true",
@@ -4334,9 +4435,6 @@ class HindsightConfig:
                 os.getenv(ENV_RECALL_CONNECTION_BUDGET, str(DEFAULT_RECALL_CONNECTION_BUDGET))
             ),
             recall_max_query_tokens=int(os.getenv(ENV_RECALL_MAX_QUERY_TOKENS, str(DEFAULT_RECALL_MAX_QUERY_TOKENS))),
-            mental_model_refresh_concurrency=int(
-                os.getenv(ENV_MENTAL_MODEL_REFRESH_CONCURRENCY, str(DEFAULT_MENTAL_MODEL_REFRESH_CONCURRENCY))
-            ),
             link_expansion_per_entity_limit=int(
                 os.getenv(ENV_LINK_EXPANSION_PER_ENTITY_LIMIT, str(DEFAULT_LINK_EXPANSION_PER_ENTITY_LIMIT))
             ),
@@ -4686,7 +4784,7 @@ class HindsightConfig:
             in ("true", "1", "yes"),
             otel_exporter_otlp_endpoint=os.getenv(ENV_OTEL_EXPORTER_OTLP_ENDPOINT) or None,
             otel_exporter_otlp_headers=os.getenv(ENV_OTEL_EXPORTER_OTLP_HEADERS) or None,
-            otel_service_name=os.getenv(ENV_OTEL_SERVICE_NAME, DEFAULT_OTEL_SERVICE_NAME),
+            otel_service_name=os.getenv(ENV_OTEL_SERVICE_NAME) or None,
             otel_deployment_environment=os.getenv(ENV_OTEL_DEPLOYMENT_ENVIRONMENT, DEFAULT_OTEL_DEPLOYMENT_ENVIRONMENT),
             metrics_include_bank_id=os.getenv(ENV_METRICS_INCLUDE_BANK_ID, str(DEFAULT_METRICS_INCLUDE_BANK_ID)).lower()
             in ("true", "1", "yes"),
@@ -4772,12 +4870,6 @@ class HindsightConfig:
                 for t in os.getenv(ENV_WEBHOOK_EVENT_TYPES, DEFAULT_WEBHOOK_EVENT_TYPES).split(",")
                 if t.strip()
             ],
-            webhook_delivery_poll_interval_seconds=int(
-                os.getenv(
-                    ENV_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS,
-                    str(DEFAULT_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS),
-                )
-            ),
             webhook_allowed_hosts=[h.strip() for h in os.getenv(ENV_WEBHOOK_ALLOWED_HOSTS, "").split(",") if h.strip()],
             webhook_expose_response_body=_parse_boolean_env(
                 ENV_WEBHOOK_EXPOSE_RESPONSE_BODY, DEFAULT_WEBHOOK_EXPOSE_RESPONSE_BODY

--- a/hindsight-api-slim/hindsight_api/config.py
+++ b/hindsight-api-slim/hindsight_api/config.py
@@ -38,8 +38,18 @@ def load_dotenv_for_entrypoint() -> None:
     is authoritative over the ambient process environment). Because a library
     import never reaches this code path, that precedence no longer leaks into
     embedders.
+
+    The cache clear matters as much as the load. ``HindsightConfig`` is built once and
+    cached for the process, and an entry point imports its whole module graph before
+    ``main()`` reaches this call — so a module that reads the config at import scope
+    (``llm_wrapper`` sizes its semaphores there, for one) has already frozen a config
+    built from an environment the ``.env`` had not been applied to. Leaving that in
+    place makes the discovered ``.env`` silently ineffective for every later reader.
+    Clearing here means the next read rebuilds against the environment this function
+    just finished assembling.
     """
     load_dotenv(find_dotenv(usecwd=True), override=True)
+    clear_config_cache()
 
 
 class ConfigFieldAccessError(AttributeError):

--- a/hindsight-api-slim/hindsight_api/daemon.py
+++ b/hindsight-api-slim/hindsight_api/daemon.py
@@ -19,13 +19,24 @@ import sys
 from pathlib import Path
 from typing import IO
 
-from .config import get_config
+from .config import ENV_DAEMON_LOG, get_config
 
 # Default daemon configuration
 DEFAULT_DAEMON_PORT = 8888
 
-# Allow override via configuration (HINDSIGHT_API_DAEMON_LOG) for profile-specific logs
-DAEMON_LOG_PATH = Path(get_config().daemon_log or Path.home() / ".hindsight" / "daemon.log")
+
+def daemon_log_path() -> Path:
+    """Where the daemon redirects its stdio (HINDSIGHT_API_DAEMON_LOG).
+
+    Resolved per call, not once at import: this module is imported by ``main`` at
+    module scope, which is *before* ``main()`` runs ``load_dotenv_for_entrypoint()``.
+    Reading the config here at import time would build and cache it from an
+    environment that has not yet had the discovered ``.env`` applied — and since that
+    config is then cached for the process, every later reader would see the wrong
+    values too (a whole `.env` silently ignored).
+    """
+    return Path(get_config().daemon_log or Path.home() / ".hindsight" / "daemon.log")
+
 
 # Internal env var: set by daemonize() in the re-exec'd child so the child
 # skips re-exec and just redirects stdio.  Also set by hindsight-embed's
@@ -67,7 +78,7 @@ def _redirect_stdio_to_log() -> None:
 
     Called in the daemon child process after re-exec.
     """
-    DAEMON_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    daemon_log_path().parent.mkdir(parents=True, exist_ok=True)
 
     sys.stdout.flush()
     sys.stderr.flush()
@@ -75,7 +86,7 @@ def _redirect_stdio_to_log() -> None:
     with open(os.devnull, "r") as devnull:
         os.dup2(devnull.fileno(), sys.stdin.fileno())
 
-    log_fd = open(DAEMON_LOG_PATH, "a")
+    log_fd = open(daemon_log_path(), "a")
     os.dup2(log_fd.fileno(), sys.stdout.fileno())
     os.dup2(log_fd.fileno(), sys.stderr.fileno())
 
@@ -104,7 +115,7 @@ def daemonize():
     We still ensure the log directory exists.
     """
     if sys.platform == "win32":
-        DAEMON_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        daemon_log_path().parent.mkdir(parents=True, exist_ok=True)
         return
 
     # If we are already the daemon child (re-exec'd by a previous daemonize()
@@ -123,11 +134,11 @@ def daemonize():
 
     env = os.environ.copy()
     env[ENV_DAEMON_CHILD] = "1"
-    env["HINDSIGHT_API_DAEMON_LOG"] = str(DAEMON_LOG_PATH)
+    env[ENV_DAEMON_LOG] = str(daemon_log_path())
 
-    DAEMON_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    daemon_log_path().parent.mkdir(parents=True, exist_ok=True)
 
-    with open(DAEMON_LOG_PATH, "ab") as log_handle:
+    with open(daemon_log_path(), "ab") as log_handle:
         subprocess.Popen(cmd, env=env, **_detach_popen_kwargs(log_handle))
 
     sys.exit(0)

--- a/hindsight-api-slim/hindsight_api/daemon.py
+++ b/hindsight-api-slim/hindsight_api/daemon.py
@@ -19,11 +19,13 @@ import sys
 from pathlib import Path
 from typing import IO
 
+from .config import get_config
+
 # Default daemon configuration
 DEFAULT_DAEMON_PORT = 8888
 
-# Allow override via environment variable for profile-specific logs
-DAEMON_LOG_PATH = Path(os.getenv("HINDSIGHT_API_DAEMON_LOG", str(Path.home() / ".hindsight" / "daemon.log")))
+# Allow override via configuration (HINDSIGHT_API_DAEMON_LOG) for profile-specific logs
+DAEMON_LOG_PATH = Path(get_config().daemon_log or Path.home() / ".hindsight" / "daemon.log")
 
 # Internal env var: set by daemonize() in the re-exec'd child so the child
 # skips re-exec and just redirects stdio.  Also set by hindsight-embed's

--- a/hindsight-api-slim/hindsight_api/engine/embeddings.py
+++ b/hindsight-api-slim/hindsight_api/engine/embeddings.py
@@ -46,8 +46,6 @@ from ..config import (
     ENV_EMBEDDINGS_GEMINI_API_KEY,
     ENV_EMBEDDINGS_LITELLM_DIMENSIONS,
     ENV_EMBEDDINGS_OPENAI_API_KEY,
-    ENV_EMBEDDINGS_OPENAI_BASE_URL,
-    ENV_EMBEDDINGS_OPENAI_MODEL,
     ENV_EMBEDDINGS_PROVIDER,
     ENV_EMBEDDINGS_TEI_URL,
     ENV_EMBEDDINGS_ZEROENTROPY_API_KEY,
@@ -2177,14 +2175,14 @@ def create_embeddings_from_env() -> Embeddings:
         )
     elif provider == "openai":
         # Use dedicated embeddings API key, or fall back to LLM API key
-        api_key = os.environ.get(ENV_EMBEDDINGS_OPENAI_API_KEY) or os.environ.get(ENV_LLM_API_KEY)
+        api_key = config.embeddings_openai_api_key
         if not api_key:
             raise ValueError(
                 f"{ENV_EMBEDDINGS_OPENAI_API_KEY} or {ENV_LLM_API_KEY} is required "
                 f"when {ENV_EMBEDDINGS_PROVIDER} is 'openai'"
             )
-        model = os.environ.get(ENV_EMBEDDINGS_OPENAI_MODEL, DEFAULT_EMBEDDINGS_OPENAI_MODEL)
-        base_url = os.environ.get(ENV_EMBEDDINGS_OPENAI_BASE_URL) or None
+        model = config.embeddings_openai_model
+        base_url = config.embeddings_openai_base_url
         return _with_request_concurrency(
             OpenAIEmbeddings(
                 api_key=api_key,
@@ -2198,7 +2196,7 @@ def create_embeddings_from_env() -> Embeddings:
             config,
         )
     elif provider == "openai-codex":
-        model = os.environ.get(ENV_EMBEDDINGS_OPENAI_MODEL, DEFAULT_EMBEDDINGS_OPENAI_MODEL)
+        model = config.embeddings_openai_model
         return _with_request_concurrency(
             CodexOAuthEmbeddings(
                 model=model,

--- a/hindsight-api-slim/hindsight_api/engine/llm_transport.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_transport.py
@@ -21,15 +21,13 @@ exactly ``llm_timeout`` and the logs could not say which phase was stuck.
 from __future__ import annotations
 
 import logging
-import os
 
 import httpx
 
 from ..config import (
-    DEFAULT_LLM_CONNECT_TIMEOUT,
     DEFAULT_LLM_HTTP_LOG_LEVEL,
-    ENV_LLM_CONNECT_TIMEOUT,
     ENV_LLM_HTTP_LOG_LEVEL,
+    get_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -51,7 +49,7 @@ def build_sdk_timeout(total: float) -> httpx.Timeout:
     rather than consuming the whole request budget. Setting that variable to 0
     restores the old behaviour of one value across all four phases.
     """
-    connect_cap = float(os.getenv(ENV_LLM_CONNECT_TIMEOUT, str(DEFAULT_LLM_CONNECT_TIMEOUT)))
+    connect_cap = get_config().llm_connect_timeout
     if connect_cap <= 0:
         return httpx.Timeout(total)
     return httpx.Timeout(total, connect=min(connect_cap, total))
@@ -120,7 +118,7 @@ def configure_http_logging() -> None:
     in (``connect_tcp``, ``send_request_headers``, ``receive_response_headers``),
     which is what tells a hung LLM call apart from a slow one.
     """
-    raw = os.getenv(ENV_LLM_HTTP_LOG_LEVEL, DEFAULT_LLM_HTTP_LOG_LEVEL).strip().upper()
+    raw = get_config().llm_http_log_level.strip().upper()
     level = logging.getLevelName(raw)
     if not isinstance(level, int):
         logger.warning(f"{ENV_LLM_HTTP_LOG_LEVEL}={raw!r} is not a log level; using {DEFAULT_LLM_HTTP_LOG_LEVEL}")

--- a/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
+++ b/hindsight-api-slim/hindsight_api/engine/llm_wrapper.py
@@ -4,7 +4,6 @@ LLM wrapper for unified configuration across providers.
 
 import json
 import logging
-import os
 import re
 import time
 import uuid
@@ -26,11 +25,10 @@ except ImportError:
     VERTEXAI_AVAILABLE = False
 
 from ..config import (
-    DEFAULT_LLM_MAX_CONCURRENT,
     ENV_CONSOLIDATION_LLM_MAX_CONCURRENT,
-    ENV_LLM_MAX_CONCURRENT,
     ENV_REFLECT_LLM_MAX_CONCURRENT,
     ENV_RETAIN_LLM_MAX_CONCURRENT,
+    _get_raw_config,
 )
 from .cache_affinity import parse_cache_affinity
 from .llm_interface import (
@@ -43,6 +41,9 @@ from .llm_interface import (
     OutputTooLongError as OutputTooLongError,
 )
 from .llm_transport import configure_http_logging
+
+# Re-exported: this module is where callers have always imported it from.
+from .provider_auth import requires_api_key as requires_api_key
 
 if TYPE_CHECKING:
     from .response_models import LLMToolCallResult
@@ -61,12 +62,12 @@ configure_http_logging()
 # first waits on it — so the first contended LLM call claims it and any other loop
 # reaching it then fails. The cap stays process-wide, which is what --workers N
 # already implied.
-_llm_max_concurrent = int(os.getenv(ENV_LLM_MAX_CONCURRENT, str(DEFAULT_LLM_MAX_CONCURRENT)))
+_llm_max_concurrent = _get_raw_config().llm_max_concurrent
 _global_llm_semaphore = CrossLoopSemaphore(_llm_max_concurrent)
 
 
 def _build_per_op_semaphores() -> dict[str, CrossLoopSemaphore]:
-    """Build the per-operation semaphore registry from env vars.
+    """Build the per-operation semaphore registry from the resolved config.
 
     Each per-op cap is composed with — not a substitute for — the global cap:
     a call that matches a configured operation must acquire both its per-op
@@ -77,18 +78,19 @@ def _build_per_op_semaphores() -> dict[str, CrossLoopSemaphore]:
     Operations without a configured env var are absent from the registry and
     therefore only constrained by the global cap.
     """
+    config = _get_raw_config()
     semaphores: dict[str, CrossLoopSemaphore] = {}
-    for op, env_var in (
-        ("retain", ENV_RETAIN_LLM_MAX_CONCURRENT),
-        ("reflect", ENV_REFLECT_LLM_MAX_CONCURRENT),
-        ("consolidation", ENV_CONSOLIDATION_LLM_MAX_CONCURRENT),
+    for op, env_var, value in (
+        ("retain", ENV_RETAIN_LLM_MAX_CONCURRENT, config.retain_llm_max_concurrent),
+        ("reflect", ENV_REFLECT_LLM_MAX_CONCURRENT, config.reflect_llm_max_concurrent),
+        ("consolidation", ENV_CONSOLIDATION_LLM_MAX_CONCURRENT, config.consolidation_llm_max_concurrent),
     ):
-        raw = os.getenv(env_var)
-        if raw is None or raw == "":
+        # None is "unset" (config maps an absent or empty value onto it); the env name is
+        # carried alongside purely so the error names the knob the operator actually set.
+        if value is None:
             continue
-        value = int(raw)
         if value <= 0:
-            raise ValueError(f"{env_var} must be a positive integer, got {raw!r}")
+            raise ValueError(f"{env_var} must be a positive integer, got {value!r}")
         semaphores[op] = CrossLoopSemaphore(value)
     return semaphores
 
@@ -410,31 +412,6 @@ def parse_llm_json(raw: str) -> Any:
         if not repaired:
             raise
         return sanitize_value(repaired)
-
-
-_PROVIDERS_WITHOUT_API_KEY = frozenset(
-    {
-        "ollama",
-        "lmstudio",
-        "llamacpp",
-        "openai-codex",
-        "claude-code",
-        "github-copilot",
-        "mock",
-        "none",
-        "vertexai",
-        "litellm",
-        "litellmrouter",
-        "bedrock",
-        "nous",
-        "xai-oauth",
-    }
-)
-
-
-def requires_api_key(provider: str) -> bool:
-    """Return True if the given provider requires an API key to operate."""
-    return provider.lower() not in _PROVIDERS_WITHOUT_API_KEY
 
 
 def _validate_ollama_num_ctx(value: Any) -> int | None:
@@ -1667,102 +1644,53 @@ class LLMProvider:
 
     @classmethod
     def from_env(cls) -> "LLMProvider":
-        """Create provider from environment variables using config.py constants."""
-        # Read every field straight from the environment. The constructor no longer
-        # resolves global-config fallbacks, so this factory must supply them — and it
-        # does so without building the full HindsightConfig, keeping from_env() a
-        # lightweight env-only loader (see test_llm_provider_from_env_keeps_lightweight_loader).
-        from ..config import (
-            DEFAULT_LLM_CACHE_AFFINITY,
-            DEFAULT_LLM_GROQ_SERVICE_TIER,
-            DEFAULT_LLM_OPENAI_SERVICE_TIER,
-            DEFAULT_LLM_PROMPT_CACHE_ENABLED,
-            DEFAULT_LLM_PROVIDER,
-            DEFAULT_LLM_STRUCTURED_OUTPUT_FORCED_TOOL,
-            DEFAULT_LLM_TIMEOUT,
-            ENV_LLM_API_KEY,
-            ENV_LLM_BASE_URL,
-            ENV_LLM_BEDROCK_SERVICE_TIER,
-            ENV_LLM_CACHE_AFFINITY,
-            ENV_LLM_CODEX_HOME,
-            ENV_LLM_DEFAULT_HEADERS,
-            ENV_LLM_EXTRA_BODY,
-            ENV_LLM_GEMINI_SAFETY_SETTINGS,
-            ENV_LLM_GEMINI_SERVICE_TIER,
-            ENV_LLM_GROQ_SERVICE_TIER,
-            ENV_LLM_LITELLMROUTER_CONFIG,
-            ENV_LLM_MODEL,
-            ENV_LLM_OLLAMA_NUM_CTX,
-            ENV_LLM_OPENAI_SERVICE_TIER,
-            ENV_LLM_PROMPT_CACHE_ENABLED,
-            ENV_LLM_PROVIDER,
-            ENV_LLM_REASONING_EFFORT,
-            ENV_LLM_STRUCTURED_OUTPUT_FORCED_TOOL,
-            ENV_LLM_TIMEOUT,
-            ENV_LLM_VERTEXAI_PROJECT_ID,
-            ENV_LLM_VERTEXAI_REGION,
-            ENV_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY,
-            _get_default_model_for_provider,
-            _parse_boolean_env,
-            _parse_llm_router_config,
-            _parse_optional_positive_int,
-            parse_gemini_service_tier,
-        )
+        """Create provider from the resolved :class:`HindsightConfig`.
 
-        provider = os.getenv(ENV_LLM_PROVIDER, DEFAULT_LLM_PROVIDER)
-        api_key = os.getenv(ENV_LLM_API_KEY, "")
+        Every ``HINDSIGHT_API_*`` value is parsed in one place — ``config.py`` — so this
+        factory reads fields rather than re-deriving them from ``os.environ``. A second
+        parser is how the two paths drift: the env-only loader this replaced had already
+        grown its own copies of the provider defaulting, the Gemini tier gating and the
+        cache-affinity default, each needing a comment to say it must not disagree with
+        config.
+        """
+        from ..config import ENV_LLM_API_KEY, _get_raw_config
+
+        # The raw dataclass, not get_config(): gemini_safety_settings is bank-configurable,
+        # and the static proxy refuses those. This is the process-wide default provider, so
+        # the global value is the correct one to read here.
+        config = _get_raw_config()
+
+        provider = config.llm_provider
+        api_key = config.llm_api_key or ""
 
         if not api_key and not requires_api_key(provider):
             pass  # Provider handles its own auth
         elif not api_key:
             raise ValueError(f"{ENV_LLM_API_KEY} environment variable is required for provider '{provider}'")
 
-        base_url = os.getenv(ENV_LLM_BASE_URL, "")
-        model = os.getenv(ENV_LLM_MODEL) or _get_default_model_for_provider(provider)
-        extra_body = json.loads(os.getenv(ENV_LLM_EXTRA_BODY, "null"))
-        default_headers = json.loads(os.getenv(ENV_LLM_DEFAULT_HEADERS, "null"))
-        # Same default as HindsightConfig.from_env: this entry point must not
-        # resolve to a different mode than the engine's own config path.
-        cache_affinity = os.getenv(ENV_LLM_CACHE_AFFINITY, DEFAULT_LLM_CACHE_AFFINITY) or None
-        prompt_cache_enabled = os.getenv(
-            ENV_LLM_PROMPT_CACHE_ENABLED, str(DEFAULT_LLM_PROMPT_CACHE_ENABLED)
-        ).lower() in (
-            "1",
-            "true",
-            "yes",
-            "on",
-        )
-
         return cls(
             provider=provider,
             api_key=api_key,
-            base_url=base_url,
-            model=model,
-            reasoning_effort=os.getenv(ENV_LLM_REASONING_EFFORT) or None,
-            extra_body=extra_body,
-            default_headers=default_headers,
-            cache_affinity=cache_affinity,
-            groq_service_tier=os.getenv(ENV_LLM_GROQ_SERVICE_TIER, DEFAULT_LLM_GROQ_SERVICE_TIER),
-            openai_service_tier=os.getenv(ENV_LLM_OPENAI_SERVICE_TIER, DEFAULT_LLM_OPENAI_SERVICE_TIER),
-            bedrock_service_tier=os.getenv(ENV_LLM_BEDROCK_SERVICE_TIER) or None,
-            gemini_service_tier=(
-                parse_gemini_service_tier(os.getenv(ENV_LLM_GEMINI_SERVICE_TIER))
-                if provider.lower() == "gemini"
-                else None
-            ),
-            gemini_safety_settings=json.loads(os.getenv(ENV_LLM_GEMINI_SAFETY_SETTINGS, "null")),
-            prompt_cache_enabled=prompt_cache_enabled,
-            ollama_num_ctx=_parse_optional_positive_int(ENV_LLM_OLLAMA_NUM_CTX, os.getenv(ENV_LLM_OLLAMA_NUM_CTX)),
-            litellmrouter_config=_parse_llm_router_config(ENV_LLM_LITELLMROUTER_CONFIG),
-            codex_home=os.getenv(ENV_LLM_CODEX_HOME) or None,
-            vertexai_project_id=os.getenv(ENV_LLM_VERTEXAI_PROJECT_ID) or None,
-            vertexai_region=os.getenv(ENV_LLM_VERTEXAI_REGION) or None,
-            vertexai_service_account_key=os.getenv(ENV_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY) or None,
-            timeout=float(os.getenv(ENV_LLM_TIMEOUT, str(DEFAULT_LLM_TIMEOUT))),
-            structured_output_forced_tool=_parse_boolean_env(
-                ENV_LLM_STRUCTURED_OUTPUT_FORCED_TOOL,
-                DEFAULT_LLM_STRUCTURED_OUTPUT_FORCED_TOOL,
-            ),
+            base_url=config.llm_base_url or "",
+            model=config.llm_model,
+            reasoning_effort=config.llm_reasoning_effort,
+            extra_body=config.llm_extra_body,
+            default_headers=config.llm_default_headers,
+            cache_affinity=config.llm_cache_affinity,
+            groq_service_tier=config.llm_groq_service_tier,
+            openai_service_tier=config.llm_openai_service_tier,
+            bedrock_service_tier=config.llm_bedrock_service_tier,
+            gemini_service_tier=config.llm_gemini_service_tier,
+            gemini_safety_settings=config.llm_gemini_safety_settings,
+            prompt_cache_enabled=config.llm_prompt_cache_enabled,
+            ollama_num_ctx=config.llm_ollama_num_ctx,
+            litellmrouter_config=config.llm_litellmrouter_config,
+            codex_home=config.llm_codex_home,
+            vertexai_project_id=config.llm_vertexai_project_id,
+            vertexai_region=config.llm_vertexai_region,
+            vertexai_service_account_key=config.llm_vertexai_service_account_key,
+            timeout=config.llm_timeout,
+            structured_output_forced_tool=config.llm_structured_output_forced_tool,
         )
 
 

--- a/hindsight-api-slim/hindsight_api/engine/provider_auth.py
+++ b/hindsight-api-slim/hindsight_api/engine/provider_auth.py
@@ -1,0 +1,33 @@
+"""Which LLM providers need an API key.
+
+A leaf module on purpose. ``config.py`` needs this answer while it builds
+``HindsightConfig``, and ``llm_wrapper`` needs the built config at import time to
+size its process-wide semaphores; keeping the fact here is what stops those two
+from importing each other in a cycle.
+"""
+
+from __future__ import annotations
+
+_PROVIDERS_WITHOUT_API_KEY = frozenset(
+    {
+        "ollama",
+        "lmstudio",
+        "llamacpp",
+        "openai-codex",
+        "claude-code",
+        "github-copilot",
+        "mock",
+        "none",
+        "vertexai",
+        "litellm",
+        "litellmrouter",
+        "bedrock",
+        "nous",
+        "xai-oauth",
+    }
+)
+
+
+def requires_api_key(provider: str) -> bool:
+    """Return True if the given provider requires an API key to operate."""
+    return provider.lower() not in _PROVIDERS_WITHOUT_API_KEY

--- a/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/litellm_llm.py
@@ -15,13 +15,12 @@ is handled automatically by LiteLLM.
 import asyncio
 import json
 import logging
-import os
 import time
 from contextlib import AbstractAsyncContextManager, nullcontext
 from functools import lru_cache
 from typing import Any, Callable
 
-from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
+from hindsight_api.config import get_config
 from hindsight_api.engine.llm_interface import (
     LLM_TOOL_CHOICE_AUTO,
     LLMInterface,
@@ -136,7 +135,7 @@ class LiteLLMLLM(LLMInterface):
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
         # ``None`` falls back to HINDSIGHT_API_LLM_TIMEOUT, then DEFAULT_LLM_TIMEOUT — never None,
         # so the hard ``asyncio.wait_for`` backstop in ``call`` is always bounded.
-        self.timeout = timeout if timeout is not None else float(os.getenv(ENV_LLM_TIMEOUT, str(DEFAULT_LLM_TIMEOUT)))
+        self.timeout = timeout if timeout is not None else get_config().llm_timeout
         self._litellm: Any = None
         # User-configured extra params merged as top-level kwargs into every
         # completion call so LiteLLM normalizes them per-provider (e.g. maps

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_compatible_llm.py
@@ -23,7 +23,6 @@ import asyncio
 import io
 import json
 import logging
-import os
 import re
 import time
 from contextlib import AbstractAsyncContextManager, nullcontext
@@ -35,7 +34,7 @@ from urllib.parse import parse_qs, urlparse, urlunparse
 import httpx
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, LengthFinishReasonError
 
-from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
+from hindsight_api.config import get_config
 from hindsight_api.engine.bank_attribution import apply_bank_attribution
 from hindsight_api.engine.cache_affinity import (
     CacheAffinityMode,
@@ -825,7 +824,7 @@ class OpenAICompatibleLLM(LLMInterface):
         self._config_extra_body = extra_body or {}
 
         # Get timeout config
-        self.timeout = timeout or float(os.getenv(ENV_LLM_TIMEOUT, str(DEFAULT_LLM_TIMEOUT)))
+        self.timeout = timeout or get_config().llm_timeout
 
         # Backend prompt-cache pinning. "auto" is resolved ONCE here rather than
         # per call: base_url is immutable after construction, so the answer can

--- a/hindsight-api-slim/hindsight_api/engine/providers/openai_responses_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/openai_responses_llm.py
@@ -34,7 +34,6 @@ possible future optimization.
 import asyncio
 import json
 import logging
-import os
 import time
 from contextlib import AbstractAsyncContextManager, nullcontext
 from typing import Any, Callable
@@ -42,7 +41,7 @@ from urllib.parse import parse_qs, urlparse, urlunparse
 
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI
 
-from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
+from hindsight_api.config import get_config
 from hindsight_api.engine.bank_attribution import apply_bank_attribution
 from hindsight_api.engine.llm_interface import (
     LLM_TOOL_CHOICE_AUTO,
@@ -212,7 +211,7 @@ class OpenAIResponsesLLM(LLMInterface):
         self.openai_service_tier = kwargs.get("openai_service_tier")
         self._config_extra_body = extra_body or {}
         self.default_headers = default_headers
-        self.timeout = timeout or float(os.getenv(ENV_LLM_TIMEOUT, str(DEFAULT_LLM_TIMEOUT)))
+        self.timeout = timeout or get_config().llm_timeout
 
         # Manual retries (max_retries=0). Extract query params from base_url so an
         # Azure-style ``?api-version=`` is forwarded as a default query param.

--- a/hindsight-api-slim/hindsight_api/engine/providers/xai_oauth_auth.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/xai_oauth_auth.py
@@ -66,6 +66,14 @@ from urllib.parse import urlparse
 
 import httpx
 
+from ...config import (
+    DEFAULT_XAI_OAUTH_CLIENT_ID,
+    DEFAULT_XAI_OAUTH_REFRESH_SKEW_SECONDS,
+    DEFAULT_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS,
+    DEFAULT_XAI_OAUTH_SCOPE,
+    get_config,
+)
+
 try:
     import fcntl
 except ImportError:  # pragma: no cover - Windows
@@ -106,22 +114,20 @@ __all__ = [
 # Environment surface
 # ---------------------------------------------------------------------------
 
-#: Relocate the token store. The read and the write both follow it, so this is
-#: a full relocation rather than a read-side override.
-ENV_TOKEN_PATH = "HINDSIGHT_API_XAI_OAUTH_TOKEN_PATH"
-
-#: Override the OAuth client id used for both login and refresh.
-ENV_CLIENT_ID = "HINDSIGHT_API_XAI_OAUTH_CLIENT_ID"
-
-#: Override the scope string requested at login.
-ENV_SCOPE = "HINDSIGHT_API_XAI_OAUTH_SCOPE"
-
-#: Per-HTTP-call timeout for discovery, device-code and refresh requests.
-ENV_REFRESH_TIMEOUT_SECONDS = "HINDSIGHT_API_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS"
-
-#: How long before ``expires_at`` a token counts as due for refresh.
-ENV_REFRESH_SKEW_SECONDS = "HINDSIGHT_API_XAI_OAUTH_REFRESH_SKEW_SECONDS"
-
+#: Every ``HINDSIGHT_API_*`` name and default is declared in config.py; these aliases
+#: keep this module's historical spellings without a second declaration of either.
+#:
+#: * ``ENV_TOKEN_PATH`` relocates the token store — read and write both follow it.
+#: * ``ENV_CLIENT_ID`` / ``ENV_SCOPE`` override the OAuth client used at login and refresh.
+#: * ``ENV_REFRESH_TIMEOUT_SECONDS`` is the per-HTTP-call timeout for discovery,
+#:   device-code and refresh requests.
+#: * ``ENV_REFRESH_SKEW_SECONDS`` is how long before ``expires_at`` a token is due.
+from ...config import ENV_XAI_OAUTH_CLIENT_ID as ENV_CLIENT_ID
+from ...config import ENV_XAI_OAUTH_REFRESH_SKEW_SECONDS as ENV_REFRESH_SKEW_SECONDS
+from ...config import ENV_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS as ENV_REFRESH_TIMEOUT_SECONDS
+from ...config import ENV_XAI_OAUTH_SCOPE as ENV_SCOPE
+from ...config import ENV_XAI_OAUTH_TOKEN_PATH as ENV_TOKEN_PATH
+from ...config import get_config
 
 # ---------------------------------------------------------------------------
 # Vendor constants
@@ -137,21 +143,21 @@ XAI_OAUTH_DEVICE_CODE_URL = f"{XAI_OAUTH_ISSUER}/oauth2/device/code"
 #: Public OAuth client id published in xAI's Apache-2.0 Grok CLI sources
 #: (``crates/codegen/xai-grok-shell/src/auth/config.rs`` in
 #: github.com/xai-org/grok-build). Not a secret: a device-code public client has
-#: no client secret by construction.
-DEFAULT_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+#: no client secret by construction. Declared in config.py with its env var.
+DEFAULT_CLIENT_ID = DEFAULT_XAI_OAUTH_CLIENT_ID
 
 #: Scope string the vendor's own device-code login requests.
-DEFAULT_SCOPE = "openid profile email offline_access grok-cli:access api:access"
+DEFAULT_SCOPE = DEFAULT_XAI_OAUTH_SCOPE
 
 DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
 
 #: Refresh this many seconds before ``expires_at``. 60s matches
 #: ``codex_auth.py``'s skew; deployments that touch the provider rarely (a cron
 #: or gateway shape) can widen it with ``ENV_REFRESH_SKEW_SECONDS``.
-DEFAULT_REFRESH_SKEW_SECONDS = 60.0
+DEFAULT_REFRESH_SKEW_SECONDS = DEFAULT_XAI_OAUTH_REFRESH_SKEW_SECONDS
 
 #: Hard per-request timeout for every call this module makes.
-DEFAULT_REFRESH_TIMEOUT_SECONDS = 20.0
+DEFAULT_REFRESH_TIMEOUT_SECONDS = DEFAULT_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS
 
 #: Anti-spin floor: a credential obtained less than this many seconds ago is
 #: not refreshed again. Measured from the store's ``obtained_at``.
@@ -236,7 +242,7 @@ def default_token_path() -> Path:
     Resolved on each call rather than cached at import, so the environment is
     read at the point of use.
     """
-    configured = os.environ.get(ENV_TOKEN_PATH, "").strip()
+    configured = get_config().xai_oauth_token_path
     if configured:
         return Path(configured).expanduser()
     return Path.home() / ".hindsight" / "xai_oauth.json"
@@ -599,13 +605,10 @@ def device_code_login(
     from the module's ``login`` entrypoint — no request path calls it.
     """
     path = token_path or default_token_path()
-    resolved_client_id = client_id or os.environ.get(ENV_CLIENT_ID, "").strip() or DEFAULT_CLIENT_ID
-    resolved_scope = scope or os.environ.get(ENV_SCOPE, "").strip() or DEFAULT_SCOPE
-    timeout = (
-        timeout_seconds
-        if timeout_seconds is not None
-        else _env_float(ENV_REFRESH_TIMEOUT_SECONDS, DEFAULT_REFRESH_TIMEOUT_SECONDS)
-    )
+    config = get_config()
+    resolved_client_id = client_id or config.xai_oauth_client_id
+    resolved_scope = scope or config.xai_oauth_scope
+    timeout = timeout_seconds if timeout_seconds is not None else config.xai_oauth_refresh_timeout_seconds
 
     with httpx.Client(timeout=httpx.Timeout(max(20.0, timeout)), headers={"Accept": "application/json"}) as client:
         endpoints = discover_endpoints(client)
@@ -653,17 +656,6 @@ def device_code_login(
     return path
 
 
-def _env_float(name: str, default: float) -> float:
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        return float(raw)
-    except ValueError:
-        logger.warning("Ignoring non-numeric %s; using %s", name, default)
-        return default
-
-
 # ---------------------------------------------------------------------------
 # Manager
 # ---------------------------------------------------------------------------
@@ -689,16 +681,14 @@ class XaiOAuthManager:
         http_client: httpx.Client | None = None,
     ) -> None:
         self._token_path = token_path or default_token_path()
-        self._client_id = client_id or os.environ.get(ENV_CLIENT_ID, "").strip() or DEFAULT_CLIENT_ID
+        self._client_id = client_id or get_config().xai_oauth_client_id
         self._skew_seconds = (
-            refresh_skew_seconds
-            if refresh_skew_seconds is not None
-            else _env_float(ENV_REFRESH_SKEW_SECONDS, DEFAULT_REFRESH_SKEW_SECONDS)
+            refresh_skew_seconds if refresh_skew_seconds is not None else get_config().xai_oauth_refresh_skew_seconds
         )
         self._timeout_seconds = (
             refresh_timeout_seconds
             if refresh_timeout_seconds is not None
-            else _env_float(ENV_REFRESH_TIMEOUT_SECONDS, DEFAULT_REFRESH_TIMEOUT_SECONDS)
+            else get_config().xai_oauth_refresh_timeout_seconds
         )
         self._min_refresh_gap_seconds = min_refresh_gap_seconds
         self._owns_client = http_client is None

--- a/hindsight-api-slim/hindsight_api/engine/providers/xai_oauth_llm.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/xai_oauth_llm.py
@@ -41,7 +41,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import time
 from contextlib import AbstractAsyncContextManager, nullcontext, suppress
 from dataclasses import dataclass
@@ -51,7 +50,12 @@ from urllib.parse import urlsplit
 import httpx
 from pydantic import BaseModel, Field
 
-from hindsight_api.config import DEFAULT_LLM_TIMEOUT, ENV_LLM_TIMEOUT
+from hindsight_api.config import (
+    DEFAULT_XAI_OAUTH_BASE_URL,
+    ENV_XAI_OAUTH_BASE_URL,
+    ENV_XAI_OAUTH_DEBUG_HEADERS,
+    get_config,
+)
 from hindsight_api.engine.cache_affinity import XAI_CONV_ID_HEADER, cache_affinity_id
 from hindsight_api.engine.llm_interface import LLM_TOOL_CHOICE_AUTO, LLMInterface, LLMToolChoice, LLMToolChoiceMode
 from hindsight_api.engine.llm_trace import LLMResponseUsage, stash_response_usage
@@ -86,9 +90,9 @@ __all__ = [
 #: ``HINDSIGHT_API_LLM_BASE_URL`` that deployments often set for an unrelated
 #: proxy — the same "more specific beats more general" rule the rest of
 #: Hindsight's config hierarchy follows.
-ENV_BASE_URL = "HINDSIGHT_API_XAI_OAUTH_BASE_URL"
 
-DEFAULT_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_BASE_URL = DEFAULT_XAI_OAUTH_BASE_URL
+ENV_BASE_URL = ENV_XAI_OAUTH_BASE_URL
 
 #: Body marker xAI returns when the account's spending limit stopped the call.
 SPENDING_LIMIT_CODE = "personal-team-blocked:spending-limit"
@@ -105,7 +109,8 @@ MAX_ERROR_DETAIL_CHARS = 200
 
 #: Debug-only response-header logging on a non-2xx reply (default off). See
 #: the module docstring's Logging section for the exact carve-out.
-ENV_DEBUG_HEADERS = "HINDSIGHT_API_XAI_OAUTH_DEBUG_HEADERS"
+ENV_DEBUG_HEADERS = ENV_XAI_OAUTH_DEBUG_HEADERS
+
 
 #: Response headers safe to log verbatim under ``ENV_DEBUG_HEADERS``: routing
 #: and diagnostic metadata that names no credential and carries no request
@@ -336,7 +341,7 @@ def _actual_host(base_url: str) -> str:
 
 
 def _debug_headers_enabled() -> bool:
-    return os.getenv(ENV_DEBUG_HEADERS, "false").lower() == "true"
+    return get_config().xai_oauth_debug_headers
 
 
 def _log_non_2xx_response_headers(response: httpx.Response) -> None:
@@ -378,11 +383,13 @@ class XaiOAuthLLM(LLMInterface):
         """
         super().__init__(provider, api_key, base_url, model, reasoning_effort, **kwargs)
 
-        self.base_url = (os.environ.get(ENV_BASE_URL, "").strip() or self.base_url or DEFAULT_BASE_URL).rstrip("/")
+        # None means the operator named no deployment-wide endpoint, so the caller's
+        # base_url still gets its turn ahead of the vendor default.
+        self.base_url = (get_config().xai_oauth_base_url or self.base_url or DEFAULT_BASE_URL).rstrip("/")
 
         # Honour the engine-resolved per-operation timeout; fall back to the
         # same global default the OpenAI-compatible providers use.
-        self.timeout = timeout if timeout is not None else float(os.getenv(ENV_LLM_TIMEOUT, str(DEFAULT_LLM_TIMEOUT)))
+        self.timeout = timeout if timeout is not None else get_config().llm_timeout
 
         self._auth = auth_manager or XaiOAuthManager()
         self._auth_lock = asyncio.Lock()

--- a/hindsight-api-slim/hindsight_api/engine/storage/__init__.py
+++ b/hindsight-api-slim/hindsight_api/engine/storage/__init__.py
@@ -102,7 +102,9 @@ def _load_file_storage_extension() -> FileStorage | None:
     import importlib
     import os
 
-    ext_path = os.getenv("HINDSIGHT_API_FILE_STORAGE_EXTENSION")
+    from ...config import get_config
+
+    ext_path = get_config().file_storage_extension
     if not ext_path:
         return None
     if ":" not in ext_path:

--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -25,6 +25,7 @@ from . import __version__
 from .banner import print_banner
 from .config import (
     DEFAULT_ACCESS_LOG,
+    DEFAULT_HOST,
     DEFAULT_WORKERS,
     ENV_ACCESS_LOG,
     ENV_WORKERS,
@@ -150,7 +151,9 @@ def _parse_cli_args(argv: list[str], config: HindsightConfig) -> ParsedCliArgs:
     parser.add_argument(
         "--host",
         default=argparse.SUPPRESS,
-        help=f"Host to bind to (default: {config.host}, env: HINDSIGHT_API_HOST)",
+        # config.host is None when nothing configured one; show the address that will
+        # actually be bound, not the sentinel that stands for "operator said nothing".
+        help=f"Host to bind to (default: {config.host or DEFAULT_HOST}, env: HINDSIGHT_API_HOST)",
     )
     parser.add_argument(
         "--port",

--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -27,7 +27,6 @@ from .config import (
     DEFAULT_ACCESS_LOG,
     DEFAULT_WORKERS,
     ENV_ACCESS_LOG,
-    ENV_HOST,
     ENV_WORKERS,
     HindsightConfig,
     _get_raw_config,
@@ -119,19 +118,18 @@ def resolve_daemon_host_port(
     args_port: int,
     explicit_host: bool,
     explicit_port: bool,
+    configured_host: bool = False,
 ) -> ResolvedDaemonHostPort:
     """Resolve host/port for daemon mode.
 
-    Defaults to 127.0.0.1 for security, but honors explicit user overrides
-    via --host flag or HINDSIGHT_API_HOST env var. Uses DEFAULT_DAEMON_PORT
-    unless the user specified a custom port.
+    Defaults to 127.0.0.1 for security, but honors explicit user overrides via the
+    --host flag (``explicit_host``) or HINDSIGHT_API_HOST (``configured_host``, which
+    the caller reads off the config rather than the environment). Uses
+    DEFAULT_DAEMON_PORT unless the user specified a custom port.
     """
     port = args_port if explicit_port else DEFAULT_DAEMON_PORT
     # Only force localhost if the user didn't explicitly set a host
-    if explicit_host or os.environ.get(ENV_HOST):
-        host = args_host
-    else:
-        host = "127.0.0.1"
+    host = args_host if (explicit_host or configured_host) else "127.0.0.1"
     return ResolvedDaemonHostPort(host=host, port=port)
 
 
@@ -172,7 +170,7 @@ def _parse_cli_args(argv: list[str], config: HindsightConfig) -> ParsedCliArgs:
     parser.add_argument(
         "--workers",
         type=int,
-        default=int(os.getenv(ENV_WORKERS, str(DEFAULT_WORKERS))),
+        default=config.workers,
         help=f"Number of worker processes (env: {ENV_WORKERS}, default: {DEFAULT_WORKERS})",
     )
 
@@ -180,7 +178,7 @@ def _parse_cli_args(argv: list[str], config: HindsightConfig) -> ParsedCliArgs:
     parser.add_argument(
         "--access-log",
         action="store_true",
-        default=os.getenv(ENV_ACCESS_LOG, "").lower() in ("1", "true", "yes", "on") or DEFAULT_ACCESS_LOG,
+        default=config.access_log,
         help=f"Enable access log (env: {ENV_ACCESS_LOG}, default: {DEFAULT_ACCESS_LOG})",
     )
     parser.add_argument(
@@ -221,7 +219,7 @@ def _parse_cli_args(argv: list[str], config: HindsightConfig) -> ParsedCliArgs:
     explicit_host = hasattr(args, "host")
     explicit_port = hasattr(args, "port")
     if not explicit_host:
-        args.host = config.host
+        args.host = config.host or DEFAULT_HOST
     if not explicit_port:
         args.port = config.port
 
@@ -269,6 +267,7 @@ def main():
             args_port=args.port,
             explicit_host=parsed_cli_args.explicit_host,
             explicit_port=parsed_cli_args.explicit_port,
+            configured_host=config.host is not None,
         )
         args.host = resolved_daemon_host_port.host
         args.port = resolved_daemon_host_port.port

--- a/hindsight-api-slim/hindsight_api/mcp_local.py
+++ b/hindsight-api-slim/hindsight_api/mcp_local.py
@@ -28,8 +28,12 @@ import os
 
 def main() -> None:
     """Start the Hindsight API server with local defaults."""
-    # Set local defaults (only if not already configured by the user)
-    os.environ.setdefault("HINDSIGHT_API_DATABASE_URL", "pg0://hindsight-mcp")
+    # Seeds the environment that HindsightConfig then parses — a write, not a read
+    # that bypasses the config. It has to happen before the config is first built,
+    # so it cannot be expressed as a config field.
+    from hindsight_api.config import ENV_DATABASE_URL
+
+    os.environ.setdefault(ENV_DATABASE_URL, "pg0://hindsight-mcp")
 
     from hindsight_api.main import main as api_main
 

--- a/hindsight-api-slim/hindsight_api/profiling.py
+++ b/hindsight-api-slim/hindsight_api/profiling.py
@@ -56,7 +56,7 @@ import os
 import threading
 import time
 
-ENV_PROFILE = "HINDSIGHT_API_PROFILE"
+from .config import ENV_PROFILE, get_config  # noqa: E402
 
 logger = logging.getLogger("hindsight_api.profiling")
 
@@ -71,7 +71,7 @@ def _config() -> dict | None:
     A malformed value raises rather than quietly disabling: whoever set this wants a
     profile, and a typo that produces no output costs a whole test cycle to notice.
     """
-    raw = os.getenv(ENV_PROFILE, "").strip()
+    raw = get_config().profile
     if not raw:
         return None
     cfg = json.loads(raw)

--- a/hindsight-api-slim/hindsight_api/tracing.py
+++ b/hindsight-api-slim/hindsight_api/tracing.py
@@ -12,7 +12,6 @@ to Langfuse (or any OTLP-compatible backend) via OTLP HTTP protocol.
 
 import json
 import logging
-import os
 import time
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Optional
@@ -235,7 +234,7 @@ def initialize_tracing_from_config(
     Returns:
         True when tracing was initialized, False otherwise.
     """
-    from .config import ENV_OTEL_SERVICE_NAME
+    from .config import DEFAULT_OTEL_SERVICE_NAME
 
     if not config.otel_traces_enabled:
         return False
@@ -244,10 +243,10 @@ def initialize_tracing_from_config(
         logger.warning("OTEL tracing enabled but no endpoint configured. Tracing disabled.")
         return False
 
-    # config.otel_service_name has already had the API default applied, so an
-    # unset env var is indistinguishable from one set to that default. Read the
-    # environment directly to tell them apart.
-    service_name = os.getenv(ENV_OTEL_SERVICE_NAME) or default_service_name or config.otel_service_name
+    # config.otel_service_name is None when the operator named nothing, so an explicit
+    # name still beats the caller's per-process default without this having to consult
+    # the environment a second time.
+    service_name = config.otel_service_name or default_service_name or DEFAULT_OTEL_SERVICE_NAME
 
     try:
         initialize_tracing(

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -30,9 +30,19 @@ from ..metrics import get_metrics_collector
 from .backpressure import is_store_backpressure
 from .exceptions import DeferOperation, RetryTaskAt, format_task_error
 
-# How long to hold a task a store shed for backpressure. The rationale for the default
-# lives with the value, on DEFAULT_BACKPRESSURE_DEFER_SECONDS in config.py.
-_BACKPRESSURE_DEFER_SECONDS = get_config().backpressure_defer_seconds
+
+def _backpressure_defer_seconds() -> int:
+    """How long a task the store shed for backpressure is held before a retry.
+
+    Resolved per call, not once at import: ``worker.main`` imports this module at
+    module scope, before it runs ``load_dotenv_for_entrypoint()``. Building the config
+    here at import time would cache it from a pre-``.env`` environment for the whole
+    process. The rationale for the default lives with the value, on
+    DEFAULT_BACKPRESSURE_DEFER_SECONDS in config.py.
+    """
+    return get_config().backpressure_defer_seconds
+
+
 from .stage import StageHolder, bind_holder
 
 # Map DB operation_type -> metric `operation` label, collapsing the retain
@@ -1218,7 +1228,7 @@ class WorkerPoller:
             # budget runs out while the store is still legitimately shedding. Checked before the
             # failure path so the operation keeps its retries for things that are actually wrong.
             if is_store_backpressure(e):
-                retry_at = datetime.now(timezone.utc) + timedelta(seconds=_BACKPRESSURE_DEFER_SECONDS)
+                retry_at = datetime.now(timezone.utc) + timedelta(seconds=_backpressure_defer_seconds())
                 logger.warning(
                     "Task %s deferred until %s: store backpressure (%s)",
                     task.operation_id,

--- a/hindsight-api-slim/hindsight_api/worker/poller.py
+++ b/hindsight-api-slim/hindsight_api/worker/poller.py
@@ -30,11 +30,9 @@ from ..metrics import get_metrics_collector
 from .backpressure import is_store_backpressure
 from .exceptions import DeferOperation, RetryTaskAt, format_task_error
 
-# How long to hold a task a store shed for backpressure. Long enough that a fold has a real chance
-# to drain the backlog — retrying into a still-full store just sheds again and burns the claim —
-# and short enough that a cleared backlog is not left waiting. Deferrals do not count against
-# `max_retries`, so this can afford to be patient without risking the operation.
-_BACKPRESSURE_DEFER_SECONDS = int(os.environ.get("HINDSIGHT_API_BACKPRESSURE_DEFER_SECONDS", "120"))
+# How long to hold a task a store shed for backpressure. The rationale for the default
+# lives with the value, on DEFAULT_BACKPRESSURE_DEFER_SECONDS in config.py.
+_BACKPRESSURE_DEFER_SECONDS = get_config().backpressure_defer_seconds
 from .stage import StageHolder, bind_holder
 
 # Map DB operation_type -> metric `operation` label, collapsing the retain

--- a/hindsight-api-slim/tests/conftest.py
+++ b/hindsight-api-slim/tests/conftest.py
@@ -83,6 +83,27 @@ async def _teardown_memory_engine(mem: MemoryEngine) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _reset_config_cache():
+    """Let a test's ``monkeypatch.setenv`` actually reach the code under test.
+
+    ``HindsightConfig`` is built once and cached for the process, and every
+    ``HINDSIGHT_API_*`` value is now read off it rather than from ``os.environ`` at
+    the point of use. Without this, a test that sets an environment variable and
+    then calls the code would be read against whatever config the *first* test in
+    this xdist worker happened to build — the value would silently not apply, and
+    which tests noticed would depend on file ordering.
+
+    Clearing on the way out as well keeps a config built from one test's patched
+    environment from outliving it.
+    """
+    from hindsight_api.config import clear_config_cache
+
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+@pytest.fixture(autouse=True)
 def _cleanup_leaked_span_recorders():
     """Fail-safe for the process-global LLM-trace recorder registry (#2229).
 

--- a/hindsight-api-slim/tests/test_config_is_the_only_env_reader.py
+++ b/hindsight-api-slim/tests/test_config_is_the_only_env_reader.py
@@ -1,0 +1,138 @@
+"""Every ``HINDSIGHT_API_*`` value is parsed in config.py and nowhere else.
+
+Two parsers for one variable is how the engine and the config drift apart: the
+factory that built the default LLM provider had grown its own copies of the
+provider defaulting, the Gemini tier gating and the cache-affinity default, each
+carrying a comment asking the next reader not to let them disagree. This test
+removes the need for those comments.
+
+A module that reads ``os.environ`` for a ``HINDSIGHT_API_*`` name either reads it
+off :class:`HindsightConfig` instead, or appears in ``EXEMPT`` below with the
+reason it cannot.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+import hindsight_api
+
+PACKAGE_ROOT = Path(hindsight_api.__file__).parent
+CONFIG_PATH = PACKAGE_ROOT / "config.py"
+
+#: Modules allowed to touch the environment directly, and why.
+EXEMPT: dict[str, str] = {
+    # Alembic loads migrations in its own process, against a database that may predate
+    # this build. Reaching into the application config from a migration inverts that.
+    "alembic/env.py": "runs under standalone Alembic, before/without the app config",
+    "alembic/_owned.py": "same; and is read at call time so a late setting still applies",
+    # Seeds the environment the config then parses — a write, not a read.
+    "mcp_local.py": "sets a default before the config is first built",
+    # The guard runs to decide whether this interpreter may run at all.
+    "_thread_limits.py": "sets thread-library caps before any config exists",
+    # Extensions declare open-ended `HINDSIGHT_API_<NAME>_*` settings that are handed to
+    # the extension as a dict; they cannot be enumerated as static config fields.
+    "extensions/loader.py": "dynamic per-extension config namespace",
+    "engine/storage/__init__.py": "dynamic HINDSIGHT_API_FILE_STORAGE_* config namespace",
+}
+
+
+@dataclass(frozen=True)
+class EnvRead:
+    """One resolvable ``HINDSIGHT_API_*`` read, and where it is."""
+
+    lineno: int
+    name: str
+
+
+def _env_reads(tree: ast.AST, module_env_names: dict[str, str], config_env_names: dict[str, str]) -> list[EnvRead]:
+    """Every ``os.environ``/``os.getenv`` read of a resolvable HINDSIGHT_API_* name."""
+    found: list[EnvRead] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in ("getenv", "get", "pop"):
+            continue
+        target = node.func.value
+        is_os_env = (isinstance(target, ast.Name) and target.id == "os") or (
+            isinstance(target, ast.Attribute) and target.attr == "environ"
+        )
+        if not is_os_env or not node.args:
+            continue
+        arg = node.args[0]
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            name = arg.value
+        elif isinstance(arg, ast.Name):
+            name = module_env_names.get(arg.id) or config_env_names.get(arg.id, "")
+        else:
+            continue
+        if name.startswith("HINDSIGHT_API_"):
+            found.append(EnvRead(lineno=node.lineno, name=name))
+    return found
+
+
+def _env_constants(tree: ast.AST) -> dict[str, str]:
+    names: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if isinstance(target, ast.Name) and target.id.startswith("ENV_"):
+            try:
+                value = ast.literal_eval(node.value)
+            except (ValueError, SyntaxError):
+                continue
+            if isinstance(value, str):
+                names[target.id] = value
+    return names
+
+
+@pytest.fixture(scope="module")
+def config_env_names() -> dict[str, str]:
+    return _env_constants(ast.parse(CONFIG_PATH.read_text()))
+
+
+def _modules() -> list[Path]:
+    return sorted(p for p in PACKAGE_ROOT.rglob("*.py") if p != CONFIG_PATH)
+
+
+def test_no_module_outside_config_reads_a_hindsight_env_var(config_env_names):
+    offenders: list[str] = []
+    for path in _modules():
+        rel = path.relative_to(PACKAGE_ROOT).as_posix()
+        if rel in EXEMPT or rel.startswith("alembic/versions/"):
+            continue
+        tree = ast.parse(path.read_text())
+        for read in _env_reads(tree, _env_constants(tree), config_env_names):
+            offenders.append(f"{rel}:{read.lineno} reads {read.name}")
+
+    assert not offenders, (
+        "These modules parse a HINDSIGHT_API_* variable themselves instead of reading the "
+        "resolved HindsightConfig:\n  " + "\n  ".join(offenders) + "\n\n"
+        "Add a field to HindsightConfig and read it, or — if the value is genuinely needed "
+        "before a config can exist — add the module to EXEMPT with the reason."
+    )
+
+
+def test_every_exemption_still_applies():
+    """An exemption that no longer touches the environment is stale; drop it.
+
+    Deliberately looser than the check above: these modules are exempt precisely
+    because they use forms that check cannot resolve — ``setdefault`` with a
+    computed name, a scan over ``os.environ.items()`` for a dynamic prefix. Any
+    remaining mention of ``os.environ``/``os.getenv`` keeps the exemption honest.
+    """
+    stale = []
+    for rel in EXEMPT:
+        path = PACKAGE_ROOT / rel
+        if not path.exists():
+            stale.append(f"{rel} (file is gone)")
+            continue
+        source = path.read_text()
+        if "os.environ" not in source and "os.getenv" not in source:
+            stale.append(f"{rel} (no longer touches the environment)")
+    assert not stale, "Stale entries in EXEMPT:\n  " + "\n  ".join(stale)

--- a/hindsight-api-slim/tests/test_daemon_host_resolution.py
+++ b/hindsight-api-slim/tests/test_daemon_host_resolution.py
@@ -15,9 +15,13 @@ DEFAULT_PORT = 8888
 
 
 class _Config:
+    """The fields of HindsightConfig that _parse_cli_args() reads for its defaults."""
+
     host = DEFAULT_HOST
     port = DEFAULT_PORT
     log_level = "info"
+    workers = 1
+    access_log = False
 
 
 class TestResolveDaemonHostPort:
@@ -57,29 +61,59 @@ class TestResolveDaemonHostPort:
         )
         assert resolved.host == DEFAULT_HOST
 
-    def test_honors_env_var_host(self, monkeypatch):
-        """HINDSIGHT_API_HOST=0.0.0.0 --daemon should bind to 0.0.0.0."""
-        monkeypatch.setenv("HINDSIGHT_API_HOST", "0.0.0.0")
-        # When env var is set, config.host already reflects it, so
-        # args_host matches the config default, but the env var presence is the signal.
+    def test_honors_env_var_host(self):
+        """HINDSIGHT_API_HOST=0.0.0.0 --daemon should bind to 0.0.0.0.
+
+        ``configured_host`` is the caller's answer to "did HINDSIGHT_API_HOST name a
+        host?", read off HindsightConfig rather than the environment — the env var is
+        parsed in config.py and nowhere else.
+        """
         resolved = resolve_daemon_host_port(
             args_host="0.0.0.0",
             args_port=DEFAULT_PORT,
             explicit_host=False,
             explicit_port=False,
+            configured_host=True,
         )
         assert resolved.host == "0.0.0.0"
 
-    def test_honors_custom_host_via_env(self, monkeypatch):
+    def test_honors_custom_host_via_env(self):
         """HINDSIGHT_API_HOST=10.0.0.5 should be respected in daemon mode."""
-        monkeypatch.setenv("HINDSIGHT_API_HOST", "10.0.0.5")
         resolved = resolve_daemon_host_port(
             args_host="10.0.0.5",
             args_port=DEFAULT_PORT,
             explicit_host=False,
             explicit_port=False,
+            configured_host=True,
         )
         assert resolved.host == "10.0.0.5"
+
+    def test_unset_host_narrows_to_loopback(self):
+        """Nothing configured anywhere: daemon mode still refuses to listen publicly."""
+        resolved = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST,
+            args_port=DEFAULT_PORT,
+            explicit_host=False,
+            explicit_port=False,
+            configured_host=False,
+        )
+        assert resolved.host == "127.0.0.1"
+
+    def test_configured_host_is_read_from_config_not_environ(self, monkeypatch):
+        """The env var alone no longer reaches this function.
+
+        Guards the wiring: main() must pass ``configured_host=config.host is not None``.
+        If someone reintroduces an os.environ read here, this fails.
+        """
+        monkeypatch.setenv("HINDSIGHT_API_HOST", "0.0.0.0")
+        resolved = resolve_daemon_host_port(
+            args_host=DEFAULT_HOST,
+            args_port=DEFAULT_PORT,
+            explicit_host=False,
+            explicit_port=False,
+            configured_host=False,
+        )
+        assert resolved.host == "127.0.0.1"
 
     def test_cli_flag_overrides_env_var(self, monkeypatch):
         """--host flag should take precedence over env var."""

--- a/hindsight-api-slim/tests/test_daemon_host_resolution.py
+++ b/hindsight-api-slim/tests/test_daemon_host_resolution.py
@@ -24,6 +24,39 @@ class _Config:
     access_log = False
 
 
+class TestParseCliArgsHostDefault:
+    """`_parse_cli_args` applies the bind default when nothing configured a host.
+
+    `config.host` is None when HINDSIGHT_API_HOST is unset — the state that lets daemon
+    mode tell an operator-chosen host from an unstated one. Every other test here hands
+    `_parse_cli_args` a config whose `host` is already a string, so the `or DEFAULT_HOST`
+    branch went unexercised and shipped a NameError that only a real server start caught.
+    """
+
+    def test_unset_host_falls_back_to_the_bind_default(self):
+        from hindsight_api.config import DEFAULT_HOST as CONFIG_DEFAULT_HOST
+        from hindsight_api.main import _parse_cli_args
+
+        class _UnsetHostConfig(_Config):
+            host = None
+
+        parsed = _parse_cli_args([], _UnsetHostConfig())
+
+        assert parsed.args.host == CONFIG_DEFAULT_HOST
+        assert parsed.explicit_host is False
+
+    def test_configured_host_is_used_verbatim(self):
+        from hindsight_api.main import _parse_cli_args
+
+        class _ConfiguredHostConfig(_Config):
+            host = "10.0.0.5"
+
+        parsed = _parse_cli_args([], _ConfiguredHostConfig())
+
+        assert parsed.args.host == "10.0.0.5"
+        assert parsed.explicit_host is False
+
+
 class TestResolveDaemonHostPort:
     """Test resolve_daemon_host_port under various override scenarios."""
 

--- a/hindsight-api-slim/tests/test_daemon_idle_timeout_removed.py
+++ b/hindsight-api-slim/tests/test_daemon_idle_timeout_removed.py
@@ -14,9 +14,13 @@ from hindsight_api.main import _parse_cli_args
 
 
 class _Config:
+    """The fields of HindsightConfig that _parse_cli_args() reads for its defaults."""
+
     host = "0.0.0.0"
     port = 8888
     log_level = "info"
+    workers = 1
+    access_log = False
 
 
 def test_idle_timeout_flag_is_still_accepted():

--- a/hindsight-api-slim/tests/test_daemonize.py
+++ b/hindsight-api-slim/tests/test_daemonize.py
@@ -13,7 +13,7 @@ def test_daemonize_parent_reexecs_via_popen(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "argv", ["hindsight-api", "--daemon", "--port", "9999"])
 
     log_path = tmp_path / "daemon.log"
-    monkeypatch.setattr("hindsight_api.daemon.DAEMON_LOG_PATH", log_path)
+    monkeypatch.setattr("hindsight_api.daemon.daemon_log_path", lambda: log_path)
 
     captured: dict = {}
 
@@ -59,7 +59,7 @@ def test_daemonize_child_does_not_reexec(monkeypatch, tmp_path):
     monkeypatch.setenv("_HINDSIGHT_DAEMON_CHILD", "1")
 
     log_path = tmp_path / "daemon.log"
-    monkeypatch.setattr("hindsight_api.daemon.DAEMON_LOG_PATH", log_path)
+    monkeypatch.setattr("hindsight_api.daemon.daemon_log_path", lambda: log_path)
 
     with (
         patch("hindsight_api.daemon.subprocess.Popen") as mock_popen,
@@ -77,7 +77,7 @@ def test_daemonize_windows_noop(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "platform", "win32")
 
     log_path = tmp_path / "subdir" / "daemon.log"
-    monkeypatch.setattr("hindsight_api.daemon.DAEMON_LOG_PATH", log_path)
+    monkeypatch.setattr("hindsight_api.daemon.daemon_log_path", lambda: log_path)
 
     with patch("hindsight_api.daemon.subprocess.Popen") as mock_popen:
         from hindsight_api.daemon import daemonize

--- a/hindsight-api-slim/tests/test_dotenv_wins_over_early_config_build.py
+++ b/hindsight-api-slim/tests/test_dotenv_wins_over_early_config_build.py
@@ -1,0 +1,55 @@
+"""A discovered ``.env`` must win even if something already built the config.
+
+``HindsightConfig`` is cached for the process on first build, and an entry point
+imports its whole module graph before ``main()`` calls
+``load_dotenv_for_entrypoint()``. Modules that read the config at import scope
+(``llm_wrapper`` sizes its LLM semaphores there) therefore build it from an
+environment the ``.env`` has not been applied to yet.
+
+Without the cache clear in ``load_dotenv_for_entrypoint()`` that stale config stays
+for the life of the process and the ``.env`` is silently ignored — the failure mode
+being a server that had always started refusing to, with "LLM API key is required",
+because the key only ever lived in the ``.env``.
+
+Run in a subprocess: the config cache and ``sys.modules`` are process-global, so an
+in-process version would be a no-op once another test has loaded these modules.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_dotenv_applies_even_when_the_config_was_built_before_it_loaded(tmp_path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("HINDSIGHT_API_LLM_MODEL=model-from-dotenv\n")
+
+    probe = textwrap.dedent("""
+        import hindsight_api.config as config
+
+        # Stand in for any module that reads the config at import scope, before the
+        # entry point has had a chance to load the .env.
+        early = config.get_config().llm_model
+        assert config._config_cache is not None, "probe did not actually build the config"
+
+        config.load_dotenv_for_entrypoint()
+
+        print("EARLY:" + early)
+        print("AFTER:" + config.get_config().llm_model)
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "AFTER:model-from-dotenv" in result.stdout, (
+        "load_dotenv_for_entrypoint() left a config cached from before the .env was "
+        f"applied, so the .env had no effect:\n{result.stdout}"
+    )

--- a/hindsight-api-slim/tests/test_gemini_service_tier.py
+++ b/hindsight-api-slim/tests/test_gemini_service_tier.py
@@ -53,22 +53,48 @@ def test_llm_provider_from_env_ignores_gemini_tier_for_non_gemini(monkeypatch):
     clear_config_cache()
 
 
-def test_llm_provider_from_env_keeps_lightweight_loader(monkeypatch):
-    """Reading the Gemini tier must not construct the full application config."""
-    from hindsight_api.config import clear_config_cache
+def test_llm_provider_from_env_resolves_through_hindsight_config(monkeypatch):
+    """The factory reads HindsightConfig rather than re-parsing the environment.
+
+    It used to parse ``os.environ`` itself to stay independent of the full config.
+    That second parser is gone: config.py is the only place a ``HINDSIGHT_API_*``
+    value is interpreted, so the tier the factory applies is by construction the
+    tier the rest of the engine sees.
+    """
+    from hindsight_api.config import clear_config_cache, get_config
     from hindsight_api.engine.llm_wrapper import LLMProvider
 
     monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "gemini")
     monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "fake-key")
     monkeypatch.setenv("HINDSIGHT_API_LLM_GEMINI_SERVICE_TIER", "flex")
-    monkeypatch.setenv("HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS", "1000")
-    monkeypatch.setenv("HINDSIGHT_API_RETAIN_CHUNK_SIZE", "2000")
     clear_config_cache()
 
     with patch("google.genai.Client", return_value=MagicMock()):
         provider = LLMProvider.from_env()
 
     assert provider.gemini_service_tier == "flex"
+    assert provider.gemini_service_tier == get_config().llm_gemini_service_tier
+    clear_config_cache()
+
+
+def test_llm_provider_from_env_surfaces_invalid_configuration(monkeypatch):
+    """Config-level validation now reaches this factory instead of being bypassed.
+
+    A retain budget smaller than the chunk size is rejected when the config is built.
+    Because the factory goes through that config, the misconfiguration is reported
+    here too rather than only once some later code path happened to load it.
+    """
+    from hindsight_api.config import clear_config_cache
+    from hindsight_api.engine.llm_wrapper import LLMProvider
+
+    monkeypatch.setenv("HINDSIGHT_API_LLM_PROVIDER", "gemini")
+    monkeypatch.setenv("HINDSIGHT_API_LLM_API_KEY", "fake-key")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS", "1000")
+    monkeypatch.setenv("HINDSIGHT_API_RETAIN_CHUNK_SIZE", "2000")
+    clear_config_cache()
+
+    with pytest.raises(ValueError, match="HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS"):
+        LLMProvider.from_env()
     clear_config_cache()
 
 

--- a/hindsight-api-slim/tests/test_llm_per_op_concurrency.py
+++ b/hindsight-api-slim/tests/test_llm_per_op_concurrency.py
@@ -15,6 +15,7 @@ import httpx
 import pytest
 from openai import APIConnectionError
 
+from hindsight_api.config import clear_config_cache
 from hindsight_api.engine import llm_wrapper
 from hindsight_api.engine.llm_wrapper import (
     LLMProvider,
@@ -90,7 +91,16 @@ class TestSemaphoresForScope:
 
 
 class TestBuildPerOpSemaphores:
-    """`_build_per_op_semaphores()` reads env vars and validates them."""
+    """`_build_per_op_semaphores()` reads the resolved config and validates it.
+
+    Each case clears the config cache after setting the environment: the caps come
+    from HindsightConfig now, so the env only takes effect once the config is rebuilt.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_config(self):
+        """Leave no rebuilt config behind for the next test to inherit."""
+        yield
 
     def test_empty_when_no_env_vars(self, monkeypatch):
         monkeypatch.delenv("HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT", raising=False)

--- a/hindsight-api-slim/tests/test_llm_transport_diagnostics.py
+++ b/hindsight-api-slim/tests/test_llm_transport_diagnostics.py
@@ -20,7 +20,12 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from hindsight_api.config import DEFAULT_LLM_CONNECT_TIMEOUT, ENV_LLM_CONNECT_TIMEOUT, ENV_LLM_HTTP_LOG_LEVEL
+from hindsight_api.config import (
+    DEFAULT_LLM_CONNECT_TIMEOUT,
+    ENV_LLM_CONNECT_TIMEOUT,
+    ENV_LLM_HTTP_LOG_LEVEL,
+    clear_config_cache,
+)
 from hindsight_api.engine.llm_trace import (
     LLMQueueWait,
     record_queue_wait,
@@ -212,14 +217,21 @@ def test_describe_llm_error_omits_the_bracket_without_a_cause():
 
 
 def test_http_logging_level_is_configurable(monkeypatch):
-    """httpcore at DEBUG is the instrument that names the stalled phase."""
+    """httpcore at DEBUG is the instrument that names the stalled phase.
+
+    The explicit cache clears are because this test changes the environment twice:
+    the conftest reset only covers the state the test starts from, and the level is
+    read off the config, not the environment.
+    """
     monkeypatch.setenv(ENV_LLM_HTTP_LOG_LEVEL, "DEBUG")
+    clear_config_cache()
     try:
         configure_http_logging()
         assert logging.getLogger("httpx").level == logging.DEBUG
         assert logging.getLogger("httpcore").level == logging.DEBUG
     finally:
         monkeypatch.delenv(ENV_LLM_HTTP_LOG_LEVEL, raising=False)
+        clear_config_cache()
         configure_http_logging()
 
     assert logging.getLogger("httpx").level == logging.WARNING
@@ -228,11 +240,13 @@ def test_http_logging_level_is_configurable(monkeypatch):
 
 def test_unparseable_http_log_level_falls_back(monkeypatch):
     monkeypatch.setenv(ENV_LLM_HTTP_LOG_LEVEL, "chatty")
+    clear_config_cache()
     try:
         configure_http_logging()
         assert logging.getLogger("httpx").level == logging.WARNING
     finally:
         monkeypatch.delenv(ENV_LLM_HTTP_LOG_LEVEL, raising=False)
+        clear_config_cache()
         configure_http_logging()
 
 

--- a/hindsight-api-slim/tests/test_main_module.py
+++ b/hindsight-api-slim/tests/test_main_module.py
@@ -56,6 +56,9 @@ class TestMainModuleExtensionLoading:
             mock_config.host = "0.0.0.0"
             mock_config.port = 8888
             mock_config.log_level = "info"
+            # argparse defaults: a MagicMock would compare against ints later on.
+            mock_config.workers = 1
+            mock_config.access_log = False
             mock_config.mcp_enabled = False
             mock_config.run_migrations_on_startup = False
             mock_config.database_url = "postgresql://test:test@localhost/test"
@@ -112,6 +115,9 @@ class TestMainModuleExtensionLoading:
             mock_config.host = "0.0.0.0"
             mock_config.port = 8888
             mock_config.log_level = "info"
+            # argparse defaults: a MagicMock would compare against ints later on.
+            mock_config.workers = 1
+            mock_config.access_log = False
             mock_config.mcp_enabled = False
             mock_config.run_migrations_on_startup = False
             mock_config.database_url = "postgresql://test:test@localhost/test"
@@ -161,6 +167,9 @@ class TestMainModuleExtensionLoading:
             mock_config.host = "0.0.0.0"
             mock_config.port = 8888
             mock_config.log_level = "info"
+            # argparse defaults: a MagicMock would compare against ints later on.
+            mock_config.workers = 1
+            mock_config.access_log = False
             mock_config.mcp_enabled = False
             mock_config.run_migrations_on_startup = False
             mock_config.database_url = "postgresql://test:test@localhost/test"
@@ -220,6 +229,9 @@ class TestMainModuleExtensionLoading:
             mock_config.host = "0.0.0.0"
             mock_config.port = 8888
             mock_config.log_level = "info"
+            # argparse defaults: a MagicMock would compare against ints later on.
+            mock_config.workers = 1
+            mock_config.access_log = False
             mock_config.mcp_enabled = False
             mock_config.run_migrations_on_startup = False
             mock_config.database_url = "postgresql://test:test@localhost/test"
@@ -262,6 +274,9 @@ class TestMainModuleExtensionLoading:
             mock_config.host = "0.0.0.0"
             mock_config.port = 8888
             mock_config.log_level = "info"
+            # argparse defaults: a MagicMock would compare against ints later on.
+            mock_config.workers = 1
+            mock_config.access_log = False
             mock_config.mcp_enabled = False
             mock_config.run_migrations_on_startup = False
             mock_config.database_url = "postgresql://test:test@localhost/test"
@@ -309,6 +324,9 @@ class TestMainModuleExtensionLoading:
             mock_config.host = "0.0.0.0"
             mock_config.port = 8888
             mock_config.log_level = "info"
+            # argparse defaults: a MagicMock would compare against ints later on.
+            mock_config.workers = 1
+            mock_config.access_log = False
             mock_config.mcp_enabled = False
             mock_config.run_migrations_on_startup = False
             mock_config.database_url = "postgresql://test:test@localhost/test"
@@ -350,6 +368,9 @@ class TestMainModuleExtensionLoading:
             mock_config.host = "0.0.0.0"
             mock_config.port = 8888
             mock_config.log_level = "info"
+            # argparse defaults: a MagicMock would compare against ints later on.
+            mock_config.workers = 1
+            mock_config.access_log = False
             mock_config.mcp_enabled = False
             mock_config.run_migrations_on_startup = False
             mock_config.database_url = "postgresql://test:test@localhost/test"
@@ -394,6 +415,9 @@ class TestMainModuleExtensionLoading:
             mock_config.host = "0.0.0.0"
             mock_config.port = 8888
             mock_config.log_level = "info"
+            # argparse defaults: a MagicMock would compare against ints later on.
+            mock_config.workers = 1
+            mock_config.access_log = False
             mock_config.mcp_enabled = False
             mock_config.run_migrations_on_startup = False
             mock_config.database_url = "postgresql://test:test@localhost/test"

--- a/hindsight-api-slim/tests/test_tracing.py
+++ b/hindsight-api-slim/tests/test_tracing.py
@@ -460,7 +460,8 @@ def _tracing_config(**overrides):
         "otel_traces_enabled": True,
         "otel_exporter_otlp_endpoint": "http://localhost:4318",
         "otel_exporter_otlp_headers": None,
-        "otel_service_name": "hindsight-api",
+        # None is "operator named nothing" — the state the API default stands in for.
+        "otel_service_name": None,
         "otel_deployment_environment": "test",
     }
     return dataclasses.replace(_get_raw_config(), **{**defaults, **overrides})

--- a/hindsight-docs/docs/developer/configuration.md
+++ b/hindsight-docs/docs/developer/configuration.md
@@ -524,6 +524,27 @@ export HINDSIGHT_API_LLM_PROVIDER=none
 For detailed setup instructions for **OpenAI Codex** (ChatGPT Plus/Pro), **Claude Code** (Claude Pro/Max), and **Vertex AI** (Google Cloud), see the [Models documentation](./models#openai-codex-setup-chatgpt-pluspro).
 :::
 
+### SuperGrok OAuth (`xai-oauth`)
+
+`HINDSIGHT_API_LLM_PROVIDER=xai-oauth` authenticates with a SuperGrok subscription via
+device-code OAuth instead of an API key. Log in once with
+`python -m hindsight_api.engine.providers.xai_oauth_auth login`; the grant is stored on disk
+and refreshed automatically. Every variable below is optional — the defaults match the
+vendor's own client, so a normal deployment sets none of them.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_XAI_OAUTH_TOKEN_PATH` | Where the OAuth grant is stored. Both the login and the refresh follow it, so this relocates the store rather than overriding only the read. | `~/.hindsight/xai_oauth.json` |
+| `HINDSIGHT_API_XAI_OAUTH_BASE_URL` | Deployment-wide endpoint override. Takes precedence over `HINDSIGHT_API_LLM_BASE_URL`, which deployments often set for an unrelated proxy. | `https://api.x.ai/v1` |
+| `HINDSIGHT_API_XAI_OAUTH_CLIENT_ID` | OAuth client id used at login and refresh. | xAI's published Grok CLI client |
+| `HINDSIGHT_API_XAI_OAUTH_SCOPE` | Scope string requested at login. | vendor default |
+| `HINDSIGHT_API_XAI_OAUTH_REFRESH_SKEW_SECONDS` | How long before expiry a token counts as due for refresh. Widen it if this deployment calls the provider rarely (a cron or gateway shape). | `60` |
+| `HINDSIGHT_API_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS` | Per-request timeout for discovery, device-code and refresh calls. | `20` |
+| `HINDSIGHT_API_XAI_OAUTH_DEBUG_HEADERS` | Log an allowlist of response headers (`via`, `x-request-id`, `cf-ray`, `server`, `date`) on a non-2xx reply. Diagnostic only; never logs credentials, cookies or bodies. | `false` |
+
+This is the subscription lane, not xAI API-key support — for `api.x.ai` with an API key use
+`HINDSIGHT_API_LLM_PROVIDER=openai` with `HINDSIGHT_API_LLM_BASE_URL=https://api.x.ai/v1`.
+
 ### LLM Router (LiteLLM Router)
 
 `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` runs the default LLM through [LiteLLM's `Router`](https://docs.litellm.ai/docs/routing). The config JSON is forwarded verbatim — for fallback chains, load-balancing, rate limits, routing strategies, and the rest of the supported keys, see the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing). Hindsight always issues completions against `model_name: "default"`, so include at least one entry with that name.
@@ -1376,6 +1397,8 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_BASE_PATH` | Base path for API when behind reverse proxy (e.g., `/hindsight`) | `""` (root) |
 | `HINDSIGHT_API_WORKERS` | Number of uvicorn worker processes | `1` |
 | `HINDSIGHT_API_ACCESS_LOG` | Enable uvicorn access log (`true`, `1`, `yes`, `on` to enable) | `false` |
+| `HINDSIGHT_API_DAEMON_LOG` | Where `--daemon` redirects the server's stdout and stderr. Set this per profile when several daemons run on one machine, so their output does not interleave into a single file. | `~/.hindsight/daemon.log` |
+| `HINDSIGHT_API_FREE_THREADING` | What to do when running on a free-threaded (`python3.14t`) interpreter: `strict` refuses to start if the GIL is still enabled, `warn` logs and continues, `off` disables the check. Unset lets the interpreter decide — `strict` on a free-threaded build, `off` on a normal one. | interpreter-dependent |
 | `HINDSIGHT_API_LOG_LEVEL` | Log level: `debug`, `info`, `warning`, `error` | `info` |
 | `HINDSIGHT_API_LOG_FORMAT` | Log format: `text` or `json` (structured logging for cloud platforms) | `text` |
 | `HINDSIGHT_API_LOG_JSON_FIELDS` | Comma-separated allowlist of JSON log fields to emit (e.g. `severity,message,tenant`). Available: `severity`, `message`, `timestamp`, `logger`, `tenant`, `exception`. Empty = all fields. | `""` (all) |
@@ -1409,7 +1432,6 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_RECENCY_DECAY_FUNCTION` | Shape of the recency boost applied during reranking — how a memory's age is turned into a small freshness adjustment to its final rank. `linear` (default) decays in a straight line from full freshness (today) to a floor reached at `HINDSIGHT_API_RECENCY_DECAY_LINEAR_WINDOW_DAYS`. `exponential` decays by half-life: a memory is treated as neutral (no boost or penalty) at `HINDSIGHT_API_RECENCY_DECAY_HALFLIFE_DAYS`, younger memories are boosted and older ones penalised, with a smooth fade rather than a hard cutoff. `none` disables recency entirely (age never affects ranking). | `linear` |
 | `HINDSIGHT_API_RECENCY_DECAY_LINEAR_WINDOW_DAYS` | For the `linear` decay function: the number of days over which a memory fades from full freshness to the minimum. Only used when `HINDSIGHT_API_RECENCY_DECAY_FUNCTION=linear`. | `365` |
 | `HINDSIGHT_API_RECENCY_DECAY_HALFLIFE_DAYS` | For the `exponential` decay function: the age (in days) at which a memory is considered neutral — younger memories get a recency boost, older ones a penalty. Smaller values favour very recent memories more aggressively. Only used when `HINDSIGHT_API_RECENCY_DECAY_FUNCTION=exponential`. | `90` |
-| `HINDSIGHT_API_MENTAL_MODEL_REFRESH_CONCURRENCY` | Max concurrent mental model refreshes | `8` |
 | `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY` | Track history of content changes to each mental model (previous content + timestamp), stored one row per change in the `mental_model_history` table. Set to `false` to disable entirely — no history rows are written, reducing storage if audit trails are not needed. **This is how you turn the feature off** (not a zero cap). | `true` |
 | `HINDSIGHT_API_MENTAL_MODEL_MIN_REFRESH_INTERVAL_SECONDS` | Minimum seconds between two *automatic* refreshes of the same mental model — the after-consolidation trigger and the cron schedule. A trigger that fires sooner is not dropped: its refresh is queued and parked until the window closes, and every further trigger in the meantime folds into that one queued refresh, so a burst of small retains costs one refresh instead of one per retain. Raise it when a bank ingests continuously and its models do not need to be current to the minute — the parked refresh still sees everything that accumulated while it waited. Explicit refreshes (API, MCP, control plane) ignore the floor and run immediately, and additionally release a parked refresh they fold into. `0` = no floor, every trigger refreshes at once. Hierarchical — overridable per bank via the [config API](#hierarchical-configuration), and per model via `trigger.min_refresh_interval_seconds` (which wins, including an explicit `0` to exempt one hot model from a bank-wide floor). | `0` |
 | `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` | Max history rows kept per mental model. On each refresh the previous version is inserted into the `mental_model_history` table and the oldest rows beyond this cap are deleted, so per-model history can't grow without bound. `0` or a negative value **removes the cap** (history then grows with every refresh — unbounded); to turn history off entirely set `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY=false` instead. | `50` |
@@ -1975,6 +1997,7 @@ Files uploaded via the file retain API are stored in an object storage backend b
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_FILE_STORAGE_TYPE` | Storage backend: `native`, `s3`, `gcs`, or `azure` | `native` |
+| `HINDSIGHT_API_FILE_STORAGE_EXTENSION` | `module.path:ClassName` naming your own `FileStorage` implementation, used instead of the built-in backends. Every other `HINDSIGHT_API_FILE_STORAGE_*` variable is passed to it as a lowercased config dict. | unset |
 
 #### Native (PostgreSQL)
 
@@ -2259,6 +2282,7 @@ Configuration for background task processing. By default, the API processes task
 | `HINDSIGHT_API_WORKER_POLL_INTERVAL_MS` | Database polling interval in milliseconds | `500` |
 | `HINDSIGHT_API_WORKER_MAX_RETRIES` | Max retries before marking task failed | `3` |
 | `HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS` | Seconds between retries on transient task failure | `60` |
+| `HINDSIGHT_API_BACKPRESSURE_DEFER_SECONDS` | How long a task the store shed for backpressure is held before it is retried. Long enough that the backlog has a real chance to drain — retrying into a still-full store just sheds again — and short enough that a cleared backlog is not left waiting. Deferrals do not count against `HINDSIGHT_API_WORKER_MAX_RETRIES`. | `120` |
 | `HINDSIGHT_API_WORKER_HTTP_PORT` | HTTP port for worker metrics/health (worker CLI only) | `8889` |
 | `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker (total across all operation types) | `10` |
 | `HINDSIGHT_API_OPERATION_RETENTION_DAYS` | Static server-wide retention window for completed, failed, and cancelled operation rows, including their task payload and result metadata. `0` (the default) keeps them indefinitely; set a positive number of days to enable automatic pruning. | `0` |
@@ -2335,7 +2359,6 @@ For a server handling many concurrent requests, lower values (down to `1`) favor
 | `HINDSIGHT_API_WEBHOOK_URL` | Global webhook URL for event delivery | - (disabled) |
 | `HINDSIGHT_API_WEBHOOK_SECRET` | HMAC signing secret for webhook payloads | - (unsigned) |
 | `HINDSIGHT_API_WEBHOOK_EVENT_TYPES` | Comma-separated list of event types to deliver via webhook | `consolidation.completed` |
-| `HINDSIGHT_API_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS` | How often the webhook delivery worker polls for pending deliveries (seconds) | `30` |
 | `HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS` | Comma-separated hosts or IP/CIDR ranges permitted as webhook destinations in addition to public addresses. Private, loopback, and link-local ranges (including the cloud metadata address) are blocked unless listed here. | - (public only) |
 | `HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY` | Return the raw upstream response body in the delivery-history API. Off by default to avoid exposing internal response contents; the delivery status code is always returned. | `false` |
 

--- a/hindsight-embed/hindsight_embed/env.example
+++ b/hindsight-embed/hindsight_embed/env.example
@@ -542,8 +542,45 @@ HINDSIGHT_API_LOG_LEVEL=info
 # HINDSIGHT_API_DB_ACQUIRE_WARN_THRESHOLD_MS=1000
 
 # -----------------------------------------------------------------------------
+# Operations (Optional)
+# -----------------------------------------------------------------------------
+
+# Where `--daemon` redirects the server's stdout/stderr. Set this per profile when
+# several daemons share a machine, so their output does not interleave.
+# HINDSIGHT_API_DAEMON_LOG=~/.hindsight/daemon.log
+
+# Periodic CPU profile, as JSON. Absent = profiling off.
+# HINDSIGHT_API_PROFILE={"every": 60, "top": 20, "mode": "cprofile"}
+
+# How long a task the store shed for backpressure is held before being retried.
+# Deferrals do not count against HINDSIGHT_API_WORKER_MAX_RETRIES.
+# HINDSIGHT_API_BACKPRESSURE_DEFER_SECONDS=120
+
+# Legacy MCP bearer token, checked before the TenantExtension's own auth.
+# HINDSIGHT_API_MCP_AUTH_TOKEN=your-mcp-token
+
+# -----------------------------------------------------------------------------
+# SuperGrok OAuth provider (Optional; HINDSIGHT_API_LLM_PROVIDER=xai-oauth)
+# -----------------------------------------------------------------------------
+
+# All optional — the defaults match the vendor's own client. Log in once with
+# `python -m hindsight_api.engine.providers.xai_oauth_auth login`.
+# HINDSIGHT_API_XAI_OAUTH_TOKEN_PATH=~/.hindsight/xai_oauth.json
+# HINDSIGHT_API_XAI_OAUTH_BASE_URL=https://api.x.ai/v1
+# HINDSIGHT_API_XAI_OAUTH_CLIENT_ID=your-oauth-client-id
+# HINDSIGHT_API_XAI_OAUTH_SCOPE=openid profile email offline_access
+# HINDSIGHT_API_XAI_OAUTH_REFRESH_SKEW_SECONDS=60
+# HINDSIGHT_API_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS=20
+# Debug-only: logs an allowlist of response headers on a non-2xx reply.
+# HINDSIGHT_API_XAI_OAUTH_DEBUG_HEADERS=false
+
+# -----------------------------------------------------------------------------
 # Extensions (Optional)
 # -----------------------------------------------------------------------------
+
+# Your own FileStorage implementation, used instead of the built-in backends.
+# Every other HINDSIGHT_API_FILE_STORAGE_* variable is passed to it as config.
+# HINDSIGHT_API_FILE_STORAGE_EXTENSION=my_package.storage:MyStorage
 
 # Request headers copied into RequestContext.extra_headers so a custom
 # TenantExtension / OperationValidatorExtension can read them. Comma-separated,

--- a/skills/hindsight-docs/references/developer/configuration.md
+++ b/skills/hindsight-docs/references/developer/configuration.md
@@ -524,6 +524,27 @@ export HINDSIGHT_API_LLM_PROVIDER=none
 For detailed setup instructions for **OpenAI Codex** (ChatGPT Plus/Pro), **Claude Code** (Claude Pro/Max), and **Vertex AI** (Google Cloud), see the [Models documentation](./models#openai-codex-setup-chatgpt-pluspro).
 :::
 
+### SuperGrok OAuth (`xai-oauth`)
+
+`HINDSIGHT_API_LLM_PROVIDER=xai-oauth` authenticates with a SuperGrok subscription via
+device-code OAuth instead of an API key. Log in once with
+`python -m hindsight_api.engine.providers.xai_oauth_auth login`; the grant is stored on disk
+and refreshed automatically. Every variable below is optional — the defaults match the
+vendor's own client, so a normal deployment sets none of them.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_API_XAI_OAUTH_TOKEN_PATH` | Where the OAuth grant is stored. Both the login and the refresh follow it, so this relocates the store rather than overriding only the read. | `~/.hindsight/xai_oauth.json` |
+| `HINDSIGHT_API_XAI_OAUTH_BASE_URL` | Deployment-wide endpoint override. Takes precedence over `HINDSIGHT_API_LLM_BASE_URL`, which deployments often set for an unrelated proxy. | `https://api.x.ai/v1` |
+| `HINDSIGHT_API_XAI_OAUTH_CLIENT_ID` | OAuth client id used at login and refresh. | xAI's published Grok CLI client |
+| `HINDSIGHT_API_XAI_OAUTH_SCOPE` | Scope string requested at login. | vendor default |
+| `HINDSIGHT_API_XAI_OAUTH_REFRESH_SKEW_SECONDS` | How long before expiry a token counts as due for refresh. Widen it if this deployment calls the provider rarely (a cron or gateway shape). | `60` |
+| `HINDSIGHT_API_XAI_OAUTH_REFRESH_TIMEOUT_SECONDS` | Per-request timeout for discovery, device-code and refresh calls. | `20` |
+| `HINDSIGHT_API_XAI_OAUTH_DEBUG_HEADERS` | Log an allowlist of response headers (`via`, `x-request-id`, `cf-ray`, `server`, `date`) on a non-2xx reply. Diagnostic only; never logs credentials, cookies or bodies. | `false` |
+
+This is the subscription lane, not xAI API-key support — for `api.x.ai` with an API key use
+`HINDSIGHT_API_LLM_PROVIDER=openai` with `HINDSIGHT_API_LLM_BASE_URL=https://api.x.ai/v1`.
+
 ### LLM Router (LiteLLM Router)
 
 `HINDSIGHT_API_LLM_PROVIDER=litellmrouter` runs the default LLM through [LiteLLM's `Router`](https://docs.litellm.ai/docs/routing). The config JSON is forwarded verbatim — for fallback chains, load-balancing, rate limits, routing strategies, and the rest of the supported keys, see the [LiteLLM Router docs](https://docs.litellm.ai/docs/routing). Hindsight always issues completions against `model_name: "default"`, so include at least one entry with that name.
@@ -1376,6 +1397,8 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_BASE_PATH` | Base path for API when behind reverse proxy (e.g., `/hindsight`) | `""` (root) |
 | `HINDSIGHT_API_WORKERS` | Number of uvicorn worker processes | `1` |
 | `HINDSIGHT_API_ACCESS_LOG` | Enable uvicorn access log (`true`, `1`, `yes`, `on` to enable) | `false` |
+| `HINDSIGHT_API_DAEMON_LOG` | Where `--daemon` redirects the server's stdout and stderr. Set this per profile when several daemons run on one machine, so their output does not interleave into a single file. | `~/.hindsight/daemon.log` |
+| `HINDSIGHT_API_FREE_THREADING` | What to do when running on a free-threaded (`python3.14t`) interpreter: `strict` refuses to start if the GIL is still enabled, `warn` logs and continues, `off` disables the check. Unset lets the interpreter decide — `strict` on a free-threaded build, `off` on a normal one. | interpreter-dependent |
 | `HINDSIGHT_API_LOG_LEVEL` | Log level: `debug`, `info`, `warning`, `error` | `info` |
 | `HINDSIGHT_API_LOG_FORMAT` | Log format: `text` or `json` (structured logging for cloud platforms) | `text` |
 | `HINDSIGHT_API_LOG_JSON_FIELDS` | Comma-separated allowlist of JSON log fields to emit (e.g. `severity,message,tenant`). Available: `severity`, `message`, `timestamp`, `logger`, `tenant`, `exception`. Empty = all fields. | `""` (all) |
@@ -1409,7 +1432,6 @@ For advanced authentication (JWT, OAuth, multi-tenant schemas), implement a cust
 | `HINDSIGHT_API_RECENCY_DECAY_FUNCTION` | Shape of the recency boost applied during reranking — how a memory's age is turned into a small freshness adjustment to its final rank. `linear` (default) decays in a straight line from full freshness (today) to a floor reached at `HINDSIGHT_API_RECENCY_DECAY_LINEAR_WINDOW_DAYS`. `exponential` decays by half-life: a memory is treated as neutral (no boost or penalty) at `HINDSIGHT_API_RECENCY_DECAY_HALFLIFE_DAYS`, younger memories are boosted and older ones penalised, with a smooth fade rather than a hard cutoff. `none` disables recency entirely (age never affects ranking). | `linear` |
 | `HINDSIGHT_API_RECENCY_DECAY_LINEAR_WINDOW_DAYS` | For the `linear` decay function: the number of days over which a memory fades from full freshness to the minimum. Only used when `HINDSIGHT_API_RECENCY_DECAY_FUNCTION=linear`. | `365` |
 | `HINDSIGHT_API_RECENCY_DECAY_HALFLIFE_DAYS` | For the `exponential` decay function: the age (in days) at which a memory is considered neutral — younger memories get a recency boost, older ones a penalty. Smaller values favour very recent memories more aggressively. Only used when `HINDSIGHT_API_RECENCY_DECAY_FUNCTION=exponential`. | `90` |
-| `HINDSIGHT_API_MENTAL_MODEL_REFRESH_CONCURRENCY` | Max concurrent mental model refreshes | `8` |
 | `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY` | Track history of content changes to each mental model (previous content + timestamp), stored one row per change in the `mental_model_history` table. Set to `false` to disable entirely — no history rows are written, reducing storage if audit trails are not needed. **This is how you turn the feature off** (not a zero cap). | `true` |
 | `HINDSIGHT_API_MENTAL_MODEL_MIN_REFRESH_INTERVAL_SECONDS` | Minimum seconds between two *automatic* refreshes of the same mental model — the after-consolidation trigger and the cron schedule. A trigger that fires sooner is not dropped: its refresh is queued and parked until the window closes, and every further trigger in the meantime folds into that one queued refresh, so a burst of small retains costs one refresh instead of one per retain. Raise it when a bank ingests continuously and its models do not need to be current to the minute — the parked refresh still sees everything that accumulated while it waited. Explicit refreshes (API, MCP, control plane) ignore the floor and run immediately, and additionally release a parked refresh they fold into. `0` = no floor, every trigger refreshes at once. Hierarchical — overridable per bank via the [config API](#hierarchical-configuration), and per model via `trigger.min_refresh_interval_seconds` (which wins, including an explicit `0` to exempt one hot model from a bank-wide floor). | `0` |
 | `HINDSIGHT_API_MENTAL_MODEL_HISTORY_MAX_ENTRIES` | Max history rows kept per mental model. On each refresh the previous version is inserted into the `mental_model_history` table and the oldest rows beyond this cap are deleted, so per-model history can't grow without bound. `0` or a negative value **removes the cap** (history then grows with every refresh — unbounded); to turn history off entirely set `HINDSIGHT_API_ENABLE_MENTAL_MODEL_HISTORY=false` instead. | `50` |
@@ -1975,6 +1997,7 @@ Files uploaded via the file retain API are stored in an object storage backend b
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HINDSIGHT_API_FILE_STORAGE_TYPE` | Storage backend: `native`, `s3`, `gcs`, or `azure` | `native` |
+| `HINDSIGHT_API_FILE_STORAGE_EXTENSION` | `module.path:ClassName` naming your own `FileStorage` implementation, used instead of the built-in backends. Every other `HINDSIGHT_API_FILE_STORAGE_*` variable is passed to it as a lowercased config dict. | unset |
 
 #### Native (PostgreSQL)
 
@@ -2259,6 +2282,7 @@ Configuration for background task processing. By default, the API processes task
 | `HINDSIGHT_API_WORKER_POLL_INTERVAL_MS` | Database polling interval in milliseconds | `500` |
 | `HINDSIGHT_API_WORKER_MAX_RETRIES` | Max retries before marking task failed | `3` |
 | `HINDSIGHT_API_WORKER_TASK_RETRY_BACKOFF_SECONDS` | Seconds between retries on transient task failure | `60` |
+| `HINDSIGHT_API_BACKPRESSURE_DEFER_SECONDS` | How long a task the store shed for backpressure is held before it is retried. Long enough that the backlog has a real chance to drain — retrying into a still-full store just sheds again — and short enough that a cleared backlog is not left waiting. Deferrals do not count against `HINDSIGHT_API_WORKER_MAX_RETRIES`. | `120` |
 | `HINDSIGHT_API_WORKER_HTTP_PORT` | HTTP port for worker metrics/health (worker CLI only) | `8889` |
 | `HINDSIGHT_API_WORKER_MAX_SLOTS` | Maximum concurrent tasks per worker (total across all operation types) | `10` |
 | `HINDSIGHT_API_OPERATION_RETENTION_DAYS` | Static server-wide retention window for completed, failed, and cancelled operation rows, including their task payload and result metadata. `0` (the default) keeps them indefinitely; set a positive number of days to enable automatic pruning. | `0` |
@@ -2335,7 +2359,6 @@ For a server handling many concurrent requests, lower values (down to `1`) favor
 | `HINDSIGHT_API_WEBHOOK_URL` | Global webhook URL for event delivery | - (disabled) |
 | `HINDSIGHT_API_WEBHOOK_SECRET` | HMAC signing secret for webhook payloads | - (unsigned) |
 | `HINDSIGHT_API_WEBHOOK_EVENT_TYPES` | Comma-separated list of event types to deliver via webhook | `consolidation.completed` |
-| `HINDSIGHT_API_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS` | How often the webhook delivery worker polls for pending deliveries (seconds) | `30` |
 | `HINDSIGHT_API_WEBHOOK_ALLOWED_HOSTS` | Comma-separated hosts or IP/CIDR ranges permitted as webhook destinations in addition to public addresses. Private, loopback, and link-local ranges (including the cloud metadata address) are blocked unless listed here. | - (public only) |
 | `HINDSIGHT_API_WEBHOOK_EXPOSE_RESPONSE_BODY` | Return the raw upstream response body in the delivery-history API. Off by default to avoid exposing internal response contents; the delivery status code is always returned. | `false` |
 


### PR DESCRIPTION
## What

Every fixed, server-level `HINDSIGHT_API_*` value is now parsed in `config.py` and read off `HindsightConfig`, rather than re-parsed from `os.environ` at the point of use.

About thirty call sites across the engine were reading the environment directly. Two parsers for one variable is how the engine and the config drift apart: `LLMProvider.from_env()` had grown its own copies of the provider defaulting, the Gemini tier gating and the cache-affinity default, each carrying a comment asking the next reader not to let them disagree. Those comments are gone.

## Changes

**Rewired to read config** — `engine/llm_wrapper.py` (20 vars: the whole default provider factory plus all four concurrency semaphores), `engine/llm_transport.py`, `engine/embeddings.py`, four `engine/providers/*_llm.py` timeout fallbacks, both `xai_oauth_*` modules, `_vector_index.py`, `tracing.py`, `api/mcp.py`, `main.py`, `worker/poller.py`, `profiling.py`, `daemon.py`, `engine/storage/`.

**17 variables that worked but had no config field now have one** — `WORKERS`, `ACCESS_LOG`, `DAEMON_LOG`, `PROFILE`, `MCP_AUTH_TOKEN`, `FILE_STORAGE_EXTENSION`, `BACKPRESSURE_DEFER_SECONDS`, `EMBEDDINGS_OPENAI_{API_KEY,MODEL}` and the seven `XAI_OAUTH_*` knobs. The five secret-bearing ones are registered in `_CREDENTIAL_FIELDS` so they stay off the API surface.

**Three fields become `str | None`** — `host`, `otel_service_name`, `xai_oauth_base_url`. Each had a caller that needed to tell "the operator set this" from "this is the default", and was reading the environment a second time to find out. The default is now applied at the single point of use.

**`requires_api_key` moves to a new leaf module**, `engine/provider_auth.py`. `config.py` needs it while building `HindsightConfig`, and `llm_wrapper` needs the built config at import time to size its semaphores — that cycle is why the LLM factory had its own env parser to begin with. Both existing import paths still work.

## Behaviour changes

- `LLMProvider.from_env()` builds the full config, so an unrelated invalid setting (e.g. `RETAIN_MAX_COMPLETION_TOKENS` ≤ `RETAIN_CHUNK_SIZE`) surfaces there instead of being bypassed. The test that asserted the opposite now asserts the new contract.
- `resolve_daemon_host_port()` takes `configured_host` from its caller instead of reading `HINDSIGHT_API_HOST` itself.

Value vocabularies are preserved exactly where they differed from `_parse_boolean_env` — `ACCESS_LOG` still accepts `yes`/`on`, `XAI_OAUTH_DEBUG_HEADERS` still never raises — so no working deployment turns into a start-up error.

## Guard

`tests/test_config_is_the_only_env_reader.py` walks the package AST and fails on any `HINDSIGHT_API_*` read outside `config.py`. Five exemptions, each with its reason: standalone Alembic (`env.py`, `_owned.py`), two pre-config bootstraps, and the open-ended per-extension config namespaces. A second test fails when an exemption goes stale.

`tests/conftest.py` resets the config cache per test — now that values come off a cached config, a test's `monkeypatch.setenv` would otherwise land against whichever config the first test in that xdist worker happened to build. Costs ~21 ms per rebuild.

## Also removed

Two env vars that were parsed into a field nothing ever read: `HINDSIGHT_API_MENTAL_MODEL_REFRESH_CONCURRENCY` (no semaphore governs mental-model refresh) and `HINDSIGHT_API_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS` (deliveries are queued as `webhook_delivery` worker tasks; no polling loop exists). Both were documented as working. Neither was in `_CONFIGURABLE_FIELDS`, so there is no API-schema or client impact.

## Testing

Full `hindsight-api-slim` suite: **8998 passed, 4 failed**. All four are pre-existing — `test_llm_token_metrics::test_noop_collector_when_metrics_disabled` and `test_fact_extraction_agent_experience::test_user_interaction_classified_as_experience` fail identically on a clean worktree at `main` (both make real LLM calls); the other two pass in isolation and match the suite's known flaky baseline.

`./scripts/hooks/lint.sh`, `uv run ty check`, and `check-unused.sh` are clean with no new findings.
