### PR TITLE
chore(deps): update js-yaml in the zapier integration

### DIFF
--- a/hindsight-integrations/zapier/package-lock.json
+++ b/hindsight-integrations/zapier/package-lock.json
@@ -8173,9 +8173,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -10836,7 +10836,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/hindsight-integrations/zapier/package.json
+++ b/hindsight-integrations/zapier/package.json
@@ -40,7 +40,7 @@
     "brace-expansion@^1.0.0": "^1.1.18",
     "brace-expansion@^2.0.0": "^2.1.4",
     "brace-expansion@^5.0.0": "^5.0.9",
-    "js-yaml": ">=4.3.1 <5.0.0",
+    "js-yaml": ">=4.3.2 <5.0.0",
     "ip-address": ">=10.3.1 <11.0.0",
     "undici": ">=6.28.0 <7.0.0",
     "browserslist": ">=4.28.7 <5.0.0"


### PR DESCRIPTION
Routine dependency maintenance for `hindsight-integrations/zapier/package-lock.json`. One pull request per lockfile; this one touches that lockfile and its manifest only.

## What changed

| package | was | now |
|---|---|---|
| `js-yaml` (override floor) | `>=4.3.1 <5.0.0` | 4.3.2 |

A one-line floor raise inside the existing major line; the lockfile diff is 8 lines.

## Note on `adm-zip`

This lockfile also carries an open `adm-zip` advisory (#1500), which is **not** addressed here. The advisory's vulnerable range is `>= 0.5.9, <= 0.6.0`, and 0.6.0 (published 2026-07-10) is the current and highest release on the registry, so the entire fixed range is empty — the latest release is still inside the advisory. The override already pins `adm-zip` to `>=0.6.0`, which is as high as the registry goes. No bump can close it, so the alert is left open deliberately, so that it closes on its own when a fixed release ships.

## Verification

Reproducing the `test-zapier-integration` job's own steps locally:

- `npm install --no-fund --no-audit` — clean, and confirmed byte-for-byte not to alter the committed lockfile
- `npm run validate` — app definition valid, zero errors (two pre-existing advisory warnings, D026 and D027, both unrelated to this change)
- `npm test` — 20 passing

## Alerts closed

#1501