### PR TITLE
docs(documents): say the tags PATCH replaces the array, and test clearing it

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -2505,8 +2505,9 @@ class UpdateDocumentRequest(BaseModel):
 
     tags: list[str] | None = Field(
         default=None,
-        description="New tags for the document and its memory units. "
-        "Triggers observation invalidation and re-consolidation.",
+        description="The complete new set of tags for the document and its memory units — this "
+        "REPLACES the existing tags rather than adding to them, so omitting a tag drops it and "
+        "`[]` clears them all. Triggers observation invalidation and re-consolidation.",
     )
 
 
@@ -7372,9 +7373,15 @@ def _register_routes(app: FastAPI):
         response_model=UpdateDocumentResponse,
         summary="Update document",
         description="Update mutable fields on a document without re-processing its content.\n\n"
-        "**Tags** (`tags`): Propagated to all associated memory units. Observations derived from "
+        "**Tags** (`tags`): The array REPLACES the document's tags, it is not merged into them — "
+        "send the complete set you want the document to end up with, and any tag you leave out is "
+        "dropped. An empty array (`[]`) therefore clears every tag; only omitting the field "
+        "entirely is rejected (422).\n\n"
+        "The new tags are propagated to all associated memory units. Observations derived from "
         "those units are invalidated and queued for re-consolidation under the new tags. "
-        "Co-source memories from other documents that shared those observations are also reset.\n\n"
+        "Co-source memories from other documents that shared those observations are also reset. "
+        "Tags are compared as a set, so re-sending the tags a document already has (in any order) "
+        "changes nothing and queues no re-consolidation.\n\n"
         "At least one field must be provided.",
         operation_id="update_document",
         tags=["Documents"],

--- a/hindsight-api-slim/tests/test_observation_invalidation.py
+++ b/hindsight-api-slim/tests/test_observation_invalidation.py
@@ -1124,6 +1124,88 @@ class TestUpdateDocumentTagsObservationCleanup:
         await memory.delete_bank(bank_id, request_context=request_context)
 
     @pytest.mark.asyncio
+    async def test_empty_tags_clears_them(self, memory: MemoryEngine, request_context: RequestContext):
+        """``tags=[]`` is a real update: it clears the document's tags and its units'.
+
+        The array is a REPLACEMENT, never a merge, so an empty one is how a caller drops
+        every tag. Every guard on the path is written ``is not None`` rather than a
+        truthiness check precisely so the empty list survives it — this test is what stops
+        one of them regressing to ``if tags:`` and turning a clear into a silent no-op.
+        """
+        bank_id = f"test-tag-update-clear-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            doc_id = f"doc-{uuid.uuid4().hex[:8]}"
+            doc_mem_ids = await _insert_document_with_memories(
+                memory, conn, bank_id, doc_id, [("Alice loves hiking.", "experience")]
+            )
+
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()):
+            await memory.update_document(doc_id, bank_id, tags=["a", "b"], request_context=request_context)
+
+        async with pool.acquire() as conn:
+            obs_id = await _insert_observation(memory, conn, bank_id, "Alice is outdoorsy.", doc_mem_ids)
+
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()) as mock_consolidate:
+            assert await memory.update_document(doc_id, bank_id, tags=[], request_context=request_context)
+            mock_consolidate.assert_awaited()
+
+        document = await memory.get_document(doc_id, bank_id, request_context=request_context)
+        assert list(document["tags"] or []) == [], document["tags"]
+
+        async with pool.acquire() as conn:
+            for mem_id in doc_mem_ids:
+                stored_mem = await _get_memory(conn, bank_id, mem_id)
+                assert list(stored_mem.tags or []) == [], f"Memory unit {mem_id} should have no tags left"
+            # Clearing is a tag CHANGE like any other, so it runs the same cascade.
+            assert str(obs_id) not in await _get_observation_ids(conn, bank_id)
+            for mem_id in doc_mem_ids:
+                assert await _get_consolidated_at(conn, mem_id, bank_id) is None
+
+        # And clearing tags on a document that already has none is the no-op the set
+        # comparison promises — not a second round of re-consolidation.
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()) as mock_consolidate:
+            assert await memory.update_document(doc_id, bank_id, tags=[], request_context=request_context)
+            mock_consolidate.assert_not_awaited()
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
+    async def test_patch_endpoint_accepts_empty_tags(
+        self, memory: MemoryEngine, api_client, request_context: RequestContext
+    ):
+        """PATCH ``{"tags": []}`` clears the tags; only a MISSING ``tags`` is a 422.
+
+        The route rejects "no field provided" with ``body.tags is None``. An empty list is
+        a provided value, and the documented way to drop every tag, so it must reach the
+        engine rather than trip the guard.
+        """
+        bank_id = f"test-tag-patch-empty-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            doc_id = f"doc-{uuid.uuid4().hex[:8]}"
+            await _insert_document_with_memories(memory, conn, bank_id, doc_id, [("Alice loves hiking.", "experience")])
+
+        with patch.object(memory, "submit_async_consolidation", new=AsyncMock()):
+            await memory.update_document(doc_id, bank_id, tags=["a", "b"], request_context=request_context)
+
+            resp = await api_client.patch(f"/v1/default/banks/{bank_id}/documents/{doc_id}", json={"tags": []})
+        assert resp.status_code == 200, resp.text
+
+        document = await memory.get_document(doc_id, bank_id, request_context=request_context)
+        assert list(document["tags"] or []) == [], document["tags"]
+
+        # An omitted `tags` is still the "nothing to update" 422.
+        resp = await api_client.patch(f"/v1/default/banks/{bank_id}/documents/{doc_id}", json={})
+        assert resp.status_code == 422, resp.text
+
+        await memory.delete_bank(bank_id, request_context=request_context)
+
+    @pytest.mark.asyncio
     async def test_tag_change_stamps_memory_units_updated_at(
         self, memory: MemoryEngine, request_context: RequestContext
     ):

--- a/hindsight-clients/go/api/openapi.yaml
+++ b/hindsight-clients/go/api/openapi.yaml
@@ -2571,7 +2571,9 @@ paths:
       description: |-
         Update mutable fields on a document without re-processing its content.
 
-        **Tags** (`tags`): Propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.
+        **Tags** (`tags`): The array REPLACES the document's tags, it is not merged into them — send the complete set you want the document to end up with, and any tag you leave out is dropped. An empty array (`[]`) therefore clears every tag; only omitting the field entirely is rejected (422).
+
+        The new tags are propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset. Tags are compared as a set, so re-sending the tags a document already has (in any order) changes nothing and queues no re-consolidation.
 
         At least one field must be provided.
       operationId: update_document

--- a/hindsight-clients/go/api_documents.go
+++ b/hindsight-clients/go/api_documents.go
@@ -898,7 +898,9 @@ UpdateDocument Update document
 
 Update mutable fields on a document without re-processing its content.
 
-**Tags** (`tags`): Propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.
+**Tags** (`tags`): The array REPLACES the document's tags, it is not merged into them — send the complete set you want the document to end up with, and any tag you leave out is dropped. An empty array (`[]`) therefore clears every tag; only omitting the field entirely is rejected (422).
+
+The new tags are propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset. Tags are compared as a set, so re-sending the tags a document already has (in any order) changes nothing and queues no re-consolidation.
 
 At least one field must be provided.
 

--- a/hindsight-clients/python/hindsight_client_api/api/documents_api.py
+++ b/hindsight-clients/python/hindsight_client_api/api/documents_api.py
@@ -1919,7 +1919,7 @@ class DocumentsApi:
     ) -> UpdateDocumentResponse:
         """Update document
 
-        Update mutable fields on a document without re-processing its content.  **Tags** (`tags`): Propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.  At least one field must be provided.
+        Update mutable fields on a document without re-processing its content.  **Tags** (`tags`): The array REPLACES the document's tags, it is not merged into them — send the complete set you want the document to end up with, and any tag you leave out is dropped. An empty array (`[]`) therefore clears every tag; only omitting the field entirely is rejected (422).  The new tags are propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset. Tags are compared as a set, so re-sending the tags a document already has (in any order) changes nothing and queues no re-consolidation.  At least one field must be provided.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -1999,7 +1999,7 @@ class DocumentsApi:
     ) -> ApiResponse[UpdateDocumentResponse]:
         """Update document
 
-        Update mutable fields on a document without re-processing its content.  **Tags** (`tags`): Propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.  At least one field must be provided.
+        Update mutable fields on a document without re-processing its content.  **Tags** (`tags`): The array REPLACES the document's tags, it is not merged into them — send the complete set you want the document to end up with, and any tag you leave out is dropped. An empty array (`[]`) therefore clears every tag; only omitting the field entirely is rejected (422).  The new tags are propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset. Tags are compared as a set, so re-sending the tags a document already has (in any order) changes nothing and queues no re-consolidation.  At least one field must be provided.
 
         :param bank_id: (required)
         :type bank_id: str
@@ -2079,7 +2079,7 @@ class DocumentsApi:
     ) -> RESTResponseType:
         """Update document
 
-        Update mutable fields on a document without re-processing its content.  **Tags** (`tags`): Propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.  At least one field must be provided.
+        Update mutable fields on a document without re-processing its content.  **Tags** (`tags`): The array REPLACES the document's tags, it is not merged into them — send the complete set you want the document to end up with, and any tag you leave out is dropped. An empty array (`[]`) therefore clears every tag; only omitting the field entirely is rejected (422).  The new tags are propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset. Tags are compared as a set, so re-sending the tags a document already has (in any order) changes nothing and queues no re-consolidation.  At least one field must be provided.
 
         :param bank_id: (required)
         :type bank_id: str

--- a/hindsight-clients/typescript/generated/sdk.gen.ts
+++ b/hindsight-clients/typescript/generated/sdk.gen.ts
@@ -1052,7 +1052,9 @@ export const getDocument = <ThrowOnError extends boolean = false>(
  *
  * Update mutable fields on a document without re-processing its content.
  *
- * **Tags** (`tags`): Propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.
+ * **Tags** (`tags`): The array REPLACES the document's tags, it is not merged into them — send the complete set you want the document to end up with, and any tag you leave out is dropped. An empty array (`[]`) therefore clears every tag; only omitting the field entirely is rejected (422).
+ *
+ * The new tags are propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset. Tags are compared as a set, so re-sending the tags a document already has (in any order) changes nothing and queues no re-consolidation.
  *
  * At least one field must be provided.
  */

--- a/hindsight-clients/typescript/generated/types.gen.ts
+++ b/hindsight-clients/typescript/generated/types.gen.ts
@@ -6149,7 +6149,7 @@ export type UpdateDocumentRequest = {
   /**
    * Tags
    *
-   * New tags for the document and its memory units. Triggers observation invalidation and re-consolidation.
+   * The complete new set of tags for the document and its memory units — this REPLACES the existing tags rather than adding to them, so omitting a tag drops it and `[]` clears them all. Triggers observation invalidation and re-consolidation.
    */
   tags?: Array<string> | null;
 };

--- a/hindsight-docs/docs/developer/api/documents.mdx
+++ b/hindsight-docs/docs/developer/api/documents.mdx
@@ -121,6 +121,8 @@ hindsight document get my-bank meeting-2024-03-15
 
 Update mutable fields on an existing document without re-processing the content. Currently supports updating `tags`.
 
+The `tags` array **replaces** the document's tags — it is not merged into them. Send the complete set you want the document to end up with: any tag you leave out is dropped, and an empty array clears them all. To remove a single tag, read the document's current tags, drop the one you want gone, and send the rest. Omitting the field entirely is not an update at all and is rejected with a `422`.
+
 <Tabs>
 <TabItem value="python" label="Python">
 <CodeSnippet code={documentsPy} section="document-update" language="python" />

--- a/hindsight-docs/static/openapi.json
+++ b/hindsight-docs/static/openapi.json
@@ -3646,7 +3646,7 @@
           "Documents"
         ],
         "summary": "Update document",
-        "description": "Update mutable fields on a document without re-processing its content.\n\n**Tags** (`tags`): Propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.\n\nAt least one field must be provided.",
+        "description": "Update mutable fields on a document without re-processing its content.\n\n**Tags** (`tags`): The array REPLACES the document's tags, it is not merged into them \u2014 send the complete set you want the document to end up with, and any tag you leave out is dropped. An empty array (`[]`) therefore clears every tag; only omitting the field entirely is rejected (422).\n\nThe new tags are propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset. Tags are compared as a set, so re-sending the tags a document already has (in any order) changes nothing and queues no re-consolidation.\n\nAt least one field must be provided.",
         "operationId": "update_document",
         "parameters": [
           {
@@ -17101,7 +17101,7 @@
               }
             ],
             "title": "Tags",
-            "description": "New tags for the document and its memory units. Triggers observation invalidation and re-consolidation."
+            "description": "The complete new set of tags for the document and its memory units \u2014 this REPLACES the existing tags rather than adding to them, so omitting a tag drops it and `[]` clears them all. Triggers observation invalidation and re-consolidation."
           }
         },
         "type": "object",

--- a/skills/hindsight-docs/references/developer/api/documents.md
+++ b/skills/hindsight-docs/references/developer/api/documents.md
@@ -201,6 +201,8 @@ hindsight document get my-bank meeting-2024-03-15
 
 Update mutable fields on an existing document without re-processing the content. Currently supports updating `tags`.
 
+The `tags` array **replaces** the document's tags — it is not merged into them. Send the complete set you want the document to end up with: any tag you leave out is dropped, and an empty array clears them all. To remove a single tag, read the document's current tags, drop the one you want gone, and send the rest. Omitting the field entirely is not an update at all and is rejected with a `422`.
+
 ### Python
 
 ```python

--- a/skills/hindsight-docs/references/openapi.json
+++ b/skills/hindsight-docs/references/openapi.json
@@ -3646,7 +3646,7 @@
           "Documents"
         ],
         "summary": "Update document",
-        "description": "Update mutable fields on a document without re-processing its content.\n\n**Tags** (`tags`): Propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset.\n\nAt least one field must be provided.",
+        "description": "Update mutable fields on a document without re-processing its content.\n\n**Tags** (`tags`): The array REPLACES the document's tags, it is not merged into them \u2014 send the complete set you want the document to end up with, and any tag you leave out is dropped. An empty array (`[]`) therefore clears every tag; only omitting the field entirely is rejected (422).\n\nThe new tags are propagated to all associated memory units. Observations derived from those units are invalidated and queued for re-consolidation under the new tags. Co-source memories from other documents that shared those observations are also reset. Tags are compared as a set, so re-sending the tags a document already has (in any order) changes nothing and queues no re-consolidation.\n\nAt least one field must be provided.",
         "operationId": "update_document",
         "parameters": [
           {
@@ -17101,7 +17101,7 @@
               }
             ],
             "title": "Tags",
-            "description": "New tags for the document and its memory units. Triggers observation invalidation and re-consolidation."
+            "description": "The complete new set of tags for the document and its memory units \u2014 this REPLACES the existing tags rather than adding to them, so omitting a tag drops it and `[]` clears them all. Triggers observation invalidation and re-consolidation."
           }
         },
         "type": "object",


### PR DESCRIPTION
## What

The `tags` array on `PATCH /v1/default/banks/{bank_id}/documents/{document_id}` **replaces** the document's tags — it is not merged into them. Neither the API reference nor the docs page said so: both described only that tags are "propagated to all associated memory units", leaving the question a caller actually has unanswered (does sending a tag add it? how do I drop one?). The replace semantics were documented in exactly one place — two comments in the **CLI tab** of the docs page — which an API or SDK user never reads.

Prompted by a customer question about dropping a tag from a document.

## Docs

- **Endpoint description + `tags` field description** (`api/http.py`) — the array replaces rather than merges, an omitted tag is dropped, `[]` clears them all, and only an omitted *field* is the 422. Also states the set-comparison no-op, so a repeated normalisation sweep is known to be free.
- **`docs/developer/api/documents.mdx`** — the same in prose, above the language tabs, including how to drop a single tag (read, remove, send the rest).
- Regenerated: `static/openapi.json`, the Go/Python/TypeScript clients, and `skills/hindsight-docs/references/**`.

## Tests

An empty array was the documented-but-untested case. Every guard on that path is deliberately written `is not None` rather than a truthiness check so `[]` survives it; a regression to `if tags:` would have turned a clear into a silent no-op that still returns `200`. Confirmed by mutating exactly that line — both new tests fail, and no existing test does.

- `test_empty_tags_clears_them` — engine level: a document tagged `["a", "b"]` PATCHed to `[]` ends with no tags on the document and none on its memory units; the observation built over those units is invalidated and their `consolidated_at` reset, i.e. clearing runs the same cascade as any other tag change. Repeating the `[]` PATCH is the no-op the set comparison promises.
- `test_patch_endpoint_accepts_empty_tags` — HTTP level: `{"tags": []}` is `200` and clears, while an omitted `tags` is still the `422` "at least one field" guard.

No behaviour change — tests and documentation only.

## Verification

15 passed in `TestUpdateDocumentTagsObservationCleanup` (13 existing + 2 new) against an isolated pg0 database. `./scripts/hooks/lint.sh` clean after regenerating.
