### PR TITLE
fix(memory-defense): redact Hindsight Cloud API keys

### DIFF
--- a/hindsight-api-slim/hindsight_api/extensions/memory_defense.py
+++ b/hindsight-api-slim/hindsight_api/extensions/memory_defense.py
@@ -174,6 +174,10 @@ _REDACTION_PATTERNS: list[tuple[str, str]] = [
     ("google_oauth_token", _ascii_token_pattern(r"ya29\.[0-9A-Za-z_-]{20,}")),
     ("xai_key", _ascii_token_pattern(r"xai-[A-Za-z0-9]{40,}")),
     ("groq_key", _ascii_token_pattern(r"gsk_[A-Za-z0-9]{20,}")),
+    # Hindsight's own API keys. hsk_<32 hex> from token_hex(16), optionally
+    # followed by _<hex signature>; hsk_sys_ marks a system key. Anchored on
+    # the 32 hex characters so prose containing "hsk_" is not redacted.
+    ("hindsight_key", _ascii_token_pattern(r"hsk_(?:sys_)?[0-9a-f]{32}(?:_[0-9a-f]{8,})?")),
     ("huggingface_token", _ascii_token_pattern(r"hf_[A-Za-z0-9]{30,}")),
     ("replicate_token", _ascii_token_pattern(r"r8_[A-Za-z0-9]{30,}")),
     ("perplexity_key", _ascii_token_pattern(r"pplx-[A-Za-z0-9]{40,}")),

--- a/hindsight-api-slim/tests/test_memory_defense.py
+++ b/hindsight-api-slim/tests/test_memory_defense.py
@@ -38,6 +38,9 @@ _BOUNDARY_REDACTION_SAMPLES = {
     "google_oauth_token": "ya29." + "A" * 20,
     "xai_key": "xai-" + "A" * 40,
     "groq_key": "gsk_" + "A" * 20,
+    # 32 hex from token_hex(16) plus a hex signature; hsk_sys_ is covered by
+    # test_hindsight_system_key_is_redacted below.
+    "hindsight_key": "hsk_" + "a" * 32 + "_" + "b" * 16,
     "huggingface_token": "hf_" + "A" * 30,
     "replicate_token": "r8_" + "A" * 30,
     "perplexity_key": "pplx-" + "A" * 40,


### PR DESCRIPTION
The redaction layer carries patterns for Anthropic, OpenAI, Google, AWS, GitHub,
Groq, HuggingFace and thirty-odd others — but not for Hindsight Cloud's own key
format. A memory containing an `hsk_` key was stored verbatim.

That is the wrong way round. Someone pasting a terminal transcript into content
that gets retained is more likely to be holding a **Hindsight Cloud** key than any
other kind, because that is the key they were using when whatever went wrong
went wrong. Screening every provider except ourselves leaves the most likely
secret as the one that gets through.

## The pattern

```python
("hindsight_key", _ascii_token_pattern(r"hsk_(?:sys_)?[0-9a-f]{32}(?:_[0-9a-f]{8,})?")),
```

Keys are `hsk_<32 hex>` from `token_hex(16)`, optionally followed by
`_<hex signature>`; `hsk_sys_` marks a system key.

Anchored on the 32 hex characters, so prose mentioning `hsk_` is not redacted.
Uses `_ascii_token_pattern` like its neighbours, so a key butted up against
non-ASCII text still matches.

## Verified

| input | result |
|---|---|
| signed key | redacted |
| unsigned key | redacted |
| `hsk_sys_` key | redacted |
| an existing provider pattern | still redacted (no regression) |
| `"keys start with the hsk_ prefix"` | untouched |
| `hsk_short` | untouched |
| `hsk_` + 32 non-hex characters | untouched |

## On the test sample

The entry in `_BOUNDARY_REDACTION_SAMPLES` is required rather than decorative:
`test_redaction_patterns_have_samples` asserts every pattern has one, so a
pattern added without a sample fails the suite. Worth knowing before adding the
next pattern.