### PR TITLE
fix(retain): guard concise prompt examples

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/fact_extraction.py
@@ -1130,6 +1130,10 @@ _CONCISE_EXAMPLES = """
 EXAMPLES (shown in English for illustration; for non-English input, ALL output values MUST be in the input language)
 ══════════════════════════════════════════════════════════════════════════
 
+The examples below demonstrate output format and selectivity only. Never emit
+their facts, entities, or dates unless those details also appear in the actual
+input text being processed.
+
 Example 1 - Selective extraction (Event Date: June 10, 2024):
 Input: "Hey! How's it going? Good morning! So I'm planning my wedding - want a small outdoor ceremony. Just got back from Emily's wedding, she married Sarah at a rooftop garden. It was nice weather. I grabbed a coffee on the way."
 

--- a/hindsight-api-slim/tests/test_fact_extraction_example_guard.py
+++ b/hindsight-api-slim/tests/test_fact_extraction_example_guard.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+from hindsight_api.engine.retain.fact_extraction import _build_extraction_prompt_and_schema
+
+
+def _config(mode: str) -> MagicMock:
+    config = MagicMock()
+    config.entity_labels = None
+    config.entities_allow_free_form = True
+    config.retain_extraction_mode = mode
+    config.retain_extract_causal_links = False
+    config.retain_mission = None
+    config.retain_custom_instructions = "Extract project decisions" if mode == "custom" else None
+    config.llm_output_language = None
+    return config
+
+
+def test_concise_examples_are_explicitly_excluded_from_extracted_content():
+    prompt, _ = _build_extraction_prompt_and_schema(_config("concise"))
+
+    guard = (
+        "The examples below demonstrate output format and selectivity only. Never emit\n"
+        "their facts, entities, or dates unless those details also appear in the actual\n"
+        "input text being processed."
+    )
+    assert guard in prompt
+    assert prompt.index(guard) < prompt.index("Example 1 - Selective extraction")
+
+
+def test_custom_mode_does_not_include_examples_or_their_guard():
+    prompt, _ = _build_extraction_prompt_and_schema(_config("custom"))
+
+    assert "Example 1 - Selective extraction" not in prompt
+    assert "The examples below demonstrate output format" not in prompt


### PR DESCRIPTION
## Problem

The concise extraction prompt embeds worked examples but does not explicitly distinguish their content from the input. As reported in #4280, smaller retain models can copy the example facts, entities, and dates into unrelated memories.

## Fix

Add an instruction immediately before the worked examples that limits them to demonstrating format and selectivity, and requires their details to appear in the actual input before extraction. Add prompt-construction coverage for concise mode and confirm custom mode remains example-free.

## Test

- `uv run pytest tests/test_fact_extraction_example_guard.py tests/test_fact_extraction_fact_type_prompt.py tests/test_fact_extraction_entities_schema.py` (14 passed)
- `uv run ruff check hindsight_api/engine/retain/fact_extraction.py tests/test_fact_extraction_example_guard.py`
- `uv run ruff format --check hindsight_api/engine/retain/fact_extraction.py tests/test_fact_extraction_example_guard.py`
- `git diff --check`

## Risk

Low. This changes only concise-mode prompt text. It does not filter model output or claim to eliminate stochastic hallucinations; custom, verbose, and verbatim prompt assembly are unchanged.

Closes #4280.