### PR TITLE
feat(python-client): add task-local retain suspension

### DIFF
--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -8,6 +8,9 @@ easy-to-use interface on top of the auto-generated OpenAPI client.
 import asyncio
 import json
 import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import datetime
 from importlib import metadata
 from pathlib import Path
@@ -218,7 +221,7 @@ class Hindsight:
         self._timeout = timeout
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
-        self._retain_suspended = False
+        self._retain_suspended: ContextVar[bool] = ContextVar("retain_suspended", default=False)
         if api_key:
             self._api_client.set_default_header("Authorization", f"Bearer {api_key}")
         self._memory_api = memory_api.MemoryApi(self._api_client)
@@ -236,16 +239,21 @@ class Hindsight:
 
     # -- Retain suspension ------------------------------------------------------
 
-    @property
-    def retain_suspended(self) -> bool:
-        """Whether retains through this client are currently suppressed.
+    @contextmanager
+    def suspend_retains(self) -> Iterator[None]:
+        """Temporarily suppress retains in the current execution context.
 
-        Set to ``True`` to run a read-only session against a real bank. Recall
-        and reflect are unaffected, while ``retain``, ``retain_batch`` and
-        ``retain_files`` (and their async variants) send no request and report
-        an empty result — ``items_count=0`` and no operation IDs. Useful for
-        evaluation runs, replaying a transcript against a populated bank, or
-        any session that must read a bank without adding to it.
+        Recall and reflect are unaffected, while ``retain``, ``retain_batch``
+        and ``retain_files`` (and their async variants) send no request and
+        report an empty result — ``items_count=0`` and no operation IDs. This
+        is useful for evaluation runs, replaying a transcript against a
+        populated bank, or any session that must read a bank without adding to
+        it.
+
+        The suspension is local to the current synchronous flow or async task,
+        so concurrent users of the same client are not affected. Scopes may be
+        nested and are restored when the scope exits, including after an
+        exception.
 
         Scope: this guards the convenience methods only. The low-level
         accessors (:attr:`memory`, :attr:`files`) call the generated API
@@ -253,18 +261,15 @@ class Hindsight:
 
         ::
 
-            client.retain_suspended = True
-            try:
+            with client.suspend_retains():
                 client.retain(bank_id, "not stored")   # items_count == 0
                 client.recall(bank_id, "still works")  # unaffected
-            finally:
-                client.retain_suspended = False
         """
-        return self._retain_suspended
-
-    @retain_suspended.setter
-    def retain_suspended(self, value: bool) -> None:
-        self._retain_suspended = bool(value)
+        token = self._retain_suspended.set(True)
+        try:
+            yield
+        finally:
+            self._retain_suspended.reset(token)
 
     # -- Low-level API accessors ------------------------------------------------
     # These expose the full, auto-generated API surface for operations not
@@ -521,7 +526,7 @@ class Hindsight:
         Returns:
             FileRetainResponse with operation_ids for tracking progress
         """
-        if self._retain_suspended:
+        if self._retain_suspended.get():
             return FileRetainResponse(operation_ids=[])
 
         file_data = []
@@ -1038,7 +1043,7 @@ class Hindsight:
         Returns:
             RetainResponse with success status and item count
         """
-        if self._retain_suspended:
+        if self._retain_suspended.get():
             return RetainResponse(success=True, bank_id=bank_id, items_count=0, var_async=False)
 
         from hindsight_client_api.models.content import Content

--- a/hindsight-clients/python/hindsight_client/hindsight_client.py
+++ b/hindsight-clients/python/hindsight_client/hindsight_client.py
@@ -218,6 +218,7 @@ class Hindsight:
         self._timeout = timeout
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
+        self._retain_suspended = False
         if api_key:
             self._api_client.set_default_header("Authorization", f"Bearer {api_key}")
         self._memory_api = memory_api.MemoryApi(self._api_client)
@@ -232,6 +233,38 @@ class Hindsight:
         self._webhooks_api = webhooks_api.WebhooksApi(self._api_client)
         self._monitoring_api = monitoring_api.MonitoringApi(self._api_client)
         self._document_transfer_api = document_transfer_api.DocumentTransferApi(self._api_client)
+
+    # -- Retain suspension ------------------------------------------------------
+
+    @property
+    def retain_suspended(self) -> bool:
+        """Whether retains through this client are currently suppressed.
+
+        Set to ``True`` to run a read-only session against a real bank. Recall
+        and reflect are unaffected, while ``retain``, ``retain_batch`` and
+        ``retain_files`` (and their async variants) send no request and report
+        an empty result — ``items_count=0`` and no operation IDs. Useful for
+        evaluation runs, replaying a transcript against a populated bank, or
+        any session that must read a bank without adding to it.
+
+        Scope: this guards the convenience methods only. The low-level
+        accessors (:attr:`memory`, :attr:`files`) call the generated API
+        directly and are deliberately not intercepted.
+
+        ::
+
+            client.retain_suspended = True
+            try:
+                client.retain(bank_id, "not stored")   # items_count == 0
+                client.recall(bank_id, "still works")  # unaffected
+            finally:
+                client.retain_suspended = False
+        """
+        return self._retain_suspended
+
+    @retain_suspended.setter
+    def retain_suspended(self, value: bool) -> None:
+        self._retain_suspended = bool(value)
 
     # -- Low-level API accessors ------------------------------------------------
     # These expose the full, auto-generated API surface for operations not
@@ -488,6 +521,9 @@ class Hindsight:
         Returns:
             FileRetainResponse with operation_ids for tracking progress
         """
+        if self._retain_suspended:
+            return FileRetainResponse(operation_ids=[])
+
         file_data = []
         for file_path in files:
             path = Path(file_path)
@@ -1002,6 +1038,9 @@ class Hindsight:
         Returns:
             RetainResponse with success status and item count
         """
+        if self._retain_suspended:
+            return RetainResponse(success=True, bank_id=bank_id, items_count=0, var_async=False)
+
         from hindsight_client_api.models.content import Content
         from hindsight_client_api.models.entity_input import EntityInput
         from hindsight_client_api.models.observation_scopes import ObservationScopes

--- a/hindsight-clients/python/tests/test_retain_suspension.py
+++ b/hindsight-clients/python/tests/test_retain_suspension.py
@@ -1,0 +1,87 @@
+"""
+Test the client-level retain suspension seam.
+
+``Hindsight.retain_suspended`` lets a caller run a read-only session against a
+real bank: recall and reflect keep working, while every retain entry point
+becomes a no-op that sends no request. These tests pin that both halves hold
+and that clearing the flag restores normal retains.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from hindsight_client import Hindsight
+
+BANK = "bank-1"
+
+
+def _make_client():
+    client = Hindsight(base_url="http://localhost:8888")
+    client._memory_api = MagicMock()
+    client._memory_api.retain_memories = AsyncMock(return_value=MagicMock())
+    client._memory_api.recall_memories = AsyncMock(return_value=MagicMock())
+    client._files_api = MagicMock()
+    client._files_api.file_retain = AsyncMock(return_value=MagicMock())
+    return client
+
+
+def test_retain_is_suppressed_while_suspended():
+    client = _make_client()
+
+    client.retain_suspended = True
+    response = client.retain(BANK, "should not be stored")
+
+    assert client._memory_api.retain_memories.await_count == 0
+    assert response.items_count == 0
+    assert response.success is True
+    assert response.bank_id == BANK
+
+
+def test_retain_batch_is_suppressed_while_suspended():
+    client = _make_client()
+
+    client.retain_suspended = True
+    response = client.retain_batch(BANK, [{"content": "a"}, {"content": "b"}])
+
+    assert client._memory_api.retain_memories.await_count == 0
+    assert response.items_count == 0
+
+
+def test_retain_files_is_suppressed_while_suspended(tmp_path):
+    client = _make_client()
+    sample = tmp_path / "note.txt"
+    sample.write_text("hello")
+
+    client.retain_suspended = True
+    response = client.retain_files(BANK, [sample])
+
+    assert client._files_api.file_retain.await_count == 0
+    assert response.operation_ids == []
+
+
+def test_recall_still_reaches_the_api_while_suspended():
+    client = _make_client()
+
+    client.retain_suspended = True
+    client.recall(BANK, "a question")
+
+    assert client._memory_api.recall_memories.await_count == 1
+
+
+def test_retain_resumes_after_the_block():
+    client = _make_client()
+
+    client.retain_suspended = True
+    client.retain(BANK, "dropped")
+    client.retain_suspended = False
+    client.retain(BANK, "stored")
+
+    assert client._memory_api.retain_memories.await_count == 1
+    assert client.retain_suspended is False
+
+
+def test_retains_are_enabled_by_default():
+    client = _make_client()
+
+    assert client.retain_suspended is False
+    client.retain(BANK, "stored")
+    assert client._memory_api.retain_memories.await_count == 1

--- a/hindsight-clients/python/tests/test_retain_suspension.py
+++ b/hindsight-clients/python/tests/test_retain_suspension.py
@@ -1,13 +1,16 @@
 """
 Test the client-level retain suspension seam.
 
-``Hindsight.retain_suspended`` lets a caller run a read-only session against a
+``Hindsight.suspend_retains`` lets a caller run a read-only session against a
 real bank: recall and reflect keep working, while every retain entry point
 becomes a no-op that sends no request. These tests pin that both halves hold
-and that clearing the flag restores normal retains.
+and that leaving the scope restores normal retains.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from hindsight_client import Hindsight
 
@@ -27,8 +30,8 @@ def _make_client():
 def test_retain_is_suppressed_while_suspended():
     client = _make_client()
 
-    client.retain_suspended = True
-    response = client.retain(BANK, "should not be stored")
+    with client.suspend_retains():
+        response = client.retain(BANK, "should not be stored")
 
     assert client._memory_api.retain_memories.await_count == 0
     assert response.items_count == 0
@@ -39,8 +42,8 @@ def test_retain_is_suppressed_while_suspended():
 def test_retain_batch_is_suppressed_while_suspended():
     client = _make_client()
 
-    client.retain_suspended = True
-    response = client.retain_batch(BANK, [{"content": "a"}, {"content": "b"}])
+    with client.suspend_retains():
+        response = client.retain_batch(BANK, [{"content": "a"}, {"content": "b"}])
 
     assert client._memory_api.retain_memories.await_count == 0
     assert response.items_count == 0
@@ -51,8 +54,8 @@ def test_retain_files_is_suppressed_while_suspended(tmp_path):
     sample = tmp_path / "note.txt"
     sample.write_text("hello")
 
-    client.retain_suspended = True
-    response = client.retain_files(BANK, [sample])
+    with client.suspend_retains():
+        response = client.retain_files(BANK, [sample])
 
     assert client._files_api.file_retain.await_count == 0
     assert response.operation_ids == []
@@ -61,8 +64,8 @@ def test_retain_files_is_suppressed_while_suspended(tmp_path):
 def test_recall_still_reaches_the_api_while_suspended():
     client = _make_client()
 
-    client.retain_suspended = True
-    client.recall(BANK, "a question")
+    with client.suspend_retains():
+        client.recall(BANK, "a question")
 
     assert client._memory_api.recall_memories.await_count == 1
 
@@ -70,18 +73,63 @@ def test_recall_still_reaches_the_api_while_suspended():
 def test_retain_resumes_after_the_block():
     client = _make_client()
 
-    client.retain_suspended = True
-    client.retain(BANK, "dropped")
-    client.retain_suspended = False
+    with client.suspend_retains():
+        client.retain(BANK, "dropped")
     client.retain(BANK, "stored")
 
     assert client._memory_api.retain_memories.await_count == 1
-    assert client.retain_suspended is False
 
 
-def test_retains_are_enabled_by_default():
+def test_retains_are_enabled_outside_a_suspension_scope():
     client = _make_client()
 
-    assert client.retain_suspended is False
     client.retain(BANK, "stored")
+    assert client._memory_api.retain_memories.await_count == 1
+
+
+async def test_retain_suspension_does_not_suppress_another_task():
+    client = _make_client()
+    task_a_suspended = asyncio.Event()
+    task_b_retained = asyncio.Event()
+
+    async def read_only_task():
+        with client.suspend_retains():
+            task_a_suspended.set()
+            await task_b_retained.wait()
+            return await client.aretain(BANK, "task A should not be stored")
+
+    async def normal_task():
+        await task_a_suspended.wait()
+        response = await client.aretain(BANK, "task B should be stored")
+        task_b_retained.set()
+        return response
+
+    task_a_response, task_b_response = await asyncio.gather(read_only_task(), normal_task())
+
+    assert task_a_response.items_count == 0
+    assert task_b_response is client._memory_api.retain_memories.return_value
+    assert client._memory_api.retain_memories.await_count == 1
+
+
+def test_retain_suspension_scopes_are_nested():
+    client = _make_client()
+
+    with client.suspend_retains():
+        client.retain(BANK, "outer")
+        with client.suspend_retains():
+            client.retain(BANK, "inner")
+        client.retain(BANK, "outer again")
+    client.retain(BANK, "stored")
+
+    assert client._memory_api.retain_memories.await_count == 1
+
+
+def test_retain_suspension_is_reset_after_an_exception():
+    client = _make_client()
+
+    with pytest.raises(RuntimeError, match="stop"):
+        with client.suspend_retains():
+            raise RuntimeError("stop")
+    client.retain(BANK, "stored")
+
     assert client._memory_api.retain_memories.await_count == 1


### PR DESCRIPTION
## Summary

Add a task-local `suspend_retains()` context manager that suppresses `retain`, `retain_batch`, and `retain_files` across sync and async convenience methods while leaving recall and reflect untouched.

## Motivation

Evaluation runs and transcript replays need to read a populated bank without risking new writes. A shared client flag is unsafe when async tasks reuse the same client because one task can suppress another task's unrelated retain.

The context manager uses a per-client `ContextVar`, so suspension follows the calling execution context. Unrelated concurrent tasks are unaffected. Nested scopes and exception cleanup restore state through token reset.

## Requirements

- Suppress `retain`, `retain_batch`, and `retain_files` — both sync and async — for the duration of a `with client.suspend_retains():` block, sending no request while suspended.
- Leave `recall` and `reflect` fully functional inside the suspended scope.
- Scope suspension to the calling execution context (task-local via `ContextVar`), not the whole client, so concurrent async tasks sharing one `Hindsight` instance cannot suppress each other's retains.
- Support nested scopes and restore the prior state (not just "resumed") when an inner scope exits, via `ContextVar.set`/`reset` tokens rather than a plain boolean.
- Restore normal retain behavior when the scope exits, including via an exception, using `try`/`finally`.
- Return honest, typed empty responses while suspended instead of raising or faking a partial write: `RetainResponse(success=True, items_count=0)` for `retain`/`retain_batch`, `FileRetainResponse(operation_ids=[])` for `retain_files`.

## Use Cases

- Evaluation runs that recall/reflect against a previously populated bank and must not write new memories back into it as a side effect of the code under test.
- Replaying a transcript or fixture against a shared or populated bank (e.g. for debugging or regression testing) without polluting it with retains triggered during the replay.
- A read-only task sharing a long-lived client with other tasks doing normal writes — e.g. one asyncio task auditing a bank while another concurrently retains unrelated memories on the same `Hindsight` client; suspension in the read-only task must not affect the writing task. This is the scenario the review comment flagged against the original shared-flag design and is pinned by a dedicated deterministic interleaving test.

## Non-goals

- Not server-side or permission-enforced: this is a client-side convenience guard, not access control. It does not prevent writes at the API layer.
- Not a global or process-wide switch: it deliberately replaces the earlier shared mutable `retain_suspended` flag because that flag suspended retains for every task sharing the client, not just the caller's own scope.
- Does not change `recall` or `reflect` behavior in any way.

## Scope

The suspension intentionally covers only Hindsight convenience methods. Direct calls through the low-level memory and files accessors bypass it, as documented.

Suppressed calls send no request and return honest empty results: `items_count=0` or `operation_ids=[]`.

## Tests

- Added deterministic async interleaving coverage proving a suspended task does not suppress another task's retain on the same client.
- Added coverage for single, batch, and file retains, recall passthrough, nesting, exception cleanup, resumption, and the default behavior.
- Focused suspension suite: 9 passed.
- Sync and async parity plus suspension suites: 26 passed.
- Ruff and `git diff --check`: clean.

## Disclosure

This contribution was implemented and maintained by a Hermes Labs autonomous agent acting on a task prompted and authorized by Roli Bosch.
