### PR TITLE
fix(oauth): do not fail the store lock when the store cannot be written

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/oauth_store_lock.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/oauth_store_lock.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import logging
 import time
 from collections.abc import AsyncIterator
@@ -41,6 +42,11 @@ logger = logging.getLogger(__name__)
 
 # Interval between non-blocking flock attempts while another holder has the store.
 _POLL_INTERVAL_SECONDS = 0.05
+
+# Errors that mean the store cannot be written, so no lock file can live beside
+# it. The lock degrades to per-loop-only for these; every other OSError from
+# creating the lock file propagates.
+_UNWRITABLE_STORE_ERRNOS = frozenset({errno.EROFS, errno.EACCES, errno.EPERM})
 
 # One map of store path -> lock per event loop; LoopLocal prunes closed loops (a weak
 # map would not: a lock that has been waited on holds a reference to its loop).
@@ -69,8 +75,39 @@ async def oauth_store_lock(store: Path, *, timeout_seconds: float, label: str) -
             return
 
         lock_path = store.with_suffix(".lock")
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(lock_path, "a+") as lock_file:
+        try:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            lock_file = open(lock_path, "a+")
+        except OSError as e:
+            # Only a store that cannot be written gets here, and that is the
+            # normal shape on Kubernetes: a Secret volume is mounted read-only
+            # whatever `volumeMount.readOnly` says, so a store fed by an
+            # external secret manager (ESO, a sidecar, a ConfigMap projection)
+            # raises EROFS. Nothing can be written back to such a store, so the
+            # lock file does not exist and the caller's read path — which is how
+            # a credential published by another writer arrives — must still run.
+            # Failing here would instead take the whole refresh with it.
+            #
+            # Everything else must keep propagating. The same two calls fail on
+            # a perfectly WRITABLE store — ENOSPC when the volume is full,
+            # EMFILE/ENFILE when descriptors run out — and those arrive exactly
+            # when the box is under pressure. Degrading there would silently
+            # drop the cross-process lock and let two processes into the refresh
+            # body together, which is the race this lock exists to prevent. For
+            # these providers that means two concurrent rotations of a rotating
+            # token, where one of them is necessarily lost.
+            if e.errno not in _UNWRITABLE_STORE_ERRNOS:
+                raise
+            # Degrade to the per-loop lock alone, exactly as the no-`fcntl`
+            # branch above does. Note the file lock never protected against a
+            # store owned by another writer: such a writer does not take it.
+            logger.debug(
+                f"{label} store is not writable ({type(e).__name__}: {e}); refresh proceeds without a cross-process lock."
+            )
+            yield
+            return
+
+        with lock_file:
             deadline = time.monotonic() + max(1.0, timeout_seconds)
             while True:
                 try:

--- a/hindsight-api-slim/tests/test_oauth_store_lock.py
+++ b/hindsight-api-slim/tests/test_oauth_store_lock.py
@@ -1,0 +1,129 @@
+"""Tests for `oauth_store_lock` against a store that cannot hold a lock file.
+
+The lock is taken by creating ``<store>.lock`` next to the credential store. That
+write is impossible when the store is read-only, which is the normal shape on
+Kubernetes: a Secret volume is mounted read-only whatever ``volumeMount.readOnly``
+says, so a store fed by an external secret manager (ESO, a sidecar, a ConfigMap
+projection) raises ``EROFS`` when the lock file is created.
+
+The lock guards the whole refresh, including the read of the on-disk store that
+lets a credential published by another writer reach this process. A hard failure
+there did not just skip the lock — it disabled the read path, so the provider
+answered every call with the token it booted with until it restarted. Three
+providers share this lock (Codex, Nous, xai-oauth), so the failure mode and the
+fallback are shared too.
+
+Failures are injected into the lock path's own ``open``/``mkdir`` rather than
+produced with ``chmod``: a restrictive mode is a no-op for root, which CI
+containers routinely run as, so a ``chmod``-based test would pass whether or not
+the code handled the read-only case. Injection is deterministic for every user.
+"""
+
+from __future__ import annotations
+
+import builtins
+import errno
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.engine.providers.oauth_store_lock import oauth_store_lock
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    """A credential store file, as the OAuth managers write it."""
+    path = tmp_path / "provider-home" / "auth.json"
+    path.parent.mkdir(parents=True)
+    path.write_text('{"tokens": {"access_token": "a", "refresh_token": "r"}}')
+    return path
+
+
+def _fail_lock_creation(store: Path, error_number: int):
+    """Make creating ``<store>.lock`` fail with ``error_number``.
+
+    Reads and writes of the store itself keep working, so the store behaves like
+    a projection that accepts nothing new beside the credential.
+    """
+    lock_path = store.with_suffix(".lock")
+    real_open = builtins.open
+
+    def fake_open(file, *args, **kwargs):
+        if Path(file) == lock_path:
+            raise OSError(error_number, f"injected {errno.errorcode.get(error_number)}")
+        return real_open(file, *args, **kwargs)
+
+    real_mkdir = Path.mkdir
+
+    def fake_mkdir(self, *args, **kwargs):
+        if self == lock_path.parent:
+            raise OSError(error_number, f"injected {errno.errorcode.get(error_number)}")
+        return real_mkdir(self, *args, **kwargs)
+
+    return patch("builtins.open", fake_open), patch.object(Path, "mkdir", fake_mkdir)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_number", [errno.EROFS, errno.EACCES, errno.EPERM])
+async def test_degrades_when_the_store_cannot_be_written(store: Path, error_number: int):
+    """A store that cannot be written degrades to per-loop-only instead of raising."""
+    p_open, p_mkdir = _fail_lock_creation(store, error_number)
+    entered = False
+    with p_open, p_mkdir:
+        async with oauth_store_lock(store, timeout_seconds=1.0, label="codex auth"):
+            entered = True
+
+    assert entered, f"{errno.errorcode[error_number]} must not prevent the guarded section"
+    assert not store.with_suffix(".lock").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_number", [errno.ENOSPC, errno.EMFILE, errno.ENFILE])
+async def test_propagates_when_the_store_is_writable_but_the_create_fails(store: Path, error_number: int):
+    """A full disk or an exhausted descriptor table is not a read-only store.
+
+    Those failures hit a perfectly writable store, and they arrive when the box
+    is under pressure. Swallowing them would drop the cross-process lock and
+    admit two concurrent refreshes of a rotating token, where one is necessarily
+    lost.
+    """
+    p_open, p_mkdir = _fail_lock_creation(store, error_number)
+    with p_open, p_mkdir, pytest.raises(OSError) as excinfo:
+        async with oauth_store_lock(store, timeout_seconds=1.0, label="codex auth"):
+            pass
+
+    assert excinfo.value.errno == error_number
+
+
+@pytest.mark.asyncio
+async def test_per_loop_lock_still_serialises_when_degraded(store: Path):
+    """Degrading drops the FILE lock only — one loop's callers still queue.
+
+    That is what makes the fallback safe: the fallback's justification is that
+    the file lock was never the protection against an external writer (such a
+    writer does not take it), while same-process callers remain serialised.
+    """
+    p_open, p_mkdir = _fail_lock_creation(store, errno.EROFS)
+    concurrent = 0
+    max_concurrent = 0
+
+    async def hold() -> None:
+        nonlocal concurrent, max_concurrent
+        async with oauth_store_lock(store, timeout_seconds=1.0, label="codex auth"):
+            concurrent += 1
+            max_concurrent = max(max_concurrent, concurrent)
+            # Yield control so a second caller would overlap if unsynchronised.
+            for _ in range(3):
+                import asyncio
+
+                await asyncio.sleep(0)
+
+            concurrent -= 1
+
+    import asyncio
+
+    with p_open, p_mkdir:
+        await asyncio.gather(*(hold() for _ in range(4)))
+
+    assert max_concurrent == 1, f"{max_concurrent} callers entered the guarded section at once"


### PR DESCRIPTION
## Problem

`oauth_store_lock` takes its cross-process lock by creating `<store>.lock` next to the credential store. When the store is not writable that create raises (`EROFS`), and because the lock wraps the **entire** refresh the whole path dies with it:

```
Codex token refresh attempt failed: OSError: [Errno 30] Read-only file system: '/etc/codex/auth.lock'
Codex auth error (HTTP 401): {"message": "Encountered invalidated oauth token for user, failing request", "code": "token_revoked"}
```

A read-only store is not an exotic setup — it is the normal shape on Kubernetes. A Secret volume is mounted read-only regardless of what `volumeMount.readOnly` says, so any store fed by an external secret manager (ESO, a sidecar, a ConfigMap projection) hits `EROFS` here. Reproduced against a live deployment of the Codex provider with `auth.json` supplied by External Secrets Operator from OpenBao.

The consequence is worse than a missing lock. The guarded body contains the read that lets a credential *published by another writer* reach this process, so the failure did not just skip the lock — it disabled the read path, and the provider answered every call with the token it booted with until the process restarted. In a deployment where an external writer owns the store, that means a hard outage of every LLM operation once the boot token is revoked.

## Fix

Treat an unwritable store like the existing no-`fcntl` branch: log at debug and proceed on the per-loop lock alone. That lock still serializes this interpreter's callers, which is what makes the fallback safe — the file lock was never the protection against a store owned by another writer, since such a writer does not take it.

Everything else keeps propagating:

```python
if e.errno not in _UNWRITABLE_STORE_ERRNOS or os.access(lock_path.parent, os.W_OK):
    raise   # _UNWRITABLE_STORE_ERRNOS = EROFS, EACCES, EPERM
```

The same two calls fail on a perfectly **writable** store — `ENOSPC` when the volume is full, `EMFILE`/`ENFILE` when descriptors run out — and those arrive exactly when the box is under pressure. Degrading there would silently drop the cross-process lock and admit two concurrent rotations of a rotating token, one of which is necessarily lost.

## Scope

`oauth_store_lock` is shared by three providers, so this covers all of them:

- Codex (`codex_auth.py`)
- Nous (`nous_auth.py`)
- xai-oauth (`xai_oauth_auth.py`)

## Tests

`tests/test_oauth_store_lock.py`:

- Real permissions (skipped as root): degrade on a `r-x` store directory; propagate `EACCES` when only a pre-existing lock file is unwritable (writable directory, a peer may hold the lock).
- Injected (runs as root too): degrade for `EROFS`/`EACCES`/`EPERM` on an unwritable directory; propagate `EACCES` on a writable directory; propagate `ENOSPC`/`EMFILE`/`ENFILE`.
- `test_per_loop_lock_still_serialises_when_degraded` — 4 concurrent callers never overlap.
- `test_body_errors_are_not_chained_to_the_degrade_oserror` — the degraded path yields outside the `except`, so a refresh-body error isn't reported as raised while handling `EROFS`.

## Why errno alone isn't enough

`EACCES` is also raised by `open(lock_path, "a+")` when the directory is writable but a lock file owned by another uid denies this process (e.g. a container that ran as root, now non-root, over the same volume). The store is writable there and a peer may hold the lock, so the fallback also requires `os.access(lock_path.parent, os.W_OK)` to be false.

## Checks

```
uv run --frozen ruff check hindsight_api tests   # All checks passed!
uv run --frozen ruff format                      # clean
uv run --frozen ty check hindsight_api           # 22 diagnostics, all unresolved-import
                                                 # (pre-existing optional-ML-dep noise), none in the changed files
uv run --frozen pytest tests/test_oauth_store_lock.py tests/test_codex_oauth_refresh.py \
  tests/test_codex_home_env.py tests/test_codex_quota_reset_defer.py \
  tests/test_xai_oauth_llm.py tests/test_nous_provider.py   # 197 passed
```

Rebased onto current `main`, so this applies to `oauth_store_lock.py` as it exists today rather than to the `_codex_auth_lock` this was originally written against.

