### PR TITLE
fix(coding-agents): admit one codebase survey per bank

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/session-start.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.test.ts
@@ -14,7 +14,7 @@ describe("buildSessionStartContext", () => {
   it("cold git repo + autoSeed on -> seeds + surveys, note in systemMessage (user-visible) + roster in additionalContext (model)", async () => {
     const client = { listDocumentIds: async () => new Set<string>(), listPages: listPagesOk };
     const startSeed = vi.fn();
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     const out = await buildSessionStartContext({
       cwd: "/repo/dir",
       bankId: "bank-1",
@@ -58,7 +58,7 @@ describe("buildSessionStartContext", () => {
       harness: "codex",
       hasGit: () => true,
       startSeed,
-      startSurvey: vi.fn(),
+      startSurvey: vi.fn().mockResolvedValue(true),
     });
     expect(startSeed).toHaveBeenCalledWith("/repo/dir", { limit: 300, harness: "codex" });
   });
@@ -66,7 +66,7 @@ describe("buildSessionStartContext", () => {
   it("cold git repo + codebaseSurvey:false -> starts the seed but NOT the survey", async () => {
     const client = { listDocumentIds: async () => new Set<string>(), listPages: listPagesOk };
     const startSeed = vi.fn();
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     const out = await buildSessionStartContext({
       cwd: "/repo/dir",
       bankId: "bank-1",
@@ -152,7 +152,7 @@ describe("buildSessionStartContext", () => {
 
   it("warm bank (non-empty doc set) -> deepen engine fires, but no survey/note", async () => {
     const startSeed = vi.fn();
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     const client = { listDocumentIds: async () => new Set(["git:abc"]), listPages: listPagesOk };
     const out = await buildSessionStartContext({
       cwd: "/repo/dir",
@@ -325,7 +325,7 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
   ];
 
   it(">= threshold since the latest reachable baseline -> re-surveys + records a new baseline", async () => {
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     const retain = vi.fn();
     await buildSessionStartContext({
       cwd: "/repo",
@@ -358,7 +358,7 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
       client: warmClient(["survey-baseline:oldsha"], retain),
       hasGit: () => true,
       startSeed: vi.fn(),
-      startSurvey: vi.fn(),
+      startSurvey: vi.fn().mockResolvedValue(true),
       headSha: () => "newsha",
       commitsSince: () => 25,
     });
@@ -374,7 +374,7 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
   });
 
   it("< threshold -> no re-survey, no new baseline", async () => {
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     const retain = vi.fn();
     await buildSessionStartContext({
       cwd: "/repo",
@@ -392,7 +392,7 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
   });
 
   it("no baseline yet (upgrade from a pre-feature bank) -> records HEAD as baseline, does NOT survey", async () => {
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     const retain = vi.fn();
     await buildSessionStartContext({
       cwd: "/repo",
@@ -410,7 +410,7 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
   });
 
   it("all markers unreachable (rebase/gc) -> re-baselines to HEAD, does NOT survey", async () => {
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     const retain = vi.fn();
     await buildSessionStartContext({
       cwd: "/repo",
@@ -428,7 +428,7 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
   });
 
   it("takes the MIN reachable count (newest survey), ignoring older + dead-branch markers", async () => {
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     const counts: Record<string, number | null> = { old1: 50, old2: 10, dead: null };
     await buildSessionStartContext({
       cwd: "/repo",
@@ -445,7 +445,7 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
   });
 
   it("surveyRefreshCommits=0 disables re-survey even far past threshold", async () => {
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     await buildSessionStartContext({
       cwd: "/repo",
       bankId: "bank-1",
@@ -461,7 +461,7 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
   });
 
   it("cold seed records the survey baseline", async () => {
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     const retain = vi.fn();
     await buildSessionStartContext({
       cwd: "/repo",
@@ -481,7 +481,7 @@ describe("buildSessionStartContext — periodic re-survey (bank-stored commit co
 
 describe("buildSessionStartContext — crashed-survey retry (baseline without findings)", () => {
   it("re-fires the survey when a baseline exists but NO findings docs ever arrived", async () => {
-    const startSurvey = vi.fn();
+    const startSurvey = vi.fn().mockResolvedValue(true);
     const retain = vi.fn();
     const client = {
       listDocumentIds: async (tag: string) =>
@@ -507,4 +507,34 @@ describe("buildSessionStartContext — crashed-survey retry (baseline without fi
     expect(startSurvey).toHaveBeenCalledTimes(1);
     expect(out).toBeTruthy();
   });
+});
+
+describe("survey launch admission", () => {
+  it.each([false, true])(
+    "does not advance a %s warm/cold baseline when launch is skipped or fails",
+    async (warm) => {
+      const retain = vi.fn();
+      const startSurvey = vi.fn().mockResolvedValue(false);
+      await buildSessionStartContext({
+        cwd: "/repo",
+        bankId: "bank-1",
+        cfg: resolveConfig({ surveyRefreshCommits: 20 }),
+        client: {
+          listDocumentIds: async (tag) =>
+            tag === "source:survey-baseline"
+              ? new Set(["survey-baseline:oldsha"])
+              : new Set(warm ? ["git:old"] : []),
+          listPages: listPagesOk,
+          retain,
+        },
+        hasGit: () => true,
+        startSeed: vi.fn(),
+        startSurvey,
+        headSha: () => "newsha",
+        commitsSince: () => 25,
+      });
+      expect(startSurvey).toHaveBeenCalledOnce();
+      expect(retain).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -147,10 +147,7 @@ export async function buildSessionStartContext(args: {
   stateDir?: string;
   hasGit?: (dir: string) => boolean;
   startSeed?: (repoDir: string, opts?: { limit?: number; harness?: string }) => void;
-  startSurvey?: (
-    repoDir: string,
-    opts?: { harness?: SurveyHarness; model?: string; budgetUsd?: number }
-  ) => void;
+  startSurvey?: typeof startCodebaseSurvey;
   headSha?: (dir: string) => string | null;
   commitsSince?: (dir: string, sinceSha: string) => number | null;
 }): Promise<SessionStartOutput> {
@@ -232,13 +229,13 @@ export async function buildSessionStartContext(args: {
           if (docIds.size === 0) {
             if (cfg.codebaseSurvey !== false) {
               // Run the survey under the current harness's own CLI (falls back to any available agent).
-              startSurvey(cwd, {
+              const started = await startSurvey(cwd, {
                 harness: harness as SurveyHarness,
                 model: cfg.surveyModel,
                 budgetUsd: cfg.surveyBudgetUsd,
               });
               const sha = resolveHeadSha(cwd);
-              if (sha) recordSurveyBaseline(sha); // baseline for the commit-count re-survey below
+              if (started && sha) recordSurveyBaseline(sha);
             }
             diag(harness, "seed_started", { bank: bankId });
           } else if (cfg.codebaseSurvey !== false && cfg.surveyRefreshCommits > 0) {
@@ -268,17 +265,19 @@ export async function buildSessionStartContext(args: {
               const findingsAbsent =
                 counts.length > 0 && !SURVEY_DOC_IDS.some((id) => uploads.has(id));
               if ((sinceLast !== null && sinceLast >= cfg.surveyRefreshCommits) || findingsAbsent) {
-                startSurvey(cwd, {
+                const started = await startSurvey(cwd, {
                   harness: harness as SurveyHarness,
                   model: cfg.surveyModel,
                   budgetUsd: cfg.surveyBudgetUsd,
                 });
-                recordSurveyBaseline(sha);
-                diag(harness, "survey_refresh", {
-                  bank: bankId,
-                  commits: sinceLast,
-                  retry: findingsAbsent,
-                });
+                if (started) {
+                  recordSurveyBaseline(sha);
+                  diag(harness, "survey_refresh", {
+                    bank: bankId,
+                    commits: sinceLast,
+                    retry: findingsAbsent,
+                  });
+                }
               } else if (sinceLast === null) {
                 recordSurveyBaseline(sha); // first baseline, or reset after a rebase — no survey
               }

--- a/hindsight-integrations/coding-agents/src/core/survey.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.test.ts
@@ -1,11 +1,39 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resolveClaudeBin,
-  startCodebaseSurvey,
+  startCodebaseSurvey as startSurvey,
   SURVEY_AGENT,
   SURVEY_AGENT_CONFIG,
   SURVEY_PROMPT,
 } from "./survey";
+
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, readdirSync, writeFileSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { buildSync } from "esbuild";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveHostConfig } from "./host-client";
+import { resolveConfig } from "./config";
+
+vi.mock("./host-client", () => ({ resolveHostConfig: vi.fn() }));
+let lockDir: string;
+beforeEach(() => {
+  lockDir = mkdtempSync(join(tmpdir(), "hindsight-survey-test-"));
+  vi.mocked(resolveHostConfig).mockReturnValue({
+    cfg: resolveConfig({ apiUrl: "https://api.example.test", apiToken: "test-token" }),
+    bankId: "bank-1",
+  });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(lockDir, { recursive: true, force: true });
+});
+function startCodebaseSurvey(repoDir: string, opts: Parameters<typeof startSurvey>[1] = {}) {
+  return startSurvey(repoDir, { lockDir, ...opts });
+}
 
 describe("resolveClaudeBin", () => {
   const ORIGINAL_ENV = process.env.HINDSIGHT_CLAUDE_BIN;
@@ -15,17 +43,17 @@ describe("resolveClaudeBin", () => {
     else process.env.HINDSIGHT_CLAUDE_BIN = ORIGINAL_ENV;
   });
 
-  it("an explicit argument wins over everything", () => {
+  it("an explicit argument wins over everything", async () => {
     process.env.HINDSIGHT_CLAUDE_BIN = "/env/claude";
     expect(resolveClaudeBin("/explicit/claude")).toBe("/explicit/claude");
   });
 
-  it("HINDSIGHT_CLAUDE_BIN env var wins when no explicit arg is given", () => {
+  it("HINDSIGHT_CLAUDE_BIN env var wins when no explicit arg is given", async () => {
     process.env.HINDSIGHT_CLAUDE_BIN = "/env/claude";
     expect(resolveClaudeBin()).toBe("/env/claude");
   });
 
-  it("falls back to the bare 'claude' PATH lookup when nothing else resolves", () => {
+  it("falls back to the bare 'claude' PATH lookup when nothing else resolves", async () => {
     delete process.env.HINDSIGHT_CLAUDE_BIN;
     const bin = resolveClaudeBin();
     expect(typeof bin).toBe("string");
@@ -35,14 +63,23 @@ describe("resolveClaudeBin", () => {
 
 describe("startCodebaseSurvey", () => {
   function fakeSpawn() {
-    return vi.fn().mockReturnValue({ on: vi.fn(), unref: vi.fn() });
+    return vi.fn().mockImplementation(() => {
+      const child = Object.assign(new EventEmitter(), {
+        pid: process.pid,
+        unref: vi.fn(),
+        kill: vi.fn(),
+      });
+      vi.spyOn(child, "on");
+      queueMicrotask(() => child.emit("spawn"));
+      return child;
+    });
   }
   const yes = () => true;
 
   // ── claude recipe (the default / self-contained inline-MCP one) ────────────────────────────────
-  it("claude: spawns the resolved binary with the expected argv, sandbox, and options", () => {
+  it("claude: spawns the resolved binary with the expected argv, sandbox, and options", async () => {
     const spawn = fakeSpawn();
-    startCodebaseSurvey("/repo", {
+    await startCodebaseSurvey("/repo", {
       model: "sonnet",
       mcpServerPath: "/x/mcp-server.js",
       claudeBin: "/bin/claude",
@@ -91,18 +128,18 @@ describe("startCodebaseSurvey", () => {
     expect(child.unref).toHaveBeenCalled();
   });
 
-  it("claude: defaults model to 'haiku' and --max-budget-usd to 2", () => {
+  it("claude: defaults model to 'haiku' and --max-budget-usd to 2", async () => {
     const spawn = fakeSpawn();
-    startCodebaseSurvey("/repo", { claudeBin: "/bin/claude", spawn, exists: yes });
+    await startCodebaseSurvey("/repo", { claudeBin: "/bin/claude", spawn, exists: yes });
     const argv = spawn.mock.calls[0][1];
     expect(argv[argv.indexOf("--model") + 1]).toBe("haiku");
     expect(argv[argv.indexOf("--max-budget-usd") + 1]).toBe("2");
   });
 
   // ── codex recipe (read-only sandbox + inline -c MCP) ───────────────────────────────────────────
-  it("codex: spawns `codex exec --sandbox read-only` with inline MCP overrides + the prompt", () => {
+  it("codex: spawns `codex exec --sandbox read-only` with inline MCP overrides + the prompt", async () => {
     const spawn = fakeSpawn();
-    startCodebaseSurvey("/repo", {
+    await startCodebaseSurvey("/repo", {
       harness: "codex",
       mcpServerPath: "/x/mcp-server.js",
       spawn,
@@ -125,9 +162,9 @@ describe("startCodebaseSurvey", () => {
   });
 
   // ── Antigravity recipe (plan read-only mode + global MCP config) ───────────────────────────────
-  it("antigravity: spawns `agy -p` in plan mode", () => {
+  it("antigravity: spawns `agy -p` in plan mode", async () => {
     const spawn = fakeSpawn();
-    startCodebaseSurvey("/repo", {
+    await startCodebaseSurvey("/repo", {
       harness: "antigravity-cli",
       spawn,
       exists: (b) => b === "agy",
@@ -139,9 +176,9 @@ describe("startCodebaseSurvey", () => {
   });
 
   // ── opencode recipe (our own read-only agent; tools from the loaded plugin) ────────────────────
-  it("opencode: spawns `opencode run` under OUR survey agent, never the built-in plan agent", () => {
+  it("opencode: spawns `opencode run` under OUR survey agent, never the built-in plan agent", async () => {
     const spawn = fakeSpawn();
-    startCodebaseSurvey("/repo", {
+    await startCodebaseSurvey("/repo", {
       harness: "opencode",
       spawn,
       exists: (b) => b === "opencode",
@@ -157,7 +194,7 @@ describe("startCodebaseSurvey", () => {
 
   // The recipe above is only safe because the agent it names is read-only. opencode drops denied
   // tools from the model's tool list entirely, so this ruleset IS the sandbox.
-  it("the survey agent denies everything except reading and the one ingest tool", () => {
+  it("the survey agent denies everything except reading and the one ingest tool", async () => {
     expect(SURVEY_AGENT_CONFIG.permission["*"]).toBe("deny");
     expect(SURVEY_AGENT_CONFIG.permission.hindsight_ingest_document).toBe("allow");
     const allowed = Object.entries(SURVEY_AGENT_CONFIG.permission)
@@ -171,21 +208,25 @@ describe("startCodebaseSurvey", () => {
   });
 
   // ── agent selection + fallback ─────────────────────────────────────────────────────────────────
-  it("honors the HINDSIGHT_CODEX_BIN override for the codex binary", () => {
+  it("honors the HINDSIGHT_CODEX_BIN override for the codex binary", async () => {
     const spawn = fakeSpawn();
     process.env.HINDSIGHT_CODEX_BIN = "/opt/codex";
     try {
-      startCodebaseSurvey("/repo", { harness: "codex", spawn, exists: (b) => b === "/opt/codex" });
+      await startCodebaseSurvey("/repo", {
+        harness: "codex",
+        spawn,
+        exists: (b) => b === "/opt/codex",
+      });
     } finally {
       delete process.env.HINDSIGHT_CODEX_BIN;
     }
     expect(spawn.mock.calls[0][0]).toBe("/opt/codex");
   });
 
-  it("falls back to another available agent when the preferred harness's CLI is missing", () => {
+  it("falls back to another available agent when the preferred harness's CLI is missing", async () => {
     const spawn = fakeSpawn();
     // Prefer Antigravity, but only codex is installed → survey runs under codex.
-    startCodebaseSurvey("/repo", {
+    await startCodebaseSurvey("/repo", {
       harness: "antigravity-cli",
       mcpServerPath: "/x/mcp-server.js",
       spawn,
@@ -196,20 +237,20 @@ describe("startCodebaseSurvey", () => {
     expect(argv[0]).toBe("exec");
   });
 
-  it("no capable agent found → no spawn (fail open; the git-log seed still ran)", () => {
+  it("no capable agent found → no spawn (fail open; the git-log seed still ran)", async () => {
     const spawn = fakeSpawn();
-    startCodebaseSurvey("/repo", { harness: "antigravity-cli", spawn, exists: () => false });
+    await startCodebaseSurvey("/repo", { harness: "antigravity-cli", spawn, exists: () => false });
     expect(spawn).not.toHaveBeenCalled();
   });
 
   // ── fail-safe ──────────────────────────────────────────────────────────────────────────────────
-  it("fail-safe: a spawn that throws synchronously does not throw out of startCodebaseSurvey", () => {
+  it("fail-safe: a spawn that throws synchronously does not throw out of startCodebaseSurvey", async () => {
     const spawn = vi.fn().mockImplementation(() => {
       throw new Error("spawn EMFILE");
     });
-    expect(() =>
+    await expect(
       startCodebaseSurvey("/repo", { claudeBin: "/bin/claude", spawn, exists: yes })
-    ).not.toThrow();
+    ).resolves.toBe(false);
   });
 
   it("fail-safe: an async 'error' event on the child does not crash the caller", async () => {
@@ -217,7 +258,143 @@ describe("startCodebaseSurvey", () => {
     const child = new EventEmitter() as InstanceType<typeof EventEmitter> & { unref: () => void };
     child.unref = vi.fn();
     const spawn = vi.fn().mockReturnValue(child);
-    startCodebaseSurvey("/repo", { claudeBin: "/bin/claude", spawn, exists: yes });
+    const launched = startCodebaseSurvey("/repo", { claudeBin: "/bin/claude", spawn, exists: yes });
     expect(() => child.emit("error", new Error("ENOENT"))).not.toThrow();
+    await expect(launched).resolves.toBe(false);
+    await expect(startCodebaseSurvey("/repo", { spawn: fakeSpawn(), exists: yes })).resolves.toBe(
+      true
+    );
   });
+
+  it("admits one concurrent survey and permits retry after it exits", async () => {
+    const spawn = fakeSpawn();
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () => startCodebaseSurvey("/repo", { spawn, exists: yes }))
+    );
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(results.filter(Boolean)).toHaveLength(1);
+    spawn.mock.results[0].value.emit("exit", 0);
+    await expect(startCodebaseSurvey("/repo", { spawn, exists: yes })).resolves.toBe(true);
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it("keys admission by the resolved API, credential and bank, not repository or asking harness", async () => {
+    const spawn = fakeSpawn();
+    await expect(startCodebaseSurvey("/repo-a", { spawn, exists: yes })).resolves.toBe(true);
+    // A second directory / fallback harness can write the same destination.
+    await expect(
+      startCodebaseSurvey("/repo-b", { harness: "codex", spawn, exists: yes })
+    ).resolves.toBe(false);
+    for (const [apiUrl, apiToken, bankId] of [
+      ["https://other.example.test", "test-token", "bank-1"],
+      ["https://api.example.test", "other-token", "bank-1"],
+      ["https://api.example.test", "test-token", "bank-2"],
+    ]) {
+      vi.mocked(resolveHostConfig).mockReturnValue({
+        cfg: resolveConfig({ apiUrl, apiToken }),
+        bankId,
+      });
+      await expect(startCodebaseSurvey("/repo-a", { spawn, exists: yes })).resolves.toBe(true);
+    }
+    expect(spawn).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not reclaim an owner whose PID cannot be probed", async () => {
+    const spawn = fakeSpawn();
+    await startCodebaseSurvey("/repo", { spawn, exists: yes });
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("denied"), { code: "EPERM" });
+    });
+    await expect(startCodebaseSurvey("/repo", { spawn, exists: yes })).resolves.toBe(false);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("an old child's exit cannot release a replacement generation", async () => {
+    const spawn = fakeSpawn();
+    await startCodebaseSurvey("/repo", { spawn, exists: yes });
+    const oldChild = spawn.mock.results[0].value;
+    vi.spyOn(process, "kill").mockImplementationOnce(() => {
+      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    });
+    await expect(startCodebaseSurvey("/repo", { spawn, exists: yes })).resolves.toBe(true);
+    oldChild.emit("exit", 0);
+    await expect(startCodebaseSurvey("/repo", { spawn, exists: yes })).resolves.toBe(false);
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates independent hooks after their parents exit and recovers a dead survey", async () => {
+    const bundle = join(lockDir, "survey.mjs");
+    buildSync({
+      entryPoints: [fileURLToPath(new URL("./survey.ts", import.meta.url))],
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      outfile: bundle,
+      banner: {
+        js: 'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);',
+      },
+    });
+    const config = join(lockDir, "config.json");
+    writeFileSync(
+      config,
+      JSON.stringify({
+        bankId: "bank-1",
+        apiUrl: "https://api.example.test",
+        apiToken: "test-token",
+      })
+    );
+    const paidChild = `require('node:fs').writeFileSync(${JSON.stringify(lockDir)} + '/pid-' + process.pid, ''); setInterval(() => {}, 1000);`;
+    const hook = `
+      import { startCodebaseSurvey } from ${JSON.stringify(pathToFileURL(bundle).href)};
+      import { spawn } from 'node:child_process';
+      const started = await startCodebaseSurvey(${JSON.stringify(lockDir)}, {
+        exists: () => true, mcpServerPath: '/unused-mcp-server.js', lockDir: ${JSON.stringify(join(lockDir, "locks"))},
+        spawn: () => spawn(process.execPath, ['-e', ${JSON.stringify(paidChild)}], { detached: true, stdio: 'ignore' }),
+      });
+      console.log(JSON.stringify(started));
+    `;
+    const runHook = async () => {
+      const { stdout } = await promisify(execFile)(
+        process.execPath,
+        ["--input-type=module", "-e", hook],
+        {
+          env: {
+            PATH: process.env.PATH,
+            HOME: lockDir,
+            HINDSIGHT_CONFIG: config,
+            SystemRoot: process.env.SystemRoot,
+          },
+        }
+      );
+      return JSON.parse(stdout.trim()) as boolean;
+    };
+    const pids = () =>
+      readdirSync(lockDir)
+        .filter((name) => name.startsWith("pid-"))
+        .map((name) => Number(name.slice(4)));
+    try {
+      expect((await Promise.all(Array.from({ length: 6 }, runHook))).filter(Boolean)).toHaveLength(
+        1
+      );
+      await vi.waitFor(() => expect(pids()).toHaveLength(1));
+      // Every hook has exited, but the paid child is alive: no false stale-owner recovery.
+      expect(await runHook()).toBe(false);
+      const pid = pids()[0];
+      process.kill(pid, "SIGTERM");
+      await vi.waitFor(() => expect(() => process.kill(pid, 0)).toThrow());
+      // Multiple fresh hooks race to reclaim the SAME dead generation.
+      expect((await Promise.all(Array.from({ length: 6 }, runHook))).filter(Boolean)).toHaveLength(
+        1
+      );
+      await vi.waitFor(() => expect(pids()).toHaveLength(2));
+    } finally {
+      for (const pid of pids()) {
+        try {
+          process.kill(pid, "SIGTERM");
+        } catch {
+          /* already exited */
+        }
+      }
+    }
+  }, 30_000);
 });

--- a/hindsight-integrations/coding-agents/src/core/survey.ts
+++ b/hindsight-integrations/coding-agents/src/core/survey.ts
@@ -37,11 +37,23 @@
  * missing binary or a spawn failure must silently no-op, never crash the caller.
  */
 import { spawn as realSpawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { homedir } from "node:os";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { binOnPath } from "./util";
+import { resolveHostConfig } from "./host-client";
 
 /** Deterministic doc ids of the survey's findings (its fixed titles slugified by
  *  hindsight_ingest_document). Their presence in the bank = the survey actually FINISHED —
@@ -278,13 +290,82 @@ function buildSurveyPlan(
   }
 }
 
+/** Remove only this generation's owner file. A replacement lock is nonempty and survives
+ * rmdir even if another contender acquires it between unlink and rmdir. */
+function releaseSurveyLock(directory: string, owner: string): void {
+  try {
+    unlinkSync(join(directory, owner));
+    try {
+      rmdirSync(directory);
+    } catch {
+      /* a new owner may already be there */
+    }
+  } catch {
+    /* already released/replaced; never remove an unknown generation */
+  }
+}
+
+/** Rename a POPULATED private directory into place: there is no empty-owner publication
+ * window, and competing renames cannot replace a nonempty lock. The old deepen-style
+ * read-then-write lock lets simultaneous hooks all win and launch paid work (#4255). */
+function acquireSurveyLock(
+  key: string,
+  root: string
+):
+  | {
+      handoff(pid: number): void;
+      release(): void;
+    }
+  | undefined {
+  let staging: string | undefined;
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    staging = mkdtempSync(join(root, "claim-"));
+    const token = randomUUID();
+    let owner = `${process.pid}-${token}`;
+    writeFileSync(join(staging, owner), "", { flag: "wx", mode: 0o600 });
+    const directory = join(root, `survey-${key}.lock`);
+    try {
+      renameSync(staging, directory);
+    } catch {
+      const owners = readdirSync(directory);
+      if (owners.length !== 1) return;
+      const match = /^(\d+)-[0-9a-f-]{36}$/.exec(owners[0]);
+      if (!match || Number(match[1]) <= 0) return;
+      try {
+        process.kill(Number(match[1]), 0);
+        return; // Never expire a live survey by age.
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") return;
+      }
+      releaseSurveyLock(directory, owners[0]);
+      renameSync(staging, directory); // exactly one stale-lock contender wins
+    }
+    return {
+      handoff(pid) {
+        const childOwner = `${pid}-${token}`;
+        renameSync(join(directory, owner), join(directory, childOwner));
+        owner = childOwner;
+      },
+      release() {
+        releaseSurveyLock(directory, owner);
+      },
+    };
+  } catch {
+    return; // Cannot prove admission: skip, rather than launch duplicate paid work.
+  } finally {
+    if (staging) rmSync(staging, { recursive: true, force: true });
+  }
+}
+
 /**
  * Spawn a DETACHED headless agent to survey `repoDir` and ingest structural findings via the
  * `hindsight_ingest_document` tool. Runs the survey under the current harness's own CLI when
  * available, else falls back to any available agent (claude → codex → antigravity → opencode — claude and
- * codex first because their inline-MCP recipes are self-contained). Fire-and-forget; never throws.
+ * codex first because their inline-MCP recipes are self-contained). Resolves after spawn admission,
+ * not survey completion; false means no launch. Never throws.
  */
-export function startCodebaseSurvey(
+export async function startCodebaseSurvey(
   repoDir: string,
   opts: {
     harness?: SurveyHarness;
@@ -294,8 +375,9 @@ export function startCodebaseSurvey(
     claudeBin?: string;
     spawn?: typeof realSpawn;
     exists?: (bin: string) => boolean; // seam for tests
+    lockDir?: string; // isolated scratch directory for tests
   } = {}
-): void {
+): Promise<boolean> {
   try {
     const spawnFn = opts.spawn ?? realSpawn;
     const exists = opts.exists ?? binOnPath;
@@ -324,22 +406,59 @@ export function startCodebaseSurvey(
         budgetUsd: opts.budgetUsd,
         mcpServerPath,
       });
-      const child = spawnFn(plan.bin, plan.args, {
-        cwd: repoDir,
-        detached: true,
-        stdio: "ignore",
-        windowsHide: true,
-        env: plan.env,
+      // Use the SAME resolver as the selected agent's MCP/plugin, including fallback harnesses
+      // and bank overrides. Hash credentials too: equal bank ids on one API can belong to
+      // different tenants, but neither tokens nor bank names should appear in scratch paths.
+      const { cfg, bankId } = resolveHostConfig(harness, repoDir);
+      if (cfg.disabled) return false;
+      const key = createHash("sha256")
+        .update(JSON.stringify([cfg.apiUrl.replace(/\/+$/, ""), cfg.apiToken ?? "", bankId]))
+        .digest("hex");
+      const lock = acquireSurveyLock(
+        key,
+        opts.lockDir ?? join(tmpdir(), "hindsight-coding-agent", "surveys")
+      );
+      if (!lock) return false;
+      return await new Promise<boolean>((resolve) => {
+        try {
+          const child = spawnFn(plan.bin, plan.args, {
+            cwd: repoDir,
+            detached: true,
+            stdio: "ignore",
+            windowsHide: true,
+            env: plan.env,
+          });
+          child.on("error", () => {
+            lock.release();
+            resolve(false);
+          });
+          child.once("exit", () => lock.release());
+          child.once("spawn", () => {
+            try {
+              if (!child.pid) throw new Error("survey child has no PID");
+              // A hook exits immediately; its PID cannot own the detached child's lifetime.
+              lock.handoff(child.pid);
+              child.unref();
+              resolve(true);
+            } catch {
+              try {
+                child.kill();
+              } catch {
+                /* already gone */
+              }
+              lock.release();
+              resolve(false);
+            }
+          });
+        } catch {
+          lock.release();
+          resolve(false);
+        }
       });
-      // spawn() failures (binary not found, EACCES, sandboxed environments) often arrive
-      // ASYNCHRONOUSLY as an 'error' event on the child, not as a synchronous throw — an unhandled
-      // 'error' event would crash the caller. Swallow it: fire-and-forget best-effort.
-      child.on("error", () => {});
-      child.unref();
-      return; // one survey agent is enough
     }
     // No capable agent found — fail open (the git-log seed already ran; the survey is a bonus).
   } catch {
     /* best-effort: a failed spawn must not break the caller */
   }
+  return false;
 }


### PR DESCRIPTION
Concurrent SessionStart hooks can each launch a paid codebase survey while the same bank is still cold. This gates survey admission with an atomic populated-directory lock keyed by the resolved API, credential and bank. Ownership transfers to the detached survey PID before the hook returns; dead owners can be reclaimed, and an old child cannot release a newer generation. Cold and refresh baselines are recorded only after a successful launch.

Fixes #4255.

Validation: all 967 coding-agents tests pass (70 files), TypeScript checking and package build pass, and `./scripts/hooks/lint.sh` passes. Regression coverage includes six independent hook processes, exclusion after their parents exit, concurrent dead-owner recovery, destination isolation and failed-launch baseline handling. These are deterministic process tests; no live model inference was used.

The lock coordinates processes sharing the local temporary directory; it is not distributed coordination across machines. AI-assisted implementation and self-review.
