### PR TITLE
fix(api): reserve listeners before application initialization

### DIFF
--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -14,8 +14,10 @@ import argparse
 import asyncio
 import atexit
 import dataclasses
+import logging
 import os
 import signal
+import socket
 import sys
 import warnings
 
@@ -231,8 +233,6 @@ def _parse_cli_args(argv: list[str], config: HindsightConfig) -> ParsedCliArgs:
 
 def main():
     """Main entry point for the CLI."""
-    global _memory
-
     load_dotenv_for_entrypoint()
 
     # Arm profiling here, after .env is loaded and before anything starts serving, so a
@@ -280,6 +280,46 @@ def main():
         # duplicate daemons.
         daemonize()
 
+    # Reserve the actual listeners before lazy imports or engine initialization. Keeping
+    # them through serving avoids the race in a check-then-close port probe.
+    try:
+        sockets = asyncio.run(_bind_sockets(args.host, args.port))
+    except OSError as exc:
+        logging.error("Cannot bind %s:%s: %s", args.host, args.port, exc)
+        raise SystemExit(1) from exc
+    try:
+        _serve(args, config, is_daemon, sockets)
+    finally:
+        for sock in sockets:
+            sock.close()
+
+
+async def _bind_sockets(host: str, port: int) -> list[socket.socket]:
+    """Use asyncio's hostname/IPv4/IPv6 resolution without accepting any connections."""
+    server = await asyncio.get_running_loop().create_server(asyncio.Protocol, host=host, port=port, start_serving=False)
+    sockets = []
+    try:
+        # Transfer ownership out of the temporary loop; its server never starts serving.
+        for sock in server.sockets or ():
+            sockets.append(sock.dup())
+        for sock in sockets:
+            # bind alone permits competing SO_REUSEADDR binders on some systems.
+            # Establish exclusive listeners now, before any expensive initialization.
+            sock.listen(socket.SOMAXCONN)
+            sock.set_inheritable(True)
+        return sockets
+    except BaseException:
+        for sock in sockets:
+            sock.close()
+        raise
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+def _serve(args: argparse.Namespace, config: HindsightConfig, is_daemon: bool, sockets: list[socket.socket]):
+    global _memory
+
     # Print banner (not in daemon mode)
     if not is_daemon:
         print()
@@ -314,15 +354,11 @@ def main():
     # Load operation validator extension if configured
     operation_validator = load_extension("OPERATION_VALIDATOR", OperationValidatorExtension)
     if operation_validator:
-        import logging
-
         logging.info(f"Loaded operation validator: {operation_validator.__class__.__name__}")
 
     # Load tenant extension if configured
     tenant_extension = load_extension("TENANT", TenantExtension)
     if tenant_extension:
-        import logging
-
         logging.info(f"Loaded tenant extension: {tenant_extension.__class__.__name__}")
 
     # When using workers or reload, we must use import string so each worker can import the app
@@ -432,7 +468,27 @@ def main():
             text_search_extension=config.text_search_extension,
         )
 
-    uvicorn.run(**uvicorn_config)
+    _run_uvicorn(sockets=sockets, **uvicorn_config)
+
+
+def _run_uvicorn(*, sockets: list[socket.socket], **kwargs):
+    """Keep Uvicorn's supervisor and startup-failure behavior with prebound sockets."""
+    from uvicorn.main import STARTUP_FAILURE
+    from uvicorn.supervisors import ChangeReload, Multiprocess
+
+    config = uvicorn.Config(**kwargs)
+    server = uvicorn.Server(config)
+    try:
+        if config.should_reload:
+            ChangeReload(config, target=server.run, sockets=sockets).run()
+        elif config.workers > 1:
+            Multiprocess(config, target=server.run, sockets=sockets).run()
+        else:
+            server.run(sockets=sockets)
+    except KeyboardInterrupt:
+        pass
+    if not server.started and not config.should_reload and config.workers == 1:
+        raise SystemExit(STARTUP_FAILURE)
 
 
 if __name__ == "__main__":

--- a/hindsight-api-slim/hindsight_api/main.py
+++ b/hindsight-api-slim/hindsight_api/main.py
@@ -14,6 +14,7 @@ import argparse
 import asyncio
 import atexit
 import dataclasses
+import errno
 import logging
 import os
 import signal
@@ -288,6 +289,8 @@ def main():
         logging.error("Cannot bind %s:%s: %s", args.host, args.port, exc)
         raise SystemExit(1) from exc
     try:
+        args.port = sockets[0].getsockname()[1]
+        config = dataclasses.replace(config, port=args.port)
         _serve(args, config, is_daemon, sockets)
     finally:
         for sock in sockets:
@@ -296,6 +299,25 @@ def main():
 
 async def _bind_sockets(host: str, port: int) -> list[socket.socket]:
     """Use asyncio's hostname/IPv4/IPv6 resolution without accepting any connections."""
+    if port == 0:
+        # asyncio allocates a separate ephemeral port per resolved address. Select
+        # one candidate, then reserve it across all addresses before initialization.
+        # Retry a bounded number of times if another listener wins that candidate.
+        for attempt in range(5):
+            probe = await asyncio.get_running_loop().create_server(
+                asyncio.Protocol, host=host, port=0, start_serving=False
+            )
+            try:
+                selected_port = probe.sockets[0].getsockname()[1]
+            finally:
+                probe.close()
+                await probe.wait_closed()
+            try:
+                return await _bind_sockets(host, selected_port)
+            except OSError as exc:
+                if exc.errno != errno.EADDRINUSE or attempt == 4:
+                    raise
+
     server = await asyncio.get_running_loop().create_server(asyncio.Protocol, host=host, port=port, start_serving=False)
     sockets = []
     try:

--- a/hindsight-api-slim/tests/test_main_module.py
+++ b/hindsight-api-slim/tests/test_main_module.py
@@ -10,8 +10,11 @@ These tests ensure that extensions are properly loaded in this code path.
 Compare with test_server_module.py which tests the multi-worker path (workers > 1).
 """
 
+import socket
 import sys
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 class TestMainModuleExtensionLoading:
@@ -50,11 +53,11 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.load_extension", side_effect=tracking_load_extension),
             patch("hindsight_api.main.DefaultExtensionContext"),
             patch("hindsight_api.main.print_banner"),
-            patch("uvicorn.run"),
+            patch("hindsight_api.main._run_uvicorn"),
         ):  # Don't actually start uvicorn
             mock_config = MagicMock()
             mock_config.host = "0.0.0.0"
-            mock_config.port = 8888
+            mock_config.port = 0
             mock_config.log_level = "info"
             # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
@@ -109,11 +112,11 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.load_extension", side_effect=tracking_load_extension),
             patch("hindsight_api.main.DefaultExtensionContext"),
             patch("hindsight_api.main.print_banner"),
-            patch("uvicorn.run"),
+            patch("hindsight_api.main._run_uvicorn"),
         ):
             mock_config = MagicMock()
             mock_config.host = "0.0.0.0"
-            mock_config.port = 8888
+            mock_config.port = 0
             mock_config.log_level = "info"
             # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
@@ -161,11 +164,11 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main._get_raw_config") as mock_get_config,
             patch("hindsight_api.main.DefaultExtensionContext"),
             patch("hindsight_api.main.print_banner"),
-            patch("uvicorn.run"),
+            patch("hindsight_api.main._run_uvicorn"),
         ):
             mock_config = MagicMock()
             mock_config.host = "0.0.0.0"
-            mock_config.port = 8888
+            mock_config.port = 0
             mock_config.log_level = "info"
             # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
@@ -223,11 +226,11 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main._get_raw_config") as mock_get_config,
             patch("hindsight_api.main.DefaultExtensionContext", side_effect=capture_context),
             patch("hindsight_api.main.print_banner"),
-            patch("uvicorn.run"),
+            patch("hindsight_api.main._run_uvicorn"),
         ):
             mock_config = MagicMock()
             mock_config.host = "0.0.0.0"
-            mock_config.port = 8888
+            mock_config.port = 0
             mock_config.log_level = "info"
             # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
@@ -268,11 +271,11 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.create_app") as mock_create_app,
             patch("hindsight_api.main._get_raw_config") as mock_get_config,
             patch("hindsight_api.main.print_banner"),
-            patch("uvicorn.run"),
+            patch("hindsight_api.main._run_uvicorn"),
         ):
             mock_config = MagicMock()
             mock_config.host = "0.0.0.0"
-            mock_config.port = 8888
+            mock_config.port = 0
             mock_config.log_level = "info"
             # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
@@ -318,11 +321,11 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.create_app", return_value=mock_app),
             patch("hindsight_api.main._get_raw_config") as mock_get_config,
             patch("hindsight_api.main.print_banner"),
-            patch("uvicorn.run", side_effect=capture_uvicorn_run),
+            patch("hindsight_api.main._run_uvicorn", side_effect=capture_uvicorn_run),
         ):
             mock_config = MagicMock()
             mock_config.host = "0.0.0.0"
-            mock_config.port = 8888
+            mock_config.port = 0
             mock_config.log_level = "info"
             # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
@@ -362,11 +365,11 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.create_app") as mock_create_app,
             patch("hindsight_api.main._get_raw_config") as mock_get_config,
             patch("hindsight_api.main.print_banner"),
-            patch("uvicorn.run", side_effect=capture_uvicorn_run),
+            patch("hindsight_api.main._run_uvicorn", side_effect=capture_uvicorn_run),
         ):
             mock_config = MagicMock()
             mock_config.host = "0.0.0.0"
-            mock_config.port = 8888
+            mock_config.port = 0
             mock_config.log_level = "info"
             # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
@@ -409,11 +412,11 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.create_app") as mock_create_app,
             patch("hindsight_api.main._get_raw_config") as mock_get_config,
             patch("hindsight_api.main.print_banner"),
-            patch("uvicorn.run", side_effect=capture_uvicorn_run),
+            patch("hindsight_api.main._run_uvicorn", side_effect=capture_uvicorn_run),
         ):
             mock_config = MagicMock()
             mock_config.host = "0.0.0.0"
-            mock_config.port = 8888
+            mock_config.port = 0
             mock_config.log_level = "info"
             # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
@@ -483,3 +486,181 @@ class MockOperationValidator(OperationValidatorExtension):
 
     async def validate_reflect(self, ctx: ReflectContext) -> ValidationResult:
         return ValidationResult.accept()
+
+
+@pytest.mark.parametrize("flags", [[], ["--workers", "2"], ["--reload"], ["--daemon"]])
+def test_occupied_port_fails_before_lazy_imports(monkeypatch, flags):
+    import hindsight_api.main as entrypoint
+    from hindsight_api.config import HindsightConfig
+
+    imports = []
+
+    def unexpected_import(name):
+        imports.append(name)
+        raise AssertionError(f"expensive import before bind: {name}")
+
+    for name in entrypoint._LAZY_IMPORTS:
+        monkeypatch.delitem(vars(entrypoint), name, raising=False)
+    monkeypatch.setattr(entrypoint, "__getattr__", unexpected_import)
+    monkeypatch.setattr(entrypoint, "_get_raw_config", lambda: HindsightConfig.from_env())
+    monkeypatch.setattr(entrypoint, "load_dotenv_for_entrypoint", lambda: None)
+    monkeypatch.setattr(entrypoint, "daemonize", lambda: None)
+    with socket.create_server(("127.0.0.1", 0)) as listener:
+        port = listener.getsockname()[1]
+        monkeypatch.setattr(sys, "argv", ["hindsight-api", "--host", "127.0.0.1", "--port", str(port), *flags])
+        with pytest.raises(SystemExit) as exc:
+            entrypoint.main()
+        assert exc.value.code == 1
+        assert imports == []
+        # The existing listener remains usable; the CLI never kills or reclaims it.
+        with socket.create_connection(("127.0.0.1", port), timeout=1):
+            connection, _ = listener.accept()
+            connection.close()
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_prebound_sockets_reserve_addresses_until_closed(host):
+    import asyncio
+    import errno
+
+    from hindsight_api.main import _bind_sockets
+
+    try:
+        sockets = asyncio.run(_bind_sockets(host, 0))
+    except OSError as exc:
+        if host == "::1" and exc.errno in (errno.EAFNOSUPPORT, errno.EADDRNOTAVAIL):
+            pytest.skip("IPv6 loopback unavailable")
+        raise
+    addresses = [(sock.family, sock.getsockname()) for sock in sockets]
+    try:
+        assert addresses
+        for family, address in addresses:
+            assert address[1] > 0
+            with socket.socket(family) as contender:
+                contender.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                with pytest.raises(OSError):
+                    contender.bind(address)
+                    contender.listen()
+    finally:
+        for sock in sockets:
+            sock.close()
+    for family, address in addresses:
+        with socket.socket(family) as retry:
+            retry.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            retry.bind(address)
+            retry.listen()
+
+
+def test_main_closes_sockets_when_initialization_fails(monkeypatch):
+    import hindsight_api.main as entrypoint
+    from hindsight_api.config import HindsightConfig
+
+    monkeypatch.setattr(entrypoint, "_get_raw_config", lambda: HindsightConfig.from_env())
+    monkeypatch.setattr(entrypoint, "load_dotenv_for_entrypoint", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["hindsight-api", "--host", "127.0.0.1", "--port", "0"])
+    held = []
+
+    def fail(args, config, is_daemon, sockets):
+        held.extend(sockets)
+        raise RuntimeError("engine initialization failed")
+
+    monkeypatch.setattr(entrypoint, "_serve", fail)
+    with pytest.raises(RuntimeError, match="engine initialization failed"):
+        entrypoint.main()
+    assert held and all(sock.fileno() == -1 for sock in held)
+
+
+@pytest.mark.parametrize("mode", ["single", "workers", "reload"])
+def test_uvicorn_receives_reserved_sockets_in_every_mode(monkeypatch, mode):
+    import asyncio
+
+    import uvicorn
+
+    from hindsight_api.main import _bind_sockets, _run_uvicorn
+
+    server = MagicMock(started=True)
+    monkeypatch.setattr(uvicorn, "Server", lambda config: server)
+    with patch("uvicorn.supervisors.ChangeReload") as reload, patch("uvicorn.supervisors.Multiprocess") as workers:
+        sockets = asyncio.run(_bind_sockets("127.0.0.1", 0))
+        try:
+            _run_uvicorn(
+                sockets=sockets,
+                app="hindsight_api.server:app",
+                workers=2 if mode == "workers" else 1,
+                reload=mode == "reload",
+                log_level="error",
+            )
+            if mode == "single":
+                server.run.assert_called_once_with(sockets=sockets)
+                workers.assert_not_called()
+                reload.assert_not_called()
+            else:
+                supervisor = workers if mode == "workers" else reload
+                assert supervisor.call_args.kwargs["sockets"] is sockets
+                assert supervisor.call_args.kwargs["target"] == server.run
+                supervisor.return_value.run.assert_called_once_with()
+                server.run.assert_not_called()
+        finally:
+            for sock in sockets:
+                sock.close()
+
+
+def test_prebound_socket_serves_http_and_keeps_startup_failure_exit_code(monkeypatch):
+    import asyncio
+    import threading
+    import urllib.request
+
+    import uvicorn
+
+    from hindsight_api.main import _bind_sockets, _run_uvicorn
+
+    real_server = uvicorn.Server
+    created = []
+    failures = []
+    ready = threading.Event()
+
+    class Server(real_server):
+        async def startup(self, sockets=None):
+            await super().startup(sockets=sockets)
+            ready.set()
+
+    def make_server(config):
+        server = Server(config)
+        created.append(server)
+        return server
+
+    monkeypatch.setattr(uvicorn, "Server", make_server)
+
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"reserved listener"})
+
+    sockets = asyncio.run(_bind_sockets("127.0.0.1", 0))
+    port = sockets[0].getsockname()[1]
+
+    def run():
+        try:
+            _run_uvicorn(sockets=sockets, app=app, loop="asyncio", lifespan="off", log_level="error")
+        except BaseException as exc:
+            failures.append(exc)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    try:
+        assert ready.wait(10), failures
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}", timeout=5) as response:
+            assert response.read() == b"reserved listener"
+    finally:
+        for server in created:
+            server.should_exit = True
+        thread.join(10)
+        for sock in sockets:
+            sock.close()
+    assert not thread.is_alive()
+    assert failures == []
+
+    failed = MagicMock(started=False)
+    monkeypatch.setattr(uvicorn, "Server", lambda config: failed)
+    with pytest.raises(SystemExit) as exc:
+        _run_uvicorn(sockets=[], app=app, log_level="error")
+    assert exc.value.code == 3

--- a/hindsight-api-slim/tests/test_main_module.py
+++ b/hindsight-api-slim/tests/test_main_module.py
@@ -16,6 +16,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hindsight_api.config import HindsightConfig
+
 
 class TestMainModuleExtensionLoading:
     """Tests that main.py correctly loads extensions when configured via environment."""
@@ -55,11 +57,10 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.print_banner"),
             patch("hindsight_api.main._run_uvicorn"),
         ):  # Don't actually start uvicorn
-            mock_config = MagicMock()
+            mock_config = HindsightConfig.from_env()
             mock_config.host = "0.0.0.0"
             mock_config.port = 0
             mock_config.log_level = "info"
-            # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
             mock_config.access_log = False
             mock_config.mcp_enabled = False
@@ -114,11 +115,10 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.print_banner"),
             patch("hindsight_api.main._run_uvicorn"),
         ):
-            mock_config = MagicMock()
+            mock_config = HindsightConfig.from_env()
             mock_config.host = "0.0.0.0"
             mock_config.port = 0
             mock_config.log_level = "info"
-            # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
             mock_config.access_log = False
             mock_config.mcp_enabled = False
@@ -166,11 +166,10 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.print_banner"),
             patch("hindsight_api.main._run_uvicorn"),
         ):
-            mock_config = MagicMock()
+            mock_config = HindsightConfig.from_env()
             mock_config.host = "0.0.0.0"
             mock_config.port = 0
             mock_config.log_level = "info"
-            # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
             mock_config.access_log = False
             mock_config.mcp_enabled = False
@@ -228,11 +227,10 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.print_banner"),
             patch("hindsight_api.main._run_uvicorn"),
         ):
-            mock_config = MagicMock()
+            mock_config = HindsightConfig.from_env()
             mock_config.host = "0.0.0.0"
             mock_config.port = 0
             mock_config.log_level = "info"
-            # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
             mock_config.access_log = False
             mock_config.mcp_enabled = False
@@ -273,11 +271,10 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.print_banner"),
             patch("hindsight_api.main._run_uvicorn"),
         ):
-            mock_config = MagicMock()
+            mock_config = HindsightConfig.from_env()
             mock_config.host = "0.0.0.0"
             mock_config.port = 0
             mock_config.log_level = "info"
-            # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
             mock_config.access_log = False
             mock_config.mcp_enabled = False
@@ -323,11 +320,10 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.print_banner"),
             patch("hindsight_api.main._run_uvicorn", side_effect=capture_uvicorn_run),
         ):
-            mock_config = MagicMock()
+            mock_config = HindsightConfig.from_env()
             mock_config.host = "0.0.0.0"
             mock_config.port = 0
             mock_config.log_level = "info"
-            # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
             mock_config.access_log = False
             mock_config.mcp_enabled = False
@@ -367,11 +363,10 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.print_banner"),
             patch("hindsight_api.main._run_uvicorn", side_effect=capture_uvicorn_run),
         ):
-            mock_config = MagicMock()
+            mock_config = HindsightConfig.from_env()
             mock_config.host = "0.0.0.0"
             mock_config.port = 0
             mock_config.log_level = "info"
-            # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
             mock_config.access_log = False
             mock_config.mcp_enabled = False
@@ -414,11 +409,10 @@ class TestMainModuleExtensionLoading:
             patch("hindsight_api.main.print_banner"),
             patch("hindsight_api.main._run_uvicorn", side_effect=capture_uvicorn_run),
         ):
-            mock_config = MagicMock()
+            mock_config = HindsightConfig.from_env()
             mock_config.host = "0.0.0.0"
             mock_config.port = 0
             mock_config.log_level = "info"
-            # argparse defaults: a MagicMock would compare against ints later on.
             mock_config.workers = 1
             mock_config.access_log = False
             mock_config.mcp_enabled = False
@@ -534,6 +528,7 @@ def test_prebound_sockets_reserve_addresses_until_closed(host):
     addresses = [(sock.family, sock.getsockname()) for sock in sockets]
     try:
         assert addresses
+        assert len({address[1] for _, address in addresses}) == 1
         for family, address in addresses:
             assert address[1] > 0
             with socket.socket(family) as contender:
@@ -551,6 +546,58 @@ def test_prebound_sockets_reserve_addresses_until_closed(host):
             retry.listen()
 
 
+@pytest.mark.parametrize("conflicts", [1, 5])
+def test_ephemeral_port_retries_conflicts_without_leaking_sockets(monkeypatch, conflicts):
+    import asyncio
+    import errno
+
+    from hindsight_api.main import _bind_sockets
+
+    probes = []
+    blockers = []
+    reserved = []
+    attempts = 0
+
+    async def exercise():
+        nonlocal attempts
+        loop = asyncio.get_running_loop()
+        create_server = loop.create_server
+
+        async def race(*args, **kwargs):
+            nonlocal attempts
+            if kwargs["port"]:
+                attempts += 1
+                if attempts <= conflicts:
+                    # Occupy the selected port after the probe closes, just as a
+                    # competing process could. The actual asyncio bind must fail.
+                    blockers.append(socket.create_server(("127.0.0.1", kwargs["port"])))
+            server = await create_server(*args, **kwargs)
+            if kwargs["port"] == 0:
+                probes.extend(server.sockets)
+            return server
+
+        monkeypatch.setattr(loop, "create_server", race)
+        if conflicts == 5:
+            with pytest.raises(OSError) as exc:
+                await _bind_sockets("localhost", 0)
+            assert exc.value.errno == errno.EADDRINUSE
+        else:
+            reserved.extend(await _bind_sockets("localhost", 0))
+            assert len({sock.getsockname()[1] for sock in reserved}) == 1
+
+    try:
+        asyncio.run(exercise())
+        assert attempts == min(conflicts + 1, 5)
+        assert probes and all(sock.fileno() == -1 for sock in probes)
+        for blocker in blockers:
+            with socket.create_connection(blocker.getsockname(), timeout=1):
+                connection, _ = blocker.accept()
+                connection.close()
+    finally:
+        for sock in reserved + blockers:
+            sock.close()
+
+
 def test_main_closes_sockets_when_initialization_fails(monkeypatch):
     import hindsight_api.main as entrypoint
     from hindsight_api.config import HindsightConfig
@@ -562,6 +609,7 @@ def test_main_closes_sockets_when_initialization_fails(monkeypatch):
 
     def fail(args, config, is_daemon, sockets):
         held.extend(sockets)
+        assert config.port == args.port == sockets[0].getsockname()[1] > 0
         raise RuntimeError("engine initialization failed")
 
     monkeypatch.setattr(entrypoint, "_serve", fail)


### PR DESCRIPTION
An occupied standalone API port currently fails only after application startup, which can repeatedly initialize models and embedded PostgreSQL under a restart policy. Reserve the effective listeners after configuration and daemon address resolution, before entrypoint lazy imports and engine construction, and retain them through serving.

The reservation uses asyncio's existing hostname/IPv4/IPv6 resolution without accepting connections, then transfers the sockets to Uvicorn's Server, reload supervisor or multiprocess supervisor. The CLI closes the sockets if initialization or serving fails. It does not probe and release the port or terminate the existing listener.

Fixes #4281.

Validation: 36 focused entrypoint/daemon tests pass, including real occupied listeners for normal/workers/reload/daemon entry, IPv4/IPv6/hostname reservation and release, cleanup on initialization failure, a real HTTP request over the retained socket, supervisor dispatch and Uvicorn startup-failure exit status. `./scripts/hooks/lint.sh` passes (including API type checking). A standalone regression reached the lazy MemoryEngine import on the original source and exits at bind on the patch. No live model/DB startup or live multiprocess/reload deployment is claimed.

Configuration parsing/profiling still occurs before reservation and may import optional model dependencies in current main; this does not claim to remove that import cost. The change prevents engine/application initialization on a port conflict. AI-assisted implementation and self-review.
