### PR TITLE
feat(control-plane): add a pause button for constellation ambient motion

### DIFF
--- a/hindsight-control-plane/src/components/constellation.tsx
+++ b/hindsight-control-plane/src/components/constellation.tsx
@@ -29,6 +29,9 @@ interface PreparedNode {
   phase: number;
 }
 
+/** Ambient-motion preference, shared by every constellation (not per bank). */
+const MOTION_STORAGE_KEY = "constellation-motion";
+
 // ============================================================================
 // Props
 // ============================================================================
@@ -266,6 +269,31 @@ export function Constellation({
   const isDark = useIsDarkMode();
   const animRef = useRef<number>(0);
   const [isFullscreen, setIsFullscreen] = useState(false);
+
+  // Ambient motion (drift/pulse/shimmer) on-off, remembered globally — not per
+  // bank — so the preference follows the user across every constellation.
+  const [motionEnabled, setMotionEnabled] = useState(true);
+  const motionRef = useRef(true);
+  // Elapsed "animation seconds". Accumulated only while motion is on, so
+  // pausing freezes the field in place and resuming continues without a jump.
+  const clockRef = useRef({ seconds: 0, lastFrameMs: 0 });
+
+  useEffect(() => {
+    const saved = localStorage.getItem(MOTION_STORAGE_KEY);
+    if (saved === "off") {
+      setMotionEnabled(false);
+      motionRef.current = false;
+    }
+  }, []);
+
+  const toggleMotion = useCallback(() => {
+    setMotionEnabled((prev) => {
+      const next = !prev;
+      motionRef.current = next;
+      localStorage.setItem(MOTION_STORAGE_KEY, next ? "on" : "off");
+      return next;
+    });
+  }, []);
 
   // Interaction state stored in ref for perf (avoid re-renders on every frame)
   const stateRef = useRef({
@@ -544,8 +572,15 @@ export function Constellation({
     ctx.fillStyle = bg;
     ctx.fillRect(0, 0, W, H);
 
-    // Ambient-motion clock (seconds).
-    const time = (typeof performance !== "undefined" ? performance.now() : 0) / 1000;
+    // Ambient-motion clock (seconds). Advances only while motion is enabled, so
+    // pausing holds every drift/pulse/shimmer exactly where it is.
+    const nowMs = typeof performance !== "undefined" ? performance.now() : 0;
+    const clock = clockRef.current;
+    if (motionRef.current && clock.lastFrameMs > 0) {
+      clock.seconds += (nowMs - clock.lastFrameMs) / 1000;
+    }
+    clock.lastFrameMs = nowMs;
+    const time = clock.seconds;
     // Drift amplitude in world units — nodes slowly wander around their home
     // position so the whole field visibly breathes.
     const DRIFT_AMP = 16;
@@ -1567,6 +1602,49 @@ export function Constellation({
             <line x1="12" y1="4" x2="12" y2="15" />
           </svg>
           {t("exportSvgLabel")}
+        </button>
+
+        {/* Ambient-motion toggle */}
+        <button
+          onClick={toggleMotion}
+          style={toolbarBtnStyle(isDark)}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.opacity = "1";
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.opacity = "0.7";
+          }}
+          title={motionEnabled ? t("pauseMotionTitle") : t("resumeMotionTitle")}
+        >
+          {motionEnabled ? (
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="6" y="4" width="4" height="16" />
+              <rect x="14" y="4" width="4" height="16" />
+            </svg>
+          ) : (
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polygon points="5 3 19 12 5 21 5 3" />
+            </svg>
+          )}
+          {motionEnabled ? t("pauseMotionLabel") : t("resumeMotionLabel")}
         </button>
 
         {/* Fullscreen toggle */}

--- a/hindsight-control-plane/src/messages/de.json
+++ b/hindsight-control-plane/src/messages/de.json
@@ -1616,7 +1616,11 @@
     "linkTypeEntity": "Entität",
     "linkTypeCausal": "kausal",
     "exportSvgTitle": "Als SVG zum Teilen herunterladen",
-    "exportSvgLabel": "Teilen"
+    "exportSvgLabel": "Teilen",
+    "pauseMotionTitle": "Bewegung anhalten",
+    "resumeMotionTitle": "Bewegung fortsetzen",
+    "pauseMotionLabel": "Pause",
+    "resumeMotionLabel": "Start"
   },
   "metadata": {
     "title": "Hindsight Cloud",

--- a/hindsight-control-plane/src/messages/en.json
+++ b/hindsight-control-plane/src/messages/en.json
@@ -1616,7 +1616,11 @@
     "linkTypeEntity": "entity",
     "linkTypeCausal": "causal",
     "exportSvgTitle": "Download as SVG to share",
-    "exportSvgLabel": "Share"
+    "exportSvgLabel": "Share",
+    "pauseMotionTitle": "Pause the ambient motion",
+    "resumeMotionTitle": "Resume the ambient motion",
+    "pauseMotionLabel": "Pause",
+    "resumeMotionLabel": "Play"
   },
   "metadata": {
     "title": "Hindsight Cloud",

--- a/hindsight-control-plane/src/messages/es.json
+++ b/hindsight-control-plane/src/messages/es.json
@@ -1616,7 +1616,11 @@
     "linkTypeEntity": "entidad",
     "linkTypeCausal": "causal",
     "exportSvgTitle": "Descargar como SVG para compartir",
-    "exportSvgLabel": "Compartir"
+    "exportSvgLabel": "Compartir",
+    "pauseMotionTitle": "Pausar el movimiento",
+    "resumeMotionTitle": "Reanudar el movimiento",
+    "pauseMotionLabel": "Pausar",
+    "resumeMotionLabel": "Reanudar"
   },
   "metadata": {
     "title": "Hindsight Cloud",

--- a/hindsight-control-plane/src/messages/fr.json
+++ b/hindsight-control-plane/src/messages/fr.json
@@ -1616,7 +1616,11 @@
     "linkTypeEntity": "entité",
     "linkTypeCausal": "causal",
     "exportSvgTitle": "Télécharger en SVG à partager",
-    "exportSvgLabel": "Partager"
+    "exportSvgLabel": "Partager",
+    "pauseMotionTitle": "Suspendre le mouvement",
+    "resumeMotionTitle": "Reprendre le mouvement",
+    "pauseMotionLabel": "Pause",
+    "resumeMotionLabel": "Reprendre"
   },
   "metadata": {
     "title": "Hindsight Cloud",

--- a/hindsight-control-plane/src/messages/ja.json
+++ b/hindsight-control-plane/src/messages/ja.json
@@ -1616,7 +1616,11 @@
     "linkTypeEntity": "エンティティ",
     "linkTypeCausal": "因果",
     "exportSvgTitle": "共有用にSVGをダウンロード",
-    "exportSvgLabel": "共有"
+    "exportSvgLabel": "共有",
+    "pauseMotionTitle": "動きを一時停止",
+    "resumeMotionTitle": "動きを再開",
+    "pauseMotionLabel": "一時停止",
+    "resumeMotionLabel": "再開"
   },
   "metadata": {
     "title": "Hindsight Cloud",

--- a/hindsight-control-plane/src/messages/ko.json
+++ b/hindsight-control-plane/src/messages/ko.json
@@ -1616,7 +1616,11 @@
     "linkTypeEntity": "엔티티",
     "linkTypeCausal": "인과",
     "exportSvgTitle": "공유용 SVG 다운로드",
-    "exportSvgLabel": "공유"
+    "exportSvgLabel": "공유",
+    "pauseMotionTitle": "움직임 일시정지",
+    "resumeMotionTitle": "움직임 다시 시작",
+    "pauseMotionLabel": "일시정지",
+    "resumeMotionLabel": "재생"
   },
   "metadata": {
     "title": "Hindsight Cloud",

--- a/hindsight-control-plane/src/messages/pt.json
+++ b/hindsight-control-plane/src/messages/pt.json
@@ -1616,7 +1616,11 @@
     "linkTypeEntity": "entidade",
     "linkTypeCausal": "causal",
     "exportSvgTitle": "Baixar como SVG para compartilhar",
-    "exportSvgLabel": "Compartilhar"
+    "exportSvgLabel": "Compartilhar",
+    "pauseMotionTitle": "Pausar o movimento",
+    "resumeMotionTitle": "Retomar o movimento",
+    "pauseMotionLabel": "Pausar",
+    "resumeMotionLabel": "Retomar"
   },
   "metadata": {
     "title": "Hindsight Cloud",

--- a/hindsight-control-plane/src/messages/yue-Hant.json
+++ b/hindsight-control-plane/src/messages/yue-Hant.json
@@ -1616,7 +1616,11 @@
     "linkTypeEntity": "實體",
     "linkTypeCausal": "因果",
     "exportSvgTitle": "下載為 SVG 以分享",
-    "exportSvgLabel": "分享"
+    "exportSvgLabel": "分享",
+    "pauseMotionTitle": "暫停動畫",
+    "resumeMotionTitle": "繼續動畫",
+    "pauseMotionLabel": "暫停",
+    "resumeMotionLabel": "繼續"
   },
   "metadata": {
     "title": "Hindsight Cloud",

--- a/hindsight-control-plane/src/messages/zh-CN.json
+++ b/hindsight-control-plane/src/messages/zh-CN.json
@@ -1616,7 +1616,11 @@
     "linkTypeEntity": "实体",
     "linkTypeCausal": "因果",
     "exportSvgTitle": "下载为 SVG 以分享",
-    "exportSvgLabel": "分享"
+    "exportSvgLabel": "分享",
+    "pauseMotionTitle": "暂停动画",
+    "resumeMotionTitle": "继续动画",
+    "pauseMotionLabel": "暂停",
+    "resumeMotionLabel": "继续"
   },
   "metadata": {
     "title": "Hindsight Cloud",

--- a/hindsight-control-plane/src/messages/zh-TW.json
+++ b/hindsight-control-plane/src/messages/zh-TW.json
@@ -1616,7 +1616,11 @@
     "linkTypeEntity": "實體",
     "linkTypeCausal": "因果",
     "exportSvgTitle": "下載為 SVG 以分享",
-    "exportSvgLabel": "分享"
+    "exportSvgLabel": "分享",
+    "pauseMotionTitle": "暫停動畫",
+    "resumeMotionTitle": "繼續動畫",
+    "pauseMotionLabel": "暫停",
+    "resumeMotionLabel": "繼續"
   },
   "metadata": {
     "title": "Hindsight Cloud",


### PR DESCRIPTION
## What

The constellation's stars drift, pulse and twinkle continuously, which is distracting when you are trying to read the graph. This adds a **Pause / Play** toggle to the constellation toolbar (next to Share and Fullscreen).

## How

Ambient motion now runs off an accumulated clock that only advances while motion is enabled, instead of reading `performance.now()` directly every frame. Pausing therefore freezes every drift, pulse, twinkle and link shimmer exactly where it is, and resuming continues from there with no jump.

Pan, zoom, hover and click keep working while paused — only the ambient animation stops.

## Persistence

The preference is stored globally in `localStorage` under `constellation-motion` (`"on"` / `"off"`), read once on mount — same pattern as the theme toggle. It is deliberately **not** per bank, so the setting follows the user across every constellation view.

## Testing

- `./scripts/hooks/lint.sh` passes
- `npm test -w @vectorize-io/hindsight-control-plane` — 198 tests pass, including the message-key parity tests for the 4 new strings across all 10 locales
- Verified by hand in a local control plane against a bank with data: pausing freezes the field, the button flips to Play, and the choice survives a reload and a bank switch