### PR TITLE
test(system): the remaining epic stories, and two bugs they found

### DIFF
--- a/hindsight-system-tests/hindsight_system_tests/steps.py
+++ b/hindsight-system-tests/hindsight_system_tests/steps.py
@@ -34,6 +34,10 @@ STEP_ANCHORS: dict[str, str] = {
     # that reshapes the prose into the caller's schema. Anchored separately
     # because a story about the schema is about this call, not the answer.
     "reflect_structured": "You are a precise data extraction assistant.",
+    # An over-long reflect answer gets a *second* call that rewrites it to the
+    # caller's token budget. Anchored separately because a story about the budget
+    # is about this call, not the one that wrote the answer.
+    "reflect_trim": "Rewrite the user's text so it fits within the requested token budget.",
     "connection_probe": "Say 'ok'",
 }
 

--- a/hindsight-system-tests/tests/test_28_consolidation_serialisation.py
+++ b/hindsight-system-tests/tests/test_28_consolidation_serialisation.py
@@ -1,0 +1,90 @@
+"""One bank consolidates one run at a time.
+
+Consolidation reads facts, writes observations, and *deletes* the ones it
+supersedes. Two runs over the same bank at once therefore race on the thing they
+are both editing: each reads the observation layer, each decides independently
+what to merge and retire, and the second to write undoes half of what the first
+concluded. The visible symptoms are the ones story 22 and 23 guard against —
+duplicate observations for one claim, a retirement that reappears — arriving via
+a route those stories cannot reach.
+
+So the server serialises per bank, and a second request joins the run in flight
+rather than starting a rival. That is what makes it safe for consolidation to be
+triggered from several directions — a retain, a scheduled sweep, an impatient
+caller — without any of them coordinating.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hindsight_system_tests.payloads import extracted, fact, observes
+
+pytestmark = pytest.mark.asyncio
+
+OBSERVATION = "Alice is settled in Berlin"
+
+
+@pytest.fixture
+async def consolidated_bank(client, llm, bank_id, settled) -> str:
+    llm.on_step("extract_facts").returns(
+        extracted(
+            fact("Alice moved to Berlin", who="Alice", entities=["Alice", "Berlin"]),
+            fact("Alice renewed her Berlin lease", who="Alice", entities=["Alice", "Berlin"]),
+        )
+    )
+    llm.on_step("consolidate").answers_with(observes(OBSERVATION))
+    await client.aretain(bank_id=bank_id, content="Alice moved to Berlin. Alice renewed her Berlin lease.")
+    await settled(bank_id)
+    return bank_id
+
+
+async def _observations(client, bank: str) -> list[str]:
+    memories = await client.memory.list_memories(bank, limit=100)
+    return sorted(m.text for m in memories.items if m.fact_type == "observation")
+
+
+async def test_a_second_request_joins_the_run_already_in_flight(client, consolidated_bank):
+    """Not merely "both succeed" — the *same* operation. Two ids would mean two
+    passes over one observation layer, which is the race."""
+    first = await client.banks.trigger_consolidation(consolidated_bank)
+    second = await client.banks.trigger_consolidation(consolidated_bank)
+
+    assert second.deduplicated is True
+    assert second.operation_id == first.operation_id
+
+
+async def test_a_burst_of_requests_produces_one_pass(client, consolidated_bank, settled):
+    """Five callers, no coordination between them — the shape of a scheduled
+    sweep landing on top of a retain that just finished."""
+    before = (await client.operations.list_operations(consolidated_bank, type="consolidation", limit=100)).total
+
+    await asyncio.gather(*(client.banks.trigger_consolidation(consolidated_bank) for _ in range(5)))
+    await settled(consolidated_bank)
+
+    after = (await client.operations.list_operations(consolidated_bank, type="consolidation", limit=100)).total
+    assert after - before <= 1, f"a burst of 5 requests produced {after - before} consolidation runs"
+
+
+async def test_the_observation_layer_survives_the_burst(client, consolidated_bank, settled):
+    """The reason serialisation matters. Concurrent passes would each decide what
+    to create and retire from their own read, and the loser's decisions would
+    reappear as duplicates."""
+    await asyncio.gather(*(client.banks.trigger_consolidation(consolidated_bank) for _ in range(5)))
+    await settled(consolidated_bank)
+
+    assert await _observations(client, consolidated_bank) == [OBSERVATION]
+
+
+async def test_the_facts_survive_the_burst(client, consolidated_bank, settled):
+    """And the layer underneath is untouched, however many passes were asked for."""
+    await asyncio.gather(*(client.banks.trigger_consolidation(consolidated_bank) for _ in range(5)))
+    await settled(consolidated_bank)
+
+    memories = await client.memory.list_memories(consolidated_bank, limit=100)
+    raw = sorted(m.text for m in memories.items if m.fact_type != "observation")
+    assert raw == sorted(
+        ["Alice moved to Berlin | Involving: Alice", "Alice renewed her Berlin lease | Involving: Alice"]
+    )

--- a/hindsight-system-tests/tests/test_33_refresh_dedupe.py
+++ b/hindsight-system-tests/tests/test_33_refresh_dedupe.py
@@ -1,0 +1,76 @@
+"""Asking for the same refresh twice runs it once.
+
+A mental-model refresh is expensive — it drives the whole reflect loop — and the
+requests arrive from several directions at once: a scheduled sweep, a
+consolidation that finished, an impatient caller. Without deduplication a busy
+bank queues one refresh per trigger and the worker spends its time recomputing
+the same answer, which is how a slow-draining bank accumulated ~45 copies of one
+model (#3487).
+
+Worse than the cost: two refreshes of one model racing each other both read the
+bank and both write, and the one that finishes second wins regardless of which
+read more.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hindsight_system_tests import reflect_loop
+from hindsight_system_tests.payloads import consolidation, extracted, fact
+
+pytestmark = pytest.mark.asyncio
+
+ANSWER = "Alice lives in Berlin."
+
+
+@pytest.fixture
+async def model(client, llm, bank_id, settled) -> str:
+    llm.on_step("extract_facts").returns(
+        extracted(fact("Alice moved to Berlin", who="Alice", entities=["Alice", "Berlin"]))
+    )
+    llm.on_step("consolidate").returns(consolidation())
+    reflect_loop(llm, answer=ANSWER)
+
+    await client.aretain(bank_id=bank_id, content="Alice moved to Berlin.")
+    await settled(bank_id)
+
+    created = await client.mental_models.create_mental_model(
+        bank_id, {"name": "Housing", "source_query": "Where does Alice live?"}
+    )
+    await settled(bank_id)
+    return created.mental_model_id
+
+
+async def test_two_requests_in_flight_share_one_operation(client, bank_id, model):
+    """Back to back, no wait between them. The second joins the first rather than
+    queueing a rival — the caller gets an operation id either way, and it is the
+    same id."""
+    first = await client.mental_models.refresh_mental_model(bank_id, model)
+    second = await client.mental_models.refresh_mental_model(bank_id, model)
+
+    assert first.operation_id == second.operation_id
+
+
+async def test_the_bank_does_not_accumulate_a_refresh_per_request(client, bank_id, model, settled):
+    """The #3487 shape. Five requests, and the queue must not grow five deep."""
+    for _ in range(5):
+        await client.mental_models.refresh_mental_model(bank_id, model)
+    await settled(bank_id)
+
+    operations = await client.operations.list_operations(bank_id, type="refresh_mental_model", limit=100)
+
+    # One for the create's own refresh, one for the batch of requests above.
+    assert operations.total <= 2, f"{operations.total} refresh operations for one model"
+
+
+async def test_the_model_still_ends_up_refreshed(client, bank_id, model, settled):
+    """Deduplication must not swallow the work — collapsing to zero refreshes
+    would look identical from the queue's point of view."""
+    for _ in range(3):
+        await client.mental_models.refresh_mental_model(bank_id, model)
+    await settled(bank_id)
+
+    current = await client.mental_models.get_mental_model(bank_id, model, detail="full")
+    assert current.content.strip() == ANSWER
+    assert current.is_stale is False

--- a/hindsight-system-tests/tests/test_36_page_maintenance.py
+++ b/hindsight-system-tests/tests/test_36_page_maintenance.py
@@ -1,0 +1,122 @@
+"""A page and its model stay in step, and a retraction reaches both.
+
+A knowledge page is a name and a place in a tree over a mental model that does
+the work. Two things have to hold as the bank changes underneath them.
+
+**A rename reaches the model.** They are separate rows, so renaming the page and
+leaving the model on its old name gives one thing two names — and the model's
+name is what shows up wherever a page is referenced by its backing id, so the two
+disagree in exactly the places nobody is looking.
+
+**A retraction propagates.** This is the sharper one. Facts are retracted because
+they were wrong, and a page written from them keeps repeating the wrong thing
+until something refreshes it. Nothing about that page looks stale: it has content,
+a timestamp, and an answer that reads perfectly well. The system has to notice on
+its own, because a caller who knew to ask would not have needed the page.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hindsight_system_tests import reflect_loop
+from hindsight_system_tests.payloads import extracted, fact, observes
+
+pytestmark = pytest.mark.asyncio
+
+ORIGINAL_ANSWER = "Alice lives in Berlin."
+CORRECTED_ANSWER = "There is nothing on record about where Alice lives."
+
+
+@pytest.fixture
+async def page(client, llm, bank_id, settled):
+    llm.on_step("extract_facts").returns(
+        extracted(fact("Alice moved to Berlin", who="Alice", entities=["Alice", "Berlin"]))
+    )
+    # A page refreshes by delta over the *observation* layer (story 35 pins those
+    # defaults), so a bank with no observations gives its refresh nothing to read
+    # and the page keeps its placeholder — which looks like a broken refresh and
+    # is not.
+    llm.on_step("consolidate").answers_with(observes("Alice is settled in Berlin"))
+    reflect_loop(llm, answer=ORIGINAL_ANSWER)
+
+    await client.aretain(bank_id=bank_id, content="Alice moved to Berlin.")
+    await settled(bank_id)
+
+    created = await client.knowledge_base.create_knowledge_page(
+        bank_id, {"name": "Housing", "source_query": "Where does Alice live?"}
+    )
+    await settled(bank_id)
+    return created
+
+
+async def test_the_page_starts_with_the_answer_it_was_written_from(client, bank_id, page):
+    read = await client.knowledge_base.get_knowledge_page(bank_id, page.page_id)
+
+    assert read.name == "Housing"
+    assert read.body.strip() == ORIGINAL_ANSWER
+
+
+async def test_renaming_a_page_renames_its_model(client, bank_id, page):
+    """Otherwise one thing has two names, and which you see depends on whether
+    you arrived via the tree or via the model id."""
+    await client.knowledge_base.update_knowledge_node(bank_id, page.page_id, {"name": "Where Alice lives"})
+
+    model = await client.mental_models.get_mental_model(bank_id, page.mental_model_id, detail="metadata")
+    assert model.name == "Where Alice lives"
+
+    tree = await client.knowledge_base.get_knowledge_base_tree(bank_id)
+    assert [node.name for node in tree.roots] == ["Where Alice lives"]
+
+
+async def test_retracting_the_evidence_schedules_the_page_to_be_rewritten(client, llm, bank_id, page, settled):
+    """Invalidating the fact the page was written from must enqueue a refresh.
+
+    Without it the page keeps asserting something the bank has explicitly
+    retracted — and reads as authoritative while doing so, since a page carries
+    no hint of how old its evidence is.
+    """
+    memories = await client.memory.list_memories(bank_id, limit=100)
+    target = next(m for m in memories.items if m.fact_type != "observation")
+
+    await client.memory.update_memory(bank_id, target.id, {"state": "invalidated", "reason": "Alice never moved"})
+
+    refreshed = False
+    for _ in range(60):
+        operations = await client.operations.list_operations(bank_id, type="refresh_mental_model", limit=100)
+        if operations.total:
+            refreshed = True
+            break
+        await asyncio.sleep(1)
+
+    assert refreshed, "retracting the evidence scheduled no refresh — the page will keep repeating it"
+
+
+async def test_the_scheduled_refresh_completes_cleanly(client, llm, bank_id, page, settled):
+    """The refresh runs to completion and leaves the page coherent.
+
+    What is *not* asserted here: that the retracted claim is gone from the text.
+    A page refreshes in delta mode — it computes a diff against its current
+    content rather than rewriting from scratch — so what the page ends up saying
+    is a judgement the model makes about that diff. Driving it from a stub would
+    mean writing the delta myself and then asserting I had written it, which
+    proves nothing about the product.
+
+    The mechanism is testable and is: the retraction is noticed, a refresh is
+    scheduled, it completes without error, and the page is still readable
+    afterwards. Whether the wording actually unsays the claim needs a real model
+    and belongs with the `hs_llm_core` judge tests.
+    """
+    memories = await client.memory.list_memories(bank_id, limit=100)
+    target = next(m for m in memories.items if m.fact_type != "observation")
+
+    await client.memory.update_memory(bank_id, target.id, {"state": "invalidated", "reason": "Alice never moved"})
+    await settled(bank_id)
+
+    failed = await client.operations.list_operations(bank_id, status="failed", limit=100)
+    assert failed.operations == [], "the refresh triggered by the retraction failed"
+
+    read = await client.knowledge_base.get_knowledge_page(bank_id, page.page_id)
+    assert read.body.strip(), "the page was left empty by the refresh"

--- a/hindsight-system-tests/tests/test_41_reflect_failures.py
+++ b/hindsight-system-tests/tests/test_41_reflect_failures.py
@@ -1,0 +1,80 @@
+"""Reflect fails loudly rather than returning a plausible non-answer.
+
+Reflect is agentic: it needs a model that calls tools, and it needs that model to
+eventually produce an answer. Both can fail — a provider without function
+calling, a model that returns empty content, output truncated before the answer
+was written.
+
+The tempting behaviour is to degrade: return an empty string, or a placeholder,
+or whatever prose happened to arrive instead of a tool call. That is the worst
+option available, because the caller is an agent that will treat the answer as
+memory and act on it. A confident empty answer is indistinguishable from "your
+bank has nothing about this", and the two demand opposite responses.
+
+So each of these must raise, and the message must name the cause — someone
+pointing reflect at a model that cannot call tools needs to be told that, not
+handed a blank.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hindsight_client_api.exceptions import ServiceException
+
+from hindsight_system_tests import reflect_loop
+from hindsight_system_tests.payloads import consolidation, extracted, fact
+
+pytestmark = pytest.mark.asyncio
+
+QUERY = "Where does Alice live?"
+
+
+@pytest.fixture
+async def bank_with_facts(client, llm, bank_id, settled) -> str:
+    llm.on_step("extract_facts").returns(
+        extracted(fact("Alice moved to Berlin", who="Alice", entities=["Alice", "Berlin"]))
+    )
+    llm.on_step("consolidate").returns(consolidation())
+    await client.aretain(bank_id=bank_id, content="Alice moved to Berlin.")
+    await settled(bank_id)
+    return bank_id
+
+
+async def test_a_model_that_never_calls_a_tool_is_an_error(client, llm, bank_with_facts):
+    """The provider-mismatch case: reflect's first turn forces a tool, and this
+    model answers with prose instead.
+
+    The failure has to name the cause. "No answer" sends someone looking at their
+    data; "this model produced no usable tool call" sends them at their config.
+    """
+    llm.on_step("reflect").returns_text("I think Alice lives in Berlin.")
+
+    with pytest.raises(ServiceException) as raised:
+        await client.areflect(bank_id=bank_with_facts, query=QUERY)
+
+    assert "tool" in str(raised.value).lower()
+
+
+async def test_an_empty_answer_is_an_error_rather_than_an_empty_result(client, llm, bank_with_facts):
+    """A model that climbs the ladder and then says nothing.
+
+    Returning "" here would be the dangerous degradation: an agent cannot tell it
+    apart from a bank that genuinely holds nothing, and those call for opposite
+    behaviour — one is "go and find out", the other is "you already know".
+    """
+    llm.on_step("reflect", tool="done").returns_tool_call("done", answer="")
+    llm.on_step("reflect").calls_the_offered_tool(query="Alice")
+    llm.on_step("reflect").returns_text("")
+
+    with pytest.raises(ServiceException):
+        await client.areflect(bank_id=bank_with_facts, query=QUERY)
+
+
+async def test_a_working_model_still_answers(client, llm, bank_with_facts):
+    """The control. Without it, the two tests above would also pass if reflect
+    were broken outright."""
+    reflect_loop(llm, answer="Alice lives in Berlin.")
+
+    response = await client.areflect(bank_id=bank_with_facts, query=QUERY)
+
+    assert response.text == "Alice lives in Berlin."

--- a/hindsight-system-tests/tests/test_45_reflect_length_budget.py
+++ b/hindsight-system-tests/tests/test_45_reflect_length_budget.py
@@ -1,0 +1,87 @@
+"""An over-long answer is shortened to the budget the caller asked for.
+
+`max_tokens` on reflect is a target for the *visible answer*, not a provider cap.
+That distinction is the whole feature: an agent embedding the answer in its own
+context has a budget, and an answer that overruns it does not fail loudly — it
+silently pushes something else out of the window, and what gets pushed out is
+whatever was least recently added.
+
+So when the answer overruns, reflect makes a second call that rewrites it to fit
+and returns the rewrite. Two things follow that are worth pinning: the rewrite
+only happens when it is needed, and an answer already inside the budget is
+returned untouched rather than paraphrased for no reason.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hindsight_system_tests import reflect_loop
+from hindsight_system_tests.payloads import consolidation, extracted, fact
+
+pytestmark = pytest.mark.asyncio
+
+QUERY = "What about Alice?"
+SHORT_ANSWER = "Alice lives in Berlin."
+LONG_ANSWER = " ".join(f"Sentence {i} about Alice living in Berlin and playing the cello." for i in range(80))
+TRIMMED = "Alice lives in Berlin and plays the cello."
+
+
+@pytest.fixture
+async def bank_with_facts(client, llm, bank_id, settled) -> str:
+    llm.on_step("extract_facts").returns(
+        extracted(fact("Alice moved to Berlin", who="Alice", entities=["Alice", "Berlin"]))
+    )
+    llm.on_step("consolidate").returns(consolidation())
+    await client.aretain(bank_id=bank_id, content="Alice moved to Berlin.")
+    await settled(bank_id)
+    return bank_id
+
+
+async def test_an_over_long_answer_is_rewritten_to_fit(client, llm, bank_with_facts):
+    reflect_loop(llm, answer=LONG_ANSWER, query="Alice Berlin")
+    llm.on_step("reflect_trim").returns_text(TRIMMED)
+
+    response = await client.areflect(bank_id=bank_with_facts, query=QUERY, max_tokens=40)
+
+    assert response.text == TRIMMED
+
+
+async def test_the_rewrite_is_told_the_budget_and_the_text(client, llm, bank_with_facts):
+    """It is a real call to a real model, so it has to carry what the model needs
+    to do the job — the target, and the whole text being cut down."""
+    reflect_loop(llm, answer=LONG_ANSWER, query="Alice Berlin")
+    llm.on_step("reflect_trim").returns_text(TRIMMED)
+
+    await client.areflect(bank_id=bank_with_facts, query=QUERY, max_tokens=40)
+
+    prompt = llm.prompts_for("reflect_trim")[0]
+    assert "Target budget: 40 tokens" in prompt
+    assert "Sentence 79" in prompt, "the rewrite was shown a truncated copy of the answer it is trimming"
+
+
+async def test_an_answer_already_inside_the_budget_is_left_alone(client, llm, bank_with_facts):
+    """No rewrite call at all — declaring no rule for the trim step *is* the
+    assertion, since an unscripted call fails the test.
+
+    Paraphrasing an answer that already fits would spend a model call to make it
+    worse, and reflect already costs several.
+    """
+    reflect_loop(llm, answer=SHORT_ANSWER, query="Alice Berlin")
+
+    response = await client.areflect(bank_id=bank_with_facts, query=QUERY, max_tokens=4096)
+
+    assert response.text == SHORT_ANSWER
+    assert llm.prompts_for("reflect_trim") == []
+
+
+async def test_no_budget_means_no_rewrite_however_long_the_answer(client, llm, bank_with_facts):
+    """Without `max_tokens` there is no target to overrun, so a long answer is
+    returned whole. Same assertion by absence: a trim call here would be
+    unscripted."""
+    reflect_loop(llm, answer=LONG_ANSWER, query="Alice Berlin")
+
+    response = await client.areflect(bank_id=bank_with_facts, query=QUERY)
+
+    assert response.text == LONG_ANSWER
+    assert llm.prompts_for("reflect_trim") == []

--- a/hindsight-system-tests/tests/test_62_operation_failures.py
+++ b/hindsight-system-tests/tests/test_62_operation_failures.py
@@ -1,0 +1,146 @@
+"""A failed operation says what went wrong, and can be run again.
+
+Async work fails — a provider outage, a model returning nonsense, a timeout. What
+separates a recoverable system from a lossy one is what the record looks like
+afterwards: a terminal status a caller can act on, the error kept rather than
+swallowed, and a way to try again without re-submitting the original request and
+risking a duplicate.
+
+The batch story is the same argument one level up. A batch retain is a parent
+operation over per-item children, and a caller who submitted fifty documents
+needs to know *which* failed — a parent that reports only its own status turns
+one bad item into an all-or-nothing retry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hindsight_system_tests.payloads import consolidation, extracted, fact
+
+pytestmark = pytest.mark.asyncio
+
+BERLIN = "Alice moved to Berlin | Involving: Alice"
+CELLO = "Alice plays cello | Involving: Alice"
+
+
+async def _fact_texts(client, bank: str) -> list[str]:
+    memories = await client.memory.list_memories(bank, limit=100)
+    return sorted(m.text for m in memories.items)
+
+
+async def _first_failed(client, bank: str):
+    """Wait for a failed operation to appear, and return it."""
+    for _ in range(60):
+        listing = await client.operations.list_operations(bank, status="failed", limit=100)
+        if listing.operations:
+            return listing.operations[0]
+        await asyncio.sleep(1)
+    raise AssertionError("no operation reported a failure")
+
+
+async def _wait_for_facts(client, bank: str, expected: list[str]) -> list[str]:
+    """Poll for an outcome rather than for an idle bank.
+
+    `settled()` refuses to return while *any* operation in the bank is failed,
+    which is the right default everywhere else and wrong here: this story creates
+    a failure on purpose, and that record survives the retry that fixes it.
+    """
+    texts: list[str] = []
+    for _ in range(60):
+        texts = await _fact_texts(client, bank)
+        if texts == expected:
+            return texts
+        await asyncio.sleep(1)
+    return texts
+
+
+async def test_a_failed_retain_is_visible_with_its_error(client, llm, bank_id):
+    """Extraction fails, and the operation record says so in words.
+
+    An operation that ends `failed` with a null message is barely better than one
+    that vanished: whoever is paged has to reproduce it to learn anything.
+    """
+    llm.on_step("extract_facts").returns_text("this is not the json you asked for")
+
+    await client.aretain(bank_id=bank_id, content="Alice moved to Berlin.", retain_async=True)
+
+    failed = await _first_failed(client, bank_id)
+
+    assert failed.error_message, "the failure carries no explanation"
+    assert failed.status == "failed"
+
+
+async def test_a_failed_operation_can_be_retried_after_the_cause_is_fixed(client, llm, bank_id):
+    """The recovery path.
+
+    Retry re-runs the stored work rather than asking the caller to re-submit —
+    which matters because re-submitting is what creates duplicates. Here the
+    model starts answering properly between the failure and the retry, standing
+    in for a provider that came back.
+    """
+    llm.on_step("extract_facts").returns_text("this is not the json you asked for")
+    await client.aretain(bank_id=bank_id, content="Alice moved to Berlin.", retain_async=True)
+
+    failed = await _first_failed(client, bank_id)
+
+    llm.reset()
+    llm.on_step("extract_facts").returns(
+        extracted(fact("Alice moved to Berlin", who="Alice", entities=["Alice", "Berlin"]))
+    )
+    llm.on_step("consolidate").returns(consolidation())
+
+    await client.operations.retry_operation(bank_id, failed.id)
+
+    assert await _wait_for_facts(client, bank_id, [BERLIN]) == [BERLIN]
+
+
+async def test_a_batch_retain_reports_a_parent_over_its_items(client, llm, bank_id, settled):
+    """One receipt for the submission, and a record per item underneath it — so
+    a fifty-document batch with one bad item is diagnosable without re-running
+    the forty-nine that worked."""
+    llm.on_step("extract_facts", contains="Berlin").returns(
+        extracted(fact("Alice moved to Berlin", who="Alice", entities=["Alice", "Berlin"]))
+    )
+    llm.on_step("extract_facts", contains="cello").returns(
+        extracted(fact("Alice plays cello", who="Alice", entities=["Alice", "cello"]))
+    )
+    llm.on_step("consolidate").returns(consolidation())
+
+    response = await client.aretain_batch(
+        bank_id=bank_id,
+        items=[{"content": "Alice moved to Berlin."}, {"content": "Alice plays cello."}],
+        retain_async=True,
+    )
+    await settled(bank_id)
+
+    parent = await client.operations.get_operation_status(bank_id, response.operation_id)
+    assert parent.status == "completed"
+    assert parent.operation_type == "batch_retain"
+    assert parent.result_metadata["is_parent"] is True
+    assert parent.result_metadata["items_count"] == 2
+
+    assert await _fact_texts(client, bank_id) == sorted([BERLIN, CELLO])
+
+
+async def test_the_parent_is_excluded_when_a_caller_asks_for_leaves_only(client, llm, bank_id, settled):
+    """A batch shows up twice in the operations list — once as the parent, once
+    per item — which double-counts every progress bar built on it. The listing
+    can drop the parents for exactly that reason."""
+    llm.on_step("extract_facts").returns(
+        extracted(fact("Alice moved to Berlin", who="Alice", entities=["Alice", "Berlin"]))
+    )
+    llm.on_step("consolidate").returns(consolidation())
+
+    response = await client.aretain_batch(
+        bank_id=bank_id, items=[{"content": "Alice moved to Berlin."}], retain_async=True
+    )
+    await settled(bank_id)
+
+    everything = await client.operations.list_operations(bank_id, limit=100)
+    leaves = await client.operations.list_operations(bank_id, limit=100, exclude_parents=True)
+
+    assert response.operation_id in [op.id for op in everything.operations]
+    assert response.operation_id not in [op.id for op in leaves.operations]

--- a/hindsight-system-tests/tests/test_72_entity_resolution.py
+++ b/hindsight-system-tests/tests/test_72_entity_resolution.py
@@ -1,0 +1,97 @@
+"""A caller can hand Hindsight entities, and decide whether they get merged.
+
+Entity resolution is what turns "Alice Smyth" in one document and "Alice Smith"
+in another into one person with a history. It is also, by construction, the
+thing that can merge two *different* people — so `resolve_entities` exists to
+turn it off for callers whose entity names are already authoritative (an id from
+their own system, a name they will not have spelled twice).
+
+The distinction worth knowing, and the reason this story exists: the flag gates
+*fuzzy* resolution, not normalisation. Case and whitespace differences collapse
+whatever it is set to, because "Alice Smith" and "alice smith" are the same
+string wearing a hat. Only a genuine variant — a typo, an alias — is what the
+flag decides about. Testing it with a case difference alone shows no difference
+at all and quietly proves nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hindsight_system_tests.payloads import consolidation, extracted, fact
+
+pytestmark = pytest.mark.asyncio
+
+EXISTING = "Alice Smith"
+FUZZY_VARIANT = "Alice Smyth"
+CASE_VARIANT = "alice smith"
+
+
+@pytest.fixture(autouse=True)
+def _extraction(llm):
+    llm.on_step("extract_facts", contains="joined").returns(
+        extracted(fact("Alice Smith joined the team", who=EXISTING, entities=[EXISTING]))
+    )
+    # The second document names nobody: the entity under test is the one the
+    # caller supplies, so extraction must not introduce a competing one.
+    llm.on_step("extract_facts", contains="shipped").returns(
+        extracted(fact("The team shipped the release", who="the team", entities=[]))
+    )
+    llm.on_step("consolidate").returns(consolidation())
+
+
+async def _entities(client, bank: str) -> list[tuple[str, int]]:
+    listing = await client.entities.list_entities(bank)
+    return sorted((e.canonical_name, e.mention_count) for e in listing.items)
+
+
+async def _seed_and_supply(client, bank: str, settled, name: str, *, resolve: bool | None = None) -> None:
+    """Establish `EXISTING`, then retain a second document naming `name`."""
+    await client.aretain(bank_id=bank, content="Alice Smith joined the team.")
+    await settled(bank)
+
+    item: dict = {"content": "The team shipped the release.", "entities": [{"text": name, "type": "person"}]}
+    if resolve is not None:
+        item["resolve_entities"] = resolve
+    await client.aretain_batch(bank_id=bank, items=[item])
+    await settled(bank)
+
+
+async def test_by_default_a_variant_is_resolved_onto_the_existing_entity(client, bank_id, settled):
+    """One person, two spellings, one history. Without this a bank accumulates a
+    near-duplicate per misspelling and no entity ever looks well-attested."""
+    await _seed_and_supply(client, bank_id, settled, FUZZY_VARIANT)
+
+    assert await _entities(client, bank_id) == [(EXISTING, 2)]
+
+
+async def test_opting_out_stores_the_name_exactly_as_written(client, bank_id, settled):
+    """For callers whose names are authoritative — an id from their own system,
+    or two genuinely different people who happen to look alike. Resolution is
+    lossy and irreversible, so it has to be refusable."""
+    await _seed_and_supply(client, bank_id, settled, FUZZY_VARIANT, resolve=False)
+
+    assert await _entities(client, bank_id) == [(EXISTING, 1), (FUZZY_VARIANT, 1)]
+
+
+async def test_case_differences_collapse_whichever_way_the_flag_is_set(client, bank_id, settled):
+    """The subtlety this story exists for.
+
+    `resolve_entities=False` means "do not merge this onto something that merely
+    resembles it" — not "treat every byte as significant". A capitalisation
+    difference is the same name, so it normalises either way, and a test that
+    used only a case variant to check the flag would see no difference and
+    conclude the flag works when it might not.
+    """
+    await _seed_and_supply(client, bank_id, settled, CASE_VARIANT, resolve=False)
+
+    assert await _entities(client, bank_id) == [(EXISTING, 2)]
+
+
+async def test_an_unrelated_name_is_never_merged(client, bank_id, settled):
+    """Resolution has to be conservative in the other direction too: a name that
+    resembles nothing in the bank becomes its own entity rather than drifting
+    onto the nearest one."""
+    await _seed_and_supply(client, bank_id, settled, "Bob Jones")
+
+    assert await _entities(client, bank_id) == [(EXISTING, 1), ("Bob Jones", 1)]

--- a/hindsight-system-tests/tests/test_74_entity_links.py
+++ b/hindsight-system-tests/tests/test_74_entity_links.py
@@ -4,15 +4,13 @@ Entities are derived from facts, so replacing or deleting a document has to move
 them: an entity only the old text named should disappear, one only the new text
 names should appear, and the traversal paths that hang off them should follow.
 
-That much works. What does not is the count. `mention_count` is what a caller
-sees on the entity list, what sizes a node in the graph, and what the curation
-listing sorts by — and it is only ever incremented (#4291). So a bank that
-updates documents accumulates entities whose stated prominence has no
-relationship to how many facts actually mention them, and the drift is
-proportional to how often documents change: the coding-agents integration
-re-retains a conversation under one `document_id` every turn.
-
-The last test here fails today for that reason.
+The count has to follow too. `mention_count` is what a caller sees on the entity
+list, what sizes a node in the graph, and what the curation listing sorts by —
+and until #4291 it was only ever incremented, so a bank that updated documents
+accumulated entities whose stated prominence had no relationship to how many
+facts actually mentioned them. The drift scaled with how often documents
+change, and the coding-agents integration re-retains under one `document_id`
+every turn.
 """
 
 from __future__ import annotations
@@ -109,12 +107,12 @@ async def test_deleting_a_document_removes_the_entities_only_it_named(client, tw
 
 
 async def test_the_mention_count_matches_the_facts_that_mention_it(client, two_documents, settled):
-    """The count has to come back down. It does not — #4291.
+    """The count comes back down when the mentions go (#4291).
 
     Alice is named by exactly two facts after the replacement, and the link table
-    agrees: filtering memories by her entity id returns two. Only the
-    denormalised counter disagrees, because it was incremented for the replaced
-    fact and never given back.
+    agrees. The denormalised counter used to disagree — incremented for the
+    replaced fact and never given back — which was invisible unless you compared
+    the two, as this does.
 
     Asserted against the links rather than a hardcoded number, so this keeps
     holding whatever the fixture grows into.
@@ -126,5 +124,5 @@ async def test_the_mention_count_matches_the_facts_that_mention_it(client, two_d
     linked = await client.memory.list_memories(two_documents, entity_id=alice.id, limit=100)
 
     assert alice.mention_count == linked.total, (
-        f"mention_count says {alice.mention_count}, but {linked.total} facts mention Alice — #4291"
+        f"mention_count says {alice.mention_count}, but {linked.total} facts mention Alice"
     )

--- a/hindsight-system-tests/tests/test_74_entity_links.py
+++ b/hindsight-system-tests/tests/test_74_entity_links.py
@@ -1,0 +1,130 @@
+"""Entity links follow the facts, including when the facts go away.
+
+Entities are derived from facts, so replacing or deleting a document has to move
+them: an entity only the old text named should disappear, one only the new text
+names should appear, and the traversal paths that hang off them should follow.
+
+That much works. What does not is the count. `mention_count` is what a caller
+sees on the entity list, what sizes a node in the graph, and what the curation
+listing sorts by — and it is only ever incremented (#4291). So a bank that
+updates documents accumulates entities whose stated prominence has no
+relationship to how many facts actually mention them, and the drift is
+proportional to how often documents change: the coding-agents integration
+re-retains a conversation under one `document_id` every turn.
+
+The last test here fails today for that reason.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hindsight_system_tests.payloads import consolidation, extracted, fact
+
+pytestmark = pytest.mark.asyncio
+
+BERLIN = "Alice moved to Berlin | Involving: Alice"
+LISBON = "Alice moved to Lisbon | Involving: Alice"
+CELLO = "Alice plays cello | Involving: Alice"
+
+
+@pytest.fixture
+async def two_documents(client, llm, bank_id, settled) -> str:
+    """`d1` names Alice and Berlin, `d2` names Alice and cello."""
+    llm.on_step("extract_facts", contains="Berlin").returns(
+        extracted(fact("Alice moved to Berlin", who="Alice", entities=["Alice", "Berlin"]))
+    )
+    llm.on_step("extract_facts", contains="cello").returns(
+        extracted(fact("Alice plays cello", who="Alice", entities=["Alice", "cello"]))
+    )
+    llm.on_step("extract_facts", contains="Lisbon").returns(
+        extracted(fact("Alice moved to Lisbon", who="Alice", entities=["Alice", "Lisbon"]))
+    )
+    llm.on_step("consolidate").returns(consolidation())
+
+    await client.aretain(bank_id=bank_id, content="Alice moved to Berlin.", document_id="d1")
+    await client.aretain(bank_id=bank_id, content="Alice plays cello.", document_id="d2")
+    await settled(bank_id)
+    return bank_id
+
+
+async def _names(client, bank: str) -> list[str]:
+    listing = await client.entities.list_entities(bank)
+    return sorted(e.canonical_name for e in listing.items)
+
+
+async def _replace_d1(client, bank: str, settled) -> None:
+    await client.aretain(bank_id=bank, content="Alice moved to Lisbon.", document_id="d1", update_mode="replace")
+    await settled(bank)
+
+
+async def test_an_entity_only_the_old_text_named_is_gone(client, two_documents, settled):
+    assert "Berlin" in await _names(client, two_documents)
+
+    await _replace_d1(client, two_documents, settled)
+
+    names = await _names(client, two_documents)
+    assert "Berlin" not in names
+    assert "Lisbon" in names
+    # `cello` came from the untouched document and must be unaffected.
+    assert "cello" in names
+
+
+async def test_the_links_themselves_follow_the_replacement(client, two_documents, settled):
+    """Not just the entity list — what each entity is actually attached to. An
+    entity whose links point at replaced facts is a dangling path the graph arm
+    can still walk."""
+    await _replace_d1(client, two_documents, settled)
+
+    listing = await client.entities.list_entities(two_documents)
+    alice = next(e for e in listing.items if e.canonical_name == "Alice")
+
+    linked = await client.memory.list_memories(two_documents, entity_id=alice.id, limit=100)
+    assert sorted(m.text for m in linked.items) == sorted([LISBON, CELLO])
+
+
+async def test_traversal_follows_the_replacement(client, two_documents, settled):
+    """End to end: the graph arm reaches the *new* fact through the shared
+    entity, and cannot reach the replaced one."""
+    await _replace_d1(client, two_documents, settled)
+
+    response = await client.arecall(bank_id=two_documents, query="cello", trace=True)
+    reached = [
+        r["text"]
+        for arm in response.trace["retrieval_results"]
+        if arm["method_name"] == "graph"
+        for r in arm["results"]
+    ]
+
+    assert reached == [LISBON]
+
+
+async def test_deleting_a_document_removes_the_entities_only_it_named(client, two_documents, settled):
+    await client.documents.delete_document(two_documents, "d1")
+    await settled(two_documents)
+
+    names = await _names(client, two_documents)
+    assert "Berlin" not in names
+    assert names == sorted(["Alice", "cello"])
+
+
+async def test_the_mention_count_matches_the_facts_that_mention_it(client, two_documents, settled):
+    """The count has to come back down. It does not — #4291.
+
+    Alice is named by exactly two facts after the replacement, and the link table
+    agrees: filtering memories by her entity id returns two. Only the
+    denormalised counter disagrees, because it was incremented for the replaced
+    fact and never given back.
+
+    Asserted against the links rather than a hardcoded number, so this keeps
+    holding whatever the fixture grows into.
+    """
+    await _replace_d1(client, two_documents, settled)
+
+    listing = await client.entities.list_entities(two_documents)
+    alice = next(e for e in listing.items if e.canonical_name == "Alice")
+    linked = await client.memory.list_memories(two_documents, entity_id=alice.id, limit=100)
+
+    assert alice.mention_count == linked.total, (
+        f"mention_count says {alice.mention_count}, but {linked.total} facts mention Alice — #4291"
+    )

--- a/hindsight-system-tests/tests/test_93_attachments.py
+++ b/hindsight-system-tests/tests/test_93_attachments.py
@@ -1,0 +1,136 @@
+"""An image retained inline reaches the model, and stays fetchable afterwards.
+
+Content can be a list of blocks rather than a string, so a screenshot sits where
+it actually appeared in the conversation. Two halves have to work, and they fail
+differently.
+
+The image has to reach the *model* — an attachment stored but never sent means
+extraction describes text that references a picture it never saw, and the facts
+are confidently wrong rather than missing. And it has to survive as a
+**retrievable** attachment, because a fact drawn from an image is unverifiable
+without it: "Alice stood in front of the Brandenburg Gate" is only auditable if
+someone can still look at the photo.
+
+The stub records what it was sent, so the first half is directly observable
+rather than inferred from the facts that came back.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from hindsight_system_tests.payloads import consolidation, extracted, fact
+
+pytestmark = pytest.mark.asyncio
+
+# A 1x1 transparent PNG — the smallest thing that is unambiguously an image.
+PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+PNG_BASE64 = base64.b64encode(PNG).decode()
+
+CAPTION = "Alice sent a photo from her trip:"
+FACT = "Alice stood in front of the Brandenburg Gate | Involving: Alice"
+
+CONTENT = [
+    {"type": "text", "text": CAPTION},
+    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": PNG_BASE64}},
+]
+
+
+@pytest.fixture
+async def bank_with_photo(client, llm, bank_id, settled) -> str:
+    llm.on_step("extract_facts").returns(
+        extracted(fact("Alice stood in front of the Brandenburg Gate", who="Alice", entities=["Alice"]))
+    )
+    llm.on_step("consolidate").returns(consolidation())
+
+    await client.aretain_batch(bank_id=bank_id, items=[{"content": CONTENT}], document_id="d1")
+    await settled(bank_id)
+    return bank_id
+
+
+def _parts(prompt_messages: list[dict]) -> list[str]:
+    return [
+        part.get("type")
+        for message in prompt_messages
+        if isinstance(message.get("content"), list)
+        for part in message["content"]
+        if isinstance(part, dict)
+    ]
+
+
+async def test_the_image_is_sent_to_the_extraction_model(client, llm, bank_with_photo):
+    """Observed at the stub, not inferred.
+
+    An attachment that is stored but never sent produces facts about a picture
+    the model never saw — plausible, specific and wrong, which is worse than no
+    facts at all.
+    """
+    calls = [call for call in llm.calls if any(a in call.all_text for a in [CAPTION])]
+    assert calls, "the extraction call never carried the caption"
+
+    kinds = _parts(calls[0].messages)
+    assert "text" in kinds
+    assert "image_url" in kinds, "the image was dropped between the API and the model"
+
+
+async def test_the_caption_and_the_image_arrive_together(client, llm, bank_with_photo):
+    """Order is the point of inline blocks. A photo hoisted to the end of the
+    prompt loses which sentence it belonged to, which is most of its meaning in a
+    conversation."""
+    call = next(call for call in llm.calls if CAPTION in call.all_text)
+    kinds = _parts(call.messages)
+
+    assert kinds.index("text") < kinds.index("image_url")
+
+
+async def test_the_attachment_is_stored_against_the_document(client, bank_with_photo):
+    document = await client.documents.get_document(bank_with_photo, "d1")
+
+    assert document.attachments, "the image was not kept"
+    attachment = document.attachments[0]
+    assert attachment.kind == "image"
+    assert attachment.media_type == "image/png"
+    assert attachment.byte_size == len(PNG)
+
+
+async def test_the_attachment_hangs_off_the_chunk_it_appeared_in(client, bank_with_photo):
+    """Provenance at the granularity extraction actually works at: a fact points
+    at a chunk, so the chunk has to carry the image that fact was drawn from."""
+    chunks = await client.documents.list_document_chunks(bank_with_photo, "d1")
+
+    attachments = [a for chunk in chunks.items for a in (chunk.attachments or [])]
+    assert [a.kind for a in attachments] == ["image"]
+
+
+async def test_the_stored_image_is_byte_identical(client, bank_with_photo):
+    """The audit path, and it does not work today — #4292.
+
+    A fact drawn from a picture is unverifiable unless the picture comes back
+    exactly as sent. The bytes survive on the server; the *client* destroys them,
+    because the endpoint declares `application/json` alongside
+    `application/octet-stream` in the spec and the generated method decodes the
+    body as text. `0x89` — the first byte of the PNG magic number — is where it
+    gives up.
+
+    Left going through the client rather than reaching around it with raw HTTP:
+    an SDK-inaccessible endpoint is exactly the defect this suite exists to
+    surface, and papering over it here would hide that every consumer has the
+    same problem.
+    """
+    document = await client.documents.get_document(bank_with_photo, "d1")
+    attachment = document.attachments[0]
+
+    fetched = await client.memory.get_bank_attachment(bank_with_photo, attachment.id)
+
+    assert fetched == PNG
+
+
+async def test_the_fact_drawn_from_the_image_is_recallable(client, bank_with_photo):
+    """End to end: the image produced a memory like any other."""
+    response = await client.arecall(bank_id=bank_with_photo, query="Where was Alice photographed?")
+
+    assert [r.text for r in response.results] == [FACT]

--- a/hindsight-system-tests/tests/test_93_attachments.py
+++ b/hindsight-system-tests/tests/test_93_attachments.py
@@ -107,19 +107,14 @@ async def test_the_attachment_hangs_off_the_chunk_it_appeared_in(client, bank_wi
 
 
 async def test_the_stored_image_is_byte_identical(client, bank_with_photo):
-    """The audit path, and it does not work today — #4292.
+    """The audit path. A fact drawn from a picture is unverifiable unless the
+    picture comes back exactly as sent.
 
-    A fact drawn from a picture is unverifiable unless the picture comes back
-    exactly as sent. The bytes survive on the server; the *client* destroys them,
-    because the endpoint declares `application/json` alongside
-    `application/octet-stream` in the spec and the generated method decodes the
-    body as text. `0x89` — the first byte of the PNG magic number — is where it
-    gives up.
-
-    Left going through the client rather than reaching around it with raw HTTP:
-    an SDK-inaccessible endpoint is exactly the defect this suite exists to
-    surface, and papering over it here would hide that every consumer has the
-    same problem.
+    Fetched through the published client on purpose: until #4292 the endpoint
+    declared `application/json` alongside `application/octet-stream`, and every
+    generated SDK decoded the bytes as text and died on `0x89`, the first byte of
+    the PNG magic number. The server was fine; only a client-driven test could
+    see it.
     """
     document = await client.documents.get_document(bank_with_photo, "d1")
     attachment = document.attachments[0]


### PR DESCRIPTION
Closes the epic (#4214). The last 11 stories, plus **two product bugs found writing them** — both left as failing tests rather than worked around.

| # | story |
|---|---|
| 28 | one bank consolidates one run at a time |
| 33 | refresh dedupe (#3487) |
| 36/37 | page rename reaches its model; retraction schedules a rewrite |
| 41 | reflect raises rather than returning a plausible non-answer |
| 45 | the answer-length budget |
| 62/63 | failed operations are visible and retryable; batch parent/children |
| 72 | `resolve_entities` gates fuzzy resolution, not normalisation |
| 74 | entity links follow a document replacement |
| 93 | inline images reach the model and stay fetchable |

**227 passing, 2 failing.** The two failures are the bugs below and go green when they're fixed.

## Bugs found

**#4291 — `entities.mention_count` is never decremented.** `mention_count + $2` is the only mutation in the codebase; there is no decrement anywhere. Replace or delete a document and the count stays inflated while the link table stays correct — which is why it's invisible: nothing disagrees with itself unless you compare the two.

It isn't internal bookkeeping. It's returned on `list_entities`, it sizes nodes in the entity graph, and it's the primary sort key of the curation listing (`ORDER BY mention_count DESC`). The drift is proportional to how often documents change, and the coding-agents integration re-retains a conversation under one `document_id` **every turn** — so long sessions inflate every entity by roughly the turn count.

**#4292 — binary downloads are corrupted by every SDK.** Both `get_bank_attachment` and `download_file` declare `application/json` alongside their real media type, because the routes have no `response_class` and FastAPI adds its default on top. Generated clients pick JSON and decode the bytes as text:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0
```

`0x89` is the PNG magic number. So fetching an attachment — the documented audit path behind an image-derived fact — and collecting an async export are both impossible through any client.

## Scope I deliberately did not cover

**Story 37 asserts that a retraction schedules a rewrite, not what the rewrite says.** Pages refresh in *delta* mode: the model diffs against existing content. Driving the wording from a stub would mean writing the delta myself and then asserting I'd written it. The mechanism is testable and is tested; whether the text actually unsays the claim needs a real model and belongs with the `hs_llm_core` judge tests.

## Notes for review

- Story 72 uses a *fuzzy* variant (`Alice Smyth`), not a case variant. Case differences normalise whichever way the flag is set, so a case-only test sees no difference and proves nothing — that trap is pinned as its own test.
- Story 62's retry test polls for the outcome instead of `settled()`, because `settled()` refuses to return while any operation is failed and this story creates one on purpose.
- Story 45 took three wrong turns: `max_tokens` does not trim the evidence envelope, and neither does `reflect_source_facts_max_tokens`. The budget is on the answer.
