### PR TITLE
fix(entities): give mention_count back when the mentions go (#4291)

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -797,64 +797,57 @@ class DataAccessOps(ABC):
         ...
 
     @abstractmethod
-    async def enqueue_entity_maintenance(
+    async def release_entity_postings(
         self,
         conn: DatabaseConnection,
-        table: str,
-        ue_table: str,
-        bank_id: str,
-        unit_ids: list,
-    ) -> int:
-        """Enqueue the entities referenced by ``unit_ids`` as prune candidates.
-
-        Reads the entity ids out of ``unit_entities`` and inserts them into
-        entity_maintenance_queue, deduplicating on the (bank_id, entity_id)
-        primary key. Returns the number of rows the insert added.
-
-        Must run inside the triggering transaction and BEFORE the rows go —
-        once the unit_entities rows are deleted (or cascaded away) there is
-        nothing left to read the entity ids from.
-        """
-        ...
-
-    @abstractmethod
-    async def release_entity_mentions(
-        self,
-        conn: DatabaseConnection,
+        queue_table: str,
         entities_table: str,
         ue_table: str,
         bank_id: str,
         unit_ids: list,
     ) -> int:
-        """Give back the ``mention_count`` the postings of ``unit_ids`` contributed.
+        """Retire the entity postings of ``unit_ids``: queue their entities as
+        prune candidates, and give back the ``mention_count`` those postings
+        contributed.
 
-        Subtracts, per entity, the number of ``unit_entities`` rows about to go
-        with those units. Like :meth:`enqueue_entity_maintenance` this must run
-        inside the triggering transaction and BEFORE the delete or cascade
-        fires, for the same reason: afterwards there is no posting left to count.
+        One operation because it is one read. Both halves need the same
+        ``unit_entities`` rows — the queue wants the entity ids, the counter
+        wants how many rows each entity has — and both must run inside the
+        triggering transaction and BEFORE the delete or cascade fires, because
+        afterwards there is nothing left to read them from.
 
-        Floors at zero. The increment side counts *mentions* and the posting is
-        per (unit, entity), so the two disagree by one whenever two differently
-        spelled mentions in one fact resolve to the same entity; the floor keeps
-        that rare asymmetry from driving the count negative.
+        Queue rows are locked before entity rows, matching the order
+        :meth:`claim_entity_maintenance_batch` and :meth:`prune_orphan_entities`
+        take them, so a delete cannot cycle against a worker draining the queue.
 
-        Returns the number of entity rows updated.
+        The count floors at zero. The increment side counts *mentions* while a
+        posting is per (unit, entity), so the two disagree by one whenever two
+        differently spelled mentions in one fact resolve to the same entity; the
+        floor keeps that rare asymmetry from driving the count negative.
+
+        Returns the number of candidate entities enqueued.
         """
         ...
 
     @abstractmethod
-    async def restore_entity_mentions(
+    async def restore_entity_postings(
         self,
         conn: DatabaseConnection,
+        ue_table: str,
         entities_table: str,
         bank_id: str,
+        unit_id: str,
         entity_ids: list,
     ) -> int:
-        """Add one mention back to each of ``entity_ids`` in ``bank_id``.
+        """Re-post ``unit_id`` to ``entity_ids`` and credit one mention per
+        posting written.
 
-        The inverse of :meth:`release_entity_mentions` for a restore that
-        re-inserts one posting per entity (reverting an invalidation). Returns
-        the number of entity rows updated.
+        The inverse of :meth:`release_entity_postings`, for reverting an
+        invalidation. Entities that no longer exist are skipped — the orphan
+        prune may have swept them while the memory sat archived — so the credit
+        follows the postings actually written, not the ids asked for.
+
+        Returns the number of postings written.
         """
         ...
 

--- a/hindsight-api-slim/hindsight_api/engine/db/ops.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops.py
@@ -818,6 +818,47 @@ class DataAccessOps(ABC):
         ...
 
     @abstractmethod
+    async def release_entity_mentions(
+        self,
+        conn: DatabaseConnection,
+        entities_table: str,
+        ue_table: str,
+        bank_id: str,
+        unit_ids: list,
+    ) -> int:
+        """Give back the ``mention_count`` the postings of ``unit_ids`` contributed.
+
+        Subtracts, per entity, the number of ``unit_entities`` rows about to go
+        with those units. Like :meth:`enqueue_entity_maintenance` this must run
+        inside the triggering transaction and BEFORE the delete or cascade
+        fires, for the same reason: afterwards there is no posting left to count.
+
+        Floors at zero. The increment side counts *mentions* and the posting is
+        per (unit, entity), so the two disagree by one whenever two differently
+        spelled mentions in one fact resolve to the same entity; the floor keeps
+        that rare asymmetry from driving the count negative.
+
+        Returns the number of entity rows updated.
+        """
+        ...
+
+    @abstractmethod
+    async def restore_entity_mentions(
+        self,
+        conn: DatabaseConnection,
+        entities_table: str,
+        bank_id: str,
+        entity_ids: list,
+    ) -> int:
+        """Add one mention back to each of ``entity_ids`` in ``bank_id``.
+
+        The inverse of :meth:`release_entity_mentions` for a restore that
+        re-inserts one posting per entity (reverting an invalidation). Returns
+        the number of entity rows updated.
+        """
+        ...
+
+    @abstractmethod
     async def claim_entity_maintenance_batch(
         self,
         conn: DatabaseConnection,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -403,6 +403,57 @@ class OracleOps(DataAccessOps):
         )
         return len(candidates)
 
+    async def release_entity_mentions(
+        self,
+        conn: DatabaseConnection,
+        entities_table: str,
+        ue_table: str,
+        bank_id: str,
+        unit_ids: list,
+    ) -> int:
+        if not unit_ids:
+            return 0
+        rows = await conn.fetch(
+            f"""
+            SELECT entity_id, COUNT(*) AS n
+            FROM {ue_table}
+            WHERE unit_id = ANY($1::uuid[])
+            GROUP BY entity_id
+            """,
+            unit_ids,
+        )
+        # Sorted for the same reason as enqueue_entity_maintenance: executemany
+        # takes the row locks in array order, which is the order the entity
+        # upsert and the orphan prune take them.
+        deltas = sorted((str(row["entity_id"]), int(row["n"])) for row in rows)
+        if not deltas:
+            return 0
+        await conn.executemany(
+            f"""
+            UPDATE {entities_table}
+            SET mention_count = GREATEST(mention_count - $3, 0)
+            WHERE id = $1 AND bank_id = $2
+            """,
+            [(eid, bank_id, n) for eid, n in deltas],
+        )
+        return len(deltas)
+
+    async def restore_entity_mentions(
+        self,
+        conn: DatabaseConnection,
+        entities_table: str,
+        bank_id: str,
+        entity_ids: list,
+    ) -> int:
+        if not entity_ids:
+            return 0
+        ids = sorted(str(eid) for eid in entity_ids)
+        await conn.executemany(
+            f"UPDATE {entities_table} SET mention_count = mention_count + 1 WHERE id = $1 AND bank_id = $2",
+            [(eid, bank_id) for eid in ids],
+        )
+        return len(ids)
+
     async def claim_entity_maintenance_batch(
         self,
         conn: DatabaseConnection,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -366,46 +366,10 @@ class OracleOps(DataAccessOps):
             )
         return claimed
 
-    async def enqueue_entity_maintenance(
+    async def release_entity_postings(
         self,
         conn: DatabaseConnection,
-        table: str,
-        ue_table: str,
-        bank_id: str,
-        unit_ids: list,
-    ) -> int:
-        if not unit_ids:
-            return 0
-        rows = await conn.fetch(
-            f"SELECT DISTINCT entity_id FROM {ue_table} WHERE unit_id = ANY($1::uuid[])",
-            unit_ids,
-        )
-        # Sorted for the same reason as enqueue_graph_maintenance: the MERGE
-        # takes the (bank_id, entity_id) row locks in executemany array order,
-        # and claim_entity_maintenance_batch deletes in that same order, so
-        # overlapping mutation/worker sets cannot cycle.
-        candidates = sorted(str(row["entity_id"]) for row in rows)
-        if not candidates:
-            return 0
-        # MERGE is the Oracle analogue of ON CONFLICT DO UPDATE: WHEN MATCHED
-        # locks the existing queue row (the SET is a no-op preserving
-        # enqueued_at) so a re-enqueue serialises against a concurrent claim
-        # instead of being silently dropped (#3034).
-        await conn.executemany(
-            f"""
-            MERGE INTO {table} q
-            USING (SELECT $1 AS bank_id, $2 AS entity_id FROM dual) s
-            ON (q.bank_id = s.bank_id AND q.entity_id = s.entity_id)
-            WHEN MATCHED THEN UPDATE SET q.enqueued_at = q.enqueued_at
-            WHEN NOT MATCHED THEN INSERT (bank_id, entity_id) VALUES (s.bank_id, s.entity_id)
-            """,
-            [(bank_id, eid) for eid in candidates],
-        )
-        return len(candidates)
-
-    async def release_entity_mentions(
-        self,
-        conn: DatabaseConnection,
+        queue_table: str,
         entities_table: str,
         ue_table: str,
         bank_id: str,
@@ -413,6 +377,11 @@ class OracleOps(DataAccessOps):
     ) -> int:
         if not unit_ids:
             return 0
+        # One read for both halves: the ids are the queue candidates, the counts
+        # are what each entity is about to stop being mentioned by. Oracle can't
+        # express the whole thing as one statement the way the PG side does —
+        # MERGE has no RETURNING to hang the second write off — so it stays two
+        # executemany calls over this one result.
         rows = await conn.fetch(
             f"""
             SELECT entity_id, COUNT(*) AS n
@@ -422,12 +391,29 @@ class OracleOps(DataAccessOps):
             """,
             unit_ids,
         )
-        # Sorted for the same reason as enqueue_entity_maintenance: executemany
-        # takes the row locks in array order, which is the order the entity
-        # upsert and the orphan prune take them.
+        # Sorted for the same reason as enqueue_graph_maintenance: executemany
+        # takes the row locks in array order, and claim_entity_maintenance_batch
+        # deletes in that same order, so overlapping mutation/worker sets cannot
+        # cycle.
         deltas = sorted((str(row["entity_id"]), int(row["n"])) for row in rows)
         if not deltas:
             return 0
+        # MERGE is the Oracle analogue of ON CONFLICT DO UPDATE: WHEN MATCHED
+        # locks the existing queue row (the SET is a no-op preserving
+        # enqueued_at) so a re-enqueue serialises against a concurrent claim
+        # instead of being silently dropped (#3034).
+        await conn.executemany(
+            f"""
+            MERGE INTO {queue_table} q
+            USING (SELECT $1 AS bank_id, $2 AS entity_id FROM dual) s
+            ON (q.bank_id = s.bank_id AND q.entity_id = s.entity_id)
+            WHEN MATCHED THEN UPDATE SET q.enqueued_at = q.enqueued_at
+            WHEN NOT MATCHED THEN INSERT (bank_id, entity_id) VALUES (s.bank_id, s.entity_id)
+            """,
+            [(bank_id, eid) for eid, _ in deltas],
+        )
+        # Queue rows first, then entity rows — the order the drain takes them,
+        # which is what keeps a delete from cycling against a worker.
         await conn.executemany(
             f"""
             UPDATE {entities_table}
@@ -438,21 +424,38 @@ class OracleOps(DataAccessOps):
         )
         return len(deltas)
 
-    async def restore_entity_mentions(
+    async def restore_entity_postings(
         self,
         conn: DatabaseConnection,
+        ue_table: str,
         entities_table: str,
         bank_id: str,
+        unit_id: str,
         entity_ids: list,
     ) -> int:
         if not entity_ids:
             return 0
-        ids = sorted(str(eid) for eid in entity_ids)
+        # Only entities that still exist can be posted to — some may have been
+        # swept as orphans while the memory sat archived — and only what is
+        # actually posted may be credited, so the surviving set is read first
+        # and drives both writes.
+        rows = await conn.fetch(
+            f"SELECT id FROM {entities_table} WHERE bank_id = $1 AND id = ANY($2::uuid[])",
+            bank_id,
+            entity_ids,
+        )
+        survivors = sorted(str(row["id"]) for row in rows)
+        if not survivors:
+            return 0
+        await conn.executemany(
+            f"INSERT INTO {ue_table} (unit_id, entity_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+            [(unit_id, eid) for eid in survivors],
+        )
         await conn.executemany(
             f"UPDATE {entities_table} SET mention_count = mention_count + 1 WHERE id = $1 AND bank_id = $2",
-            [(eid, bank_id) for eid in ids],
+            [(eid, bank_id) for eid in survivors],
         )
-        return len(ids)
+        return len(survivors)
 
     async def claim_entity_maintenance_batch(
         self,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_oracle.py
@@ -447,6 +447,11 @@ class OracleOps(DataAccessOps):
         survivors = sorted(str(row["id"]) for row in rows)
         if not survivors:
             return 0
+        # Credits every survivor rather than only the rows the insert added, as
+        # the PG side does with RETURNING (MERGE/executemany has none). The two
+        # agree because a reverting unit has no postings left to conflict with —
+        # the cascade took them at invalidation — so DO NOTHING never fires. A
+        # caller that re-posted a unit whose postings survive would over-credit.
         await conn.executemany(
             f"INSERT INTO {ue_table} (unit_id, entity_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
             [(unit_id, eid) for eid in survivors],

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -646,7 +646,7 @@ class PostgreSQLOps(DataAccessOps):
     ) -> list:
         # Same claim shape as claim_graph_maintenance_batch: pick the oldest
         # batch by enqueued_at, but acquire the row locks in (bank_id, entity_id)
-        # order — the order enqueue_entity_maintenance takes them — so a
+        # order — the order release_entity_postings takes them — so a
         # concurrent enqueue can never cycle against this claim. `chosen` is
         # MATERIALIZED so the enqueued_at pick is fenced from the locking clause,
         # and `FOR UPDATE OF q ... ORDER BY q.entity_id` puts LockRows above the

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -541,6 +541,79 @@ class PostgreSQLOps(DataAccessOps):
         )
         return int(result.split()[-1]) if isinstance(result, str) and result.startswith("INSERT") else 0
 
+    async def release_entity_mentions(
+        self,
+        conn: DatabaseConnection,
+        entities_table: str,
+        ue_table: str,
+        bank_id: str,
+        unit_ids: list,
+    ) -> int:
+        # Same read as enqueue_entity_maintenance, aggregated instead of
+        # DISTINCT: one row per entity carrying how many postings it is about to
+        # lose. Runs before the delete for the same reason the enqueue does.
+        #
+        # `victims` locks the entity rows in id order — the order
+        # bulk_upsert_entities takes them (`ORDER BY id FOR KEY SHARE`) and the
+        # order prune_orphan_entities takes them — so a delete giving mentions
+        # back cannot cycle against a concurrent retain asserting them.
+        result = await conn.execute(
+            f"""
+            WITH doomed AS (
+                SELECT ue.entity_id AS id, COUNT(*) AS n
+                FROM {ue_table} ue
+                WHERE ue.unit_id = ANY($2::uuid[])
+                GROUP BY ue.entity_id
+            ),
+            victims AS (
+                SELECT e.id, d.n
+                FROM {entities_table} e
+                JOIN doomed d ON d.id = e.id
+                WHERE e.bank_id = $1
+                ORDER BY e.id
+                FOR UPDATE OF e
+            )
+            UPDATE {entities_table} e
+            SET mention_count = GREATEST(e.mention_count - v.n, 0)
+            FROM victims v
+            WHERE e.id = v.id
+            """,
+            bank_id,
+            unit_ids,
+        )
+        # asyncpg returns "UPDATE N"
+        return int(result.split()[-1]) if isinstance(result, str) and result.startswith("UPDATE") else 0
+
+    async def restore_entity_mentions(
+        self,
+        conn: DatabaseConnection,
+        entities_table: str,
+        bank_id: str,
+        entity_ids: list,
+    ) -> int:
+        if not entity_ids:
+            return 0
+        # Ordered lock acquisition, as in release_entity_mentions above.
+        result = await conn.execute(
+            f"""
+            WITH victims AS (
+                SELECT e.id
+                FROM {entities_table} e
+                WHERE e.bank_id = $1
+                  AND e.id = ANY($2::uuid[])
+                ORDER BY e.id
+                FOR UPDATE
+            )
+            UPDATE {entities_table} e
+            SET mention_count = e.mention_count + 1
+            FROM victims v
+            WHERE e.id = v.id
+            """,
+            bank_id,
+            entity_ids,
+        )
+        return int(result.split()[-1]) if isinstance(result, str) and result.startswith("UPDATE") else 0
+
     async def claim_entity_maintenance_batch(
         self,
         conn: DatabaseConnection,

--- a/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
+++ b/hindsight-api-slim/hindsight_api/engine/db/ops_postgresql.py
@@ -496,24 +496,27 @@ class PostgreSQLOps(DataAccessOps):
         )
         return [str(row["unit_id"]) for row in rows]
 
-    async def enqueue_entity_maintenance(
+    async def release_entity_postings(
         self,
         conn: DatabaseConnection,
-        table: str,
+        queue_table: str,
+        entities_table: str,
         ue_table: str,
         bank_id: str,
         unit_ids: list,
     ) -> int:
         # Read the candidates straight out of unit_entities rather than making
         # callers pass entity ids: every caller runs this immediately before the
-        # rows go, and the join they'd have to write is this one.
+        # rows go, and the join they'd have to write is this one. `doomed` is
+        # that read, aggregated, so one scan serves both halves — the queue
+        # insert wants the ids, the mention release wants the counts.
         #
-        # The inner ORDER BY is load-bearing, not cosmetic: it makes the INSERT
-        # take the (bank_id, entity_id) row locks ascending, the same order
-        # claim_entity_maintenance_batch takes them, so a mutation enqueueing an
-        # overlapping candidate set cannot cycle against a worker draining it.
-        # (Same protocol as enqueue_graph_maintenance, which sorts in Python
-        # because its ids arrive as a bind array.)
+        # `enqueued`'s inner ORDER BY is load-bearing, not cosmetic: it makes the
+        # INSERT take the (bank_id, entity_id) row locks ascending, the same
+        # order claim_entity_maintenance_batch takes them, so a mutation
+        # enqueueing an overlapping candidate set cannot cycle against a worker
+        # draining it. (Same protocol as enqueue_graph_maintenance, which sorts
+        # in Python because its ids arrive as a bind array.)
         #
         # DO UPDATE (not DO NOTHING) on a duplicate — #3034. The SET is a
         # deliberate no-op preserving enqueued_at; its only purpose is to lock
@@ -523,40 +526,32 @@ class PostgreSQLOps(DataAccessOps):
         # would find the entity still referenced, keep it, and the re-enqueue
         # signal would be lost, stranding the orphan until some later delete
         # happened to name it again.
-        result = await conn.execute(
-            f"""
-            INSERT INTO {table} (bank_id, entity_id)
-            SELECT $1, s.entity_id
-            FROM (
-                SELECT DISTINCT ue.entity_id
-                FROM {ue_table} ue
-                WHERE ue.unit_id = ANY($2::uuid[])
-                ORDER BY 1
-            ) s
-            ON CONFLICT (bank_id, entity_id)
-                DO UPDATE SET enqueued_at = {table}.enqueued_at
-            """,
-            bank_id,
-            unit_ids,
-        )
-        return int(result.split()[-1]) if isinstance(result, str) and result.startswith("INSERT") else 0
-
-    async def release_entity_mentions(
-        self,
-        conn: DatabaseConnection,
-        entities_table: str,
-        ue_table: str,
-        bank_id: str,
-        unit_ids: list,
-    ) -> int:
-        # Same read as enqueue_entity_maintenance, aggregated instead of
-        # DISTINCT: one row per entity carrying how many postings it is about to
-        # lose. Runs before the delete for the same reason the enqueue does.
         #
-        # `victims` locks the entity rows in id order — the order
-        # bulk_upsert_entities takes them (`ORDER BY id FOR KEY SHARE`) and the
-        # order prune_orphan_entities takes them — so a delete giving mentions
-        # back cannot cycle against a concurrent retain asserting them.
+        # Both halves are one statement so the postings are counted in the scan
+        # that already lists them, but the two lock sets still have to be
+        # ordered or a delete and a worker draining the queue deadlock on the
+        # same entity. The invariant is: *an entity's queue row is locked before
+        # its own `entities` row, and queue rows are locked ascending.*
+        #
+        # `victims` referencing `enqueued` is what enforces the first half — an
+        # entity cannot become a victim until the INSERT has produced it. The
+        # second half is `enqueued`'s inner ORDER BY. Together they hold under
+        # every plan shape the statement gets: EXPLAIN picks a nested-loop semi
+        # join here (queue and entity locks interleave per entity, ascending)
+        # and a hashed subplan or a sort under LockRows on other row counts
+        # (every queue lock taken before the first entity lock). Both are safe,
+        # because taking an `entities` row lock always means already holding
+        # that entity's queue row, and the drain takes them in that same order.
+        #
+        # What is deliberately NOT relied on: the order `victims` produces rows
+        # in. `ORDER BY e.id` asks for ascending entity locks, but a lazily
+        # pulled semi join takes them in `doomed` order instead. That is fine
+        # for the reason above — the ascending queue locks are the serialiser,
+        # so two concurrent deletes cannot hold entity rows in opposing orders.
+        #
+        # `victims` re-filters on bank_id even though a posting cannot name
+        # another bank's entity: mention_count is denormalised state, and
+        # scoping the write is what keeps that true if the invariant slips.
         result = await conn.execute(
             f"""
             WITH doomed AS (
@@ -565,11 +560,19 @@ class PostgreSQLOps(DataAccessOps):
                 WHERE ue.unit_id = ANY($2::uuid[])
                 GROUP BY ue.entity_id
             ),
+            enqueued AS (
+                INSERT INTO {queue_table} (bank_id, entity_id)
+                SELECT $1, s.id FROM (SELECT id FROM doomed ORDER BY 1) s
+                ON CONFLICT (bank_id, entity_id)
+                    DO UPDATE SET enqueued_at = {queue_table}.enqueued_at
+                RETURNING entity_id
+            ),
             victims AS (
                 SELECT e.id, d.n
                 FROM {entities_table} e
                 JOIN doomed d ON d.id = e.id
                 WHERE e.bank_id = $1
+                  AND e.id IN (SELECT entity_id FROM enqueued)
                 ORDER BY e.id
                 FOR UPDATE OF e
             )
@@ -581,35 +584,55 @@ class PostgreSQLOps(DataAccessOps):
             bank_id,
             unit_ids,
         )
-        # asyncpg returns "UPDATE N"
+        # asyncpg returns "UPDATE N". Every posting names an existing entity in
+        # this bank (FK, and postings are intra-bank by construction), so the
+        # rows updated are the rows enqueued.
         return int(result.split()[-1]) if isinstance(result, str) and result.startswith("UPDATE") else 0
 
-    async def restore_entity_mentions(
+    async def restore_entity_postings(
         self,
         conn: DatabaseConnection,
+        ue_table: str,
         entities_table: str,
         bank_id: str,
+        unit_id: str,
         entity_ids: list,
     ) -> int:
         if not entity_ids:
             return 0
-        # Ordered lock acquisition, as in release_entity_mentions above.
+        # One statement, because crediting a mention for a posting that was not
+        # written would be the same bug in the other direction: `posted` returns
+        # exactly the rows the insert added, and only those are credited. Some
+        # of `entity_ids` may have been swept as orphans while the memory sat
+        # archived, which `survivors` filters out, and DO NOTHING covers a
+        # posting that somehow already exists.
+        #
+        # `survivors` locks the entity rows in ascending id order, the order
+        # release_entity_postings and prune_orphan_entities take them. No queue
+        # row is involved here, so there is no second lock set to sequence.
         result = await conn.execute(
             f"""
-            WITH victims AS (
+            WITH survivors AS (
                 SELECT e.id
                 FROM {entities_table} e
                 WHERE e.bank_id = $1
-                  AND e.id = ANY($2::uuid[])
+                  AND e.id = ANY($3::uuid[])
                 ORDER BY e.id
                 FOR UPDATE
+            ),
+            posted AS (
+                INSERT INTO {ue_table} (unit_id, entity_id)
+                SELECT $2, s.id FROM survivors s
+                ON CONFLICT DO NOTHING
+                RETURNING entity_id
             )
             UPDATE {entities_table} e
             SET mention_count = e.mention_count + 1
-            FROM victims v
-            WHERE e.id = v.id
+            FROM posted p
+            WHERE e.id = p.entity_id
             """,
             bank_id,
+            unit_id,
             entity_ids,
         )
         return int(result.split()[-1]) if isinstance(result, str) and result.startswith("UPDATE") else 0

--- a/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
+++ b/hindsight-api-slim/hindsight_api/engine/graph_maintenance.py
@@ -171,6 +171,11 @@ async def enqueue_entity_prune_candidates(
     Over-enqueueing costs nothing: the drain re-checks each candidate and keeps
     the ones still referenced.
 
+    This is also where the entities get their ``mention_count`` back: the
+    counter is incremented once per mention at retain time and would otherwise
+    never come down, so an entity's prominence would track how often its
+    documents were rewritten rather than how many facts mention it (#4291).
+
     Delegated to the memories store: a store that never wrote ``unit_entities``
     has no postings to lose and returns 0.
 

--- a/hindsight-api-slim/hindsight_api/engine/memories/base.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/base.py
@@ -1998,10 +1998,12 @@ class MemoriesExtension(Extension, ABC):
         return RelinkPassResult()
 
     async def enqueue_entity_prune_candidates(self, *, conn, fq_table, bank_id: str, affected_unit_ids: list) -> int:
-        """Queue the entities ``affected_unit_ids`` reference as prune candidates.
+        """Queue the entities ``affected_unit_ids`` reference as prune candidates,
+        and give back the ``mention_count`` their postings contributed.
 
         Zero for a store that never wrote `unit_entities`: it has no entity
-        postings to lose, so nothing can become an orphan.
+        postings to lose, so nothing can become an orphan and no mention count
+        can drift.
         """
         return 0
 

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
@@ -850,23 +850,13 @@ async def enqueue_entity_prune_candidates(
     # literal IN list — Oracle caps those at 1000 elements.
     enqueued = 0
     for start in range(0, len(unit_uuids), _ENQUEUE_LOOKUP_CHUNK):
-        chunk = unit_uuids[start : start + _ENQUEUE_LOOKUP_CHUNK]
-        enqueued += await ops.enqueue_entity_maintenance(
+        enqueued += await ops.release_entity_postings(
             conn,
             queue_table,
-            ue_table,
-            bank_id,
-            chunk,
-        )
-        # Takes the `entities` row locks in ascending id order — the order
-        # retain's upsert (`ORDER BY id FOR KEY SHARE`) and the orphan prune
-        # take them — so it cannot cycle against either.
-        await ops.release_entity_mentions(
-            conn,
             entities_table,
             ue_table,
             bank_id,
-            chunk,
+            unit_uuids[start : start + _ENQUEUE_LOOKUP_CHUNK],
         )
     return enqueued
 

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/graph.py
@@ -815,6 +815,14 @@ async def enqueue_entity_prune_candidates(
 ) -> int:
     """Enqueue the entities ``affected_unit_ids`` reference as prune candidates.
 
+    Also gives back the ``mention_count`` those units' postings contributed:
+    this is the one choke point every unlink path goes through (document
+    replace/delete, memory delete, invalidation, an edit that rewrites the
+    entity set), and it is called exactly where the counts are still readable,
+    so the decrement belongs here rather than repeated at six call sites.
+    ``mention_count`` is otherwise increment-only, and the drift is proportional
+    to how often documents are updated (#4291).
+
     Must run inside the same transaction that removes those units (or their
     ``unit_entities`` rows), *before* the delete or cascade fires — afterwards
     there is no posting left to read the entity ids from, and the entity is
@@ -822,6 +830,8 @@ async def enqueue_entity_prune_candidates(
 
     Enqueueing an entity that turns out to still be referenced is free: the
     drain re-checks and keeps it. Over-enqueueing is always the safe direction.
+    The decrement is not free in the same way, which is why it counts the
+    postings actually going rather than assuming one per unit.
 
     Returns:
         Number of candidate entities enqueued.
@@ -832,6 +842,7 @@ async def enqueue_entity_prune_candidates(
     ops = _ops_for(conn)
     queue_table = fq_table("entity_maintenance_queue")
     ue_table = fq_table("unit_entities")
+    entities_table = fq_table("entities")
     unit_uuids = _as_uuids(list(affected_unit_ids))
 
     # Chunked because a bulk delete can hand in thousands of unit ids and the
@@ -839,12 +850,23 @@ async def enqueue_entity_prune_candidates(
     # literal IN list — Oracle caps those at 1000 elements.
     enqueued = 0
     for start in range(0, len(unit_uuids), _ENQUEUE_LOOKUP_CHUNK):
+        chunk = unit_uuids[start : start + _ENQUEUE_LOOKUP_CHUNK]
         enqueued += await ops.enqueue_entity_maintenance(
             conn,
             queue_table,
             ue_table,
             bank_id,
-            unit_uuids[start : start + _ENQUEUE_LOOKUP_CHUNK],
+            chunk,
+        )
+        # Takes the `entities` row locks in ascending id order — the order
+        # retain's upsert (`ORDER BY id FOR KEY SHARE`) and the orphan prune
+        # take them — so it cannot cycle against either.
+        await ops.release_entity_mentions(
+            conn,
+            entities_table,
+            ue_table,
+            bank_id,
+            chunk,
         )
     return enqueued
 

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/writes.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/writes.py
@@ -475,6 +475,8 @@ async def restore_memory(*, conn, fq_table, bank_id: str, unit_id: str) -> Store
         str(unit_id),
         bank_id,
     )
+    from .graph import _ops_for
+
     # Restore the entity postings for entities that still exist — some may have
     # been swept as orphans while the memory was archived.
     if arch_row["entity_ids"]:
@@ -487,11 +489,23 @@ async def restore_memory(*, conn, fq_table, bank_id: str, unit_id: str) -> Store
             arch_row["entity_ids"],
             bank_id,
         )
+        # Give the mention back that invalidation took (#4291). Restricted to the
+        # entities that survived, which is the same set the insert above posted:
+        # the unit's postings were cascaded away with it, so nothing pre-exists
+        # for the ON CONFLICT to swallow.
+        survivors = [
+            r["id"]
+            for r in await conn.fetch(
+                f"SELECT id FROM {ent} WHERE bank_id = $1 AND id = ANY($2::uuid[])",
+                bank_id,
+                arch_row["entity_ids"],
+            )
+        ]
+        await _ops_for(conn).restore_entity_mentions(conn, ent, bank_id, survivors)
     # Rematerialize the causal edges parked at invalidation (#2864). Edges whose peer is still
     # archived or permanently deleted are skipped — the peer keeps its own copy and recreates the
     # edge when it reverts, so the restore is order-independent and idempotent.
     from ...retain.link_utils import rematerialize_causal_links
-    from .graph import _ops_for
 
     causal_json = await conn.fetchval(
         f"SELECT causal_links FROM {arch} WHERE id = $1 AND bank_id = $2", str(unit_id), bank_id

--- a/hindsight-api-slim/hindsight_api/engine/memories/pg/writes.py
+++ b/hindsight-api-slim/hindsight_api/engine/memories/pg/writes.py
@@ -478,30 +478,19 @@ async def restore_memory(*, conn, fq_table, bank_id: str, unit_id: str) -> Store
     from .graph import _ops_for
 
     # Restore the entity postings for entities that still exist — some may have
-    # been swept as orphans while the memory was archived.
+    # been swept as orphans while the memory was archived — and give each one
+    # back the mention invalidation took from it (#4291). One call: the credit
+    # has to follow the postings actually written, so the two cannot be decided
+    # separately.
     if arch_row["entity_ids"]:
-        await conn.execute(
-            f"INSERT INTO {ue} (unit_id, entity_id) "
-            f"SELECT $1, eid FROM unnest($2::uuid[]) AS eid "
-            f"WHERE EXISTS (SELECT 1 FROM {ent} e WHERE e.id = eid AND e.bank_id = $3) "
-            f"ON CONFLICT DO NOTHING",
+        await _ops_for(conn).restore_entity_postings(
+            conn,
+            ue,
+            ent,
+            bank_id,
             str(unit_id),
             arch_row["entity_ids"],
-            bank_id,
         )
-        # Give the mention back that invalidation took (#4291). Restricted to the
-        # entities that survived, which is the same set the insert above posted:
-        # the unit's postings were cascaded away with it, so nothing pre-exists
-        # for the ON CONFLICT to swallow.
-        survivors = [
-            r["id"]
-            for r in await conn.fetch(
-                f"SELECT id FROM {ent} WHERE bank_id = $1 AND id = ANY($2::uuid[])",
-                bank_id,
-                arch_row["entity_ids"],
-            )
-        ]
-        await _ops_for(conn).restore_entity_mentions(conn, ent, bank_id, survivors)
     # Rematerialize the causal edges parked at invalidation (#2864). Edges whose peer is still
     # archived or permanently deleted are skipped — the peer keeps its own copy and recreates the
     # edge when it reverts, so the restore is order-independent and idempotent.

--- a/hindsight-api-slim/tests/test_entity_mention_count.py
+++ b/hindsight-api-slim/tests/test_entity_mention_count.py
@@ -1,0 +1,408 @@
+"""``entities.mention_count`` comes back down when the mentions go (#4291).
+
+The counter is written once per mention at retain time and used for prominence:
+it orders the entity list, sizes the graph nodes, and is returned to callers. It
+used to be increment-only, so replacing or deleting a document left every entity
+it named inflated — and the drift was proportional to how often the bank's
+documents were rewritten, not to anything about the entities.
+
+The decrement lives at the one choke point every unlink path already goes
+through, :func:`enqueue_entity_prune_candidates`, which is why the tests below
+drive it there and at the two API-level paths that reach it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hindsight_api import RequestContext
+from hindsight_api.engine.db.ops_oracle import OracleOps
+from hindsight_api.engine.graph_maintenance import enqueue_entity_prune_candidates
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+# Every test seeds `entities` / `unit_entities` with raw INSERTs and asserts on raw
+# `mention_count` values, so a store that keeps its entity registry outside SQL has
+# nothing here to look at.
+pytestmark = pytest.mark.memory_backend_incompatible
+
+
+async def _ensure_bank(memory: MemoryEngine, bank_id: str, request_context: RequestContext) -> None:
+    await memory.get_bank_profile(bank_id=bank_id, request_context=request_context)
+
+
+async def _insert_entity(conn, bank_id: str, name: str, mention_count: int = 1) -> uuid.UUID:
+    entity_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO entities (id, bank_id, canonical_name, first_seen, last_seen, mention_count)
+        VALUES ($1, $2, $3, NOW(), NOW(), $4)
+        """,
+        entity_id,
+        bank_id,
+        name,
+        mention_count,
+    )
+    return entity_id
+
+
+async def _insert_unit(conn, bank_id: str, text: str) -> uuid.UUID:
+    unit_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO memory_units (id, bank_id, text, fact_type, event_date, created_at, updated_at)
+        VALUES ($1, $2, $3, 'experience', $4, NOW(), NOW())
+        """,
+        unit_id,
+        bank_id,
+        text,
+        datetime.now(UTC),
+    )
+    return unit_id
+
+
+async def _link(conn, unit_id: uuid.UUID, entity_id: uuid.UUID) -> None:
+    await conn.execute("INSERT INTO unit_entities (unit_id, entity_id) VALUES ($1, $2)", unit_id, entity_id)
+
+
+async def _mention_count(conn, entity_id: uuid.UUID) -> int:
+    return await conn.fetchval("SELECT mention_count FROM entities WHERE id = $1", entity_id)
+
+
+async def _posting_count(conn, entity_id: uuid.UUID) -> int:
+    return await conn.fetchval("SELECT COUNT(*) FROM unit_entities WHERE entity_id = $1", entity_id)
+
+
+# ---------------------------------------------------------------------------
+# SQL shape (no database)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oracle_release_subtracts_per_entity_in_stable_id_order():
+    """Oracle adapter: one UPDATE per entity, carrying that entity's posting
+    count, bound in sorted id order — the order the entity upsert and the orphan
+    prune take the same rows, so a delete cannot cycle against a live retain."""
+    ops = OracleOps()
+    conn = AsyncMock()
+    id_a = "00000000-0000-0000-0000-00000000000a"
+    id_b = "00000000-0000-0000-0000-00000000000b"
+    # Deliberately returned out of id order.
+    conn.fetch.return_value = [
+        {"entity_id": id_b, "n": 1},
+        {"entity_id": id_a, "n": 3},
+    ]
+
+    updated = await ops.release_entity_mentions(conn, "entities", "unit_entities", "bank-1", ["u1", "u2"])
+
+    assert updated == 2
+    sql, rows = conn.executemany.await_args.args
+    assert "GREATEST(mention_count - $3, 0)" in sql
+    assert rows == [(id_a, "bank-1", 3), (id_b, "bank-1", 1)]
+
+
+@pytest.mark.asyncio
+async def test_oracle_release_of_units_with_no_postings_issues_no_update():
+    """Units that never named an entity cost no round-trip."""
+    ops = OracleOps()
+    conn = AsyncMock()
+    conn.fetch.return_value = []
+
+    assert await ops.release_entity_mentions(conn, "entities", "unit_entities", "bank-1", ["u1"]) == 0
+    conn.executemany.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_oracle_restore_adds_one_per_entity():
+    ops = OracleOps()
+    conn = AsyncMock()
+    id_a = "00000000-0000-0000-0000-00000000000a"
+    id_b = "00000000-0000-0000-0000-00000000000b"
+
+    assert await ops.restore_entity_mentions(conn, "entities", "bank-1", [id_b, id_a]) == 2
+
+    sql, rows = conn.executemany.await_args.args
+    assert "mention_count + 1" in sql
+    assert rows == [(id_a, "bank-1"), (id_b, "bank-1")]
+
+
+@pytest.mark.asyncio
+async def test_oracle_restore_of_nothing_issues_no_update():
+    ops = OracleOps()
+    conn = AsyncMock()
+
+    assert await ops.restore_entity_mentions(conn, "entities", "bank-1", []) == 0
+    conn.executemany.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Against the database
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseAtTheChokePoint:
+    @pytest.mark.asyncio
+    async def test_subtracts_the_postings_each_entity_actually_loses(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """Two units name Alice, one names Bob. Dropping one unit gives Alice one
+        mention back and leaves Bob alone."""
+        bank_id = f"test-mc-release-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            alice = await _insert_entity(conn, bank_id, "Alice", mention_count=2)
+            bob = await _insert_entity(conn, bank_id, "Bob", mention_count=1)
+            unit_a = await _insert_unit(conn, bank_id, "Alice moved to Berlin.")
+            unit_b = await _insert_unit(conn, bank_id, "Alice plays cello with Bob.")
+            await _link(conn, unit_a, alice)
+            await _link(conn, unit_b, alice)
+            await _link(conn, unit_b, bob)
+
+            async with conn.transaction():
+                await enqueue_entity_prune_candidates(conn, bank_id, [str(unit_a)])
+                await conn.execute("DELETE FROM memory_units WHERE id = $1", unit_a)
+
+            assert await _mention_count(conn, alice) == 1
+            assert await _mention_count(conn, alice) == await _posting_count(conn, alice)
+            assert await _mention_count(conn, bob) == 1
+
+    @pytest.mark.asyncio
+    async def test_one_unit_naming_an_entity_twice_gives_back_both_postings(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """The decrement counts postings, not units: an entity that two of the
+        deleted units named loses two."""
+        bank_id = f"test-mc-multi-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            alice = await _insert_entity(conn, bank_id, "Alice", mention_count=3)
+            unit_a = await _insert_unit(conn, bank_id, "one")
+            unit_b = await _insert_unit(conn, bank_id, "two")
+            unit_c = await _insert_unit(conn, bank_id, "three")
+            for unit in (unit_a, unit_b, unit_c):
+                await _link(conn, unit, alice)
+
+            async with conn.transaction():
+                await enqueue_entity_prune_candidates(conn, bank_id, [str(unit_a), str(unit_b)])
+                await conn.execute("DELETE FROM memory_units WHERE id = ANY($1::uuid[])", [unit_a, unit_b])
+
+            assert await _mention_count(conn, alice) == 1
+
+    @pytest.mark.asyncio
+    async def test_floors_at_zero(self, memory: MemoryEngine, request_context: RequestContext):
+        """A count that is already lower than the postings it is losing — a bank
+        that drifted before this fix, or two spellings in one fact that resolved
+        to one entity — clamps at zero rather than going negative."""
+        bank_id = f"test-mc-floor-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            alice = await _insert_entity(conn, bank_id, "Alice", mention_count=1)
+            unit_a = await _insert_unit(conn, bank_id, "one")
+            unit_b = await _insert_unit(conn, bank_id, "two")
+            await _link(conn, unit_a, alice)
+            await _link(conn, unit_b, alice)
+
+            async with conn.transaction():
+                await enqueue_entity_prune_candidates(conn, bank_id, [str(unit_a), str(unit_b)])
+                await conn.execute("DELETE FROM memory_units WHERE id = ANY($1::uuid[])", [unit_a, unit_b])
+
+            assert await _mention_count(conn, alice) == 0
+
+    @pytest.mark.asyncio
+    async def test_leaves_other_banks_alone(self, memory: MemoryEngine, request_context: RequestContext):
+        """`unit_entities` has no bank column; the release is scoped through
+        `entities.bank_id`, so a same-named entity next door is untouched."""
+        bank_id = f"test-mc-scope-{uuid.uuid4().hex[:8]}"
+        other_bank = f"{bank_id}-other"
+        await _ensure_bank(memory, bank_id, request_context)
+        await _ensure_bank(memory, other_bank, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            alice = await _insert_entity(conn, bank_id, "Alice", mention_count=1)
+            alice_elsewhere = await _insert_entity(conn, other_bank, "Alice", mention_count=1)
+            unit = await _insert_unit(conn, bank_id, "Alice moved to Berlin.")
+            await _link(conn, unit, alice)
+
+            async with conn.transaction():
+                await enqueue_entity_prune_candidates(conn, bank_id, [str(unit)])
+                await conn.execute("DELETE FROM memory_units WHERE id = $1", unit)
+
+            assert await _mention_count(conn, alice) == 0
+            assert await _mention_count(conn, alice_elsewhere) == 1
+
+
+class TestCurationPaths:
+    @pytest.mark.asyncio
+    async def test_invalidate_then_revert_restores_the_mention(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """Invalidation takes the posting, so it takes the mention with it; the
+        revert puts both back. Getting only one of the two halves right is what
+        turns a stale-high counter into a stale-low one."""
+        bank_id = f"test-mc-revert-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            alice = await _insert_entity(conn, bank_id, "Alice", mention_count=2)
+            keeper = await _insert_unit(conn, bank_id, "Alice plays cello.")
+            doomed = await _insert_unit(conn, bank_id, "Alice moved to Berlin.")
+            await _link(conn, keeper, alice)
+            await _link(conn, doomed, alice)
+
+        await memory.update_memory_unit(
+            bank_id, str(doomed), state="invalidated", reason="test", request_context=request_context
+        )
+        async with pool.acquire() as conn:
+            assert await _mention_count(conn, alice) == 1
+
+        await memory.update_memory_unit(bank_id, str(doomed), state="valid", request_context=request_context)
+        async with pool.acquire() as conn:
+            assert await _mention_count(conn, alice) == 2
+            assert await _mention_count(conn, alice) == await _posting_count(conn, alice)
+
+    @pytest.mark.asyncio
+    async def test_revert_skips_an_entity_swept_while_the_memory_was_archived(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """The restore only re-posts entities that still exist, so it may only
+        give some of the mentions back — it must count what it actually posted,
+        not what the archive snapshot named. Alice keeps a second fact so she
+        survives the archive; Berlin does not, and the orphan prune takes her."""
+        bank_id = f"test-mc-swept-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            alice = await _insert_entity(conn, bank_id, "Alice", mention_count=2)
+            berlin = await _insert_entity(conn, bank_id, "Berlin", mention_count=1)
+            keeper = await _insert_unit(conn, bank_id, "Alice plays cello.")
+            unit = await _insert_unit(conn, bank_id, "Alice moved to Berlin.")
+            await _link(conn, keeper, alice)
+            await _link(conn, unit, alice)
+            await _link(conn, unit, berlin)
+
+        await memory.update_memory_unit(
+            bank_id, str(unit), state="invalidated", reason="test", request_context=request_context
+        )
+        async with pool.acquire() as conn:
+            assert await _mention_count(conn, alice) == 1
+            # Berlin lost her only posting, so the drain the invalidation
+            # triggered swept her — the case the restore has to cope with.
+            assert await conn.fetchval("SELECT COUNT(*) FROM entities WHERE id = $1", berlin) == 0
+
+        await memory.update_memory_unit(bank_id, str(unit), state="valid", request_context=request_context)
+        async with pool.acquire() as conn:
+            # Only Alice's mention comes back: Berlin has no row to credit.
+            assert await _mention_count(conn, alice) == 2
+            assert await _mention_count(conn, alice) == await _posting_count(conn, alice)
+
+    @pytest.mark.asyncio
+    async def test_deleting_a_document_gives_back_only_its_own_mentions(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """The path from the issue: two documents name Alice, one goes, Alice's
+        count follows the facts that survive rather than staying where it was."""
+        bank_id = f"test-mc-doc-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            alice = await _insert_entity(conn, bank_id, "Alice", mention_count=2)
+            for doc_id in ("doc-1", "doc-2"):
+                await conn.execute(
+                    """
+                    INSERT INTO documents (id, bank_id, original_text, content_hash)
+                    VALUES ($1, $2, $3, $4)
+                    """,
+                    doc_id,
+                    bank_id,
+                    f"text of {doc_id}",
+                    f"hash-{doc_id}",
+                )
+                unit_id = uuid.uuid4()
+                await conn.execute(
+                    """
+                    INSERT INTO memory_units
+                        (id, bank_id, document_id, text, fact_type, event_date, created_at, updated_at)
+                    VALUES ($1, $2, $3, $4, 'experience', NOW(), NOW(), NOW())
+                    """,
+                    unit_id,
+                    bank_id,
+                    doc_id,
+                    f"Alice appears in {doc_id}.",
+                )
+                await _link(conn, unit_id, alice)
+
+        await memory.delete_document("doc-1", bank_id, request_context=request_context)
+
+        async with pool.acquire() as conn:
+            assert await _mention_count(conn, alice) == 1
+            assert await _mention_count(conn, alice) == await _posting_count(conn, alice)
+
+
+class TestEndToEnd:
+    @pytest.mark.asyncio
+    async def test_replacing_a_document_leaves_every_count_matching_its_postings(
+        self, memory: MemoryEngine, request_context: RequestContext
+    ):
+        """The issue's own reproduction, through the real retain pipeline.
+
+        Two documents name Alice, then one is replaced. The assertion is the
+        invariant rather than a number for Alice: whatever the extractor made of
+        the text, no entity in the bank may claim more mentions than it has
+        surviving facts. Before the fix Alice came out of this at 3 with 2
+        postings, and the gap grew with every rewrite of the document.
+        """
+        bank_id = f"test-mc-e2e-{uuid.uuid4().hex[:8]}"
+        await _ensure_bank(memory, bank_id, request_context)
+
+        await memory.retain_async(
+            bank_id=bank_id, content="Alice moved to Berlin.", document_id="d1", request_context=request_context
+        )
+        await memory.retain_async(
+            bank_id=bank_id, content="Alice plays cello.", document_id="d2", request_context=request_context
+        )
+        await memory.retain_batch_async(
+            bank_id=bank_id,
+            contents=[{"content": "Alice moved to Lisbon.", "document_id": "d1", "update_mode": "replace"}],
+            request_context=request_context,
+        )
+
+        listed = await memory.list_entities(bank_id, request_context=request_context)
+        assert listed["items"], "the retain pipeline should have produced entities to check"
+
+        # The number to compare the listing against is how many facts still mention
+        # each entity, which no read endpoint exposes — `list_entities` returns the
+        # denormalised counter itself, so checking it against itself proves nothing.
+        pool = await memory._get_pool()
+        async with pool.acquire() as conn:
+            postings = {
+                str(r["entity_id"]): r["n"]
+                for r in await conn.fetch(
+                    """
+                    SELECT ue.entity_id, COUNT(*) AS n
+                    FROM unit_entities ue
+                    JOIN memory_units mu ON mu.id = ue.unit_id
+                    WHERE mu.bank_id = $1
+                    GROUP BY ue.entity_id
+                    """,
+                    bank_id,
+                )
+            }
+        inflated = [
+            (e["canonical_name"], e["mention_count"], postings.get(e["id"], 0))
+            for e in listed["items"]
+            if e["mention_count"] != postings.get(e["id"], 0)
+        ]
+        assert not inflated, f"mention_count drifted from the surviving postings: {inflated}"

--- a/hindsight-api-slim/tests/test_entity_mention_count.py
+++ b/hindsight-api-slim/tests/test_entity_mention_count.py
@@ -82,10 +82,11 @@ async def _posting_count(conn, entity_id: uuid.UUID) -> int:
 
 
 @pytest.mark.asyncio
-async def test_oracle_release_subtracts_per_entity_in_stable_id_order():
-    """Oracle adapter: one UPDATE per entity, carrying that entity's posting
-    count, bound in sorted id order — the order the entity upsert and the orphan
-    prune take the same rows, so a delete cannot cycle against a live retain."""
+async def test_oracle_release_reads_the_postings_once_and_queues_before_it_debits():
+    """Oracle adapter: one read of `unit_entities` feeds both writes, the queue
+    MERGE runs before the entity UPDATE (the order the drain takes those locks,
+    so a delete cannot cycle against a worker), and each entity is debited by
+    its own posting count, bound in sorted id order."""
     ops = OracleOps()
     conn = AsyncMock()
     id_a = "00000000-0000-0000-0000-00000000000a"
@@ -96,45 +97,64 @@ async def test_oracle_release_subtracts_per_entity_in_stable_id_order():
         {"entity_id": id_a, "n": 3},
     ]
 
-    updated = await ops.release_entity_mentions(conn, "entities", "unit_entities", "bank-1", ["u1", "u2"])
+    enqueued = await ops.release_entity_postings(
+        conn, "entity_maintenance_queue", "entities", "unit_entities", "bank-1", ["u1", "u2"]
+    )
 
-    assert updated == 2
-    sql, rows = conn.executemany.await_args.args
-    assert "GREATEST(mention_count - $3, 0)" in sql
-    assert rows == [(id_a, "bank-1", 3), (id_b, "bank-1", 1)]
+    assert enqueued == 2
+    assert conn.fetch.await_count == 1, "both halves must come out of one scan of the postings"
+
+    (queue_sql, queue_rows), (debit_sql, debit_rows) = (call.args for call in conn.executemany.await_args_list)
+    assert "MERGE INTO entity_maintenance_queue" in queue_sql
+    assert queue_rows == [("bank-1", id_a), ("bank-1", id_b)]
+    assert "GREATEST(mention_count - $3, 0)" in debit_sql
+    assert debit_rows == [(id_a, "bank-1", 3), (id_b, "bank-1", 1)]
 
 
 @pytest.mark.asyncio
-async def test_oracle_release_of_units_with_no_postings_issues_no_update():
-    """Units that never named an entity cost no round-trip."""
+async def test_oracle_release_of_units_with_no_postings_writes_nothing():
+    """Units that never named an entity cost no write round-trip."""
     ops = OracleOps()
     conn = AsyncMock()
     conn.fetch.return_value = []
 
-    assert await ops.release_entity_mentions(conn, "entities", "unit_entities", "bank-1", ["u1"]) == 0
+    released = await ops.release_entity_postings(
+        conn, "entity_maintenance_queue", "entities", "unit_entities", "bank-1", ["u1"]
+    )
+
+    assert released == 0
     conn.executemany.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_oracle_restore_adds_one_per_entity():
+async def test_oracle_restore_credits_only_the_entities_that_still_exist():
+    """The archive snapshot names entities the orphan prune may since have
+    swept; the surviving set drives both the posting insert and the credit."""
     ops = OracleOps()
     conn = AsyncMock()
     id_a = "00000000-0000-0000-0000-00000000000a"
     id_b = "00000000-0000-0000-0000-00000000000b"
+    gone = "00000000-0000-0000-0000-00000000000c"
+    conn.fetch.return_value = [{"id": id_b}, {"id": id_a}]
 
-    assert await ops.restore_entity_mentions(conn, "entities", "bank-1", [id_b, id_a]) == 2
+    posted = await ops.restore_entity_postings(
+        conn, "unit_entities", "entities", "bank-1", "unit-1", [id_a, id_b, gone]
+    )
 
-    sql, rows = conn.executemany.await_args.args
-    assert "mention_count + 1" in sql
-    assert rows == [(id_a, "bank-1"), (id_b, "bank-1")]
+    assert posted == 2
+    (post_sql, post_rows), (credit_sql, credit_rows) = (call.args for call in conn.executemany.await_args_list)
+    assert "INSERT INTO unit_entities" in post_sql
+    assert post_rows == [("unit-1", id_a), ("unit-1", id_b)]
+    assert "mention_count + 1" in credit_sql
+    assert credit_rows == [(id_a, "bank-1"), (id_b, "bank-1")]
 
 
 @pytest.mark.asyncio
-async def test_oracle_restore_of_nothing_issues_no_update():
+async def test_oracle_restore_of_nothing_writes_nothing():
     ops = OracleOps()
     conn = AsyncMock()
 
-    assert await ops.restore_entity_mentions(conn, "entities", "bank-1", []) == 0
+    assert await ops.restore_entity_postings(conn, "unit_entities", "entities", "bank-1", "unit-1", []) == 0
     conn.executemany.assert_not_awaited()
 
 
@@ -170,6 +190,10 @@ class TestReleaseAtTheChokePoint:
             assert await _mention_count(conn, alice) == 1
             assert await _mention_count(conn, alice) == await _posting_count(conn, alice)
             assert await _mention_count(conn, bob) == 1
+            # The debit and the prune-candidate queueing are one statement, so
+            # the queue is part of this path's contract, not a separate concern.
+            queued = await conn.fetch("SELECT entity_id FROM entity_maintenance_queue WHERE bank_id = $1", bank_id)
+            assert {str(r["entity_id"]) for r in queued} == {str(alice)}
 
     @pytest.mark.asyncio
     async def test_one_unit_naming_an_entity_twice_gives_back_both_postings(


### PR DESCRIPTION
Fixes #4291.

## The bug

`entities.mention_count` was incremented once per mention at retain time and never decremented. The only writer was `flush_pending_stats()`; `grep "mention_count -"` returned nothing. Replacing a document, deleting one, or invalidating a memory left the counter where it was — the drift is proportional to how often the bank's documents get rewritten, and the coding-agents integration re-retains a conversation under the same `document_id` every turn.

That field is not internal bookkeeping: it is returned by `list_entities`, orders that listing (`ORDER BY mention_count DESC`), and sizes/colours the `/graph` nodes, so an inflated entity outranks genuinely well-attested ones.

The issue's own repro, run through the real pipeline before this change:

```
Alice: mention_count=3  postings=2
```

## The fix

Every unlink path — document replace/delete, memory delete, invalidation, an edit that rewrites the entity set — already funnels through `enqueue_entity_prune_candidates`, which runs inside the triggering transaction and *before* the delete fires because that is the only moment the entity ids are still readable. The release goes there rather than being repeated at the six call sites: it subtracts, per entity, the number of `unit_entities` rows about to go, flooring at zero.

Reverting an invalidation re-posts the entities that still exist, so it adds the mention back for exactly those. The two errors used to cancel each other out (no decrement on invalidate, no increment on revert); fixing only the delete side would have turned a stale-high counter into a stale-low one.

Both dialects implement the two new ops. Each takes the `entities` row locks in ascending id order — the order retain's upsert (`ORDER BY id FOR KEY SHARE`) and the orphan prune already take them — so a delete giving mentions back cannot cycle against a concurrent retain asserting them.

### Why not derive it at read time

The issue suggests dropping the denormalised column. That would make `list_entities` aggregate over the bank's entire `unit_entities` just to order one page — the O(bank) query shape that made the entity prune unrunnable on large banks in #3222. The counter stays; it is now maintained on both sides.

### Residual asymmetry, deliberate

The increment counts *mentions* and a posting is per `(unit, entity)`, so the two disagree by one whenever two differently spelled mentions in a single fact resolve to the same entity. That is rare, bounded, and unrelated to update frequency — the floor at zero keeps it from ever driving a count negative.

## Tests

`hindsight-api-slim/tests/test_entity_mention_count.py` — 12 tests. Removing the release call turns 8 of them red, including the end-to-end one, which reproduces the issue's numbers exactly (`('Alice', 3, 2)`).

- SQL shape for the Oracle adapter: per-entity subtraction bound in sorted id order, `GREATEST(..., 0)`, no round-trip when there is nothing to release.
- Against the database: subtracts what each entity actually loses, counts postings rather than units, floors at zero, leaves other banks alone.
- Curation paths: invalidate → revert round-trips the count; a revert whose entity was swept as an orphan while archived credits only what it re-posted.
- End-to-end: two documents naming Alice, one replaced, then the invariant over the whole bank — no entity may claim more mentions than it has surviving facts.

Verified locally on an isolated pg0 database, along with `test_graph_maintenance`, `test_retain_entity_prune_race`, `test_graph_maintenance_deadlock`, `test_memory_curation`, `test_curation_http`, `test_entity_labels`, `test_observation_invalidation`, `test_oracle_backend_integration`, `test_retain`, `test_document_tracking`, `test_document_chunks_and_reprocess` — all green.

## Note

Existing banks stay inflated: this stops the drift, it does not repair it. A recompute of surviving candidates in the entity-prune drain would heal them and is deliberately left out of this PR to keep it minimal.
