### PR TITLE
fix(coding-agents): strip Grok-normalized Hindsight tables before re-install

### DIFF
--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -1298,6 +1298,79 @@ describe("grok-build installer", () => {
     expect(existsSync(join(ctx.home, ".claude"))).toBe(false);
   });
 
+  // Grok rewrites config.toml on `grok mcp add` and from the /mcps modal, dropping comments: the
+  // sentinel markers vanish while the tables survive in Grok's normalized layout. Appending a
+  // fresh block after that leaves two `[mcp_servers.hindsight]` tables, and Grok rejects the whole
+  // file as a duplicate key — every MCP server, ours included, silently disappears.
+  const rewrittenByGrok = (ctx: InstallCtx) =>
+    [
+      "[[hooks.SessionStart]]",
+      "",
+      "[[hooks.SessionStart.hooks]]",
+      'type = "command"',
+      `command = 'node "${join(ctx.dist, "grok-sessionstart-hook.js")}"'`,
+      "timeout = 30",
+      "",
+      "[[hooks.Stop]]",
+      "",
+      "[[hooks.Stop.hooks]]",
+      'type = "command"',
+      "command = 'echo user-owned'",
+      "timeout = 5",
+      "",
+      "[[hooks.Stop.hooks]]",
+      'type = "command"',
+      `command = 'node "${join(ctx.dist, "grok-stop-hook.js")}"'`,
+      "timeout = 60",
+      "",
+      "[mcp_servers.hindsight]",
+      'command = "node"',
+      `args = ["${join(ctx.dist, "mcp-server.js")}"]`,
+      "",
+      "[mcp_servers.hindsight.env]",
+      'HINDSIGHT_MCP_HARNESS = "grok-build"',
+      "",
+      "[mcp_servers.other]",
+      'url = "https://mcp.example/mcp"',
+      "enabled = true",
+      "",
+      "[ui]",
+      'theme = "dark"',
+      "",
+    ].join("\n");
+
+  it("re-install after Grok stripped the markers still yields exactly one hooks + MCP definition", () => {
+    const ctx = makeCtx();
+    mkdirSync(dirname(configPath(ctx)), { recursive: true });
+    writeFileSync(configPath(ctx), rewrittenByGrok(ctx));
+    expect(run(["install", "grok-build"], ctx)).toBe(0);
+    const config = readFileSync(configPath(ctx), "utf8");
+    expect(config.match(/\[mcp_servers\.hindsight\]/g)).toHaveLength(1);
+    expect(config).not.toContain("[mcp_servers.hindsight.env]");
+    expect(config.match(/grok-sessionstart-hook\.js/g)).toHaveLength(1);
+    expect(config.match(/grok-stop-hook\.js/g)).toHaveLength(1);
+    expect(config.match(/\[\[hooks\.SessionStart\]\]/g)).toHaveLength(1);
+    // The user's own Stop hook keeps its enclosing entry; only ours left it.
+    expect(config).toContain("command = 'echo user-owned'");
+    expect(config.match(/\[\[hooks\.Stop\]\]/g)).toHaveLength(2);
+    expect(config).toContain('[mcp_servers.other]\nurl = "https://mcp.example/mcp"');
+    expect(config).toContain('[ui]\ntheme = "dark"');
+  });
+
+  it("uninstall strips the unmarked layout Grok leaves behind", () => {
+    const ctx = makeCtx();
+    mkdirSync(dirname(configPath(ctx)), { recursive: true });
+    writeFileSync(configPath(ctx), rewrittenByGrok(ctx));
+    run(["uninstall", "grok-build"], ctx);
+    const config = readFileSync(configPath(ctx), "utf8");
+    expect(config).not.toContain("mcp_servers.hindsight");
+    expect(config).not.toContain(ctx.dist);
+    expect(config).not.toContain("[[hooks.SessionStart]]");
+    expect(config).toContain("command = 'echo user-owned'");
+    expect(config).toContain("[mcp_servers.other]");
+    expect(config).toContain('[ui]\ntheme = "dark"');
+  });
+
   it("removes only its marked Grok TOML block", () => {
     const ctx = makeCtx();
     mkdirSync(dirname(configPath(ctx)), { recursive: true });

--- a/hindsight-integrations/coding-agents/src/installer.test.ts
+++ b/hindsight-integrations/coding-agents/src/installer.test.ts
@@ -1304,7 +1304,7 @@ describe("grok-build installer", () => {
   // file as a duplicate key — every MCP server, ours included, silently disappears.
   const rewrittenByGrok = (ctx: InstallCtx) =>
     [
-      "[[hooks.SessionStart]]",
+      "[[hooks.SessionStart]] # hindsight",
       "",
       "[[hooks.SessionStart.hooks]]",
       'type = "command"',
@@ -1323,7 +1323,7 @@ describe("grok-build installer", () => {
       `command = 'node "${join(ctx.dist, "grok-stop-hook.js")}"'`,
       "timeout = 60",
       "",
-      "[mcp_servers.hindsight]",
+      "[mcp_servers.hindsight] # managed by hindsight",
       'command = "node"',
       `args = ["${join(ctx.dist, "mcp-server.js")}"]`,
       "",

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -1278,7 +1278,12 @@ export function stripGrokOwned(toml: string): string {
   }
   sections.push(current);
 
-  const tableName = (header: string) => header.replace(/^\[+|\]+$/g, "").trim();
+  // Headers may carry a trailing comment: `[mcp_servers.hindsight] # managed`.
+  const tableName = (header: string) =>
+    header
+      .replace(/\s*#.*$/, "")
+      .replace(/^\[+|\]+$/g, "")
+      .trim();
   const ownsMcp = (header: string) => /^mcp_servers\.hindsight(\.|$)/.test(tableName(header));
   const ownsHook = (section: Section) =>
     /^hooks\.[^.]+\.hooks$/.test(tableName(section.header)) &&
@@ -1292,7 +1297,9 @@ export function stripGrokOwned(toml: string): string {
   const result: Section[] = [];
   for (let index = 0; index < kept.length; index += 1) {
     const section = kept[index];
-    const event = /^\[\[hooks\.([^.\]]+)\]\]$/.exec(section.header)?.[1];
+    const event = section.header.startsWith("[[")
+      ? /^hooks\.([^.]+)$/.exec(tableName(section.header))?.[1]
+      : undefined;
     if (event !== undefined) {
       const hasBody = section.lines
         .slice(1)

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -1284,7 +1284,9 @@ export function stripGrokOwned(toml: string): string {
     /^hooks\.[^.]+\.hooks$/.test(tableName(section.header)) &&
     section.lines.some((line) => /^\s*command\s*=/.test(line) && line.includes(MARKER));
 
-  const kept = sections.filter((section) => section.header === "" || !(ownsMcp(section.header) || ownsHook(section)));
+  const kept = sections.filter(
+    (section) => section.header === "" || !(ownsMcp(section.header) || ownsHook(section))
+  );
   // A `[[hooks.<event>]]` entry whose only content was our hook is now an empty array entry;
   // Grok would surface it as a hook with no commands.
   const result: Section[] = [];
@@ -1292,7 +1294,9 @@ export function stripGrokOwned(toml: string): string {
     const section = kept[index];
     const event = /^\[\[hooks\.([^.\]]+)\]\]$/.exec(section.header)?.[1];
     if (event !== undefined) {
-      const hasBody = section.lines.slice(1).some((line) => line.trim() !== "" && !line.trim().startsWith("#"));
+      const hasBody = section.lines
+        .slice(1)
+        .some((line) => line.trim() !== "" && !line.trim().startsWith("#"));
       const next = kept[index + 1];
       const hasChild = next !== undefined && tableName(next.header) === `hooks.${event}.hooks`;
       if (!hasBody && !hasChild) continue;

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -1251,6 +1251,60 @@ const GROK_MARKER_END = "# HINDSIGHT_CODING_AGENTS_GROK_END";
 /** Our sentinel-delimited block; shared by install (replace) and uninstall (strip). */
 const GROK_BLOCK_RE = new RegExp(`\\n?${GROK_MARKER_START}[\\s\\S]*?${GROK_MARKER_END}\\n?`);
 
+/**
+ * Strip everything Hindsight owns from a Grok config, marked or not.
+ *
+ * Grok rewrites `~/.grok/config.toml` itself (`grok mcp add`, the `/mcps` modal, settings saves)
+ * and that rewrite drops comments, so the sentinel markers vanish while our hook and MCP tables
+ * survive in Grok's normalized layout. Stripping only the marked block then appends a second
+ * `[mcp_servers.hindsight]`, which is a TOML duplicate-key error: Grok logs it on every command
+ * and disables every MCP server in the file. So also drop, section by section, the
+ * `[mcp_servers.hindsight]` table with its subtables, and any `[[hooks.<event>.hooks]]` entry
+ * whose command runs a script from this package (its path contains MARKER); an enclosing
+ * `[[hooks.<event>]]` entry is removed only once nothing else is left in it.
+ */
+export function stripGrokOwned(toml: string): string {
+  const withoutMarked = toml.replace(GROK_BLOCK_RE, "\n");
+  type Section = { header: string; lines: string[] };
+  const sections: Section[] = [];
+  let current: Section = { header: "", lines: [] };
+  for (const line of withoutMarked.split("\n")) {
+    if (/^\s*\[/.test(line)) {
+      sections.push(current);
+      current = { header: line.trim(), lines: [line] };
+    } else {
+      current.lines.push(line);
+    }
+  }
+  sections.push(current);
+
+  const tableName = (header: string) => header.replace(/^\[+|\]+$/g, "").trim();
+  const ownsMcp = (header: string) => /^mcp_servers\.hindsight(\.|$)/.test(tableName(header));
+  const ownsHook = (section: Section) =>
+    /^hooks\.[^.]+\.hooks$/.test(tableName(section.header)) &&
+    section.lines.some((line) => /^\s*command\s*=/.test(line) && line.includes(MARKER));
+
+  const kept = sections.filter((section) => section.header === "" || !(ownsMcp(section.header) || ownsHook(section)));
+  // A `[[hooks.<event>]]` entry whose only content was our hook is now an empty array entry;
+  // Grok would surface it as a hook with no commands.
+  const result: Section[] = [];
+  for (let index = 0; index < kept.length; index += 1) {
+    const section = kept[index];
+    const event = /^\[\[hooks\.([^.\]]+)\]\]$/.exec(section.header)?.[1];
+    if (event !== undefined) {
+      const hasBody = section.lines.slice(1).some((line) => line.trim() !== "" && !line.trim().startsWith("#"));
+      const next = kept[index + 1];
+      const hasChild = next !== undefined && tableName(next.header) === `hooks.${event}.hooks`;
+      if (!hasBody && !hasChild) continue;
+    }
+    result.push(section);
+  }
+  return result
+    .flatMap((section) => section.lines)
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
 const grok: HarnessInstaller = {
   name: "grok-build",
   detect: (c) => onPath("grok") || existsSync(join(c.home, ".grok")),
@@ -1260,7 +1314,7 @@ const grok: HarnessInstaller = {
     // REPLACE any previous block rather than skipping when one exists. Skipping made this
     // install-once-only: after the package moved, a re-install silently left the old (now dead)
     // paths in place, which is exactly the case `install` is meant to repair.
-    const withoutOurs = existing.replace(GROK_BLOCK_RE, "\n");
+    const withoutOurs = stripGrokOwned(existing);
     // Grok executes this shell command verbatim. Quote the absolute script path so a globally
     // installed package still works when its installation directory contains spaces.
     const command = (entry: string) => JSON.stringify(`node "${join(c.dist, entry)}"`);
@@ -1283,7 +1337,7 @@ const grok: HarnessInstaller = {
     const path = join(c.home, ".grok", "config.toml");
     if (existsSync(path)) {
       const existing = readFileSync(path, "utf8");
-      const cleaned = existing.replace(GROK_BLOCK_RE, "\n");
+      const cleaned = stripGrokOwned(existing);
       if (cleaned !== existing) writeFileSync(path, cleaned);
     }
     uninstallSkill(c, "grok-build");


### PR DESCRIPTION
Closes #4295.

Grok rewrites `~/.grok/config.toml` itself (`grok mcp add`, the `/mcps` modal, settings saves) and drops comments. After that the `# HINDSIGHT_CODING_AGENTS_GROK_START/END` markers are gone while the hook and MCP tables survive in Grok's normalized layout (`[mcp_servers.hindsight.env]` as a subtable, hooks flattened). The next `install grok-build` only stripped the marked block and appended a fresh one, leaving two `[mcp_servers.hindsight]` tables:

```
ERROR config toml has syntax errors: TOML parse error at line 66, column 14: duplicate key
```

Grok logs that on every command and reports "No MCP servers configured", so every MCP server in the file, Hindsight included, silently disappears.

- `stripGrokOwned` removes the marked block and then, section by section, the `mcp_servers.hindsight` table with its subtables and any `[[hooks.<event>.hooks]]` entry whose `command` runs a script from this package (path contains `MARKER`). An enclosing `[[hooks.<event>]]` entry is dropped only when nothing else is left in it, so a user's own Stop hook keeps its entry.
- `install` and `uninstall` both go through it, so uninstall also cleans the unmarked layout.
- Tests: re-install on a Grok-rewritten config yields exactly one hooks + MCP definition and keeps foreign servers, user hooks, and `[ui]`; uninstall strips the unmarked layout. Verified the same function against a real Grok-normalized config from a 1.0.25 host and that `grok mcp list` parses the result.