### PR TITLE
fix(reranker): release the MLX buffer cache after each jina-mlx batch

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
+++ b/hindsight-api-slim/hindsight_api/engine/cross_encoder.py
@@ -1453,6 +1453,10 @@ class JinaMLXCrossEncoder(CrossEncoderModel):
         # Device::end_encoding() crash with SIGSEGV (NULL deref).
         # Serialize all reranker inference through this lock.
         self._mlx_lock = threading.Lock()
+        # Picked up by release_local_inference_memory() below, which routes "mlx" to
+        # mx.clear_cache(). Without it MLX holds every freed Metal buffer for the life
+        # of the process.
+        self._device_type = "mlx"
         logger.info("Reranker: jina-mlx provider initialized")
 
     def _predict_sync(self, pairs: list[tuple[str, str]]) -> list[float]:
@@ -1467,13 +1471,18 @@ class JinaMLXCrossEncoder(CrossEncoderModel):
         all_scores = [0.0] * len(pairs)
 
         with self._mlx_lock:
-            for query, indexed_docs in query_groups.items():
-                docs = [doc for _, doc in indexed_docs]
-                indices = [idx for idx, _ in indexed_docs]
-                results = self._reranker.rerank(query, docs)
-                for result in results:
-                    original_idx = result["index"]
-                    all_scores[indices[original_idx]] = result["relevance_score"]
+            try:
+                for query, indexed_docs in query_groups.items():
+                    docs = [doc for _, doc in indexed_docs]
+                    indices = [idx for idx, _ in indexed_docs]
+                    results = self._reranker.rerank(query, docs)
+                    for result in results:
+                        original_idx = result["index"]
+                        all_scores[indices[original_idx]] = result["relevance_score"]
+            finally:
+                # Inside the lock: MLX Metal ops are not thread-safe, which is why
+                # #1113 introduced _mlx_lock in the first place.
+                release_local_inference_memory(self._device_type)
 
         return all_scores
 

--- a/hindsight-api-slim/hindsight_api/engine/local_device.py
+++ b/hindsight-api-slim/hindsight_api/engine/local_device.py
@@ -172,6 +172,19 @@ def _empty_gpu_cache(device_type: str | None) -> None:
     """Empty the allocator pool of the GPU backend the model ran on, if any."""
     if not device_type or device_type == "cpu":
         return
+    if device_type == "mlx":
+        # MLX keeps freed Metal buffers in its own cache and only returns them to
+        # the OS once the cache limit is exceeded. That limit defaults to the device
+        # memory limit — 121.60 GB measured on a 128 GB M-series host — so without
+        # this the cache is effectively unbounded. torch has no "mlx" attribute, so
+        # the lookup below would silently free nothing.
+        try:
+            import mlx.core as mx
+
+            mx.clear_cache()
+        except Exception:  # pragma: no cover - defensive
+            pass
+        return
     try:
         import torch
 
@@ -189,10 +202,14 @@ def release_local_inference_memory(device_type: str | None = None) -> None:
     the model ran on a GPU. Python's normal reference counting already releases
     the short-lived CPU inference buffers; a full cyclic-GC scan on every batch is
     needlessly expensive on that hot path, so CPU callers leave cyclic GC to its
-    normal threshold-based schedule. GPU callers retain the existing full cleanup
+    normal threshold-based schedule. MLX callers skip it for the same reason: MLX
+    arrays are refcounted too. Torch GPU callers retain the existing full cleanup
     because allocator release is part of the opt-in accelerator memory policy.
     """
-    if device_type != "cpu":
+    # "mlx" is exempt for the same reason "cpu" is: MLX arrays are refcounted C++
+    # objects behind Python wrappers, so reference counting already releases them and
+    # a process-wide cycle scan on every batch does not release anything extra.
+    if device_type not in ("cpu", "mlx"):
         gc.collect()
     _heap_trim()
     _empty_gpu_cache(device_type)

--- a/hindsight-api-slim/tests/test_jina_mlx_release.py
+++ b/hindsight-api-slim/tests/test_jina_mlx_release.py
@@ -1,0 +1,104 @@
+"""
+Regression test for the JinaMLXCrossEncoder post-batch memory release.
+
+`JinaMLXCrossEncoder._predict_sync` did not call `release_local_inference_memory`,
+so MLX kept every freed Metal buffer in its own cache. That cache is bounded by
+`mx.set_cache_limit`, which defaults to the device memory limit (121.60 GB measured
+on a 128 GB Mac), so it grew for the life of the process — 42.7 GB of IOAccelerator
+memory after 486 rerank calls on a laptop.
+
+The other two in-process rerankers already release: LocalSTCrossEncoder and
+FlashRankCrossEncoder both call the shared helper in a `finally`.
+
+These tests verify:
+1. Loading the model marks the provider as an mlx device.
+2. A successful batch releases, and passes the provider's own device type.
+3. A batch that raises still releases.
+4. An empty batch does not release — nothing was allocated.
+"""
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+from hindsight_api.engine.cross_encoder import JinaMLXCrossEncoder
+
+
+class _NullLock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _encoder_with_fake_reranker(*, raises=False):
+    """Build a JinaMLXCrossEncoder wired to a stub reranker, skipping model load."""
+    enc = JinaMLXCrossEncoder.__new__(JinaMLXCrossEncoder)
+    enc._device_type = "mlx"
+    enc._mlx_lock = _NullLock()
+
+    def rerank(query, docs):
+        if raises:
+            raise RuntimeError("Metal command buffer failed")
+        return [{"index": i, "relevance_score": 1.0 - i * 0.1} for i in range(len(docs))]
+
+    enc._reranker = types.SimpleNamespace(rerank=rerank)
+    return enc
+
+
+PAIRS = [("q", "first document"), ("q", "second document")]
+
+
+def test_successful_batch_releases_with_the_mlx_device_type():
+    calls = []
+    enc = _encoder_with_fake_reranker()
+    with patch(
+        "hindsight_api.engine.cross_encoder.release_local_inference_memory",
+        lambda device_type=None: calls.append(device_type),
+    ):
+        scores = enc._predict_sync(PAIRS)
+
+    assert len(scores) == len(PAIRS)
+    assert calls == ["mlx"]
+
+
+def test_release_runs_even_when_scoring_raises():
+    calls = []
+    enc = _encoder_with_fake_reranker(raises=True)
+    with patch(
+        "hindsight_api.engine.cross_encoder.release_local_inference_memory",
+        lambda device_type=None: calls.append(device_type),
+    ):
+        with pytest.raises(RuntimeError):
+            enc._predict_sync(PAIRS)
+
+    assert calls == ["mlx"]
+
+
+def test_empty_batch_does_not_release():
+    calls = []
+    enc = _encoder_with_fake_reranker()
+    with patch(
+        "hindsight_api.engine.cross_encoder.release_local_inference_memory",
+        lambda device_type=None: calls.append(device_type),
+    ):
+        assert enc._predict_sync([]) == []
+
+    assert calls == []
+
+
+def test_load_model_marks_the_provider_as_mlx():
+    """Without this the release call reaches _empty_gpu_cache with the wrong device type,
+    which falls through to the torch lookup and frees nothing."""
+    enc = JinaMLXCrossEncoder.__new__(JinaMLXCrossEncoder)
+    enc.model_path = "/tmp/does-not-matter"
+
+    with patch(
+        "hindsight_api.engine.jina_mlx_reranker.MLXReranker",
+        lambda **kwargs: object(),
+    ):
+        enc._load_model()
+
+    assert enc._device_type == "mlx"

--- a/hindsight-api-slim/tests/test_local_device.py
+++ b/hindsight-api-slim/tests/test_local_device.py
@@ -43,6 +43,22 @@ def _fake_torch(*, cuda=False, mps=False, xpu=False, has_xpu=None, empty_cache_l
     return torch
 
 
+def _fake_mlx(*, clear_cache_log=None, raises=False):
+    """Build a stand-in ``mlx.core`` module exposing just what local_device touches."""
+
+    def clear_cache():
+        if raises:
+            raise RuntimeError("Metal device unavailable")
+        if clear_cache_log is not None:
+            clear_cache_log.append("mlx")
+
+    core = types.ModuleType("mlx.core")
+    core.clear_cache = clear_cache
+    mlx = types.ModuleType("mlx")
+    mlx.core = core
+    return mlx, core
+
+
 class TestSelectLocalDevice:
     def test_force_cpu_short_circuits(self):
         # force_cpu wins even if a GPU is present — no torch import needed.
@@ -147,6 +163,31 @@ class TestEmptyGpuCache:
         with patch.dict(sys.modules, {"torch": _fake_torch()}):
             _empty_gpu_cache("rocm")  # torch has no .rocm — must not raise
 
+    def test_mlx_clears_its_own_cache(self):
+        log = []
+        mlx, core = _fake_mlx(clear_cache_log=log)
+        with patch.dict(sys.modules, {"mlx": mlx, "mlx.core": core, "torch": _fake_torch()}):
+            _empty_gpu_cache("mlx")
+        assert log == ["mlx"]
+
+    def test_mlx_does_not_reach_torch(self):
+        """The mlx branch must return before the torch lookup: getattr(torch, "mlx") is None,
+        so falling through would free nothing and report no error."""
+        torch_log = []
+        mlx, core = _fake_mlx()
+        with patch.dict(sys.modules, {"mlx": mlx, "mlx.core": core, "torch": _fake_torch(empty_cache_log=torch_log)}):
+            _empty_gpu_cache("mlx")
+        assert torch_log == []
+
+    def test_mlx_absent_is_safe(self):
+        with patch.dict(sys.modules, {"mlx": None, "mlx.core": None, "torch": _fake_torch()}):
+            _empty_gpu_cache("mlx")  # import fails — must not raise
+
+    def test_mlx_clear_cache_raising_is_swallowed(self):
+        mlx, core = _fake_mlx(raises=True)
+        with patch.dict(sys.modules, {"mlx": mlx, "mlx.core": core, "torch": _fake_torch()}):
+            _empty_gpu_cache("mlx")  # must not propagate
+
 
 class TestReleaseLocalInferenceMemory:
     def test_release_runs_all_steps_for_gpu(self):
@@ -172,3 +213,18 @@ class TestReleaseLocalInferenceMemory:
             release_local_inference_memory("cpu")
         assert calls == ["trim"]
         assert log == []
+
+    def test_release_mlx_skips_gc_but_clears_the_mlx_cache(self):
+        """MLX arrays are refcounted, so the CPU exemption from #3858 applies here too:
+        skip the process-wide cycle scan, still trim the heap and clear the MLX cache."""
+        calls = []
+        mlx_log = []
+        mlx, core = _fake_mlx(clear_cache_log=mlx_log)
+        with (
+            patch.dict(sys.modules, {"mlx": mlx, "mlx.core": core, "torch": _fake_torch()}),
+            patch.object(local_device.gc, "collect", lambda: calls.append("gc")),
+            patch.object(local_device, "_heap_trim", lambda: calls.append("trim")),
+        ):
+            release_local_inference_memory("mlx")
+        assert calls == ["trim"]
+        assert mlx_log == ["mlx"]


### PR DESCRIPTION
`JinaMLXCrossEncoder` does not release its inference memory after a batch. The other two in-process rerankers do: `LocalSTCrossEncoder` (`cross_encoder.py:333`) and `FlashRankCrossEncoder` (`cross_encoder.py:1106`) both call `release_local_inference_memory` in a `finally`.

MLX keeps freed Metal buffers in its own cache and only releases them once the cache limit is exceeded. That limit defaults to the device memory limit — measured at **121.60 GB on a 128 GB Mac** — so in practice it never releases anything. On a laptop running `jina-mlx` as the reranker, `IOAccelerator` memory reached **42.7 GB after 486 rerank calls**, about 90 MB per call. Only 3.9 GB of that was still in use. macOS cannot drop the rest, because the GPU driver marks those regions non-discardable, so it compresses them instead: system-wide compressed memory sat at 41.67 GB at a compression ratio of 1.21:1. After the process was restarted with the cache bounded, the same ratio came back to 2.44:1.

Adding the missing call alone would not have fixed it. `_empty_gpu_cache` (`local_device.py:171`) looks the backend up with `getattr(torch, device_type, None)`, and torch has no `mlx` attribute, so it returns having freed nothing — no error, no log. Any future non-torch backend has the same gap.

## The change

- `_empty_gpu_cache` gets an `mlx` branch that calls `mx.clear_cache()` and returns before the torch lookup.
- `JinaMLXCrossEncoder` sets `self._device_type = "mlx"` and wraps its scoring loop in `try/finally`, the same shape the other two use. The release runs inside `self._mlx_lock`, since MLX Metal ops are not thread safe — that is why #1113 added the lock.
- The `gc.collect()` gate from #3858 now skips `mlx` as well as `cpu`. MLX arrays are refcounted C++ objects behind Python wrappers, the same reason that gate was written for CPU, so a full cycle scan on every batch does not release anything extra.

I could not measure the cost of that last one. Running the same no-release baseline three times over the batch gave 1125.7 / 1223.0 / 1182.3 ms — a 97 ms spread. The difference I was trying to see, between calling the helper with `"mlx"` and with `"cpu"`, was 40 ms. A live instance was sharing the GPU on that machine, so a clean number would need the service stopped. This part follows #3858's reasoning rather than a measurement.

## Why clear instead of cap

Capping the cache with `mx.set_cache_limit()` also works, and is what I run locally. But a cap needs a number, and a number that fits one machine's workload does not fit another's. Clearing after each batch needs no configuration, and matches what the other two providers already do. Clearing measured 1209.4 ms against a 1182.3 ms baseline on the run above — 27 ms, inside the same 97 ms spread, so I would not read it as a cost.

## Tests

`tests/test_local_device.py` — four cases in `TestEmptyGpuCache`, one in
`TestReleaseLocalInferenceMemory`, using a `_fake_mlx()` stub built the same way as the
existing `_fake_torch()`:

- `_empty_gpu_cache("mlx")` calls `mx.clear_cache()` once
- the `mlx` branch returns before the torch lookup, so `torch.*.empty_cache` is never reached
- with `mlx.core` unimportable, nothing raises
- a `clear_cache()` that raises does not propagate
- `release_local_inference_memory("mlx")` trims the heap and clears the MLX cache, and skips `gc.collect()`

`tests/test_jina_mlx_release.py` — four cases on the provider:

- `_load_model()` sets `_device_type` to `"mlx"`
- a successful batch releases, and passes `"mlx"` as the device type
- a batch that raises still releases
- an empty batch does not release, since nothing was allocated

```
tests/test_local_device.py ............................ 27 passed
tests/test_jina_mlx_release.py ......................... 4 passed
+ test_jina_mlx_import_error.py, test_local_cross_encoder.py
                                                  54 passed in 5.4s
```

Each change reverted one at a time, to check the tests actually catch it:

```
drop the finally in _predict_sync            2 failed
drop self._device_type = "mlx"               1 failed
drop the mlx branch in _empty_gpu_cache      2 failed
restore the gc gate to `!= "cpu"`            1 failed
```

`ruff check`, `ruff format --check` and `ty check hindsight_api` pass.

Happy to change any of this, including dropping the `gc` gate change if you would rather keep it separate.
