### PR TITLE
fix(recall): a store-owned bank's attachment lookup does not read memory_units

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -6678,6 +6678,16 @@ class MemoryEngine(MemoryEngineInterface):
 
         if not unit_ids:
             return {}
+        # A store-owned bank keeps its memories outside SQL, so `memory_units` holds none of
+        # them and this read can only come back empty. It is not a cheap empty read either:
+        # the table carries partial vector indexes per bank, and the planner opens and locks
+        # every one of them to plan any statement against it. In a tenant with a few thousand
+        # banks that is ~15k locks and ~450ms of planning to return nothing -- on every recall,
+        # which is where this is called from.
+        from .memories import get_memories
+
+        if get_memories().store_owned_for(bank_id):
+            return {}
         profile = await self.get_bank_profile(bank_id, request_context=request_context, create_if_missing=False)
         if profile is None:
             return {}

--- a/hindsight-api-slim/tests/test_attachments_store_owned.py
+++ b/hindsight-api-slim/tests/test_attachments_store_owned.py
@@ -1,0 +1,56 @@
+"""A store-owned bank's attachment lookup must not touch Postgres.
+
+Recall resolves the attachments behind each fact through ``attachments_for_memories``, which
+reads ``memory_units.attachment_ids``. For a bank whose memories store owns its rows, that table
+holds none of them, so the read can only come back empty -- and it is not a cheap empty read. The
+table carries partial vector indexes per bank, and the planner opens and locks every index on a
+table to plan any statement against it: in a tenant with a few thousand banks, ~15k locks and
+hundreds of milliseconds of planning, on every recall.
+
+So the property asserted is that the lookup returns before it asks for the bank profile or a
+connection, not merely that it returns ``{}``: an empty result is what the expensive read
+produced too.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import hindsight_api.engine.memories as memories_module
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+
+class _NoPostgres:
+    """Stands in for the engine: any attempt to reach Postgres fails the test."""
+
+    async def get_bank_profile(self, *a, **k):
+        raise AssertionError("a store-owned bank's attachment lookup read the bank profile")
+
+    async def _get_backend(self):
+        raise AssertionError("a store-owned bank's attachment lookup took a connection")
+
+
+def _memories(store_owned: bool):
+    return SimpleNamespace(store_owned_for=lambda bank_id: store_owned)
+
+
+@pytest.mark.asyncio
+async def test_a_store_owned_bank_resolves_no_attachments_without_touching_postgres(monkeypatch):
+    monkeypatch.setattr(memories_module, "get_memories", lambda: _memories(store_owned=True))
+
+    result = await MemoryEngine.attachments_for_memories(
+        _NoPostgres(), "bank-1", ["00000000-0000-0000-0000-000000000001"], request_context=None
+    )
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_a_bank_whose_rows_live_in_sql_still_reads_them(monkeypatch):
+    """The guard must not swallow the Postgres-backed case: there the read is the feature."""
+    monkeypatch.setattr(memories_module, "get_memories", lambda: _memories(store_owned=False))
+
+    with pytest.raises(AssertionError, match="read the bank profile"):
+        await MemoryEngine.attachments_for_memories(
+            _NoPostgres(), "bank-1", ["00000000-0000-0000-0000-000000000001"], request_context=None
+        )


### PR DESCRIPTION
Follow-up to #4277. Recall now resolves the attachments behind each fact through `attachments_for_memories`, which reads `memory_units.attachment_ids` — on **every** recall, unconditionally.

## The problem

For a bank whose memories store owns its rows, `memory_units` holds none of them, so the read always returns nothing. It is also **not** the cheap empty read #4277 assumed.

`memory_units` carries partial vector indexes per bank (`idx_mu_emb_{expr,worl,obsv}_<bank>`), and Postgres opens and locks **every** index on a table to plan any statement against it. Measured on a tenant with 5,286 banks:

| | indexes on `memory_units` | planning | execution | locks |
| --- | ---: | ---: | ---: | ---: |
| 5,286-bank tenant | 15,877 | 434–484 ms | 0.04 ms | 15,880 (15,863 slow-path) |
| few-bank tenant | 19 | ~2 ms | 0.02 ms | 22 |

Only 16 locks fit the fast path, so concurrent planners queue on `LWLock:LockManager` and slow the **whole** database, not just the caller.

| same API image, 2 vCPU, same load | throughput | p99 |
| --- | ---: | ---: |
| with the lookup on every recall | ~13 rps (flat at any offered rate) | 16–20 s |
| lookup skipped | **180 rps** | **406 ms** |

Readiness checks on API pods receiving none of the load slowed from ~6 ms to ~870 ms while it ran.

## The fix

One guard, using the same `get_memories().store_owned_for(bank_id)` check as the other store-owned paths. Store-owned banks report no attachments on recall until the store can carry the ids itself; Postgres-backed banks are unchanged.

## Tests

`test_attachments_store_owned.py` asserts the lookup returns **before** it reads the bank profile or takes a connection — not merely that it returns `{}`, since the expensive read returned `{}` too — and that the Postgres-backed path still performs the read. Existing `test_attachment_read_surfaces.py` passes unchanged. ruff check and format clean.

## Not addressed here

Any other `memory_units` query on a hot path pays the same per-bank planning cost in a many-bank tenant. That is the index-per-bank design, and worth its own look.