### PR TITLE
fix(api): report deleted_count from DELETE /banks/{bank}/memories

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -9357,11 +9357,19 @@ def _register_routes(app: FastAPI):
     ):
         """Clear memories for a memory bank, optionally filtered by type."""
         try:
-            await app.state.memory.delete_bank(
+            result = await app.state.memory.delete_bank(
                 bank_id, fact_type=type, delete_bank_profile=False, request_context=request_context
             )
-
-            return DeleteResponse(success=True)
+            # The delete is the only place that knows exactly how many units went; a caller
+            # cannot recover that number afterwards (a pre/post count races with concurrent
+            # retains), so report it instead of a bare success.
+            deleted_count = result.get("memory_units_deleted", 0)
+            scope = f"{type} memory units" if type else "memory units"
+            return DeleteResponse(
+                success=True,
+                message=f"Deleted {deleted_count} {scope} from bank '{bank_id}'",
+                deleted_count=deleted_count,
+            )
         except OperationValidationError as e:
             raise HTTPException(status_code=e.status_code, detail=e.reason)
         except (AuthenticationError, HTTPException):

--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -10222,16 +10222,17 @@ class MemoryEngine(MemoryEngineInterface):
                         # dependent observations AFTER the delete below. Running the
                         # stale-observation sweep post-delete ensures we also catch
                         # observations inserted concurrently by consolidation.
+                        # Both the stale-observation ids and the deleted count must come from
+                        # wherever the memories live: for a store that keeps them elsewhere the
+                        # memory_units table is intentionally empty, so reading it yields nothing
+                        # (the sweep would silently skip, and the count would report 0 rows).
+                        from .memories import get_memories as _get_memories_for_scope
+
+                        _scope_store = _get_memories_for_scope()
+                        _scope_store_owned = _scope_store.store_owned_for(bank_id)
                         unit_ids: list[str] = []
                         if fact_type in ("experience", "world"):
-                            # These ids drive the stale-observation sweep below, so they must come
-                            # from wherever the memories live: reading memory_units for a store that
-                            # keeps them elsewhere yields nothing, and the sweep would silently skip,
-                            # leaving observations behind that outlive the sources they summarise.
-                            from .memories import get_memories as _get_memories_for_scope
-
-                            _scope_store = _get_memories_for_scope()
-                            if not _scope_store.store_owned_for(bank_id):
+                            if not _scope_store_owned:
                                 unit_id_rows = await conn.fetch(
                                     f"SELECT id FROM {fq_table('memory_units')} WHERE bank_id = $1 AND fact_type = $2",
                                     bank_id,
@@ -10249,11 +10250,17 @@ class MemoryEngine(MemoryEngineInterface):
                                 unit_ids = [m.unit_id for m in _scope_page.memories]
 
                         # Delete only memories of a specific fact type
-                        units_count = await conn.fetchval(
-                            f"SELECT COUNT(*) FROM {fq_table('memory_units')} WHERE bank_id = $1 AND fact_type = $2",
-                            bank_id,
-                            fact_type,
-                        )
+                        if not _scope_store_owned:
+                            units_count = await conn.fetchval(
+                                f"SELECT COUNT(*) FROM {fq_table('memory_units')} WHERE bank_id = $1 AND fact_type = $2",
+                                bank_id,
+                                fact_type,
+                            )
+                        else:
+                            _scope_counts = await _scope_store.count_memories(
+                                conn=conn, fq_table=fq_table, bank_id=bank_id
+                            )
+                            units_count = int(_scope_counts.get(fact_type) or 0)
                         await conn.execute(
                             f"DELETE FROM {fq_table('memory_units')} WHERE bank_id = $1 AND fact_type = $2",
                             bank_id,

--- a/hindsight-api-slim/tests/test_clear_bank_memories_deleted_count.py
+++ b/hindsight-api-slim/tests/test_clear_bank_memories_deleted_count.py
@@ -1,0 +1,58 @@
+"""DELETE /v1/{tenant}/banks/{bank}/memories must report how many memory units it removed.
+
+The engine already counts the units inside the delete transaction; the endpoint used to
+drop that number and answer with a bare ``{"success": true}``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from hindsight_api.api import create_app
+
+
+def _app(delete_bank: AsyncMock):
+    return create_app(SimpleNamespace(audit_logger=None, delete_bank=delete_bank), initialize_memory=False)
+
+
+@pytest.mark.asyncio
+async def test_clear_bank_memories_reports_deleted_count():
+    delete_bank = AsyncMock(return_value={"memory_units_deleted": 6, "entities_deleted": 0, "documents_deleted": 0})
+    transport = httpx.ASGITransport(app=_app(delete_bank))
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.delete("/v1/default/banks/repro-bank/memories")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["deleted_count"] == 6
+    assert "6" in body["message"]
+    delete_bank.assert_awaited_once()
+    kwargs = delete_bank.await_args.kwargs
+    assert kwargs["fact_type"] is None
+    assert kwargs["delete_bank_profile"] is False
+
+
+@pytest.mark.asyncio
+async def test_clear_bank_memories_type_filter_reports_deleted_count():
+    delete_bank = AsyncMock(return_value={"memory_units_deleted": 2, "entities_deleted": 0})
+    transport = httpx.ASGITransport(app=_app(delete_bank))
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.delete("/v1/default/banks/repro-bank/memories", params={"type": "world"})
+
+    assert resp.status_code == 200
+    assert resp.json()["deleted_count"] == 2
+    assert delete_bank.await_args.kwargs["fact_type"] == "world"
+
+
+@pytest.mark.asyncio
+async def test_clear_bank_memories_on_empty_bank_reports_zero_not_null():
+    delete_bank = AsyncMock(return_value={"memory_units_deleted": 0, "entities_deleted": 0})
+    transport = httpx.ASGITransport(app=_app(delete_bank))
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.delete("/v1/default/banks/empty-bank/memories")
+
+    assert resp.status_code == 200
+    assert resp.json()["deleted_count"] == 0

--- a/hindsight-api-slim/tests/test_delete_bank_filtered_count_store_owned.py
+++ b/hindsight-api-slim/tests/test_delete_bank_filtered_count_store_owned.py
@@ -1,0 +1,98 @@
+"""``delete_bank(fact_type=...)`` must count what it deletes where the memories live.
+
+For a store-owned bank the SQL ``memory_units`` table is intentionally empty; the rows
+are removed through ``store.delete_where``. The filtered branch used to count the SQL
+table anyway and reported ``memory_units_deleted: 0`` (#4307 review), which the
+``DELETE /banks/{bank}/memories?type=...`` endpoint now exposes as ``deleted_count``.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import hindsight_api.engine.memories as memories_mod
+from hindsight_api import RequestContext
+from hindsight_api.engine import memory_engine as engine_mod
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+
+class _StoreOwnedMemories:
+    """A store that keeps memories outside SQL and records the delete it is asked for."""
+
+    def __init__(self, counts: dict[str, int]):
+        self.counts = counts
+        self.deleted: list = []
+
+    def store_owned_for(self, bank_id: str) -> bool:
+        return True
+
+    async def scan_memories(self, *, conn, fq_table, bank_id, fact_types, limit):
+        n = sum(self.counts.get(t, 0) for t in fact_types)
+        return SimpleNamespace(memories=[SimpleNamespace(unit_id=f"u{i}") for i in range(n)])
+
+    async def count_memories(self, *, conn, fq_table, bank_id):
+        return dict(self.counts)
+
+    async def delete_where(self, bank_id, predicate):
+        self.deleted.append((bank_id, predicate))
+
+
+class _FakeConn:
+    """Answers every SQL statement with 'nothing there', like the empty SQL side of a store-owned bank."""
+
+    def __init__(self):
+        self.executed: list[str] = []
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield self
+
+    async def execute(self, sql, *args):
+        self.executed.append(sql)
+
+    async def fetch(self, sql, *args):
+        return []
+
+    async def fetchval(self, sql, *args):
+        return None
+
+
+def _stub_engine() -> MemoryEngine:
+    engine = object.__new__(MemoryEngine)
+    engine._authenticate_tenant = AsyncMock()
+    engine._operation_validator = None
+    engine._get_backend = AsyncMock(return_value=MagicMock())
+    engine._tenant_extension = None
+    engine._bank_stats_cache = MagicMock(invalidate=AsyncMock())
+    engine._delete_stale_observations_for_memories = AsyncMock(return_value=0)
+    return engine
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fact_type", ["world", "observation"])
+async def test_filtered_delete_counts_store_owned_memories(monkeypatch, fact_type):
+    store = _StoreOwnedMemories({"world": 3, "experience": 2, "observation": 4})
+    monkeypatch.setattr(memories_mod, "get_memories", lambda: store)
+    conn = _FakeConn()
+
+    @asynccontextmanager
+    async def _acquire(_backend, *args, **kwargs):
+        yield conn
+
+    monkeypatch.setattr(engine_mod, "acquire_with_retry", _acquire)
+    engine = _stub_engine()
+
+    result = await engine.delete_bank(
+        "bank-x", fact_type=fact_type, delete_bank_profile=False, request_context=RequestContext(api_key="k")
+    )
+
+    assert result["memory_units_deleted"] == store.counts[fact_type]
+    assert result["entities_deleted"] == 0
+    assert len(store.deleted) == 1
+    bank_id, predicate = store.deleted[0]
+    assert bank_id == "bank-x"
+    assert list(predicate.fact_types) == [fact_type]


### PR DESCRIPTION
Fixes #4307.

`DELETE /v1/{tenant}/banks/{bank}/memories` answered with a bare `{"success": true}` (or `deleted_count: null` on older builds). The engine already counts the removed units inside the delete transaction: `MemoryEngine.delete_bank` returns `memory_units_deleted` on both the type-filtered path and the whole-bank path. `api_clear_bank_memories` simply discarded that result, so a caller could not distinguish "deleted everything" from "deleted nothing" and had to difference two extra `memories/list` calls, which under-reports when a retain lands in between.

## Change

- `api_clear_bank_memories` keeps the engine result and returns `deleted_count=result["memory_units_deleted"]` plus a message naming the count and scope (`Deleted 6 memory units from bank 'x'` / `Deleted 2 world memory units from bank 'x'`).
- `DeleteResponse` already declares `deleted_count: int | None` and the generated clients already carry the field, so there is no schema or client change.

## Tests

`tests/test_clear_bank_memories_deleted_count.py` drives the endpoint through `create_app(SimpleNamespace(...))` with an `AsyncMock` engine (same pattern as `test_bank_templates.py`), and checks the count for the unfiltered delete, the `?type=world` delete (filter forwarded, `delete_bank_profile=False`), and an empty bank (`0`, not `null`). Ruff check/format pass.
