### PR TITLE
fix(codex): safely adopt externally rotated credentials from read-only stores

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/providers/codex_auth.py
+++ b/hindsight-api-slim/hindsight_api/engine/providers/codex_auth.py
@@ -20,17 +20,20 @@ from __future__ import annotations
 import base64
 import binascii
 import contextlib
+import errno
 import json
 import logging
 import os
 import tempfile
 import threading
 import time
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import httpx
+from pydantic import BaseModel, Field, ValidationError
 
 try:
     import fcntl
@@ -104,31 +107,54 @@ def _path_scoped_lock(auth_file: Path) -> threading.Lock:
 
 
 @contextlib.contextmanager
-def _codex_auth_lock(auth_file: Path, timeout_seconds: float = _CODEX_AUTH_LOCK_TIMEOUT_SECONDS):
-    """Cross-process advisory lock for one Codex auth store."""
+def _codex_auth_lock(auth_file: Path, timeout_seconds: float = _CODEX_AUTH_LOCK_TIMEOUT_SECONDS) -> Iterator[bool]:
+    """Yield whether refresh may proceed; False permits only external-token adoption."""
     with _path_scoped_lock(auth_file):
         if fcntl is None:  # pragma: no cover - Windows
             logger.debug("fcntl unavailable; Codex refresh proceeds without a cross-process lock.")
-            yield
+            yield True
             return
 
         lock_path = auth_file.with_suffix(".lock")
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(lock_path, "a+") as lock_file:
+        try:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            lock_file = open(lock_path, "a+")
+        except OSError as exc:
+            if exc.errno not in (errno.EROFS, errno.EACCES):
+                raise
+            # A read-only consumer can still have an external credential writer.
+            # Never rotate its refresh token without the shared lock/persistence.
+            yield False
+            return
+
+        with lock_file:
             deadline = time.monotonic() + max(1.0, timeout_seconds)
             while True:
                 try:
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                     break
-                except (BlockingIOError, OSError):
+                except OSError as exc:
+                    if exc.errno not in (errno.EAGAIN, errno.EACCES):
+                        raise
                     if time.monotonic() >= deadline:
                         raise TimeoutError("Timed out waiting for the Codex auth store lock") from None
                     time.sleep(0.05)
             try:
-                yield
+                yield True
             finally:
                 with contextlib.suppress(OSError):
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+class _ExternalCodexTokens(BaseModel):
+    access_token: str = Field(min_length=1)
+    refresh_token: str | None = None
+    account_id: str | None = None
+
+
+class _ExternalCodexAuth(BaseModel):
+    auth_mode: Literal["chatgpt"]
+    tokens: _ExternalCodexTokens
 
 
 class CodexRefreshExpiredError(RuntimeError):
@@ -395,6 +421,39 @@ class CodexAuthManager:
     # Refresh
     # ------------------------------------------------------------------
 
+    def _adopt_external_tokens(self) -> None:
+        """Read one snapshot without writing or attempting an unlocked OAuth refresh."""
+        message = (
+            "Codex auth store lock is unavailable: an external writer must atomically publish "
+            "a different access_token with a known expiry beyond the refresh window. "
+            "OAuth refresh is disabled while the lock file cannot be created."
+        )
+        try:
+            with open(self._auth_file) as auth_file:
+                tokens = _ExternalCodexAuth.model_validate_json(auth_file.read(), strict=True).tokens
+        except (ValidationError, UnicodeError):
+            # Validation errors can include credentials; do not chain or log them.
+            raise RuntimeError(message) from None
+
+        try:
+            exp = self._decode_jwt_exp_unixtime(tokens.access_token)
+        except (AttributeError, OverflowError):
+            # The shared decoder assumes an object payload and a finite exp.
+            raise RuntimeError(message) from None
+        if (
+            tokens.access_token == self.access_token
+            or exp is None
+            or exp <= int(time.time()) + _CODEX_TOKEN_REFRESH_SKEW_SECONDS
+        ):
+            raise RuntimeError(message)
+
+        # Validate before mutating: a refresh-token-only change cannot recover a 401.
+        self.access_token = tokens.access_token
+        if tokens.refresh_token:
+            self.refresh_token = tokens.refresh_token
+        if tokens.account_id:
+            self.account_id = tokens.account_id
+
     def refresh_tokens(self, reason: str = "", *, force: bool = False) -> None:
         """Synchronous single-flight OAuth token refresh.
 
@@ -427,7 +486,11 @@ class CodexAuthManager:
                 if not self._token_is_stale():
                     return
 
-            with _codex_auth_lock(self._auth_file):
+            with _codex_auth_lock(self._auth_file) as refresh_allowed:
+                if not refresh_allowed:
+                    self._adopt_external_tokens()
+                    return
+
                 disk_tokens = self._load_tokens_from_file(self._auth_file)
                 if disk_tokens and self._adopt_tokens(disk_tokens):
                     # Only skip the network refresh when the adopted token is

--- a/hindsight-api-slim/tests/test_codex_readonly_auth_store.py
+++ b/hindsight-api-slim/tests/test_codex_readonly_auth_store.py
@@ -1,0 +1,265 @@
+"""Read-only consumers adopt external credentials, never rotate them without a lock.
+
+Use injected errnos rather than chmod, which does not constrain privileged CI.
+All credentials are synthetic; HTTP and persistence are forbidden in fallback.
+"""
+
+from __future__ import annotations
+
+import base64
+import builtins
+import errno
+import json
+import multiprocessing
+import os
+import threading
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from hindsight_api.engine.providers import codex_auth as auth
+
+pytestmark = pytest.mark.skipif(auth.fcntl is None, reason="POSIX auth-store locking")
+NOW = 1_800_000_000
+
+
+def jwt(offset: int, label: str = "external") -> str:
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": NOW + offset, "label": label}).encode()).decode()
+    return f"synthetic.{payload}.signature"
+
+
+def publish(path: Path, access: str, refresh: str = "external-refresh") -> None:
+    replacement = path.with_suffix(".new")
+    replacement.write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": access,
+                    "refresh_token": refresh,
+                    "account_id": "external-account",
+                },
+            }
+        )
+    )
+    os.replace(replacement, path)
+
+
+@pytest.fixture
+def manager(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[auth.CodexAuthManager]:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setattr(auth.time, "time", lambda: NOW)
+    monkeypatch.setattr(auth.httpx.Client, "post", Mock(side_effect=AssertionError("OAuth forbidden")))
+    monkeypatch.setattr(
+        auth.CodexAuthManager, "_persist_auth_atomic", Mock(side_effect=AssertionError("write forbidden"))
+    )
+    path = tmp_path / "auth.json"
+    publish(path, jwt(-120, "old"), "old-refresh")
+    mgr = auth.CodexAuthManager.from_file(path)
+    try:
+        yield mgr
+    finally:
+        mgr.close()
+
+
+def deny_lock(monkeypatch: pytest.MonkeyPatch, path: Path, error: int = errno.EROFS, stage: str = "open") -> None:
+    if stage == "mkdir":
+        monkeypatch.setattr(Path, "mkdir", Mock(side_effect=OSError(error, "injected mkdir")))
+    else:
+        real_open = builtins.open
+
+        def open_file(file, *args, **kwargs):
+            if Path(file) == path.with_suffix(".lock"):
+                raise OSError(error, "injected lock open")
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(auth, "open", open_file, raising=False)
+
+
+@pytest.mark.parametrize("error", [errno.EROFS, errno.EACCES])
+@pytest.mark.parametrize("stage", ["mkdir", "open"])
+@pytest.mark.parametrize("force", [False, True])
+def test_adopts_fresh_external_token(manager, monkeypatch, error, stage, force):
+    publish(manager._auth_file, jwt(3600))
+    before = manager._auth_file.read_bytes()
+    deny_lock(monkeypatch, manager._auth_file, error, stage)
+    manager.refresh_tokens(force=force)
+    assert manager.access_token == jwt(3600)
+    assert manager.refresh_token == "external-refresh"
+    assert manager.account_id == "external-account"
+    assert manager._auth_file.read_bytes() == before
+    auth.httpx.Client.post.assert_not_called()
+    manager._persist_auth_atomic.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "unchanged",
+        "unchanged_fresh",
+        "refresh_only",
+        "account_only",
+        "expired",
+        "skew",
+        "opaque",
+        "malformed",
+        "wrong_mode",
+        "wrong_schema",
+        "wrong_tokens",
+        "wrong_access",
+        "wrong_refresh",
+        "wrong_account",
+    ],
+)
+def test_rejects_unusable_snapshot_without_mutating(manager, monkeypatch, kind):
+    path = manager._auth_file
+    if kind == "unchanged_fresh":
+        manager.access_token = jwt(3600)
+        publish(path, manager.access_token)
+    elif kind in ("refresh_only", "account_only"):
+        publish(path, manager.access_token, "different-refresh" if kind == "refresh_only" else manager.refresh_token)
+    elif kind in ("expired", "skew", "opaque"):
+        publish(path, {"expired": jwt(-1), "skew": jwt(60), "opaque": "opaque"}[kind])
+    elif kind == "malformed":
+        path.write_text("{private-synthetic-marker")
+    elif kind == "wrong_mode":
+        path.write_text(json.dumps({"auth_mode": "apikey", "tokens": {"access_token": jwt(3600)}}))
+    elif kind == "wrong_schema":
+        path.write_text("[]")
+    elif kind == "wrong_tokens":
+        path.write_text('{"auth_mode":"chatgpt","tokens":[]}')
+    elif kind in ("wrong_access", "wrong_refresh", "wrong_account"):
+        field = {"wrong_access": "access_token", "wrong_refresh": "refresh_token", "wrong_account": "account_id"}[kind]
+        path.write_text(json.dumps({"auth_mode": "chatgpt", "tokens": {"access_token": jwt(3600), field: 123}}))
+    before = (manager.access_token, manager.refresh_token, manager.account_id)
+    deny_lock(monkeypatch, path)
+    with pytest.raises(RuntimeError, match="external writer") as caught:
+        manager.refresh_tokens(force=True)
+    assert "private-synthetic-marker" not in str(caught.value)
+    assert (manager.access_token, manager.refresh_token, manager.account_id) == before
+    auth.httpx.Client.post.assert_not_called()
+    manager._persist_auth_atomic.assert_not_called()
+
+
+@pytest.mark.parametrize("stage", ["mkdir", "open"])
+@pytest.mark.parametrize("error", [errno.EIO, errno.EMFILE, errno.EPERM])
+def test_unexpected_lock_errors_propagate(manager, monkeypatch, stage, error):
+    publish(manager._auth_file, jwt(3600))
+    deny_lock(monkeypatch, manager._auth_file, error, stage)
+    with pytest.raises(OSError) as caught:
+        manager.ensure_fresh_token()
+    assert caught.value.errno == error
+    assert manager.access_token == jwt(-120, "old")
+
+
+@pytest.mark.parametrize("error", [errno.EIO, errno.EACCES, errno.ENOENT])
+def test_auth_read_errors_propagate(manager, monkeypatch, error):
+    def open_file(path, *args, **kwargs):
+        raise OSError(errno.EROFS if Path(path).suffix == ".lock" else error, "injected")
+
+    monkeypatch.setattr(auth, "open", open_file, raising=False)
+    with pytest.raises(OSError) as caught:
+        manager.ensure_fresh_token()
+    assert caught.value.errno == error
+
+
+def test_retry_after_external_publication(manager, monkeypatch):
+    deny_lock(monkeypatch, manager._auth_file)
+    with pytest.raises(RuntimeError, match="external writer"):
+        manager.ensure_fresh_token()
+    publish(manager._auth_file, jwt(3600))
+    manager.ensure_fresh_token()
+    assert manager.access_token == jwt(3600)
+
+
+@pytest.mark.parametrize("same_manager", [False, True])
+def test_concurrent_consumers_adopt(manager, monkeypatch, same_manager):
+    managers = [manager] if same_manager else [auth.CodexAuthManager.from_file(manager._auth_file) for _ in range(8)]
+    publish(manager._auth_file, jwt(3600))
+    deny_lock(monkeypatch, manager._auth_file)
+    barrier = threading.Barrier(8)
+
+    def consume(index: int) -> None:
+        barrier.wait(timeout=5)
+        managers[index % len(managers)].ensure_fresh_token()
+
+    try:
+        with ThreadPoolExecutor(8) as pool:
+            list(pool.map(consume, range(8)))
+        assert all(m.access_token == jwt(3600) for m in managers)
+        auth.httpx.Client.post.assert_not_called()
+    finally:
+        for m in managers:
+            if m is not manager:
+                m.close()
+
+
+def test_path_lock_retained_during_fallback(manager, monkeypatch):
+    deny_lock(monkeypatch, manager._auth_file)
+    with auth._codex_auth_lock(manager._auth_file) as allowed:
+        assert allowed is False
+        lock = auth._path_scoped_lock(manager._auth_file)
+        assert not lock.acquire(blocking=False)
+
+
+@pytest.mark.parametrize("readonly", [False, True])
+def test_body_permission_error_is_not_reinterpreted(manager, monkeypatch, readonly):
+    if readonly:
+        deny_lock(monkeypatch, manager._auth_file)
+    with pytest.raises(OSError) as caught:
+        with auth._codex_auth_lock(manager._auth_file):
+            raise OSError(errno.EACCES, "body failure")
+    assert caught.value.errno == errno.EACCES
+
+
+def test_unexpected_flock_error_propagates(manager, monkeypatch):
+    monkeypatch.setattr(auth.fcntl, "flock", Mock(side_effect=OSError(errno.EIO, "injected")))
+    monkeypatch.setattr(auth.time, "monotonic", Mock(side_effect=[0, 100]))
+    with pytest.raises(OSError) as caught:
+        manager.ensure_fresh_token()
+    assert caught.value.errno == errno.EIO
+
+
+def hold_lock(path, ready, release):
+    import fcntl
+
+    with open(path, "a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        ready.set()
+        release.wait(10)
+
+
+@pytest.mark.parametrize("payload", [[], None, {"exp": float("inf")}])
+def test_malformed_jwt_payload_fails_closed(manager, monkeypatch, payload):
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    publish(manager._auth_file, f"synthetic.{encoded}.signature")
+    deny_lock(monkeypatch, manager._auth_file)
+    with pytest.raises(RuntimeError, match="external writer"):
+        manager.refresh_tokens(force=True)
+    assert manager.access_token == jwt(-120, "old")
+    auth.httpx.Client.post.assert_not_called()
+
+
+def test_busy_process_lock_times_out_then_releases(manager):
+    ctx = multiprocessing.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    process = ctx.Process(target=hold_lock, args=(manager._auth_file.with_suffix(".lock"), ready, release))
+    process.start()
+    try:
+        assert ready.wait(5)
+        with pytest.raises(TimeoutError):
+            with auth._codex_auth_lock(manager._auth_file, timeout_seconds=1):
+                pytest.fail("busy lock must not permit adoption or refresh")
+    finally:
+        release.set()
+        process.join(5)
+        if process.is_alive():
+            process.terminate()
+            process.join(5)
+    assert process.exitcode == 0
+    with auth._codex_auth_lock(manager._auth_file) as allowed:
+        assert allowed is True

--- a/hindsight-docs/docs/developer/models.mdx
+++ b/hindsight-docs/docs/developer/models.mdx
@@ -399,6 +399,34 @@ rotate out from under it.
 
 `CODEX_HOME` is also honored by the `openai-codex` embeddings provider.
 
+#### Read-only Codex credential stores
+
+A read-only consumer requires an **external credential writer** to refresh and
+atomically publish `auth.json` (for example, a secret-volume publisher). Ensure
+updates are visible through the consumer's mount; a single-file bind mount can
+remain pinned to an old inode after the writer replaces the file.
+
+When creating the sibling `auth.lock` fails with `EROFS` or `EACCES`, Hindsight
+can still adopt an externally published credential during proactive expiry
+handling or reactive authentication recovery. It does **not** call the OAuth
+refresh endpoint or persist credentials in this fallback: rotating a single-use
+refresh token without the shared lock and durable publication can disrupt other
+consumers, even when this consumer's own mount is read-only.
+
+Adoption requires a different access token with a parseable JWT expiry more than
+60 seconds in the future. An unchanged token (even if unexpired), a changed
+refresh token alone, or a stale/opaque replacement cannot recover a rejected
+access token. If no usable replacement has been published, the operation fails
+with an external-writer message; a later request can try again. There is no
+background polling or automatic external refresher. JWT expiry is a scheduling
+check, not signature verification or proof that the server accepts the token.
+Malformed credential snapshots fail closed, and filesystem read errors propagate.
+
+Writable stores retain the existing locked refresh and atomic-persistence path.
+Lock contention still times out rather than permitting unlocked refresh. This
+fallback does not address a store becoming unwritable *after* locking succeeds,
+and does not change the existing Windows behavior when `fcntl` is unavailable.
+
 #### Two Codex profiles in one process
 
 `CODEX_HOME` is process-wide, so every Codex provider a Hindsight process builds


### PR DESCRIPTION
Credit first: @LoneExile identified the read-only `auth.lock` failure and proposed allowing on-disk credential adoption in #4286. This is a collaborative refinement of that work, not a claim of first discovery. The original PR remains the starting point; its author is welcome to incorporate this patch instead of maintaining a separate PR.

## Summary

Permit adoption of externally published Codex credentials when creating `auth.lock` fails with `EROFS` or `EACCES`, without permitting unlocked OAuth refresh.

The separate contribution here is the adoption-only safety boundary, strict snapshot validation before mutation, errno-specific handling, deterministic permission/concurrency regressions, and external-writer documentation. The code is conceptually reimplemented on current main rather than cherry-picked; no upstream author identity or co-author email has been invented.

## Why refine the fallback?

A consumer's read-only mount does not imply there is no other writer: a secret publisher or another process can rotate the same credentials through a writable view. If no usable replacement is on disk, proceeding to OAuth refresh without the cross-process lock can consume a rotating refresh token without durably publishing its replacement.

- Only `mkdir`/`open` `EROFS` and `EACCES` enable adoption-only mode, still under the path-scoped in-process lock.
- That mode never calls the OAuth endpoint or persists credentials.
- Adopt only a different access token with known expiry beyond the existing 60-second skew. Refresh-token/account-only changes, unchanged unexpired tokens, stale tokens and opaque tokens do not count as recovery.
- Validate one file snapshot before updating state. Invalid data produces a credential-free external-writer message; read errors propagate.
- Unexpected lock errors propagate; busy `flock` retains its deadline and never enables fallback.
- Preserve the current writable OAuth retry/recovery and persistence flow, including the improvements from #3804 and credential routing from #3983.

## Evidence on this branch

Base: `5be9ad9156b8c02896b9c522671d516aeefc5cd4`.

Using Python 3.11.15 and a minimal uv-managed test environment, with the repository conftest loaded:

- All `tests/test_codex_*.py`: **116 passed**, including **42 new read-only cases**.
- New test module against the unchanged base implementation: **35 failed, 7 passed**; restored implementation: **42 passed**. In particular, fresh adoption fails at the injected permission error on the base.
- Codex-selected cases across embedding retry/prefix/batch/concurrency modules: **2 passed, 73 deselected**.
- `ruff check hindsight_api tests`: passed (repository configuration excludes tests from lint rules).
- `ruff format --check` on both changed Python files: passed.
- `ty check hindsight_api/engine/providers/codex_auth.py`: passed.
- Full configured `ty check hindsight_api`: **181 diagnostics**, with byte-identical output on the unchanged base in the same minimal environment; none mention `codex_auth.py`. This is not a full-project type-clean claim.
- An exploratory run of the four entire embedding modules had 73 passes and 2 failures because the unrelated LiteLLM dependency was deliberately not installed.
- `git diff --check`: passed.

Commands from `hindsight-api-slim` (with the test environment activated and `PYTHONPATH=.`):

```sh
pytest -o addopts='' -o log_cli=false tests/test_codex_*.py -q
pytest -o addopts='' -o log_cli=false tests/test_embedding_retry.py tests/test_embeddings_asymmetric_prefixes.py tests/test_embeddings_openai_batch_size.py tests/test_embeddings_request_concurrency.py -k codex -q
ruff check hindsight_api tests
ruff format --check hindsight_api/engine/providers/codex_auth.py tests/test_codex_readonly_auth_store.py
ty check hindsight_api/engine/providers/codex_auth.py
```

No full bootstrap, ML downloads, database service, full monorepo lint hook, docs build or remote CI run was performed. The lint hook unconditionally synchronizes the workspace and runs unrelated Node tasks, so targeted equivalent Python checks were used instead.

## Scope and limitations

The earlier adaptation to an older installed source had a separate 34-test local suite; those are not 34 additional current-main pytest results. Earlier operational read-only/Docker/extraction canary work is also separate: this branch was not exercised against a real read-only mount, live OAuth, live Codex requests or end-to-end fact extraction. This PR's evidence is the synthetic pytest suite above, with deterministic errno injection, real atomic filesystem replacement, threads, and an actual subprocess `flock`. It does not claim a production canary for this revision.

An external writer must atomically publish a usable credential visible through the consumer mount. There is no background polling; absent publication, recovery intentionally fails. A known JWT expiry does not prove validity or non-revocation. Existing Windows behavior and the existing writable-path warning if persistence fails after a successful OAuth refresh remain unchanged. The fallback does not redesign writable 401 recovery, enforce external writer coordination, or make multiple credential fields an atomic read for lock-free readers.

## AI assistance

Implementation, review and testing were AI-assisted using Hermes Agent under human direction. This disclosure is not a claim of independent human security review. This is a draft for maintainer review, not a claim of independent human security approval.
