### PR TITLE
feat(coding-agents): warn when the old Claude Code plugin is still installed

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/legacy.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/legacy.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { readLegacyEndpoint } from "./legacy";
+import { detectLegacyClaudePlugin, readLegacyEndpoint } from "./legacy";
 
 const homes: string[] = [];
 
@@ -99,5 +99,63 @@ describe("readLegacyEndpoint", () => {
   it("falls back to any known legacy config", () => {
     const home = homeWith({ hindsightApiUrl: "http://cx:8888" }, "codex.json");
     expect(readLegacyEndpoint(home, ["cursor-cli"])?.apiUrl).toBe("http://cx:8888");
+  });
+});
+
+describe("detectLegacyClaudePlugin", () => {
+  /** A fake `~/.claude` with the given plugin registry and user settings. */
+  function claudeDir(plugins: unknown, settings?: unknown): string {
+    const dir = mkdtempSync(join(tmpdir(), "hindsight-claude-"));
+    homes.push(dir);
+    mkdirSync(join(dir, "plugins"), { recursive: true });
+    writeFileSync(join(dir, "plugins", "installed_plugins.json"), JSON.stringify(plugins));
+    if (settings !== undefined) writeFileSync(join(dir, "settings.json"), JSON.stringify(settings));
+    return dir;
+  }
+  const userInstall = { scope: "user", installPath: "/x", version: "0.7.5" };
+
+  it("finds a user-scope install, whatever the marketplace is called", () => {
+    const dir = claudeDir({ version: 2, plugins: { "hindsight-memory@hindsight": [userInstall] } });
+    expect(detectLegacyClaudePlugin("/any/repo", dir)).toBe("hindsight-memory@hindsight");
+  });
+
+  it("reads the v1 registry shape (one install object, not an array)", () => {
+    const dir = claudeDir({ plugins: { "hindsight-memory@vectorize": userInstall } });
+    expect(detectLegacyClaudePlugin("/any/repo", dir)).toBe("hindsight-memory@vectorize");
+  });
+
+  it("ignores other plugins, including similarly named ones", () => {
+    const dir = claudeDir({
+      version: 2,
+      plugins: { "hindsight-memory-extra@x": [userInstall], "telegram@official": [userInstall] },
+    });
+    expect(detectLegacyClaudePlugin("/any/repo", dir)).toBeUndefined();
+  });
+
+  it("skips a plugin the user explicitly disabled", () => {
+    const dir = claudeDir(
+      { version: 2, plugins: { "hindsight-memory@hindsight": [userInstall] } },
+      { enabledPlugins: { "hindsight-memory@hindsight": false } }
+    );
+    expect(detectLegacyClaudePlugin("/any/repo", dir)).toBeUndefined();
+  });
+
+  it("counts a project-scope install only inside that project", () => {
+    const dir = claudeDir({
+      version: 2,
+      plugins: { "hindsight-memory@hindsight": [{ scope: "project", projectPath: "/work/app" }] },
+    });
+    expect(detectLegacyClaudePlugin("/work/app", dir)).toBe("hindsight-memory@hindsight");
+    expect(detectLegacyClaudePlugin("/work/app/src", dir)).toBe("hindsight-memory@hindsight");
+    expect(detectLegacyClaudePlugin("/work/app-other", dir)).toBeUndefined();
+  });
+
+  it("is undefined when Claude has no plugin registry or it is unreadable", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hindsight-claude-"));
+    homes.push(dir);
+    expect(detectLegacyClaudePlugin("/any/repo", dir)).toBeUndefined();
+    mkdirSync(join(dir, "plugins"));
+    writeFileSync(join(dir, "plugins", "installed_plugins.json"), "{not json");
+    expect(detectLegacyClaudePlugin("/any/repo", dir)).toBeUndefined();
   });
 });

--- a/hindsight-integrations/coding-agents/src/core/legacy.ts
+++ b/hindsight-integrations/coding-agents/src/core/legacy.ts
@@ -20,8 +20,68 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, relative, isAbsolute } from "node:path";
 import { DEFAULT_DAEMON_PORT } from "./config";
+
+/** The old per-agent Claude Code plugin's name in Claude's plugin registry (`<name>@<marketplace>`). */
+const LEGACY_CLAUDE_PLUGIN = "hindsight-memory";
+
+/**
+ * The registry key (`hindsight-memory@<marketplace>`) of the old Claude Code plugin when it is still
+ * installed AND active for `cwd`, else undefined.
+ *
+ * Running both is not harmless: each recalls into every prompt and retains every transcript, so the
+ * agent sees two memory blocks and conversations land twice — the old plugin's copy in its single
+ * static `claude_code` bank. The installer does not uninstall it (Claude owns its plugin registry),
+ * so the session start is where the user finds out.
+ *
+ * Read from Claude's own files: `plugins/installed_plugins.json` for what is installed (user scope,
+ * or a project/local scope whose `projectPath` contains `cwd`) and `settings.json` `enabledPlugins`
+ * for an explicit disable. Any read failure means "not detected" — this only ever adds a warning.
+ */
+export function detectLegacyClaudePlugin(
+  cwd: string,
+  claudeDir: string = join(homedir(), ".claude")
+): string | undefined {
+  const registry = readJson(join(claudeDir, "plugins", "installed_plugins.json"));
+  const plugins = registry?.plugins;
+  if (!plugins || typeof plugins !== "object") return undefined;
+  const enabled = readJson(join(claudeDir, "settings.json"))?.enabledPlugins as
+    | Record<string, unknown>
+    | undefined;
+  for (const [key, raw] of Object.entries(plugins as Record<string, unknown>)) {
+    if (key.split("@")[0] !== LEGACY_CLAUDE_PLUGIN) continue;
+    if (enabled && enabled[key] === false) continue;
+    // v2 registry: an array of installs; v1: a single install object.
+    const installs = (Array.isArray(raw) ? raw : [raw]) as Array<Record<string, unknown> | null>;
+    const active = installs.some((i) => {
+      if (!i || typeof i !== "object") return false;
+      if (typeof i.projectPath !== "string") return true; // user scope: every project
+      const rel = relative(i.projectPath, cwd);
+      return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+    });
+    if (active) return key;
+  }
+  return undefined;
+}
+
+function readJson(path: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** The user-visible SessionStart warning for a still-active old plugin. */
+export function legacyClaudePluginWarning(key: string): string {
+  return (
+    `⚠️ The old Hindsight Claude Code plugin (${key}) is still installed — it runs alongside this ` +
+    `one, so memory is recalled and retained twice.\n` +
+    `  ↳ remove it: claude plugin uninstall ${key}`
+  );
+}
 
 /**
  * The old per-agent plugins that shipped a user config, and its filename.

--- a/hindsight-integrations/coding-agents/src/core/session-start.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.test.ts
@@ -11,6 +11,34 @@ import { HOOK_HARNESSES } from "../harness/hook-lifecycle";
 const listPagesOk = async () => ({ items: [{ id: "p1", name: "Component map" }] });
 
 describe("buildSessionStartContext", () => {
+  it("warns in the user-visible banner when the old Claude Code plugin is still active", async () => {
+    const client = { listDocumentIds: async () => new Set(["git:a"]), listPages: listPagesOk };
+    const detectLegacyPlugin = vi.fn().mockReturnValue("hindsight-memory@hindsight");
+    const out = await buildSessionStartContext({
+      cwd: "/repo/dir",
+      bankId: "bank-1",
+      cfg: resolveConfig({ autoSeed: false }),
+      client,
+      detectLegacyPlugin,
+    });
+    expect(detectLegacyPlugin).toHaveBeenCalledWith("/repo/dir");
+    expect(out.systemMessage).toContain("bank-1");
+    expect(out.systemMessage).toContain("claude plugin uninstall hindsight-memory@hindsight");
+    expect(out.additionalContext).not.toContain("hindsight-memory@hindsight");
+  });
+
+  it("no warning when the old plugin is absent", async () => {
+    const client = { listDocumentIds: async () => new Set(["git:a"]), listPages: listPagesOk };
+    const out = await buildSessionStartContext({
+      cwd: "/repo/dir",
+      bankId: "bank-1",
+      cfg: resolveConfig({ autoSeed: false }),
+      client,
+      detectLegacyPlugin: () => undefined,
+    });
+    expect(out.systemMessage).not.toContain("plugin uninstall");
+  });
+
   it("cold git repo + autoSeed on -> seeds + surveys, note in systemMessage (user-visible) + roster in additionalContext (model)", async () => {
     const client = { listDocumentIds: async () => new Set<string>(), listPages: listPagesOk };
     const startSeed = vi.fn();

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -35,6 +35,7 @@ import { setLogLevel } from "./log";
 import { parsePageList, buildKnowledgePreamble, type PageRef } from "./knowledge-injection";
 import type { ClientOpts, RetainOpts } from "./hindsight";
 import { buildRetainStamp } from "./retain-stamp";
+import { detectLegacyClaudePlugin, legacyClaudePluginWarning } from "./legacy";
 import { HindsightClient } from "./hindsight";
 import { sessionCacheFile, sessionRootDir, writeSessionCache } from "./session-cache";
 
@@ -150,6 +151,9 @@ export async function buildSessionStartContext(args: {
   startSurvey?: typeof startCodebaseSurvey;
   headSha?: (dir: string) => string | null;
   commitsSince?: (dir: string, sinceSha: string) => number | null;
+  /** Registry key of the old Claude Code plugin still active for `cwd`; defaults to reading
+   *  Claude's plugin files, and only for the claude-code harness. */
+  detectLegacyPlugin?: (cwd: string) => string | undefined;
 }): Promise<SessionStartOutput> {
   const { cwd, bankId, cfg, client, stateDir } = args;
   const t0 = Date.now();
@@ -318,6 +322,16 @@ export async function buildSessionStartContext(args: {
     }).catch(() => undefined);
   }
   systemMessage = buildSeedBanner(bankId, cold === true, gitNote);
+
+  // The old per-agent plugin keeps running next to this one until the user removes it — say so
+  // where they will see it. Only Claude Code had that plugin.
+  const detectLegacy =
+    args.detectLegacyPlugin ?? (harness === "claude-code" ? detectLegacyClaudePlugin : undefined);
+  const legacyPlugin = detectLegacy?.(cwd);
+  if (legacyPlugin) {
+    systemMessage += `\n${legacyClaudePluginWarning(legacyPlugin)}`;
+    diag(harness, "legacy_plugin_active", { plugin: legacyPlugin });
+  }
 
   // ALWAYS record the session start (warm sessions used to log nothing — undebuggable).
   diag(harness, "session_start", { bank: bankId, cold, pages: pages.length, ms: Date.now() - t0 });


### PR DESCRIPTION
## Summary
If the old per-agent Claude Code plugin (`hindsight-memory@<marketplace>`, from `hindsight-integrations/claude-code`) is still installed, it runs next to coding-agents. Every prompt then gets two memory recalls, and every transcript is retained twice (the old copy goes to its static `claude_code` bank). The installer can't remove it because Claude owns its plugin registry, so users never find out.

The claude-code SessionStart banner (`systemMessage`, shown in the chat) now adds a warning when the old plugin is active:

```
⚠️ The old Hindsight Claude Code plugin (hindsight-memory@hindsight) is still installed — it runs alongside this one, so memory is recalled and retained twice.
  ↳ remove it: claude plugin uninstall hindsight-memory@hindsight
```

## How detection works (`core/legacy.ts` → `detectLegacyClaudePlugin`)
- Reads `~/.claude/plugins/installed_plugins.json` and handles both registry shapes: v2 (an array of installs) and v1 (a single install object).
- Counts a user-scope install everywhere. Counts a project- or local-scope install only when `cwd` is inside its `projectPath`.
- Skips the plugin when `~/.claude/settings.json` has `enabledPlugins[key] === false`.
- If a file is missing or can't be read, nothing is detected. The worst case is a missing warning.
- Runs only for the `claude-code` harness. The warning is not added to the model's context.

## Tests
- `legacy.test.ts`: user scope, v1 shape, a plugin with a similar name, explicit disable, project-scope boundary (`/work/app` vs `/work/app-other`), unreadable registry.
- `session-start.test.ts`: the warning appears in `systemMessage` and not in `additionalContext`; no warning when the plugin is absent.