### PR TITLE
chore(deps): update adm-zip in the zapier integration

### DIFF
--- a/hindsight-integrations/zapier/package-lock.json
+++ b/hindsight-integrations/zapier/package-lock.json
@@ -3781,9 +3781,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
-      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.1.tgz",
+      "integrity": "sha512-Xwrja8nx9e5o2N1my4DsKCeKpdrnACyr1wtbPxBDgGzKzKyE9kRtBFA8mWldI+RVlD7CBZNWY/wQ2+ydwOR6kQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/hindsight-integrations/zapier/package.json
+++ b/hindsight-integrations/zapier/package.json
@@ -36,7 +36,7 @@
     "tar": ">=7.5.18 <8.0.0",
     "tmp": "^0.2.6",
     "yeoman-environment": "^6.0.1",
-    "adm-zip": ">=0.6.0",
+    "adm-zip": ">=0.6.1",
     "brace-expansion@^1.0.0": "^1.1.18",
     "brace-expansion@^2.0.0": "^2.1.4",
     "brace-expansion@^5.0.0": "^5.0.9",


### PR DESCRIPTION
Routine dependency maintenance for the Zapier integration.

Closes Dependabot alert #1500 (`adm-zip`, GHSA-vwc7-r8mq-g2x9 — extraction follows destination symlinks).

## Change

- `hindsight-integrations/zapier/package.json`: raise the existing `adm-zip` override floor from `>=0.6.0` to `>=0.6.1`.
- `hindsight-integrations/zapier/package-lock.json`: `adm-zip` 0.6.0 -> 0.6.1. That is the whole lockfile diff (4 lines); nothing else re-resolved.

`adm-zip` is a transitive dev dependency via `zapier-platform-cli` (which declares it exactly as `0.5.16`, hence the override).

## Why 0.6.1 is the fix

The advisory's vulnerable range is `>= 0.5.9, <= 0.6.0` and it records no patched version, because it was written before a fix existed. `adm-zip` 0.6.1 was published on 2026-09-11 and sits outside that range. Its changelog includes "Blocked extraction from writing through symlinks inside the target" (upstream commit `eaa35fa73`). The diff between 0.6.0 and 0.6.1 adds an `lstat` check on every destination path component below the extraction root, which is exactly the path the advisory describes.

## Consumer surface checked

`zapier-platform-cli` 19.0.0 uses `adm-zip` in two places, and only through these calls:

- `src/utils/api.js`: `new AdmZip(path)` and `zip.readAsText('definition.json')`
- `src/oclif/commands/pull.js`: `new AdmZip(path)` and `zip.extractAllTo(dst, true)` into a freshly created temp directory

The only public-API change between 0.6.0 and 0.6.1 is in the `addLocalFileAsync` callback error ordering, and nothing here calls it. The other 0.6.1 hardening (duplicate entry names rejected, setuid/setgid bits stripped, size caps enforced on the async path) does not affect a normal app bundle.

## Verification (local, Node 23 / npm 10.9.2, mirroring `test-zapier-integration`)

- `npm install --package-lock-only`: minimal diff, adm-zip only
- `npm ci`: ok; `npm ls adm-zip` -> `adm-zip@0.6.1 overridden`
- `npm install --no-fund --no-audit` (the CI install step): up to date, no lockfile drift
- `npm run validate`: 26 checks passed, 0 failed. The same two general warnings appear before and after.
- `npm test`: 20 passing, identical to `main`
- Smoke test of the exact calls above against 0.6.1: `writeZip` -> `readAsText` -> `extractAllTo(dst, true)` all behave as before. Extracting into a directory that contains a symlink pointing outside the target now throws `FILE_IN_THE_WAY` instead of writing through it.
