### PR TITLE
feat(coding-agents): record Hindsight tool usage and move logs to ~/.hindsight/coding-agents-logs

### DIFF
--- a/hindsight-docs/docs-integrations/coding-agents.md
+++ b/hindsight-docs/docs-integrations/coding-agents.md
@@ -28,6 +28,7 @@ npx @vectorize-io/hindsight-coding-agents install all          # every detected 
 npx @vectorize-io/hindsight-coding-agents install claude-code  # or just one
 npx @vectorize-io/hindsight-coding-agents uninstall all        # removes exactly what install added
 npx @vectorize-io/hindsight-coding-agents update               # refresh the runtime only, no rewiring
+npx @vectorize-io/hindsight-coding-agents stats                # how often each agent uses Hindsight
 ```
 
 `install` takes an explicit target — `all`, or one or more harness names. A bare
@@ -436,8 +437,8 @@ as `HINDSIGHT_MAX_PARALLEL_RETAINS` for containers and CI.
 
 `HINDSIGHT_CONFIG` moves the file itself — point it at another path for a container or a test
 harness where `$HOME` is not the right anchor. It is still exactly one file; only its location
-changes. (The other variables that are not settings are `HINDSIGHT_LOG_FILE`, `HINDSIGHT_DIAG_FILE`
-and `HINDSIGHT_LOG_LEVEL` — see Diagnostics & logging.)
+changes. (The other variables that are not settings are `HINDSIGHT_LOG_FILE`, `HINDSIGHT_DIAG_FILE`,
+`HINDSIGHT_USAGE_FILE` and `HINDSIGHT_LOG_LEVEL` — see Diagnostics & logging.)
 
 ### When a change takes effect
 
@@ -774,16 +775,18 @@ they stay where they were built, and new work accrues under the new setting.
 
 ## Diagnostics & logging
 
-Two files, two audiences:
+All logs live in `~/.hindsight/coding-agents-logs/` (owner-only). Each file rotates to `<file>.1`
+at 10 MB.
 
-**Leveled plugin log** (humans debugging): `$TMPDIR/hindsight-coding-agent/plugin.log` (override
+**Leveled plugin log** (humans debugging): `~/.hindsight/coding-agents-logs/plugin.log` (override
 `HINDSIGHT_LOG_FILE`) — timestamped `LEVEL [scope] message` lines from every component, including
 the ingestion engine. Level defaults to `info`; set `"logLevel": "debug"` in config or
 `HINDSIGHT_LOG_LEVEL=debug` for ad-hoc debugging (at `debug`, every diag event below is mirrored
 here too, so one file tells the whole story).
 
 **Structured diag events** (machines/harnesses): every reflect and page-fetch outcome is appended
-as a JSON line to `/tmp/hindsight-plugin.log` (override with `HINDSIGHT_DIAG_FILE`):
+as a JSON line to `~/.hindsight/coding-agents-logs/diag.jsonl` (override with
+`HINDSIGHT_DIAG_FILE`):
 
 ```json
 {
@@ -799,6 +802,17 @@ as a JSON line to `/tmp/hindsight-plugin.log` (override with `HINDSIGHT_DIAG_FIL
 `reflect_failed` / `pages_failed` record the error; if you're comparing memory-on vs memory-off,
 check this file — a run whose reflects failed is a no-memory run. Seed starts are logged as
 `seed_started`.
+
+**Tool usage** (is the agent using Hindsight?): one JSON line per finished user turn in
+`~/.hindsight/coding-agents-logs/usage.jsonl` (override `HINDSIGHT_USAGE_FILE`) — the `hindsight_*`
+tools the agent called during that turn, and whether its reply credited Hindsight memory ("From
+Hindsight memory"). The credit rate counts only turns that called a retrieval tool (search, list,
+read, reflect); saving a document is not expected to be credited. Recorded when the session is written back, so a scope with
+`retainSessions: false` records none. It never leaves your machine. Summarize it per agent with:
+
+```bash
+npx @vectorize-io/hindsight-coding-agents stats
+```
 
 ### Is the memory ready yet?
 

--- a/hindsight-integrations/coding-agents/README.md
+++ b/hindsight-integrations/coding-agents/README.md
@@ -23,6 +23,7 @@ npx @vectorize-io/hindsight-coding-agents install all          # every detected 
 npx @vectorize-io/hindsight-coding-agents install claude-code  # or just one
 npx @vectorize-io/hindsight-coding-agents uninstall all        # removes exactly what install added
 npx @vectorize-io/hindsight-coding-agents update               # refresh the runtime only, no rewiring
+npx @vectorize-io/hindsight-coding-agents stats                # how often each agent uses Hindsight
 ```
 
 `install` takes an explicit target — `all`, or one or more harness names. A bare
@@ -439,8 +440,8 @@ as `HINDSIGHT_MAX_PARALLEL_RETAINS` for containers and CI.
 
 `HINDSIGHT_CONFIG` moves the file itself — point it at another path for a container or a test
 harness where `$HOME` is not the right anchor. It is still exactly one file; only its location
-changes. (The other variables that are not settings are `HINDSIGHT_LOG_FILE`, `HINDSIGHT_DIAG_FILE`
-and `HINDSIGHT_LOG_LEVEL` — see [Diagnostics & logging](#diagnostics--logging).)
+changes. (The other variables that are not settings are `HINDSIGHT_LOG_FILE`, `HINDSIGHT_DIAG_FILE`,
+`HINDSIGHT_USAGE_FILE` and `HINDSIGHT_LOG_LEVEL` — see [Diagnostics & logging](#diagnostics--logging).)
 
 ### When a change takes effect
 
@@ -822,16 +823,18 @@ drops the markers along with the contributor-only sections.
 
 ## Diagnostics & logging
 
-Two files, two audiences:
+All logs live in `~/.hindsight/coding-agents-logs/` (owner-only). Each file rotates to `<file>.1`
+at 10 MB.
 
-**Leveled plugin log** (humans debugging): `$TMPDIR/hindsight-coding-agent/plugin.log` (override
+**Leveled plugin log** (humans debugging): `~/.hindsight/coding-agents-logs/plugin.log` (override
 `HINDSIGHT_LOG_FILE`) — timestamped `LEVEL [scope] message` lines from every component, including
 the ingestion engine. Level defaults to `info`; set `"logLevel": "debug"` in config or
 `HINDSIGHT_LOG_LEVEL=debug` for ad-hoc debugging (at `debug`, every diag event below is mirrored
 here too, so one file tells the whole story).
 
 **Structured diag events** (machines/harnesses): every reflect and page-fetch outcome is appended
-as a JSON line to `/tmp/hindsight-plugin.log` (override with `HINDSIGHT_DIAG_FILE`):
+as a JSON line to `~/.hindsight/coding-agents-logs/diag.jsonl` (override with
+`HINDSIGHT_DIAG_FILE`):
 
 ```json
 {
@@ -847,6 +850,17 @@ as a JSON line to `/tmp/hindsight-plugin.log` (override with `HINDSIGHT_DIAG_FIL
 `reflect_failed` / `pages_failed` record the error; if you're comparing memory-on vs memory-off,
 check this file — a run whose reflects failed is a no-memory run. Seed starts are logged as
 `seed_started`.
+
+**Tool usage** (is the agent using Hindsight?): one JSON line per finished user turn in
+`~/.hindsight/coding-agents-logs/usage.jsonl` (override `HINDSIGHT_USAGE_FILE`) — the `hindsight_*`
+tools the agent called during that turn, and whether its reply credited Hindsight memory ("From
+Hindsight memory"). The credit rate counts only turns that called a retrieval tool (search, list,
+read, reflect); saving a document is not expected to be credited. Recorded when the session is written back, so a scope with
+`retainSessions: false` records none. It never leaves your machine. Summarize it per agent with:
+
+```bash
+npx @vectorize-io/hindsight-coding-agents stats
+```
 
 ### Is the memory ready yet?
 

--- a/hindsight-integrations/coding-agents/skill/SKILL.md
+++ b/hindsight-integrations/coding-agents/skill/SKILL.md
@@ -69,6 +69,7 @@ npx @vectorize-io/hindsight-coding-agents install all          # every detected 
 npx @vectorize-io/hindsight-coding-agents install claude-code  # or just one
 npx @vectorize-io/hindsight-coding-agents uninstall all        # removes exactly what install added
 npx @vectorize-io/hindsight-coding-agents update               # refresh the runtime only, no rewiring
+npx @vectorize-io/hindsight-coding-agents stats                # how often each agent uses Hindsight
 ```
 
 `install` takes an explicit target — `all`, or one or more harness names. A bare
@@ -121,8 +122,8 @@ as `HINDSIGHT_MAX_PARALLEL_RETAINS` for containers and CI.
 
 `HINDSIGHT_CONFIG` moves the file itself — point it at another path for a container or a test
 harness where `$HOME` is not the right anchor. It is still exactly one file; only its location
-changes. (The other variables that are not settings are `HINDSIGHT_LOG_FILE`, `HINDSIGHT_DIAG_FILE`
-and `HINDSIGHT_LOG_LEVEL` — see [Diagnostics & logging](#diagnostics--logging).)
+changes. (The other variables that are not settings are `HINDSIGHT_LOG_FILE`, `HINDSIGHT_DIAG_FILE`,
+`HINDSIGHT_USAGE_FILE` and `HINDSIGHT_LOG_LEVEL` — see [Diagnostics & logging](#diagnostics--logging).)
 
 ### When a change takes effect
 
@@ -459,16 +460,18 @@ they stay where they were built, and new work accrues under the new setting.
 
 ## Diagnostics & logging
 
-Two files, two audiences:
+All logs live in `~/.hindsight/coding-agents-logs/` (owner-only). Each file rotates to `<file>.1`
+at 10 MB.
 
-**Leveled plugin log** (humans debugging): `$TMPDIR/hindsight-coding-agent/plugin.log` (override
+**Leveled plugin log** (humans debugging): `~/.hindsight/coding-agents-logs/plugin.log` (override
 `HINDSIGHT_LOG_FILE`) — timestamped `LEVEL [scope] message` lines from every component, including
 the ingestion engine. Level defaults to `info`; set `"logLevel": "debug"` in config or
 `HINDSIGHT_LOG_LEVEL=debug` for ad-hoc debugging (at `debug`, every diag event below is mirrored
 here too, so one file tells the whole story).
 
 **Structured diag events** (machines/harnesses): every reflect and page-fetch outcome is appended
-as a JSON line to `/tmp/hindsight-plugin.log` (override with `HINDSIGHT_DIAG_FILE`):
+as a JSON line to `~/.hindsight/coding-agents-logs/diag.jsonl` (override with
+`HINDSIGHT_DIAG_FILE`):
 
 ```json
 {
@@ -484,6 +487,17 @@ as a JSON line to `/tmp/hindsight-plugin.log` (override with `HINDSIGHT_DIAG_FIL
 `reflect_failed` / `pages_failed` record the error; if you're comparing memory-on vs memory-off,
 check this file — a run whose reflects failed is a no-memory run. Seed starts are logged as
 `seed_started`.
+
+**Tool usage** (is the agent using Hindsight?): one JSON line per finished user turn in
+`~/.hindsight/coding-agents-logs/usage.jsonl` (override `HINDSIGHT_USAGE_FILE`) — the `hindsight_*`
+tools the agent called during that turn, and whether its reply credited Hindsight memory ("From
+Hindsight memory"). The credit rate counts only turns that called a retrieval tool (search, list,
+read, reflect); saving a document is not expected to be credited. Recorded when the session is written back, so a scope with
+`retainSessions: false` records none. It never leaves your machine. Summarize it per agent with:
+
+```bash
+npx @vectorize-io/hindsight-coding-agents stats
+```
 
 ### Is the memory ready yet?
 

--- a/hindsight-integrations/coding-agents/src/cline.test.ts
+++ b/hindsight-integrations/coding-agents/src/cline.test.ts
@@ -130,10 +130,15 @@ describe("Cline native plugin adapter", () => {
 
     await hooks.afterRun({ snapshot });
 
-    expect(core.onTranscript).toHaveBeenCalledWith("conversation-1", [
-      expect.objectContaining({ role: "user", content: "remember the preference" }),
-      expect.objectContaining({ role: "assistant", content: "I will do that." }),
-    ]);
+    // `true`: afterRun sees the finished run — the reply's turn is complete (usage stats).
+    expect(core.onTranscript).toHaveBeenCalledWith(
+      "conversation-1",
+      [
+        expect.objectContaining({ role: "user", content: "remember the preference" }),
+        expect.objectContaining({ role: "assistant", content: "I will do that." }),
+      ],
+      true
+    );
     expect(clineTranscript(snapshot.messages)).toEqual([
       expect.objectContaining({ role: "user", content: "remember the preference" }),
       expect.objectContaining({ role: "assistant", content: "I will do that." }),

--- a/hindsight-integrations/coding-agents/src/cline.ts
+++ b/hindsight-integrations/coding-agents/src/cline.ts
@@ -179,7 +179,9 @@ export function createClineHooks(
     },
     async afterRun({ snapshot }: { snapshot: ClineSnapshot }): Promise<void> {
       const turns = clineTranscript(snapshot.messages);
-      if (turns.length) await core.onTranscript(sessionId(snapshot, configuredSessionId), turns);
+      // afterRun: the run has ended, so the last turn is complete.
+      if (turns.length)
+        await core.onTranscript(sessionId(snapshot, configuredSessionId), turns, true);
     },
   };
 }

--- a/hindsight-integrations/coding-agents/src/core/diag.ts
+++ b/hindsight-integrations/coding-agents/src/core/diag.ts
@@ -7,18 +7,18 @@
  * hook (UserPromptSubmit, Stop, and future ones like SessionStart) can depend on it without
  * reaching into another hook's module.
  */
-import { appendFileSync } from "node:fs";
-import { log } from "./log";
+import { join } from "node:path";
+import { appendLogLine, log, logsDir } from "./log";
 
 /** Where the JSONL trail lands. Exported so a failure notice can name the file to open. */
 export function diagFilePath(): string {
-  return process.env.HINDSIGHT_DIAG_FILE || "/tmp/hindsight-plugin.log";
+  return process.env.HINDSIGHT_DIAG_FILE || join(logsDir(), "diag.jsonl");
 }
 
 export function diag(harness: string, event: string, extra: Record<string, unknown> = {}): void {
   log.debug(harness, `diag:${event}`, extra); // debug level shows the full story in ONE file
   try {
-    appendFileSync(
+    appendLogLine(
       diagFilePath(),
       JSON.stringify({ ts: new Date().toISOString(), harness, event, ...extra }) + "\n"
     );

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
@@ -23,6 +23,7 @@ import type { ZodRawShape } from "zod";
 import type { HindsightClient } from "./hindsight";
 import { syncStatus } from "./status";
 import { applyBankConfig, DEFAULT_REFLECT_TOOL_TIMEOUT_MS, loadConfig } from "./config";
+import { diagFilePath } from "./diag";
 import { describeError } from "./log";
 import type { RetainStamp } from "./retain-stamp";
 import type { PageTrigger } from "./missions";
@@ -173,7 +174,7 @@ export function buildKnowledgeTools(
             config_override: Boolean(process.env.HINDSIGHT_CONFIG),
             hooks_disabled: Boolean(process.env.HINDSIGHT_DISABLE_HOOKS),
             log_level: process.env.HINDSIGHT_LOG_LEVEL ?? null,
-            diagnostics_file: process.env.HINDSIGHT_DIAG_FILE ?? "/tmp/hindsight-plugin.log",
+            diagnostics_file: diagFilePath(),
             channel_id_configured: Boolean(process.env.HINDSIGHT_CHANNEL_ID),
             user_id_configured: Boolean(process.env.HINDSIGHT_USER_ID),
           },

--- a/hindsight-integrations/coding-agents/src/core/log.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/log.test.ts
@@ -1,5 +1,26 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { describeError } from "./log";
+import { appendLogLine, describeError, LOG_MAX_BYTES } from "./log";
+
+describe("appendLogLine", () => {
+  it("creates an owner-only directory and rotates one generation past the cap", () => {
+    const root = mkdtempSync(join(tmpdir(), "hs-log-"));
+    try {
+      const file = join(root, "logs", "diag.jsonl");
+      appendLogLine(file, "first\n");
+      expect(statSync(join(root, "logs")).mode & 0o777).toBe(0o700);
+
+      writeFileSync(file, "x".repeat(LOG_MAX_BYTES));
+      appendLogLine(file, "after\n");
+      expect(readFileSync(file, "utf8")).toBe("after\n");
+      expect(statSync(`${file}.1`).size).toBe(LOG_MAX_BYTES);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("describeError", () => {
   it("names the transport failure Node's fetch hides behind 'fetch failed'", () => {

--- a/hindsight-integrations/coding-agents/src/core/log.ts
+++ b/hindsight-integrations/coding-agents/src/core/log.ts
@@ -2,7 +2,7 @@
  * Leveled plugin logging — ONE human-readable log file for debugging, next to (not replacing) the
  * structured diag JSONL contract (core/diag.ts, which benchmarks/harnesses parse).
  *
- *   file : $TMPDIR/hindsight-coding-agent/plugin.log   (override: HINDSIGHT_LOG_FILE)
+ *   file : ~/.hindsight/coding-agents-logs/plugin.log   (override: HINDSIGHT_LOG_FILE)
  *   level: "info" default — config `logLevel`, or HINDSIGHT_LOG_LEVEL for ad-hoc debugging
  *          without touching config ("debug" | "info" | "warn" | "error")
  *
@@ -10,9 +10,44 @@
  * every diag event is mirrored here too, so one file tells the whole story. Never throws: logging
  * must not break the agent.
  */
-import { appendFileSync, mkdirSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { appendFileSync, mkdirSync, renameSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+
+/**
+ * Every log this plugin keeps (plugin.log, diag.jsonl, usage.jsonl) lives here.
+ *
+ * They used to be split between `/tmp/hindsight-plugin.log` and `$TMPDIR/hindsight-coding-agent/`:
+ * the first is shared by every user on the machine (and the lines carry queries and code), both are
+ * wiped on reboot, which loses exactly the history usage stats are for, and neither was bounded. A
+ * sibling of the staged runtime (`~/.hindsight/coding-agents`), not a child of it: `update`
+ * replaces that directory wholesale. Scratch state (session cache, cursors, locks) stays in the OS
+ * temp dir on purpose — losing it is harmless.
+ */
+export function logsDir(): string {
+  return join(homedir(), ".hindsight", "coding-agents-logs");
+}
+
+/** Past this size a log is rotated to `<file>.1` (one generation kept), so each is capped at ~2x. */
+export const LOG_MAX_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Append to a log file, rotating it first once it has reached LOG_MAX_BYTES. Throws — callers are
+ * the fail-open wrappers. The directory is owner-only: these lines carry prompts, queries and code.
+ *
+ * Rotation is not coordinated across processes (every hook is its own process). Two that rotate at
+ * once can push the just-restarted file over `.1`, losing one old generation — a bounded,
+ * diagnostics-only loss that is cheaper than a lock on every log line.
+ */
+export function appendLogLine(file: string, text: string): void {
+  mkdirSync(dirname(file), { recursive: true, mode: 0o700 });
+  try {
+    if (statSync(file).size >= LOG_MAX_BYTES) renameSync(file, `${file}.1`);
+  } catch {
+    /* no file yet, or another process just rotated it */
+  }
+  appendFileSync(file, text, { mode: 0o600 });
+}
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 const WEIGHT: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, error: 40 };
@@ -28,16 +63,14 @@ export function setLogLevel(level: LogLevel): void {
 }
 
 export function logFilePath(): string {
-  return process.env.HINDSIGHT_LOG_FILE || join(tmpdir(), "hindsight-coding-agent", "plugin.log");
+  return process.env.HINDSIGHT_LOG_FILE || join(logsDir(), "plugin.log");
 }
 
 function write(level: LogLevel, scope: string, msg: string, extra?: Record<string, unknown>): void {
   if (WEIGHT[level] < WEIGHT[current]) return;
   try {
-    const file = logFilePath();
-    mkdirSync(dirname(file), { recursive: true });
-    appendFileSync(
-      file,
+    appendLogLine(
+      logFilePath(),
       `${new Date().toISOString()} ${level.toUpperCase().padEnd(5)} [${scope}] ${msg}` +
         (extra && Object.keys(extra).length ? ` ${JSON.stringify(extra)}` : "") +
         "\n"

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.test.ts
@@ -9,6 +9,7 @@ import type { HindsightClient } from "./hindsight";
 import { buildRetain, runRetainHook } from "./retain-hook";
 import { memoryCursorStore, type RetainCursorStore } from "./retain-cursor";
 import { dcodeAssistantText } from "./transcript-dcode";
+import { memoryUsageCursorStore } from "./usage";
 
 /** The Stop event `runRetainHook` reads from fd 0; every other read stays real. */
 let stdin = "";
@@ -39,6 +40,52 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(root, { recursive: true, force: true });
+});
+
+describe("buildRetain usage stats", () => {
+  it("records the Hindsight calls and credit of a real Claude Code transcript", async () => {
+    // The raw host format end to end: tool_use blocks through readClaudeTranscript's action turns.
+    const usageFile = join(root, "usage.jsonl");
+    vi.stubEnv("HINDSIGHT_USAGE_FILE", usageFile);
+    const msg = (type: string, content: unknown) =>
+      JSON.stringify({ type, message: { role: type, content } });
+    writeFileSync(
+      file,
+      [
+        msg("user", "how do we round?"),
+        msg("assistant", [
+          {
+            type: "tool_use",
+            name: "mcp__hindsight__hindsight_search_knowledge_pages",
+            input: { query: "rounding" },
+          },
+          { type: "tool_use", name: "Grep", input: { pattern: "round" } },
+        ]),
+        msg("user", [{ type: "tool_result", content: "page kp-1" }]),
+        msg("assistant", [{ type: "text", text: "> 🧠 **From Hindsight memory** — half up" }]),
+      ].join("\n")
+    );
+    try {
+      await buildRetain({
+        harness: "claude-code",
+        sessionId: "sess-usage",
+        transcriptPath: file,
+        bankId: "bank-1",
+        usageCursors: memoryUsageCursorStore(),
+        client: { retain: vi.fn().mockResolvedValue(undefined) } as unknown as HindsightClient,
+      });
+      expect(JSON.parse(readFileSync(usageFile, "utf8"))).toMatchObject({
+        harness: "claude-code",
+        session: "sess-usage",
+        bank: "bank-1",
+        turn: 1,
+        calls: ["hindsight_search_knowledge_pages"],
+        credited: true,
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
 });
 
 describe("buildRetain", () => {

--- a/hindsight-integrations/coding-agents/src/core/retain-hook.ts
+++ b/hindsight-integrations/coding-agents/src/core/retain-hook.ts
@@ -24,10 +24,11 @@ import type { ClientOpts } from "./hindsight";
 import { HindsightClient } from "./hindsight";
 import type { RetainCursorStore } from "./retain-cursor";
 import { buildRetainStamp, type RetainStamp } from "./retain-stamp";
-import { fileCursorStore, sessionRootDir } from "./session-cache";
+import { fileCursorStore, fileUsageCursorStore, sessionRootDir } from "./session-cache";
 import { readClaudeTranscript } from "./transcript";
 import { appendJournalTurn, journalPath, readJournalTranscript } from "./turn-journal";
 import { stripInjectedMemory } from "./transcript-util";
+import { recordUsage, type UsageCursorStore } from "./usage";
 
 /** Headroom left before the host's kill: the response still has to come back after the last wait. */
 const HOST_DEADLINE_MARGIN_MS = 2000;
@@ -109,6 +110,10 @@ export async function buildRetain(args: {
   cursors?: RetainCursorStore;
   /** Absolute time the host will kill this process; bounds any rate-limit retry. */
   retryUntil?: number;
+  /** Resolved bank, recorded on the usage line. */
+  bankId?: string;
+  /** Injectable for tests; defaults to the per-session temp file. */
+  usageCursors?: UsageCursorStore;
 }): Promise<void> {
   const { harness, sessionId, transcriptPath, client } = args;
   const readTranscript = args.readTranscript ?? readClaudeTranscript;
@@ -133,6 +138,15 @@ export async function buildRetain(args: {
     });
   }
   if (turns.length === 0) return;
+  // Stop fires once the reply is finished, so every turn in the transcript is complete.
+  recordUsage({
+    harness,
+    sessionId,
+    bankId: args.bankId ?? "",
+    turns,
+    cursors: args.usageCursors ?? fileUsageCursorStore(harness),
+    lastTurnComplete: true,
+  });
 
   const startTs = turns[0]?.timestamp ?? new Date().toISOString();
   const t0 = Date.now();
@@ -239,6 +253,7 @@ export async function runRetainHook(
     lastAssistantMessage,
     readLastMessage: spec.readLastMessage,
     retryUntil: hostDeadline,
+    bankId,
     stamp: buildRetainStamp(cfg, {
       directory: cwd,
       sessionRoot,

--- a/hindsight-integrations/coding-agents/src/core/runtime.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/runtime.test.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveConfig } from "./config";
 import type { HindsightClient } from "./hindsight";
@@ -54,7 +57,7 @@ describe("RuntimeCore session-idle write-back", () => {
     const runtime = new RuntimeCore(client, "bank-1", resolveConfig({}));
 
     // The turn-driven path sees only what existed BEFORE the reply.
-    await runtime.onTranscript("s1", [turn("user", "how do we round?")]);
+    await runtime.onTranscript("s1", [turn("user", "how do we round?")], false);
     await new Promise((r) => setTimeout(r, 0)); // retain is fire-and-forget
     expect(retained).toHaveLength(1);
     expect(String(retained[0].turns)).not.toContain("we round half up");
@@ -80,7 +83,7 @@ describe("RuntimeCore session-idle write-back", () => {
     const { client, retained } = makeClient();
     const runtime = new RuntimeCore(client, "bank-1", resolveConfig({}));
 
-    await runtime.onTranscript("s2", [turn("user", "only turn")]);
+    await runtime.onTranscript("s2", [turn("user", "only turn")], false);
     await new Promise((r) => setTimeout(r, 0));
     expect(retained).toHaveLength(1);
 
@@ -99,6 +102,42 @@ describe("RuntimeCore session-idle write-back", () => {
     await runtime.onSessionIdle("s3");
     await new Promise((r) => setTimeout(r, 0));
     expect(retained).toHaveLength(1);
+  });
+
+  it("records Hindsight usage for a turn only once its reply is in", async () => {
+    const usageFile = join(mkdtempSync(join(tmpdir(), "hs-rt-usage-")), "usage.jsonl");
+    vi.stubEnv("HINDSIGHT_USAGE_FILE", usageFile);
+    try {
+      const { client } = makeClient();
+      const runtime = new RuntimeCore(client, "bank-1", resolveConfig({}), "kilo");
+
+      // Built before the reply: recording turn 1 now would log it with no calls, for good.
+      await runtime.onTranscript("s6", [turn("user", "how do we round?")], false);
+      expect(existsSync(usageFile)).toBe(false);
+
+      runtime.setTranscriptSource(async () => [
+        turn("user", "how do we round?"),
+        turn("action", "hindsight_search_knowledge_pages rounding"),
+        turn("assistant", "🧠 From Hindsight memory — half up"),
+      ]);
+      await runtime.onSessionIdle("s6");
+      const recorded = readFileSync(usageFile, "utf8")
+        .trim()
+        .split("\n")
+        .map((l) => JSON.parse(l));
+      expect(recorded).toMatchObject([
+        {
+          harness: "kilo",
+          session: "s6",
+          bank: "bank-1",
+          turn: 1,
+          calls: ["hindsight_search_knowledge_pages"],
+          credited: true,
+        },
+      ]);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("no-ops when the host cannot refetch, rather than retaining a stale transcript", async () => {

--- a/hindsight-integrations/coding-agents/src/core/runtime.ts
+++ b/hindsight-integrations/coding-agents/src/core/runtime.ts
@@ -8,7 +8,7 @@
  *   - onPrompt(sessionId, prompt)   : each user turn -> recall + build this turn's injection
  *   - getInjection(sessionId)       : the system-prompt text to inject this turn (or undefined)
  *   - toolSpecs()                   : the hindsight_* knowledge/recall tools to register natively
- *   - onTranscript(sessionId, turns): full transcript -> write back every N turns (on by default)
+ *   - onTranscript(sessionId, turns, lastTurnComplete): full transcript -> write back (on by default)
  *   - onSessionIdle(sessionId)      : assistant finished -> refetch + write back the completed
  *                                     exchange (the Stop-equivalent these hosts lack)
  * No opencode/claude specifics live here — only the memory logic.
@@ -23,6 +23,7 @@ import { buildKnowledgeTools, type ToolSpec } from "./knowledge-tools";
 import { buildPageTrigger } from "./missions";
 import { retainLiveSession, type TransportTurn } from "./chat";
 import { memoryCursorStore } from "./retain-cursor";
+import { memoryUsageCursorStore, recordUsage } from "./usage";
 import { buildRetainStamp } from "./retain-stamp";
 import { buildSessionStartContext } from "./session-start";
 import { buildHookOutput } from "./hook";
@@ -36,6 +37,8 @@ export class RuntimeCore {
   private readonly sessionState = new Map<string, { startTs: string; retainedTurns: number }>();
   /** Live write-back cursors. In memory, unlike the hook harnesses': this host outlives the session. */
   private readonly cursors = memoryCursorStore();
+  /** Turns already written to the usage log (core/usage.ts), per session. */
+  private readonly usageCursors = memoryUsageCursorStore();
   /** Pulls a session's CURRENT transcript from the host (set by the adapter); see onSessionIdle. */
   private fetchTranscript?: (sessionId: string) => Promise<TransportTurn[]>;
   private lastInjection = ""; // most recent turn's injection block, keyed by nothing (see getInjection)
@@ -208,9 +211,17 @@ export class RuntimeCore {
    * (`engine.retain.fold`), so submitting every turn costs one extraction, not one per turn, and
    * nothing is ever held somewhere it can be lost.
    */
-  async onTranscript(sessionId: string, turns: TransportTurn[]): Promise<void> {
+  async onTranscript(
+    sessionId: string,
+    turns: TransportTurn[],
+    /** Whether the agent has finished answering the last prompt. Required, not defaulted: opencode
+     *  hands this over while BUILDING a request (false), pi and Cline after the run ends (true), and
+     *  a wrong default records every turn one late and never the session's last. */
+    lastTurnComplete: boolean
+  ): Promise<void> {
     if (process.env.HINDSIGHT_DISABLE_HOOKS) return; // anti-recursion (see seedIfCold)
     if (!this.writeBackEnabled || !sessionId || !turns.length) return;
+    this.recordUsage(sessionId, turns, lastTurnComplete);
     const st = this.stateFor(sessionId);
     this.retain(sessionId, turns, st.startTs);
   }
@@ -241,12 +252,24 @@ export class RuntimeCore {
       return;
     }
     if (!turns.length) return;
+    this.recordUsage(sessionId, turns, true); // idle: the reply is in
     const st = this.stateFor(sessionId);
     // idle can fire more than once for one exchange (and again on a session with no new activity);
     // only retain when this transcript actually grew past what we last wrote.
     if (turns.length <= st.retainedTurns) return;
     st.retainedTurns = turns.length;
     this.retain(sessionId, turns, st.startTs, "idle");
+  }
+
+  private recordUsage(sessionId: string, turns: TransportTurn[], lastTurnComplete: boolean): void {
+    recordUsage({
+      harness: this.harness,
+      sessionId,
+      bankId: this.bankId,
+      turns,
+      cursors: this.usageCursors,
+      lastTurnComplete,
+    });
   }
 
   private stateFor(sessionId: string): {

--- a/hindsight-integrations/coding-agents/src/core/session-cache.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-cache.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { PageRef } from "./knowledge-injection";
 import type { RetainCursor, RetainCursorStore } from "./retain-cursor";
+import type { UsageCursorStore } from "./usage";
 
 /** Process-shared state for hook harnesses. SessionStart and prompt hooks are separate Node
  * processes, so this temp-file handoff carries lifecycle decisions without writing user config or
@@ -105,6 +106,33 @@ export function sessionRootDir(
     /* best-effort: an unrecorded root costs stability, never data */
   }
   return cwd;
+}
+
+/**
+ * How many of a session's turns core/usage.ts has recorded. Its own file for the same reason as
+ * the retain cursor below; losing it re-records the session's turns, which the report dedupes.
+ */
+export function fileUsageCursorStore(harness: string): UsageCursorStore {
+  const file = (sessionId: string) =>
+    join(tmpdir(), `hindsight-${harness}`, `${sessionId}.usage.json`);
+  return {
+    read: (sessionId) => {
+      try {
+        const turns = (JSON.parse(readFileSync(file(sessionId), "utf8")) as { turns?: unknown })
+          .turns;
+        return typeof turns === "number" ? turns : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    write: (sessionId, turns) => {
+      try {
+        writeFileAtomic(file(sessionId), JSON.stringify({ turns }));
+      } catch {
+        /* best-effort */
+      }
+    },
+  };
 }
 
 /** The cursor's own file, deliberately NOT the shared session cache — see fileCursorStore. */

--- a/hindsight-integrations/coding-agents/src/core/usage.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/usage.test.ts
@@ -1,0 +1,179 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TransportTurn } from "./chat";
+import {
+  formatUsageReport,
+  memoryUsageCursorStore,
+  readUsage,
+  recordUsage,
+  summarizeTurns,
+} from "./usage";
+
+const t = (role: string, content: string): TransportTurn => ({ role, content });
+
+let root: string;
+let usageFile: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "hs-usage-"));
+  usageFile = join(root, "usage.jsonl");
+  vi.stubEnv("HINDSIGHT_USAGE_FILE", usageFile);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  rmSync(root, { recursive: true, force: true });
+});
+
+const lines = () =>
+  readFileSync(usageFile, "utf8")
+    .trim()
+    .split("\n")
+    .map((l) => JSON.parse(l));
+
+describe("summarizeTurns", () => {
+  it("counts only Hindsight tools, whatever prefix the host gives them", () => {
+    const usage = summarizeTurns([
+      t("system", "REF-ID: x"), // before the first user turn: belongs to no turn
+      t("user", "how do we round?"),
+      t("action", "mcp__hindsight__hindsight_search_knowledge_pages rounding"),
+      t("action", "Read src/round.ts"),
+      t("action", "hindsight.hindsight_reflect why half-up"),
+      t("assistant", "> 🧠 **From Hindsight memory (Conventions)** — half up"),
+      t("user", "thanks"),
+      t("action", "hindsight_read_knowledge_page kp-1"),
+      t("assistant", "done"),
+    ]);
+    expect(usage).toEqual([
+      {
+        turn: 1,
+        calls: ["hindsight_search_knowledge_pages", "hindsight_reflect"],
+        credited: true,
+      },
+      { turn: 2, calls: ["hindsight_read_knowledge_page"], credited: false },
+    ]);
+  });
+
+  it("reads credit from Gemini-shaped `model` turns, and never from the user's own words", () => {
+    const usage = summarizeTurns([
+      t("user", "did it come From Hindsight memory?"),
+      t("user", "second"),
+      t("model", "🧠 From Hindsight memory — yes"),
+    ]);
+    expect(usage.map((u) => u.credited)).toEqual([false, true]);
+  });
+});
+
+describe("recordUsage", () => {
+  const base = { harness: "claude-code", sessionId: "s1", bankId: "bank-1" };
+
+  it("records each turn once across repeated Stops over the growing transcript", () => {
+    const cursors = memoryUsageCursorStore();
+    const first = [t("user", "a"), t("action", "mcp__hindsight__hindsight_reflect q")];
+    recordUsage({ ...base, turns: first, cursors, lastTurnComplete: true });
+    recordUsage({ ...base, turns: first, cursors, lastTurnComplete: true }); // Stop re-delivered
+    recordUsage({
+      ...base,
+      turns: [...first, t("user", "b"), t("assistant", "ok")],
+      cursors,
+      lastTurnComplete: true,
+    });
+
+    expect(lines()).toMatchObject([
+      {
+        harness: "claude-code",
+        session: "s1",
+        bank: "bank-1",
+        turn: 1,
+        calls: ["hindsight_reflect"],
+      },
+      { turn: 2, calls: [], credited: false },
+    ]);
+  });
+
+  it("holds back an unanswered last turn instead of recording it empty", () => {
+    const cursors = memoryUsageCursorStore();
+    recordUsage({ ...base, turns: [t("user", "a")], cursors, lastTurnComplete: false });
+    expect(() => readFileSync(usageFile)).toThrow(); // nothing finished yet
+
+    recordUsage({
+      ...base,
+      turns: [t("user", "a"), t("action", "hindsight_reflect q"), t("assistant", "done")],
+      cursors,
+      lastTurnComplete: true,
+    });
+    expect(lines()).toMatchObject([{ turn: 1, calls: ["hindsight_reflect"] }]);
+  });
+});
+
+describe("readUsage", () => {
+  it("aggregates per harness, dedupes re-recorded turns and includes the rotated generation", () => {
+    const line = (o: object) => JSON.stringify({ ts: "x", bank: "b", ...o }) + "\n";
+    writeFileSync(
+      `${usageFile}.1`,
+      line({
+        harness: "codex",
+        session: "a",
+        turn: 1,
+        calls: ["hindsight_reflect"],
+        credited: true,
+      })
+    );
+    writeFileSync(
+      usageFile,
+      line({
+        harness: "codex",
+        session: "a",
+        turn: 1,
+        calls: ["hindsight_reflect"],
+        credited: true,
+      }) +
+        line({ harness: "codex", session: "a", turn: 2, calls: [], credited: false }) +
+        // A write-only turn: counts as a call, never against the credit rate.
+        line({
+          harness: "codex",
+          session: "a",
+          turn: 3,
+          calls: ["hindsight_ingest_document"],
+          credited: false,
+        }) +
+        line({
+          harness: "codex",
+          session: "b",
+          turn: 1,
+          calls: ["hindsight_reflect", "hindsight_search_knowledge_pages"],
+          credited: false,
+        }) +
+        "not json\n"
+    );
+
+    const usage = readUsage(usageFile);
+    expect(usage).toEqual([
+      {
+        harness: "codex",
+        turns: 4,
+        turnsWithCalls: 3,
+        calls: 4,
+        turnsWithRetrieval: 2,
+        creditedTurnsWithRetrieval: 1,
+        byTool: {
+          hindsight_reflect: 2,
+          hindsight_search_knowledge_pages: 1,
+          hindsight_ingest_document: 1,
+        },
+      },
+    ]);
+    expect(formatUsageReport(usage, usageFile)).toContain(
+      "codex: 4 turns · 3 with a Hindsight call (75%) · 1.00 calls/turn · " +
+        "credited after retrieval 1/2 (50%)"
+    );
+  });
+
+  it("says so when nothing is recorded", () => {
+    expect(formatUsageReport(readUsage(usageFile), usageFile)).toBe(
+      `no Hindsight usage recorded yet (${usageFile})`
+    );
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/usage.ts
+++ b/hindsight-integrations/coding-agents/src/core/usage.ts
@@ -1,0 +1,242 @@
+/**
+ * Hindsight tool usage — is the agent calling our tools, and does it credit what they returned?
+ *
+ * One JSON line per finished user turn in `~/.hindsight/coding-agents-logs/usage.jsonl`:
+ *
+ *   {"ts","harness","session","bank","turn":7,"calls":["hindsight_reflect"],"credited":true}
+ *
+ * - `calls`    the hindsight_* tools the agent called during that turn (other tools are not counted)
+ * - `credited` the agent's reply carried the "From Hindsight memory" credit the tool guide asks for
+ *              whenever retrieved memory contributed — the cheap proxy for "the result was useful".
+ *              The report rates it over turns that called a retrieval tool (see RETRIEVAL_TOOLS)
+ *
+ * Computed from the NORMALIZED transcript every write-back already reads, not per harness: every
+ * transcript reader renders a tool call as a `role:"action"` turn led by the tool name, so one pass
+ * covers all of them. Recorded once per turn: a per-session cursor remembers how many turns are
+ * already written, because the Stop hook re-reads the whole transcript on every reply. Losing that
+ * cursor re-records a session's turns; the report dedupes by (harness, session, turn).
+ *
+ * Local only — nothing here is sent anywhere. Fail-open throughout.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { TransportTurn } from "./chat";
+import { appendLogLine, logsDir } from "./log";
+
+export function usageFilePath(): string {
+  return process.env.HINDSIGHT_USAGE_FILE || join(logsDir(), "usage.jsonl");
+}
+
+/** A Hindsight tool name at the END of a host's tool name: hosts prefix MCP tools differently
+ *  (`mcp__hindsight__hindsight_reflect`, `hindsight.hindsight_reflect`, bare `hindsight_reflect`).
+ *  Each segment needs a letter, so `hindsight__hindsight_reflect` cannot match from the first one. */
+const HINDSIGHT_TOOL_RE = /hindsight_(?:[a-z]+_)*[a-z]+$/;
+
+/** The credit line the injected tool guide prescribes (core/knowledge-injection.ts). */
+const CREDIT_RE = /from hindsight memory/i;
+
+/**
+ * The tools that hand memory BACK to the agent — the only calls a credit can follow. The write tools
+ * (ingest_document, capture_initiative) and the status probes never do, so counting them in the
+ * credit rate's denominator measured how often the agent saved things, not whether retrieval helped:
+ * on real sessions it read ~5% because ingest_document dominated.
+ */
+const RETRIEVAL_TOOLS = new Set([
+  "hindsight_search_knowledge_pages",
+  "hindsight_list_knowledge_pages",
+  "hindsight_read_knowledge_page",
+  "hindsight_reflect",
+]);
+
+/** Roles a reader uses for the agent's own prose (Gemini-shaped transcripts say "model"). */
+const ASSISTANT_ROLES = new Set(["assistant", "model"]);
+
+export interface TurnUsage {
+  /** 1-based index of the user turn within the session. */
+  turn: number;
+  calls: string[];
+  credited: boolean;
+}
+
+/** Split a transcript into user turns: each `user` turn opens one, and everything up to the next
+ *  belongs to it. Anything before the first user turn (a system preamble) belongs to none. */
+export function summarizeTurns(turns: TransportTurn[]): TurnUsage[] {
+  const out: TurnUsage[] = [];
+  for (const t of turns) {
+    if (t.role === "user") {
+      out.push({ turn: out.length + 1, calls: [], credited: false });
+      continue;
+    }
+    const current = out.at(-1);
+    if (!current) continue;
+    if (t.role === "action") {
+      const tool = t.content.split(" ", 1)[0].match(HINDSIGHT_TOOL_RE)?.[0];
+      if (tool) current.calls.push(tool);
+    } else if (ASSISTANT_ROLES.has(t.role) && CREDIT_RE.test(t.content)) {
+      current.credited = true;
+    }
+  }
+  return out;
+}
+
+/** How many of a session's turns are already recorded. File-backed for hook harnesses (a fresh
+ *  process per event), in memory for the persistent-plugin runtime. */
+export interface UsageCursorStore {
+  read(sessionId: string): number | undefined;
+  write(sessionId: string, turns: number): void;
+}
+
+export function memoryUsageCursorStore(): UsageCursorStore {
+  const recorded = new Map<string, number>();
+  return {
+    read: (sessionId) => recorded.get(sessionId),
+    write: (sessionId, turns) => void recorded.set(sessionId, turns),
+  };
+}
+
+/**
+ * Append a usage line for every finished turn not recorded yet.
+ *
+ * `lastTurnComplete` is false when the transcript was captured while the agent was still answering
+ * its last prompt (the persistent-plugin runtime builds it before sending the request): that turn
+ * is left for a later call, or it would be recorded with no calls and no credit and never revisited.
+ */
+export function recordUsage(args: {
+  harness: string;
+  sessionId: string;
+  bankId: string;
+  turns: TransportTurn[];
+  cursors: UsageCursorStore;
+  lastTurnComplete: boolean;
+}): void {
+  const summary = summarizeTurns(args.turns);
+  const finished = args.lastTurnComplete ? summary : summary.slice(0, -1);
+  const from = args.cursors.read(args.sessionId) ?? 0;
+  // `<=` also covers a transcript that shrank (rewritten): nothing new to say about it.
+  if (finished.length <= from) return;
+  const ts = new Date().toISOString();
+  const lines = finished
+    .slice(from)
+    .map(
+      (u) =>
+        JSON.stringify({
+          ts,
+          harness: args.harness,
+          session: args.sessionId,
+          bank: args.bankId,
+          turn: u.turn,
+          calls: u.calls,
+          credited: u.credited,
+        }) + "\n"
+    )
+    .join("");
+  try {
+    appendLogLine(usageFilePath(), lines);
+    args.cursors.write(args.sessionId, finished.length);
+  } catch {
+    /* usage stats must never break the agent */
+  }
+}
+
+interface UsageLine {
+  harness: string;
+  session: string;
+  turn: number;
+  calls: string[];
+  credited: boolean;
+}
+
+function isUsageLine(v: unknown): v is UsageLine {
+  const r = v as UsageLine | null;
+  return (
+    typeof r === "object" &&
+    r !== null &&
+    typeof r.harness === "string" &&
+    typeof r.session === "string" &&
+    typeof r.turn === "number" &&
+    Array.isArray(r.calls) &&
+    typeof r.credited === "boolean"
+  );
+}
+
+export interface HarnessUsage {
+  harness: string;
+  turns: number;
+  /** Turns with at least one hindsight_* call. */
+  turnsWithCalls: number;
+  calls: number;
+  /** Turns that called a RETRIEVAL tool — the credit rate's denominator. */
+  turnsWithRetrieval: number;
+  /** Of `turnsWithRetrieval`, how many replies credited Hindsight memory. */
+  creditedTurnsWithRetrieval: number;
+  byTool: Record<string, number>;
+}
+
+/** Aggregate the usage log (the rotated generation first) per harness, one line per turn. */
+export function readUsage(path = usageFilePath()): HarnessUsage[] {
+  const latest = new Map<string, UsageLine>();
+  for (const file of [`${path}.1`, path]) {
+    let text = "";
+    try {
+      text = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const raw of text.split("\n")) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+      if (!isUsageLine(parsed)) continue;
+      latest.set(`${parsed.harness}\n${parsed.session}\n${parsed.turn}`, parsed);
+    }
+  }
+
+  const byHarness = new Map<string, HarnessUsage>();
+  for (const line of latest.values()) {
+    let h = byHarness.get(line.harness);
+    if (!h) {
+      h = {
+        harness: line.harness,
+        turns: 0,
+        turnsWithCalls: 0,
+        calls: 0,
+        turnsWithRetrieval: 0,
+        creditedTurnsWithRetrieval: 0,
+        byTool: {},
+      };
+      byHarness.set(line.harness, h);
+    }
+    h.turns++;
+    h.calls += line.calls.length;
+    for (const tool of line.calls) h.byTool[tool] = (h.byTool[tool] ?? 0) + 1;
+    if (line.calls.length) h.turnsWithCalls++;
+    if (line.calls.some((tool) => RETRIEVAL_TOOLS.has(tool))) {
+      h.turnsWithRetrieval++;
+      if (line.credited) h.creditedTurnsWithRetrieval++;
+    }
+  }
+  return [...byHarness.values()].sort((a, b) => b.turns - a.turns);
+}
+
+const pct = (n: number, d: number) => (d ? `${Math.round((100 * n) / d)}%` : "-");
+
+/** Human-readable report for `hindsight-coding-agents stats`. */
+export function formatUsageReport(usage: HarnessUsage[], path = usageFilePath()): string {
+  if (!usage.length) return `no Hindsight usage recorded yet (${path})`;
+  const out = [`Hindsight tool usage (${path})`, ""];
+  for (const h of usage) {
+    out.push(
+      `${h.harness}: ${h.turns} turns · ${h.turnsWithCalls} with a Hindsight call ` +
+        `(${pct(h.turnsWithCalls, h.turns)}) · ${(h.calls / h.turns).toFixed(2)} calls/turn · ` +
+        `credited after retrieval ${h.creditedTurnsWithRetrieval}/${h.turnsWithRetrieval} ` +
+        `(${pct(h.creditedTurnsWithRetrieval, h.turnsWithRetrieval)})`
+    );
+    for (const [tool, n] of Object.entries(h.byTool).sort((a, b) => b[1] - a[1])) {
+      out.push(`    ${tool}: ${n}`);
+    }
+  }
+  return out.join("\n");
+}

--- a/hindsight-integrations/coding-agents/src/harness/opencode.ts
+++ b/hindsight-integrations/coding-agents/src/harness/opencode.ts
@@ -128,7 +128,7 @@ function createRuntime(core: RuntimeCore) {
       const msgs = output.messages || [];
       const sid = opencodeSessionId(msgs);
       if (!sid) return;
-      await core.onTranscript(sid, readOpencodeMessages(msgs));
+      await core.onTranscript(sid, readOpencodeMessages(msgs), false);
     },
     // The Stop-equivalent these hosts otherwise lack: `session.idle` fires once the assistant has
     // finished, which is the only moment the completed exchange is readable. Without it a session's

--- a/hindsight-integrations/coding-agents/src/harness/pi-extension.test.ts
+++ b/hindsight-integrations/coding-agents/src/harness/pi-extension.test.ts
@@ -84,11 +84,16 @@ describe("pi extension adapter", () => {
       "session-1"
     );
 
-    expect(onTranscript).toHaveBeenCalledWith("session-1", [
-      { role: "user", content: "remember the preference" },
-      { role: "assistant", content: "I will do that." },
-      { role: "action", content: "read README.md" },
-    ]);
+    // `true`: agent_end sees the finished run — the reply's turn is complete (usage stats).
+    expect(onTranscript).toHaveBeenCalledWith(
+      "session-1",
+      [
+        { role: "user", content: "remember the preference" },
+        { role: "assistant", content: "I will do that." },
+        { role: "action", content: "read README.md" },
+      ],
+      true
+    );
   });
 
   it("does not write back an empty exchange", async () => {

--- a/hindsight-integrations/coding-agents/src/harness/pi-extension.ts
+++ b/hindsight-integrations/coding-agents/src/harness/pi-extension.ts
@@ -143,7 +143,7 @@ export function createPiHooks(
     },
     async agentEnd(event: { messages: readonly PiMessage[] }, sessionId: string): Promise<void> {
       const turns = readPiMessages(event.messages);
-      if (turns.length) await core.onTranscript(sessionId, turns);
+      if (turns.length) await core.onTranscript(sessionId, turns, true); // the run has ended
     },
   };
 }

--- a/hindsight-integrations/coding-agents/src/installer.ts
+++ b/hindsight-integrations/coding-agents/src/installer.ts
@@ -46,6 +46,7 @@ import { importLocalHistory } from "./core/history";
 import { detectLlm, hasRustToolchain, hasUvx, type LlmChoice } from "./core/daemon";
 import { readLegacyEndpoint } from "./core/legacy";
 import { SKILL_DIRS } from "./core/skill-dirs";
+import { formatUsageReport, readUsage } from "./core/usage";
 import { createInstallerUi, type SelectOption } from "./install-ui";
 
 /**
@@ -1942,6 +1943,11 @@ export function run(argv: string[], ctxIn: InstallCtx): number {
   // read as a harness name and rejected.
   const valueArgs = flagValueArgs(rawArgs, ["server", "api-url", "api-token"]);
   const names = rawArgs.filter((a) => !a.startsWith("--") && !valueArgs.has(a));
+  // Read-only: summarizes the local usage log (core/usage.ts) and touches nothing else.
+  if (command === "stats") {
+    ctx.log?.(formatUsageReport(readUsage()));
+    return 0;
+  }
   // Everything we write into a host's config is an ABSOLUTE path into this package. Run straight
   // from an npx cache those paths die on the first eviction and every hook stops SILENTLY, which is
   // why installing from a cache used to be refused outright. Copying the runtime somewhere stable
@@ -1969,6 +1975,7 @@ export function run(argv: string[], ctxIn: InstallCtx): number {
     ctx.log?.(
       `usage: hindsight-coding-agents <install|uninstall> <all|harness...>\n` +
         `       hindsight-coding-agents update\n` +
+        `       hindsight-coding-agents stats\n` +
         `       [--server cloud|self-hosted|daemon] [--api-url <url>] [--api-token <token>]\n` +
         `       [--import-conversations]\n` +
         `  all      every agent detected on this machine\n` +

--- a/hindsight-integrations/coding-agents/vitest.config.ts
+++ b/hindsight-integrations/coding-agents/vitest.config.ts
@@ -6,9 +6,10 @@ export default defineConfig({
   test: {
     env: {
       // Unit tests exercise code paths that emit diagnostics; keep them out of the REAL
-      // /tmp/hindsight-plugin.log so a developer's diag trail isn't polluted with test noise.
+      // ~/.hindsight/coding-agents-logs so a developer's trail isn't polluted with test noise.
       HINDSIGHT_DIAG_FILE: join(tmpdir(), "hindsight-plugin-test.log"),
       HINDSIGHT_LOG_FILE: join(tmpdir(), "hindsight-plugin-test-leveled.log"),
+      HINDSIGHT_USAGE_FILE: join(tmpdir(), "hindsight-plugin-test-usage.jsonl"),
       // Same reasoning for the CONFIG file: `loadConfig` otherwise resolves the developer's real
       // ~/.hindsight/coding-agent.json, so a machine that has a token (or a bank override, or a
       // different apiUrl) fails assertions that a clean machine passes. It must be set HERE rather

--- a/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
+++ b/skills/hindsight-docs/references/sdks/integrations/coding-agents.md
@@ -23,6 +23,7 @@ npx @vectorize-io/hindsight-coding-agents install all          # every detected 
 npx @vectorize-io/hindsight-coding-agents install claude-code  # or just one
 npx @vectorize-io/hindsight-coding-agents uninstall all        # removes exactly what install added
 npx @vectorize-io/hindsight-coding-agents update               # refresh the runtime only, no rewiring
+npx @vectorize-io/hindsight-coding-agents stats                # how often each agent uses Hindsight
 ```
 
 `install` takes an explicit target — `all`, or one or more harness names. A bare
@@ -431,8 +432,8 @@ as `HINDSIGHT_MAX_PARALLEL_RETAINS` for containers and CI.
 
 `HINDSIGHT_CONFIG` moves the file itself — point it at another path for a container or a test
 harness where `$HOME` is not the right anchor. It is still exactly one file; only its location
-changes. (The other variables that are not settings are `HINDSIGHT_LOG_FILE`, `HINDSIGHT_DIAG_FILE`
-and `HINDSIGHT_LOG_LEVEL` — see Diagnostics & logging.)
+changes. (The other variables that are not settings are `HINDSIGHT_LOG_FILE`, `HINDSIGHT_DIAG_FILE`,
+`HINDSIGHT_USAGE_FILE` and `HINDSIGHT_LOG_LEVEL` — see Diagnostics & logging.)
 
 ### When a change takes effect
 
@@ -769,16 +770,18 @@ they stay where they were built, and new work accrues under the new setting.
 
 ## Diagnostics & logging
 
-Two files, two audiences:
+All logs live in `~/.hindsight/coding-agents-logs/` (owner-only). Each file rotates to `<file>.1`
+at 10 MB.
 
-**Leveled plugin log** (humans debugging): `$TMPDIR/hindsight-coding-agent/plugin.log` (override
+**Leveled plugin log** (humans debugging): `~/.hindsight/coding-agents-logs/plugin.log` (override
 `HINDSIGHT_LOG_FILE`) — timestamped `LEVEL [scope] message` lines from every component, including
 the ingestion engine. Level defaults to `info`; set `"logLevel": "debug"` in config or
 `HINDSIGHT_LOG_LEVEL=debug` for ad-hoc debugging (at `debug`, every diag event below is mirrored
 here too, so one file tells the whole story).
 
 **Structured diag events** (machines/harnesses): every reflect and page-fetch outcome is appended
-as a JSON line to `/tmp/hindsight-plugin.log` (override with `HINDSIGHT_DIAG_FILE`):
+as a JSON line to `~/.hindsight/coding-agents-logs/diag.jsonl` (override with
+`HINDSIGHT_DIAG_FILE`):
 
 ```json
 {
@@ -794,6 +797,17 @@ as a JSON line to `/tmp/hindsight-plugin.log` (override with `HINDSIGHT_DIAG_FIL
 `reflect_failed` / `pages_failed` record the error; if you're comparing memory-on vs memory-off,
 check this file — a run whose reflects failed is a no-memory run. Seed starts are logged as
 `seed_started`.
+
+**Tool usage** (is the agent using Hindsight?): one JSON line per finished user turn in
+`~/.hindsight/coding-agents-logs/usage.jsonl` (override `HINDSIGHT_USAGE_FILE`) — the `hindsight_*`
+tools the agent called during that turn, and whether its reply credited Hindsight memory ("From
+Hindsight memory"). The credit rate counts only turns that called a retrieval tool (search, list,
+read, reflect); saving a document is not expected to be credited. Recorded when the session is written back, so a scope with
+`retainSessions: false` records none. It never leaves your machine. Summarize it per agent with:
+
+```bash
+npx @vectorize-io/hindsight-coding-agents stats
+```
 
 ### Is the memory ready yet?
 


### PR DESCRIPTION
## What

Two answers we couldn't get before: **is the agent calling the Hindsight tools**, and **does it use what they return**.

- New `~/.hindsight/coding-agents-logs/usage.jsonl` — one line per finished user turn:
  `{harness, session, bank, turn, calls: ["hindsight_reflect", …], credited}`.
  `credited` = the reply carried the "From Hindsight memory" credit the tool guide asks for — a cheap proxy for "the result was useful".
- `npx @vectorize-io/hindsight-coding-agents stats` — per agent: turns, % of turns with a Hindsight call, calls/turn, and credit rate over turns that called a **retrieval** tool (search/list/read/reflect). Write tools (`ingest_document`, `capture_initiative`) are excluded from the credit denominator: on real sessions they dominated and made the rate read ~5%.
- Logs move out of `/tmp`: `plugin.log` (was `$TMPDIR/hindsight-coding-agent/`) and the diag trail (was `/tmp/hindsight-plugin.log`, shared by every user on the machine) now live in an owner-only `~/.hindsight/coding-agents-logs/`, each rotating to `<file>.1` at 10 MB. `HINDSIGHT_LOG_FILE` / `HINDSIGHT_DIAG_FILE` still override; `HINDSIGHT_USAGE_FILE` added.

## How

Computed from the normalized transcript the write-back already reads (every reader renders a tool call as a `role:"action"` turn led by the tool name), so one path covers all harnesses: `buildRetain` for hook harnesses, `RuntimeCore.onTranscript`/`onSessionIdle` for persistent-plugin hosts. A per-session cursor records each turn once; the report also dedupes by (harness, session, turn).

`onTranscript` now takes an explicit `lastTurnComplete`: opencode calls it while building a request (reply not in yet), pi and Cline after the run ends. A single default would record every turn one late and never the session's last.

Stats piggyback on write-back, so a scope with `retainSessions: false` records none (documented). Nothing leaves the machine.

## Tests

`usage.test.ts` (turn splitting, tool-name prefixes, credit, cursor, rotation-aware aggregation), log rotation + dir mode, a real Claude Code JSONL through `buildRetain`, and the runtime holding back an unanswered turn. Lint + full coding-agents suite green.