### PR TITLE
fix(paperclip): resolve the Cloud API key through a real secret reference

### DIFF
--- a/hindsight-integrations/paperclip/package-lock.json
+++ b/hindsight-integrations/paperclip/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/plugin-sdk": "^2026.403.0"
+        "@paperclipai/plugin-sdk": "^2026.720.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -534,16 +534,19 @@
       }
     },
     "node_modules/@paperclipai/plugin-sdk": {
-      "version": "2026.512.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.512.0.tgz",
-      "integrity": "sha512-Rk0Ds7+ZuYekNYY+pd78TYOnm6yOuuPCUNI24QV3Re5zN/me/ECbAhp6mUTtfUhp97cvnCIHBpsEJ1tfVhA6QQ==",
+      "version": "2026.831.1",
+      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.831.1.tgz",
+      "integrity": "sha512-de69dihx3PJOHBgJfy/Z1Oe5RmyxfsIdYFDJufFFtvr+oQlj3B83OntmNb/gaPCH3sKQ+rEIHY82Qx2fbIfD9w==",
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/shared": "2026.512.0",
-        "zod": "^3.24.2"
+        "@paperclipai/shared": "2026.831.1",
+        "zod": "^4.4.3"
       },
       "bin": {
         "paperclip-plugin-dev-server": "dist/dev-cli.js"
+      },
+      "engines": {
+        "node": ">=24.11.0"
       },
       "peerDependencies": {
         "react": ">=18"
@@ -555,12 +558,15 @@
       }
     },
     "node_modules/@paperclipai/shared": {
-      "version": "2026.512.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.512.0.tgz",
-      "integrity": "sha512-OkSsGy2X+yrtZSzobA/GZSM2FxWAOGvhSTPeL+kPlTtKTe3p5IvZIINZr5Kxogq3ms2J8x05jGvGkjF+rIOAAw==",
+      "version": "2026.831.1",
+      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.831.1.tgz",
+      "integrity": "sha512-rkpful4jL71GIl8+SRBD4oUm1Kcrz4V4RXz75kQYq8DX2xmLA0gKzcDWeenouYrAmFvzeOshDCQpc1u8FrN4xQ==",
       "license": "MIT",
       "dependencies": {
-        "zod": "^3.24.2"
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=24.11.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1690,474 +1696,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.3.tgz",
@@ -2183,50 +1721,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/vitest/node_modules/vite": {
@@ -2325,9 +1819,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.6.2.tgz",
+      "integrity": "sha512-lh5RCAGFa1Cm2hjtNwLQhSs/AsqdWnTQaBER9fEwN/88pSh7KOtJavtBx/0VlkN/uFd61SwYmljLMDAsHlvzBQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/hindsight-integrations/paperclip/package-lock.json
+++ b/hindsight-integrations/paperclip/package-lock.json
@@ -534,19 +534,16 @@
       }
     },
     "node_modules/@paperclipai/plugin-sdk": {
-      "version": "2026.831.1",
-      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.831.1.tgz",
-      "integrity": "sha512-de69dihx3PJOHBgJfy/Z1Oe5RmyxfsIdYFDJufFFtvr+oQlj3B83OntmNb/gaPCH3sKQ+rEIHY82Qx2fbIfD9w==",
+      "version": "2026.720.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/plugin-sdk/-/plugin-sdk-2026.720.0.tgz",
+      "integrity": "sha512-xs3dUKXcPw8sOl2tTo8g8AByzqawX7c8lPAjDe+dAhshFbdWNigBbMO6OgB7urnwoJ4RuQhWjeIJFC0CsyY0ZA==",
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/shared": "2026.831.1",
-        "zod": "^4.4.3"
+        "@paperclipai/shared": "2026.720.0",
+        "zod": "^3.24.2"
       },
       "bin": {
         "paperclip-plugin-dev-server": "dist/dev-cli.js"
-      },
-      "engines": {
-        "node": ">=24.11.0"
       },
       "peerDependencies": {
         "react": ">=18"
@@ -558,15 +555,12 @@
       }
     },
     "node_modules/@paperclipai/shared": {
-      "version": "2026.831.1",
-      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.831.1.tgz",
-      "integrity": "sha512-rkpful4jL71GIl8+SRBD4oUm1Kcrz4V4RXz75kQYq8DX2xmLA0gKzcDWeenouYrAmFvzeOshDCQpc1u8FrN4xQ==",
+      "version": "2026.720.0",
+      "resolved": "https://registry.npmjs.org/@paperclipai/shared/-/shared-2026.720.0.tgz",
+      "integrity": "sha512-n02fw0780z9SKb3xxKxOjgZqGStenfaCqxzOz/UtMpEsziEfdRCKG06IudWLdnqtLuR4atJCr4zBgHw11bRiXQ==",
       "license": "MIT",
       "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "engines": {
-        "node": ">=24.11.0"
+        "zod": "^3.24.2"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1819,9 +1813,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.6.2.tgz",
-      "integrity": "sha512-lh5RCAGFa1Cm2hjtNwLQhSs/AsqdWnTQaBER9fEwN/88pSh7KOtJavtBx/0VlkN/uFd61SwYmljLMDAsHlvzBQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/hindsight-integrations/paperclip/package.json
+++ b/hindsight-integrations/paperclip/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@paperclipai/plugin-sdk": "^2026.720.0"
+    "@paperclipai/plugin-sdk": "^2026.403.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/hindsight-integrations/paperclip/package.json
+++ b/hindsight-integrations/paperclip/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@paperclipai/plugin-sdk": "^2026.403.0"
+    "@paperclipai/plugin-sdk": "^2026.720.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/hindsight-integrations/paperclip/src/manifest.ts
+++ b/hindsight-integrations/paperclip/src/manifest.ts
@@ -35,11 +35,26 @@ const manifest: PaperclipPluginManifestV1 = {
         default: "https://api.hindsight.vectorize.io",
       },
       hindsightApiKeyRef: {
-        type: "string",
+        // `format` drives the host's secret picker; the picker writes a
+        // { type: "secret_ref", secretId } object, and the host validates the raw
+        // config with Ajv before extracting refs — so the schema has to admit that
+        // object as well as a plain string (a pasted value or a legacy UUID).
         format: "secret-ref",
         title: "Hindsight API Key (secret ref)",
         description:
           "Paperclip secret holding your Hindsight Cloud API key. Leave empty for self-hosted.",
+        oneOf: [
+          { type: "string" },
+          {
+            type: "object",
+            required: ["type", "secretId"],
+            properties: {
+              type: { const: "secret_ref" },
+              secretId: { type: "string" },
+              version: { type: "string" },
+            },
+          },
+        ],
       },
       dynamicBankId: {
         type: "boolean",

--- a/hindsight-integrations/paperclip/src/manifest.ts
+++ b/hindsight-integrations/paperclip/src/manifest.ts
@@ -36,9 +36,10 @@ const manifest: PaperclipPluginManifestV1 = {
       },
       hindsightApiKeyRef: {
         type: "string",
+        format: "secret-ref",
         title: "Hindsight API Key (secret ref)",
         description:
-          "Name of the Paperclip secret holding your Hindsight Cloud API key. Leave empty for self-hosted.",
+          "Paperclip secret holding your Hindsight Cloud API key. Leave empty for self-hosted.",
       },
       dynamicBankId: {
         type: "boolean",

--- a/hindsight-integrations/paperclip/src/worker.ts
+++ b/hindsight-integrations/paperclip/src/worker.ts
@@ -18,13 +18,21 @@
  */
 
 import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
-import type { ToolRunContext } from "@paperclipai/plugin-sdk";
+import type {
+  EnvSecretRefBinding,
+  PluginContext,
+  ToolRunContext,
+} from "@paperclipai/plugin-sdk";
 import { HindsightClient, formatMemories } from "./client.js";
 import { deriveBankId, extractUserFromIssue } from "./bank.js";
 
 interface PluginConfig {
   hindsightApiUrl: string;
-  hindsightApiKeyRef?: string;
+  /**
+   * Reference stored by the host's secret picker for the `format: "secret-ref"`
+   * field. The host fails closed on a bare string, so it travels through as-is.
+   */
+  hindsightApiKeyRef?: EnvSecretRefBinding;
   bankId?: string;
   dynamicBankId?: boolean;
   bankGranularity?: Array<"company" | "agent" | "user">;
@@ -58,11 +66,17 @@ async function getConfig(ctx: {
 }
 
 async function resolveApiKey(
-  ctx: { secrets: { resolve(ref: string): Promise<string | null> } },
-  config: PluginConfig
+  ctx: Pick<PluginContext, "secrets">,
+  config: PluginConfig,
+  companyId: string
 ): Promise<string | undefined> {
   if (!config.hindsightApiKeyRef) return undefined;
-  const resolved = await ctx.secrets.resolve(config.hindsightApiKeyRef);
+  // configPath identifies which binding to read when a plugin holds several
+  // secrets; companyId scopes the lookup to the run's company.
+  const resolved = await ctx.secrets.resolve(config.hindsightApiKeyRef, {
+    companyId,
+    configPath: "hindsightApiKeyRef",
+  });
   return resolved ?? undefined;
 }
 
@@ -120,7 +134,7 @@ const plugin = definePlugin({
       }
 
       try {
-        const apiKey = await resolveApiKey(ctx, config);
+        const apiKey = await resolveApiKey(ctx, config, companyId);
         const client = new HindsightClient(config.hindsightApiUrl, apiKey);
         const bankId = deriveBankId({ companyId, agentId, userId }, config);
 
@@ -220,7 +234,7 @@ const plugin = definePlugin({
       }
 
       try {
-        const apiKey = await resolveApiKey(ctx, config);
+        const apiKey = await resolveApiKey(ctx, config, companyId);
         const client = new HindsightClient(config.hindsightApiUrl, apiKey);
         const bankId = deriveBankId({ companyId, agentId: bankAgentId, userId }, config);
         await client.retain(bankId, body, commentId, {
@@ -305,7 +319,7 @@ const plugin = definePlugin({
 
         // Live recall fallback
         try {
-          const apiKey = await resolveApiKey(ctx, config);
+          const apiKey = await resolveApiKey(ctx, config, runCtx.companyId);
           const client = new HindsightClient(config.hindsightApiUrl, apiKey);
           const response = await client.recall(bankId, query, config.recallBudget ?? "mid");
           const memories = formatMemories(response.results);
@@ -357,7 +371,7 @@ const plugin = definePlugin({
         );
 
         try {
-          const apiKey = await resolveApiKey(ctx, config);
+          const apiKey = await resolveApiKey(ctx, config, runCtx.companyId);
           const client = new HindsightClient(config.hindsightApiUrl, apiKey);
           await client.retain(bankId, content, undefined, {
             agentId: runCtx.agentId,

--- a/hindsight-integrations/paperclip/tests/plugin.spec.ts
+++ b/hindsight-integrations/paperclip/tests/plugin.spec.ts
@@ -756,15 +756,29 @@ describe("hindsightApiKeyRef", () => {
     vi.restoreAllMocks();
   });
 
-  it("is declared as a secret-ref field", () => {
+  it("is declared as a secret-ref field that admits the picker's reference object", () => {
     const field = (
       manifest.instanceConfigSchema as {
-        properties: Record<string, { format?: string }>;
+        properties: Record<
+          string,
+          { format?: string; oneOf?: Array<Record<string, unknown>> }
+        >;
       }
     ).properties.hindsightApiKeyRef;
-    // Without this the host renders a plain text box, stores whatever is typed,
-    // and every resolve() fails closed on a bare string.
+
+    // Without `format` the host renders a plain text box, stores whatever is
+    // typed, and every resolve() fails closed on a bare string.
     expect(field?.format).toBe("secret-ref");
+
+    // With `format` alone but `type: "string"`, the host's Ajv pass rejects what
+    // its own picker submits: "Configuration does not match the plugin's
+    // instanceConfigSchema". The schema must admit the reference object too.
+    const objectBranch = field?.oneOf?.find((branch) => branch.type === "object") as
+      | { required?: string[]; properties?: Record<string, unknown> }
+      | undefined;
+    expect(objectBranch).toBeDefined();
+    expect(objectBranch?.required).toEqual(["type", "secretId"]);
+    expect(field?.oneOf?.some((branch) => branch.type === "string")).toBe(true);
   });
 
   it("resolves the stored reference for the run's company and authenticates recall", async () => {

--- a/hindsight-integrations/paperclip/tests/plugin.spec.ts
+++ b/hindsight-integrations/paperclip/tests/plugin.spec.ts
@@ -745,3 +745,71 @@ describe("enabledAgentIds", () => {
     expect(retainCalls.length).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hindsight Cloud API key — secret reference
+// ---------------------------------------------------------------------------
+
+describe("hindsightApiKeyRef", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("is declared as a secret-ref field", () => {
+    const field = (
+      manifest.instanceConfigSchema as {
+        properties: Record<string, { format?: string }>;
+      }
+    ).properties.hindsightApiKeyRef;
+    // Without this the host renders a plain text box, stores whatever is typed,
+    // and every resolve() fails closed on a bare string.
+    expect(field?.format).toBe("secret-ref");
+  });
+
+  it("resolves the stored reference for the run's company and authenticates recall", async () => {
+    const fetchMock = mockFetch([{ url: /recall/, body: { results: [] } }]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const secretRef = { type: "secret_ref" as const, secretId: "sec-1" };
+    const harness = buildHarness({ ...DEFAULT_CONFIG, hindsightApiKeyRef: secretRef });
+    const resolve = vi
+      .spyOn(harness.ctx.secrets, "resolve")
+      .mockResolvedValue("hs-cloud-key");
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "Ship it" });
+
+    await harness.emit(
+      "agent.run.started",
+      { agentId: "ag-1", runId: "run-1", issueId: issue.id },
+      { companyId: "co-1" }
+    );
+
+    expect(resolve).toHaveBeenCalledWith(secretRef, {
+      companyId: "co-1",
+      configPath: "hindsightApiKeyRef",
+    });
+
+    const recallCall = fetchMock.mock.calls.find(([url]: [string]) => url.includes("recall"));
+    const headers = recallCall?.[1]?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer hs-cloud-key");
+  });
+
+  it("never touches the secrets client when no reference is configured", async () => {
+    const fetchMock = mockFetch([{ url: /recall/, body: { results: [] } }]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const harness = buildHarness();
+    const resolve = vi.spyOn(harness.ctx.secrets, "resolve");
+    await setupPlugin(harness);
+    const issue = await seedIssue(harness, { companyId: "co-1", title: "Self-hosted" });
+
+    await harness.emit(
+      "agent.run.started",
+      { agentId: "ag-1", runId: "run-1", issueId: issue.id },
+      { companyId: "co-1" }
+    );
+
+    expect(resolve).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### What

`hindsightApiKeyRef` is declared as a plain string — "name of the Paperclip secret" — and handed
straight to `ctx.secrets.resolve()`. Since `@paperclipai/plugin-sdk` **2026.720.0** the host
requires a `{ type: "secret_ref", secretId }` object and fails closed on a bare string, so any
Cloud-backed instance logs, on every single run:

```
[plugin] Failed to recall memories on run start
JsonRpcCallError: Invalid secret reference for plugin: <secret name>.
Use { type: "secret_ref", secretId, version? }
```

and never recalls or retains anything. The plugin's own config test stays green throughout,
because `onValidateConfig` builds its client **without** a token and only probes `/health` —
which is why this can run unnoticed for a long time.

### Why it happens

`package.json` allows `^2026.403.0`, but the committed lockfile still resolves **2026.512.0**,
whose `PluginSecretsClient.resolve(secretRef: string)` typed the old string contract. The plugin
was written against that signature and never moved.

### The change

- `manifest.ts`: declare `format: "secret-ref"` on the field, so the host renders its secret
  picker and stores the reference object (the shape first-party plugins use, e.g. the `e2b`
  sandbox provider's `apiKey`).
- `worker.ts`: type the field as the SDK's own `EnvSecretRefBinding`, take `ctx` as
  `Pick<PluginContext, "secrets">`, and pass `{ companyId, configPath: "hindsightApiKeyRef" }`
  to `resolve()` — matching the usage documented in `define-plugin.ts`. `configPath` is what the
  host uses to disambiguate bindings; `companyId` scopes the lookup to the run's company.
- SDK floor raised to `^2026.720.0`, the release that introduced the object signature.

Self-hosted instances are unaffected: an empty reference still skips the secrets client entirely.

### Tests

Three tests in `tests/plugin.spec.ts`, using the existing `createTestHarness` setup. Two of them
fail on `main` and pass with this change:

- the manifest field declares `format: "secret-ref"`;
- a configured reference reaches `ctx.secrets.resolve` untouched, with `companyId` and
  `configPath`, and the resolved key ends up in the recall `Authorization` header;
- no reference configured → the secrets client is never called (guards the self-hosted path).

`npm ci`, `npm run typecheck`, `npm run build` and `npm test` are green (60 tests).

### Note on the lockfile

The SDK bump is deliberately pinned to **2026.720.0** rather than the newest release: newer SDKs
pull in zod 4 and an `engines: node >=24.11` constraint that this fix does not need. The lockfile
diff also dedupes vitest's nested `@esbuild/*` copies — an incidental `npm install` outcome, with
no package lost (26 esbuild platform entries before and after).

The three commits are best squashed on merge.
