### PR TITLE
fix(coding-agents): preserve distinct non-ASCII document titles

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.test.ts
@@ -376,20 +376,40 @@ describe("buildKnowledgeTools", () => {
     );
   });
 
-  it("hindsight_ingest_document falls back to 'doc' when the title has no safe characters", async () => {
-    const client = stubClient();
-    const tools = buildKnowledgeTools(client, "repo-a");
-    const tool = findTool(tools, "hindsight_ingest_document");
-    await tool.handler({ title: "!!!///???", content: "x" });
-    expect(client.retain).toHaveBeenCalledWith(
-      "x",
-      "ingested document",
-      "doc",
-      ["source:upload"],
-      "document",
-      {} // no harness in these tests: nothing to stamp
-    );
-  });
+  it.each([
+    ["测试问题17记忆文档一", "测试问题17记忆文档二"],
+    ["记忆文档一", "记忆文档二"],
+    ["Résumé", "Rèsumé"],
+    ["!!!///???", "???///!!!"],
+  ])(
+    "hindsight_ingest_document keeps distinct lossy titles: %s / %s",
+    async (title, otherTitle) => {
+      const documents = new Map<string, string>();
+      const client = stubClient({
+        retain: vi.fn(async (content: string, _context: string, documentId: string) => {
+          documents.set(documentId, content);
+        }),
+      });
+      const tool = findTool(buildKnowledgeTools(client, "repo-a"), "hindsight_ingest_document");
+      const first = JSON.parse(
+        (await tool.handler({ title, content: "first document" })).content[0].text
+      );
+      const second = JSON.parse(
+        (await tool.handler({ title: otherTitle, content: "second document" })).content[0].text
+      );
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(true);
+      expect(first.doc_id).not.toBe(second.doc_id);
+      expect(documents.get(first.doc_id)).toBe("first document");
+      expect(documents.get(second.doc_id)).toBe("second document");
+
+      const updated = await tool.handler({ title, content: "updated first document" });
+      expect(JSON.parse(updated.content[0].text)).toEqual(first);
+      expect(documents.size).toBe(2);
+      expect(documents.get(first.doc_id)).toBe("updated first document");
+      expect(documents.get(second.doc_id)).toBe("second document");
+    }
+  );
 
   for (const name of [
     "hindsight_list_knowledge_pages",

--- a/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
+++ b/hindsight-integrations/coding-agents/src/core/knowledge-tools.ts
@@ -15,6 +15,7 @@
  * (core/survey.ts).
  */
 import { z } from "zod";
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -306,11 +307,17 @@ export function buildKnowledgeTools(
       inputSchema: { title: z.string(), content: z.string() },
       annotations: NON_DESTRUCTIVE_WRITE_ANNOTATIONS,
       handler: guarded(async ({ title, content }) => {
+        const slug = title
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "");
+        // ASCII-only slugs erased non-Latin titles (or shared the "doc" fallback),
+        // overwriting unrelated documents. Hash the original title, not its content,
+        // so re-ingestion still updates it; "--" cannot occur in a legacy slug.
         const docId =
-          title
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, "-")
-            .replace(/^-+|-+$/g, "") || "doc";
+          /[^\x00-\x7f]/.test(title) || !slug
+            ? `${slug || "doc"}--${createHash("sha256").update(title).digest("hex")}`
+            : slug;
         const stamp = opts.stampFor?.();
         const metadata = {
           ...stamp?.metadata,


### PR DESCRIPTION
`hindsight_ingest_document` gives `测试问题17记忆文档一` and `测试问题17记忆文档二` the same document ID, `17`, so saving the second document can overwrite the first. Titles without ASCII letters or numbers all share the `doc` fallback.

Append a SHA-256 hash of the original title when it contains non-ASCII characters or produces an empty slug. Saving the same exact title with new content keeps its ID, while existing nonempty ASCII slugs remain unchanged. Already-saved affected titles will receive a new ID when imported again; this does not migrate old documents or recover overwritten content.

Fixes #4329.

Validation: all 1,020 coding-agents tests pass across 72 files, including regressions for Chinese titles with a shared number, pure Chinese titles, accented titles, punctuation-only titles, and repeated imports. TypeScript checking, the package build, and formatting checks on the changed files pass. The new regression uses the real tool handler with a stubbed retain client; no live backend or LLM is required. The repository-wide `lint.sh` was attempted but stops during Python dependency sync because this sparse checkout lacks the `hindsight-all` workspace, so a full-workspace lint pass is not claimed.
