### PR TITLE
fix(embeddings): retry once smaller when a provider rejects a capped input

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
+++ b/hindsight-api-slim/hindsight_api/engine/retain/embedding_utils.py
@@ -6,6 +6,7 @@ import logging
 from typing import Literal, Protocol
 
 from ...config import ENV_EMBEDDINGS_MAX_INPUT_TOKENS, get_config
+from ..remote_retry import status_code_of
 from ..token_encoding import count_tokens, truncate_many_to_tokens
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,16 @@ def _prefix_tokens(backend: EmbeddingsBackend, input_type: EmbeddingInputType) -
     attr = "query_prefix" if input_type == "query" else "passage_prefix"
     prefix = getattr(backend, attr, "")
     return count_tokens(prefix) if isinstance(prefix, str) and prefix else 0
+
+
+# A provider that rejects an input for its size answers with one of these. The body is
+# not a reliable signal: some gateways say only "The parameter is invalid".
+_INPUT_SIZE_REJECTION_STATUSES = frozenset({400, 413, 422})
+
+
+def _is_input_size_rejection(exc: Exception) -> bool:
+    """True for a 4xx that plausibly means the input was too large for the provider."""
+    return status_code_of(exc) in _INPUT_SIZE_REJECTION_STATUSES
 
 
 def _truncate_inputs(
@@ -116,13 +127,35 @@ async def generate_embeddings_batch(
     # out of the individual backends so every provider (and every call path — retain,
     # recall queries, consolidation, import) gets identical, model-agnostic truncation.
     max_input_tokens = get_config().embeddings_max_input_tokens
+    original_texts = texts
     if max_input_tokens is not None and texts:
         texts = _truncate_inputs(texts, max_input_tokens, embeddings_backend, input_type)
+    capped = texts != original_texts
 
     try:
         embeddings = await _encode_with_input_type(embeddings_backend, texts, input_type)
     except Exception as e:
-        raise Exception(f"Failed to generate batch embeddings: {str(e)}")
+        if not (capped and max_input_tokens and _is_input_size_rejection(e)):
+            raise Exception(f"Failed to generate batch embeddings: {str(e)}") from e
+        # The cap counts with HINDSIGHT_API_TOKENIZER_ENCODING and the provider counts
+        # with its own, so a text cut to exactly the cap can still arrive over the
+        # provider's limit and come back as a permanent 4xx (#4331). Halving the budget
+        # once costs one extra call on a request that already failed, and needs no
+        # knowledge of the provider's tokenizer.
+        halved_budget = max(max_input_tokens // 2, 1)
+        logger.warning(
+            "Embeddings: provider %s rejected a capped input with a %s; retrying once at "
+            "%d tokens. Set %s below the model's real limit to avoid the extra call.",
+            getattr(embeddings_backend, "provider_name", "?"),
+            status_code_of(e),
+            halved_budget,
+            ENV_EMBEDDINGS_MAX_INPUT_TOKENS,
+        )
+        texts = _truncate_inputs(texts, halved_budget, embeddings_backend, input_type)
+        try:
+            embeddings = await _encode_with_input_type(embeddings_backend, texts, input_type)
+        except Exception as retry_error:
+            raise Exception(f"Failed to generate batch embeddings: {str(retry_error)}") from retry_error
 
     # Guarantee 1:1 alignment with input texts. A silent length mismatch here
     # propagates downstream as zip() drops items, eventually surfacing as an

--- a/hindsight-api-slim/tests/test_embeddings_max_input_tokens.py
+++ b/hindsight-api-slim/tests/test_embeddings_max_input_tokens.py
@@ -172,3 +172,73 @@ class TestFinalPayloadFitsTheCap:
             await embedding_utils.generate_embeddings_batch(backend, [f"User working preferences {content}"])
 
         assert count_tokens(backend.received[0]) <= 8192
+
+
+class _RejectsOversizeBackend(_FakeBackend):
+    """A provider that answers a too-large input with a permanent 4xx.
+
+    Its own tokenizer counts more than ours, so a text cut to exactly the cap
+    still arrives over its limit (#4331). It accepts anything at or below
+    ``accepts_tokens``.
+    """
+
+    def __init__(self, accepts_tokens: int, status_code: int = 400) -> None:
+        super().__init__()
+        self.accepts_tokens = accepts_tokens
+        self.status_code = status_code
+        self.calls: list[list[str]] = []
+
+    async def encode_documents(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        if any(count_tokens(text) > self.accepts_tokens for text in texts):
+            error = Exception("The parameter is invalid. Please check again.")
+            error.status_code = self.status_code
+            raise error
+        return await super().encode_documents(texts)
+
+
+class TestOversizeRejectionRetry:
+    @pytest.mark.asyncio
+    async def test_retries_once_at_half_the_budget(self, caplog):
+        # Accepts half the cap, refuses the cap: the shape of a provider whose
+        # tokenizer runs ahead of ours.
+        backend = _RejectsOversizeBackend(accepts_tokens=25)
+        long_text = "word " * 500
+
+        with _patch_cap(50), caplog.at_level(logging.WARNING):
+            embeddings = await embedding_utils.generate_embeddings_batch(backend, [long_text])
+
+        assert len(embeddings) == 1
+        assert len(backend.calls) == 2, "expected exactly one retry"
+        assert count_tokens(backend.calls[0][0]) > 25
+        assert count_tokens(backend.calls[1][0]) <= 25
+        assert any("retrying once at" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_an_input_the_cap_did_not_touch(self):
+        backend = _RejectsOversizeBackend(accepts_tokens=0)
+
+        with _patch_cap(50), pytest.raises(Exception, match="Failed to generate batch embeddings"):
+            await embedding_utils.generate_embeddings_batch(backend, ["short text"])
+
+        assert len(backend.calls) == 1, "nothing was truncated, so there is nothing to shrink"
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_a_rejection_that_is_not_about_size(self):
+        backend = _RejectsOversizeBackend(accepts_tokens=25, status_code=401)
+        long_text = "word " * 500
+
+        with _patch_cap(50), pytest.raises(Exception, match="Failed to generate batch embeddings"):
+            await embedding_utils.generate_embeddings_batch(backend, [long_text])
+
+        assert len(backend.calls) == 1, "an auth failure is not fixed by a smaller input"
+
+    @pytest.mark.asyncio
+    async def test_keeps_the_provider_error_as_the_cause(self):
+        backend = _RejectsOversizeBackend(accepts_tokens=0, status_code=401)
+
+        with _patch_cap(50), pytest.raises(Exception) as excinfo:
+            await embedding_utils.generate_embeddings_batch(backend, ["short text"])
+
+        assert excinfo.value.__cause__ is not None
+        assert getattr(excinfo.value.__cause__, "status_code", None) == 401


### PR DESCRIPTION
Closes #4331.

## The gap

`HINDSIGHT_API_EMBEDDINGS_MAX_INPUT_TOKENS` bounds the input with our tokenizer, and the provider bounds it with its own. `token_encoding.py` already says so in writing, "the configured encoding is an approximation of any given provider's tokenizer, so set `max_tokens` with a little headroom below the model's real limit", and #4182 shipped a default of 8192, which is the limit itself and therefore has no headroom. A text cut to exactly the cap can arrive over the provider's limit.

What comes back is a permanent 4xx, and `generate_embeddings_batch` turns it into a bare `Exception` that fails the whole batch. For consolidation that is the owning task: `_embed_observation_text` has no handler, and neither do its callers.

## Change

When the cap actually truncated something and the provider answers 400, 413 or 422, the batch is retried once at half the budget. That needs no knowledge of the provider's tokenizer, which is the part we cannot have, and it is the smallest thing that turns a permanent failure into a completed one.

It deliberately does not fire when

- nothing was truncated, so the input size is not the suspect
- the status is not one a size rejection uses, so an auth or quota failure still fails fast, as `remote_retry.py` intends
- the first call succeeded, which is every ordinary run: no extra call, no behaviour change

The message body is not part of the decision. The report's own provider answers `{'code': 20015, 'message': 'The parameter is invalid. Please check again.'}`, which no substring match could classify.

The wrapper now also raises `from e`. Flattening the provider error into a string dropped the status, so a caller that wants to classify the failure has nothing left to read.

What this does not do: change the 8192 default or add a margin setting. That is a policy call about whether Hindsight should ship headroom and shrink everyone's embeddings, and it belongs to you rather than to a drive-by patch. This PR makes the failure survivable either way.

## Tests

`tests/test_embeddings_max_input_tokens.py`, next to the existing cap tests, with a `_RejectsOversizeBackend` that refuses anything above a token count and records each call:

- a capped input that the provider refuses is retried once, and the second call carries at most half the tokens
- an input the cap did not touch is not retried
- a 401 is not retried
- the provider error survives as `__cause__` with its status

```
uv run pytest tests/test_embeddings_max_input_tokens.py tests/test_token_encoding.py -q
34 passed
ruff check / ruff format --check   clean
ty check hindsight_api             no diagnostics on the changed file
```

The rest of the suite needs the `pg0` harness, which I do not have here, so I did not run it. Note that `test-api` is gated on `has_secrets` and will skip on a fork PR.
