### PR TITLE
fix(memory-defense): avoid redacting technical numbers as credit cards

### DIFF
--- a/hindsight-api-slim/hindsight_api/extensions/builtin/memory_defense_regex.py
+++ b/hindsight-api-slim/hindsight_api/extensions/builtin/memory_defense_regex.py
@@ -1,9 +1,10 @@
 """Memory Defense (regex) — the default extension shipping with hindsight-api-slim.
 
 Scrubs known secret/PII patterns from retained content via the
-``sensitive_data`` detector. Matching is pure regex (see ``apply_redaction``):
-no LLM call, no external dependency. A ``sensitive_data`` rule may either
-``redact`` matches in place or ``block`` the item entirely.
+``sensitive_data`` detector. Matching uses regex with a checksum for card
+candidates (see ``apply_redaction``): no LLM call, no external dependency.
+A ``sensitive_data`` rule may either ``redact`` matches in place or ``block``
+the item entirely.
 """
 
 from __future__ import annotations

--- a/hindsight-api-slim/hindsight_api/extensions/memory_defense.py
+++ b/hindsight-api-slim/hindsight_api/extensions/memory_defense.py
@@ -220,12 +220,13 @@ _REDACTION_PATTERNS: list[tuple[str, str]] = [
     ("private_key_pem", r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY( BLOCK)?-----"),
     ("jwt", _ascii_token_pattern(r"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}")),
     # --- PII (US-centric defaults; can be tuned per deployment) ---
-    # Keep the existing 13-16 digit formats, but exclude parts of decimals.
+    # Keep the existing 13-16 Unicode decimal-digit formats, but exclude parts
+    # of decimals and longer digit runs with the same Unicode digit semantics.
     # Candidates also need a Luhn check below: digit count alone redacted
     # timestamps and port lists as if they were cards.
     (
         "credit_card",
-        _ascii_token_pattern(r"(?<![0-9]\.)(?:[0-9]{4}[ -]?){3}[0-9]{1,4}(?!\.[0-9])"),
+        _ascii_token_pattern(r"(?<!\d)(?<!\d\.)(?:\d{4}[ -]?){3}\d{1,4}(?!\d)(?!\.\d)"),
     ),
     ("ssn_us", _ascii_token_pattern(r"\d{3}-\d{2}-\d{4}")),
 ]
@@ -238,14 +239,14 @@ _UUID_PATTERN = re.compile(_ascii_token_pattern(r"[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{
 
 
 def _is_luhn_card(value: str) -> bool:
-    """Validate an ASCII digit candidate already bounded by the card regex."""
-    digits = value.replace(" ", "").replace("-", "")
+    """Validate a decimal-digit candidate already bounded by the card regex."""
+    # int() normalizes Unicode decimal digits, including mixed-script placeholders.
+    digits = [int(char) for char in value if char not in " -"]
     # Repeated-digit placeholders (including all zeroes) can pass Luhn.
     if len(set(digits)) == 1:
         return False
     checksum = 0
-    for index, char in enumerate(reversed(digits)):
-        digit = int(char)
+    for index, digit in enumerate(reversed(digits)):
         if index % 2:
             digit *= 2
             if digit > 9:
@@ -267,33 +268,44 @@ def apply_redaction(content: str) -> RedactionResult:
         The raw secret never appears in ``hits``.
 
     Most detectors capture fingerprints before substitution. Credit-card
-    candidates are validated in the substitution callback so rejected values
+    candidates are validated before substitution so rejected values
     produce neither a replacement nor an audit hit.
     """
     matched: list[str] = []
     hits: list[dict] = []
     for label, pattern in _COMPILED_REDACTIONS:
         if label == "credit_card":
-            # Validate each occurrence before both replacement and audit capture;
-            # rejected numeric candidates must not trigger REDACT or BLOCK.
-            def redact_card(match: re.Match[str]) -> str:
+            # A rejected candidate must not consume a later valid start (e.g.
+            # "2026 4111 1111 1111 1111"). re.sub resumes at the rejected span's
+            # end; search again from its next character instead. Keep offsets in
+            # the original content so boundaries and UUID checks remain intact.
+            parts: list[str] = []
+            search_start = 0
+            copied_until = 0
+            while match := pattern.search(content, search_start):
+                search_start = match.start() + 1
                 value = match.group()
                 if not _is_luhn_card(value):
-                    return value
+                    continue
                 # A UUID's numeric segments may pass Luhn. Inspect only the
                 # bounded neighborhood of this candidate (UUIDs are 36 chars),
                 # without excluding cards next to ordinary prose punctuation.
-                for identifier in _UUID_PATTERN.finditer(
-                    match.string, max(0, match.start() - 35), min(len(match.string), match.end() + 36)
+                if any(
+                    identifier.start() < match.end() and identifier.end() > match.start()
+                    for identifier in _UUID_PATTERN.finditer(
+                        content, max(0, match.start() - 35), min(len(content), match.end() + 36)
+                    )
                 ):
-                    if identifier.start() < match.end() and identifier.end() > match.start():
-                        return value
+                    continue
                 if "credit_card" not in matched:
                     matched.append("credit_card")
                 hits.append({"detector": "credit_card", "preview": _fingerprint_value(value)})
-                return "[REDACTED:credit_card]"
+                parts.extend((content[copied_until : match.start()], "[REDACTED:credit_card]"))
+                copied_until = match.end()
+                search_start = match.end()
 
-            content = pattern.sub(redact_card, content)
+            parts.append(content[copied_until:])
+            content = "".join(parts)
             continue
         raw_hits = pattern.findall(content)
         if not raw_hits:

--- a/hindsight-api-slim/hindsight_api/extensions/memory_defense.py
+++ b/hindsight-api-slim/hindsight_api/extensions/memory_defense.py
@@ -220,9 +220,13 @@ _REDACTION_PATTERNS: list[tuple[str, str]] = [
     ("private_key_pem", r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY( BLOCK)?-----"),
     ("jwt", _ascii_token_pattern(r"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}")),
     # --- PII (US-centric defaults; can be tuned per deployment) ---
-    # NOTE: credit_card regex is intentionally narrowed to 13-19 digits with
-    # exact separators to reduce false positives on long product IDs.
-    ("credit_card", _ascii_token_pattern(r"(?:\d{4}[ -]?){3}\d{1,4}")),
+    # Keep the existing 13-16 digit formats, but exclude parts of decimals.
+    # Candidates also need a Luhn check below: digit count alone redacted
+    # timestamps and port lists as if they were cards.
+    (
+        "credit_card",
+        _ascii_token_pattern(r"(?<![0-9]\.)(?:[0-9]{4}[ -]?){3}[0-9]{1,4}(?!\.[0-9])"),
+    ),
     ("ssn_us", _ascii_token_pattern(r"\d{3}-\d{2}-\d{4}")),
 ]
 
@@ -230,6 +234,24 @@ _REDACTION_PATTERNS: list[tuple[str, str]] = [
 _COMPILED_REDACTIONS: list[tuple[str, re.Pattern]] = [
     (label, re.compile(pattern)) for label, pattern in _REDACTION_PATTERNS
 ]
+_UUID_PATTERN = re.compile(_ascii_token_pattern(r"[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}"))
+
+
+def _is_luhn_card(value: str) -> bool:
+    """Validate an ASCII digit candidate already bounded by the card regex."""
+    digits = value.replace(" ", "").replace("-", "")
+    # Repeated-digit placeholders (including all zeroes) can pass Luhn.
+    if len(set(digits)) == 1:
+        return False
+    checksum = 0
+    for index, char in enumerate(reversed(digits)):
+        digit = int(char)
+        if index % 2:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        checksum += digit
+    return checksum % 10 == 0
 
 
 def apply_redaction(content: str) -> RedactionResult:
@@ -244,13 +266,35 @@ def apply_redaction(content: str) -> RedactionResult:
         where ``preview`` is a length-aware redaction of the original value.
         The raw secret never appears in ``hits``.
 
-    The two-pass shape (find matches first, then substitute) lets us capture
-    raw values for fingerprinting before they're replaced by ``[REDACTED:type]``
-    markers. A single-pass approach would lose the originals.
+    Most detectors capture fingerprints before substitution. Credit-card
+    candidates are validated in the substitution callback so rejected values
+    produce neither a replacement nor an audit hit.
     """
     matched: list[str] = []
     hits: list[dict] = []
     for label, pattern in _COMPILED_REDACTIONS:
+        if label == "credit_card":
+            # Validate each occurrence before both replacement and audit capture;
+            # rejected numeric candidates must not trigger REDACT or BLOCK.
+            def redact_card(match: re.Match[str]) -> str:
+                value = match.group()
+                if not _is_luhn_card(value):
+                    return value
+                # A UUID's numeric segments may pass Luhn. Inspect only the
+                # bounded neighborhood of this candidate (UUIDs are 36 chars),
+                # without excluding cards next to ordinary prose punctuation.
+                for identifier in _UUID_PATTERN.finditer(
+                    match.string, max(0, match.start() - 35), min(len(match.string), match.end() + 36)
+                ):
+                    if identifier.start() < match.end() and identifier.end() > match.start():
+                        return value
+                if "credit_card" not in matched:
+                    matched.append("credit_card")
+                hits.append({"detector": "credit_card", "preview": _fingerprint_value(value)})
+                return "[REDACTED:credit_card]"
+
+            content = pattern.sub(redact_card, content)
+            continue
         raw_hits = pattern.findall(content)
         if not raw_hits:
             continue

--- a/hindsight-api-slim/tests/test_memory_defense.py
+++ b/hindsight-api-slim/tests/test_memory_defense.py
@@ -260,6 +260,83 @@ def regex_defense() -> MemoryDefenseRegexExtension:
     return MemoryDefenseRegexExtension({})
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        "score: 0.1234567890123456",
+        "timestamp_ms: 1700000000000",
+        "task_id: aaaaaaaa-bbbb-cccc-1234-123456789012",
+        "ports: 8000 8080 8888 9999",
+        "count: 123456",
+        "score: 0.123456",
+        # A checksum alone cannot distinguish a card-shaped decimal or UUID tail.
+        "score: 0.4111111111111111",
+        "task_id: aaaaaaaa-bbbb-cccc-4111-111111111111",
+        "task_id: 41111111-1111-1111-1111-111111111111",
+        "value: 4111111111111111.25",
+        "card typo: 4111 1111 1111 1112",
+        "placeholder: 0000 0000 0000 0000",
+    ],
+)
+def test_credit_card_rejects_technical_values(content: str) -> None:
+    result = apply_redaction(content)
+    assert result.content == content
+    assert result.matched_types == []
+    assert result.hits == []
+
+
+@pytest.mark.parametrize(
+    "card",
+    [
+        "4111111111111111",
+        "4111 1111 1111 1111",
+        "4111-1111-1111-1111",
+        "4222222222222",
+        "378282246310005",
+        "5555555555554444",
+    ],
+)
+@pytest.mark.parametrize("template", ["{}", "卡号{}请删除", "Card: {}.", "card-{}", "-{}", "{}.Next", "{}-expires"])
+def test_credit_card_keeps_valid_test_numbers(card: str, template: str) -> None:
+    result = apply_redaction(template.format(card))
+    assert result.content == template.format("[REDACTED:credit_card]")
+    assert result.matched_types == ["credit_card"]
+    assert result.hits == [{"detector": "credit_card", "preview": _fingerprint_value(card)}]
+
+
+def test_credit_card_filters_each_match_without_losing_other_detectors() -> None:
+    content = "1700000000000; 4111 1111 1111 1111; 8000 8080 8888 9999; 5555555555554444; 123-45-6789"
+    result = apply_redaction(content)
+    assert result.content == (
+        "1700000000000; [REDACTED:credit_card]; 8000 8080 8888 9999; [REDACTED:credit_card]; [REDACTED:ssn_us]"
+    )
+    assert result.matched_types == ["credit_card", "ssn_us"]
+    assert result.hits == [
+        {"detector": "credit_card", "preview": "4111...1111"},
+        {"detector": "credit_card", "preview": "5555...4444"},
+        {"detector": "ssn_us", "preview": "12...89"},
+    ]
+
+
+@pytest.mark.parametrize("action", ["redact", "block"])
+@pytest.mark.parametrize("content", ["score: 0.4111111111111111", "4111 1111 1111 1111"])
+async def test_credit_card_policy_uses_validated_matches(
+    regex_defense: MemoryDefenseRegexExtension, action: str, content: str
+) -> None:
+    policy = parse_policy({"enabled": True, "rules": [{"on": "sensitive_data", "action": action}]})
+    decision = await regex_defense.screen(policy=policy, bank_id="test", document_id=None, content=content, tags=[])
+    if content.startswith("score:"):
+        assert decision.action is DefenseAction.ALLOW
+        assert decision.matched_types == []
+        assert decision.hits == []
+        assert decision.redacted_content is None
+    else:
+        assert decision.action == DefenseAction(action)
+        assert decision.matched_types == ["credit_card"]
+        assert decision.hits == [{"detector": "credit_card", "preview": "4111...1111"}]
+        assert decision.redacted_content == ("[REDACTED:credit_card]" if action == "redact" else None)
+
+
 @pytest.fixture
 def redact_policy() -> dict:
     return {"enabled": True, "rules": [{"on": "sensitive_data", "action": "redact"}]}
@@ -900,6 +977,17 @@ def _defense_config(memory_defense: dict | None) -> HindsightConfig:
     from hindsight_api.config import _get_raw_config
 
     return dataclasses.replace(_get_raw_config(), memory_defense=memory_defense)
+
+
+def test_redact_document_body_preserves_technical_values_and_scrubs_cards() -> None:
+    from hindsight_api.engine.retain.orchestrator import redact_document_body
+
+    technical = "score: 0.4111111111111111; task_id: aaaaaaaa-bbbb-cccc-4111-111111111111; "
+    out = redact_document_body(
+        technical + "card: 4111 1111 1111 1111",
+        _defense_config({"enabled": True, "rules": [{"on": "sensitive_data", "action": "redact"}]}),
+    )
+    assert out == technical + "card: [REDACTED:credit_card]"
 
 
 def test_redact_document_body_scrubs_when_the_policy_redacts():

--- a/hindsight-api-slim/tests/test_memory_defense.py
+++ b/hindsight-api-slim/tests/test_memory_defense.py
@@ -304,6 +304,62 @@ def test_credit_card_keeps_valid_test_numbers(card: str, template: str) -> None:
     assert result.hits == [{"detector": "credit_card", "preview": _fingerprint_value(card)}]
 
 
+@pytest.mark.parametrize("action", ["redact", "block"])
+@pytest.mark.parametrize("prefix", ["card: ", "2026 ", "2026 2026 "])
+@pytest.mark.parametrize(
+    "card",
+    ["4111 1111 1111 1111", "４１１１１１１１１１１１１１１１", "٤١١١١١١١١١١١١١١١", "４١11 １１١1 1111 1111"],
+)
+async def test_credit_card_policy_preserves_overlapping_and_unicode_matches(
+    regex_defense: MemoryDefenseRegexExtension, action: str, prefix: str, card: str
+) -> None:
+    policy = parse_policy({"enabled": True, "rules": [{"on": "sensitive_data", "action": action}]})
+    decision = await regex_defense.screen(
+        policy=policy, bank_id="test", document_id=None, content=prefix + card, tags=[]
+    )
+    assert decision.action == DefenseAction(action)
+    assert decision.matched_types == ["credit_card"]
+    assert decision.hits == [{"detector": "credit_card", "preview": _fingerprint_value(card)}]
+    assert decision.redacted_content == (prefix + "[REDACTED:credit_card]" if action == "redact" else None)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "０.4111111111111111",
+        "4111111111111111.٢",
+        "0.４１１１１１１１１１１１１１１１",
+        "٤١١١١١١١١١١١١١١١.25",
+        "４1111111111111111",
+        "4111111111111111٤",
+        "００٠٠ 0000 ００٠٠ 0000",
+        "٤١١١ ١١١١ ١١١١ ١١١٢",
+    ],
+)
+@pytest.mark.parametrize("action", ["redact", "block"])
+async def test_credit_card_policy_rejects_unicode_non_cards(
+    regex_defense: MemoryDefenseRegexExtension, action: str, content: str
+) -> None:
+    policy = parse_policy({"enabled": True, "rules": [{"on": "sensitive_data", "action": action}]})
+    decision = await regex_defense.screen(policy=policy, bank_id="test", document_id=None, content=content, tags=[])
+    assert decision.action is DefenseAction.ALLOW
+    assert decision.matched_types == []
+    assert decision.hits == []
+    assert decision.redacted_content is None
+
+
+def test_credit_card_overlapping_search_preserves_multiple_hits() -> None:
+    # Both year-prefixed candidates fail Luhn, unlike "2026 5555 5555 5555".
+    content = "2026 4111 1111 1111 1111; 2025 5555 5555 5555 4444; 2026"
+    result = apply_redaction(content)
+    assert result.content == "2026 [REDACTED:credit_card]; 2025 [REDACTED:credit_card]; 2026"
+    assert result.matched_types == ["credit_card"]
+    assert result.hits == [
+        {"detector": "credit_card", "preview": "4111...1111"},
+        {"detector": "credit_card", "preview": "5555...4444"},
+    ]
+
+
 def test_credit_card_filters_each_match_without_losing_other_detectors() -> None:
     content = "1700000000000; 4111 1111 1111 1111; 8000 8080 8888 9999; 5555555555554444; 123-45-6789"
     result = apply_redaction(content)
@@ -977,6 +1033,17 @@ def _defense_config(memory_defense: dict | None) -> HindsightConfig:
     from hindsight_api.config import _get_raw_config
 
     return dataclasses.replace(_get_raw_config(), memory_defense=memory_defense)
+
+
+@pytest.mark.parametrize("card", ["4111 1111 1111 1111", "４１１１１１１１１１１１１１１１", "٤١١١١١١١١١١١١١١١"])
+def test_redact_document_body_preserves_overlapping_and_unicode_matches(card: str) -> None:
+    from hindsight_api.engine.retain.orchestrator import redact_document_body
+
+    out = redact_document_body(
+        "2026 " + card,
+        _defense_config({"enabled": True, "rules": [{"on": "sensitive_data", "action": "redact"}]}),
+    )
+    assert out == "2026 [REDACTED:credit_card]"
 
 
 def test_redact_document_body_preserves_technical_values_and_scrubs_cards() -> None:


### PR DESCRIPTION
## Summary

Fixes #4323.

The default card detector currently treats digit count as sufficient evidence. Under a redact policy, that changes technical data in retained documents; under a block policy, it can reject the item.

This change validates individual credit-card candidates before creating either a replacement or an audit hit:

- Require a Luhn checksum and reject repeated-digit placeholders.
- Exclude decimal components and candidates overlapping a UUID, including numeric UUID segments that happen to pass Luhn.
- Keep card detection beside ordinary punctuation and CJK text. Preserve the existing 13–16 digit candidate formats and other detectors.
- Preserve Unicode decimal-digit recognition, normalize digits for validation, and use consistent Unicode digit boundaries.
- Reconsider overlapping candidate starts after a rejected match instead of consuming the rejected span.
- Exercise the helper, REDACT/BLOCK decisions, and the document-body scrubber with synthetic data.

The UUID check scans only a bounded neighborhood of each candidate. There are no new dependencies, model calls, configuration fields, or API changes.

This remains a heuristic detector: Luhn does not prove a number is an issued card or distinguish every possible technical identifier. This PR addresses the reported examples and explicitly covered boundary cases, not comprehensive international payment-card detection.

## Verification

After the review fixes, on Linux / CPython 3.12.14:

```text
pytest tests/test_memory_defense.py -o addopts= -o log_cli=false -q -rs
360 passed, 14 skipped
```

The 14 existing integration tests require the unavailable local-ML extra. The new tests all run without it. Ruff 0.14.9 check and format-check pass for all three changed files; `git diff --check` passes.

The follow-up adds 44 cases covering REDACT/BLOCK decisions, Unicode and mixed-script digits, consistent decimal/long-number boundaries, repeated placeholders, overlapping starts, multiple hits, and document-body scrubbing. A supplemental runner executes the unchanged credit-card test functions with real detector modules while bypassing unrelated package initializers/conftest: 100 passed; loading the previous PR head gives 29 failures. Independently reverting overlap retry or Unicode matching gives 9 and 18 failures respectively. The full-file Linux run above uses the normal imports and conftest, without those bypasses.

Regression checks were run before the implementation: the original focused run had 12 failures. Temporarily bypassing checksum validation made five regression tests fail again; disabling the UUID guard in a separate process made two UUID regressions fail. Additional positive tests caught an overly broad punctuation guard during development; that guard was replaced before the final run.

Broader validation limitations:

- `pytest tests -x -o addopts= -o log_cli=false -q --timeout=60` stopped at the attachment-attribution LLM test because `HINDSIGHT_API_LLM_API_KEY` is not configured: 68 passed, 74 skipped, 1 failed. This is not a complete API-suite pass.
- `scripts/hooks/lint.sh` cannot run from this Windows CRLF checkout under WSL. The file was not changed; targeted checks were run directly.
- ty 0.0.8 reports one existing `invalid-argument-type` diagnostic in the generic `findall` / fingerprint path. The same diagnostic was reproduced from the unmodified base file at `4cc131c0b238c8f206def60804d7b6591f6a45e7`; that path is unchanged.

## Review path

Start with `test_credit_card_rejects_technical_values` and the positive card matrix, then review the credit-card search loop in `apply_redaction`. The policy and document-body tests verify that the filtered matches reach the existing consumers consistently.
