### PR TITLE
fix(coding-agents): capture background git stderr

### DIFF
--- a/hindsight-integrations/coding-agents/src/core/git-stderr.test.ts
+++ b/hindsight-integrations/coding-agents/src/core/git-stderr.test.ts
@@ -1,0 +1,171 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { buildSync } from "esbuild";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+// Observe the host process's actual stderr. A spy on console.error cannot see
+// execFileSync forwarding a failed child's stderr before the caller catches it.
+describe("background git stderr isolation", () => {
+  let buildDir: string;
+  let bundle: string;
+  const repos: string[] = [];
+
+  beforeAll(() => {
+    buildDir = mkdtempSync(join(tmpdir(), "hs-git-stderr-build-"));
+    bundle = pathToFileURL(join(buildDir, "probe.mjs")).href;
+    buildSync({
+      stdin: {
+        contents: `
+          export { gitHeadSha, hasGitHistory, commitsSince, gitLogText, gitLogNewestAuthorDate, ingestGit } from './git';
+          export { syncStatus } from './status';
+          export { syncGit } from './sync';
+          export { buildSessionStartContext } from './session-start';
+          export { resolveConfig } from './config';
+        `,
+        resolveDir: fileURLToPath(new URL(".", import.meta.url)),
+        loader: "ts",
+      },
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      outfile: fileURLToPath(bundle),
+      banner: {
+        js: 'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);',
+      },
+    });
+  });
+
+  afterEach(() => {
+    for (const repo of repos.splice(0)) rmSync(repo, { recursive: true, force: true });
+  });
+  afterAll(() => rmSync(buildDir, { recursive: true, force: true }));
+
+  function directory(): string {
+    const repo = mkdtempSync(join(tmpdir(), "hs-git-stderr-repo-"));
+    repos.push(repo);
+    return repo;
+  }
+
+  function run(repo: string, code: string): unknown {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+      import * as api from ${JSON.stringify(bundle)};
+      const repo = ${JSON.stringify(repo)};
+      const client = {
+        listDocumentIds: async () => new Set(),
+        listPages: async () => ({ items: [] }),
+        activeOperations: async () => 0,
+      };
+      ${code}
+    `,
+      ],
+      {
+        encoding: "utf8",
+        timeout: 10_000,
+        windowsHide: true,
+        env: {
+          ...process.env,
+          GIT_CEILING_DIRECTORIES: repo,
+          GIT_DIR: undefined,
+          GIT_WORK_TREE: undefined,
+        },
+      }
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    return JSON.parse(result.stdout);
+  }
+
+  it("quietly returns the existing fallback values outside a repository", () => {
+    expect(
+      run(
+        directory(),
+        `console.log(JSON.stringify([
+      api.gitHeadSha(repo), api.hasGitHistory(repo), api.commitsSince(repo, 'missing'),
+      api.gitLogText(repo, 10), api.gitLogNewestAuthorDate(repo)
+    ]));`
+      )
+    ).toEqual([null, false, null, "", null]);
+  });
+
+  it("keeps diagnostics on an uncaught ingestion failure without printing them", () => {
+    expect(
+      run(
+        directory(),
+        `
+      try { await api.ingestGit(client, repo); throw new Error('expected git to fail'); }
+      catch (error) { console.log(JSON.stringify({ status: error.status, stderr: String(error.stderr) })); }
+    `
+      )
+    ).toEqual({ status: 128, stderr: expect.stringContaining("fatal:") });
+  });
+
+  it("returns an unknown sync target without leaking the commit-count error", () => {
+    expect(
+      run(
+        directory(),
+        `console.log(JSON.stringify((await api.syncStatus(client, 'bank', repo)).gitDiffTarget));`
+      )
+    ).toBeNull();
+  });
+
+  it("preserves best-effort sync when neither the preferred ref nor HEAD exists", () => {
+    expect(
+      run(
+        directory(),
+        `console.log(JSON.stringify(await api.syncGit(client, repo, { fetch: true })));`
+      )
+    ).toEqual({
+      ref: null,
+      total: 0,
+      ingested: 0,
+      failures: 0,
+      inSync: true,
+    });
+  });
+
+  it("does not leak a late commit-count failure while building the full-sync banner", () => {
+    const repo = directory();
+    const git = (...args: string[]) =>
+      execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+    git("init", "-q");
+    git(
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-qm",
+      "initial"
+    );
+    expect(
+      run(
+        repo,
+        `
+      import { renameSync } from 'node:fs';
+      import { join } from 'node:path';
+      client.listDocumentIds = async (tag) => {
+        // The repository disappears after HEAD resolves but before rev-list.
+        if (tag.startsWith('gitlog-head:')) renameSync(join(repo, '.git'), join(repo, '.git-hidden'));
+        return new Set(['git:already-ingested']);
+      };
+      const result = await api.buildSessionStartContext({
+        cwd: repo, bankId: 'bank', client, harness: 'pi',
+        cfg: api.resolveConfig({ gitIngest: 'full', codebaseSurvey: false }),
+        startSeed: () => {},
+      });
+      console.log(JSON.stringify(result.systemMessage));
+    `
+      )
+    ).toContain("syncing git history (1/300)");
+  });
+});

--- a/hindsight-integrations/coding-agents/src/core/git.ts
+++ b/hindsight-integrations/coding-agents/src/core/git.ts
@@ -20,6 +20,9 @@ function git(repo: string, ...args: string[]): string {
     encoding: "utf8",
     maxBuffer: 1 << 28,
     windowsHide: true,
+    // execFileSync otherwise forwards failed git stderr into the host's TUI,
+    // even when callers catch the error. Keep diagnostics on the error instead.
+    stdio: ["ignore", "pipe", "pipe"],
   });
 }
 

--- a/hindsight-integrations/coding-agents/src/core/session-start.ts
+++ b/hindsight-integrations/coding-agents/src/core/session-start.ts
@@ -103,6 +103,7 @@ async function gitSyncNote(args: {
       execFileSync("git", ["-C", cwd, "rev-list", "--count", "HEAD"], {
         encoding: "utf8",
         windowsHide: true,
+        stdio: ["ignore", "pipe", "pipe"], // do not corrupt the host banner on a late git failure
       }).trim()
     );
     if (n > 0) target = Math.min(DEEPEN_DIFF_TARGET, n);

--- a/hindsight-integrations/coding-agents/src/core/status.ts
+++ b/hindsight-integrations/coding-agents/src/core/status.ts
@@ -49,6 +49,7 @@ function commitCount(repoDir: string): number | null {
     const out = execFileSync("git", ["-C", repoDir, "rev-list", "--count", "HEAD"], {
       encoding: "utf8",
       windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"], // failed probes must not write into the host TUI
     });
     return Number(out.trim()) || 0;
   } catch {

--- a/hindsight-integrations/coding-agents/src/core/sync.ts
+++ b/hindsight-integrations/coding-agents/src/core/sync.ts
@@ -20,6 +20,7 @@ function gitTry(repo: string, ...args: string[]): string | null {
       encoding: "utf8",
       maxBuffer: 1 << 28,
       windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"], // capture diagnostics before best-effort fallback
     }).trim();
   } catch {
     return null;


### PR DESCRIPTION
## Summary

Fixes #4328.

Capture stderr explicitly for background Git subprocesses in the coding-agents integration. With `execFileSync`, catching an error does not stop Node from forwarding the failed child's stderr to the host process when `stdio` is omitted. In Pi, that output can corrupt the TUI.

The change covers the shared Git helper, sync-status commit count, incremental-sync helper, and the late commit count used for the session-start full-sync banner. Stdout, error status, and captured error diagnostics remain available; existing fallback values and ingestion errors are preserved.

This is intentionally limited to stderr isolation. It does not change `autoSeed`, `gitIngest`, survey defaults, or introduce a cached repository probe.

## Regression coverage

Five tests run the actual core code with real Git subprocesses inside a child Node process and assert that the host's stderr is empty. They cover non-repository fallbacks, retained diagnostics on a propagated ingestion failure, sync status, best-effort fetch/ref fallback, and a repository disappearing before the session-start banner's late commit count.

The tests inspect process stderr rather than mocking `console.error`, which would miss this failure.

## Validation

From `hindsight-integrations/coding-agents`, on Linux with Node 24.15.0:

- `npm test`: 1,022 passed across 73 files (the package's standard command excludes live E2E tests).
- `npx tsc --noEmit`: passed.
- `npm run build`: passed.

Also checked all changed files with Prettier and `git diff --check`. The five new tests failed before the fix and passed after it. Temporarily removing the shared helper's `stdio` setting made two regression tests fail again; restoring it returned all five to green.

Windows targeted tests passed (54 tests), as did type checking and build. The Windows full suite has existing path/permission failures, reproduced on an unchanged LF checkout of the same upstream commit; the CRLF checkout also has docs-fixture failures. The monorepo lint script could not run from that CRLF checkout, so this does not claim a full-monorepo lint pass. No tests were weakened or skipped to obtain the Linux package result.

This verifies the subprocess boundary and the shared Pi session-start path, not a manual interactive Pi session.

## Review guide

The production diff only adds explicit stdio settings and comments at four Git call sites. `src/core/git-stderr.test.ts` contains the real-process regressions. There are no dependency, API, configuration, or generated-file changes.
