### PR TITLE
fix(engine): serialize same-bank cleanup before document locks

### DIFF
--- a/hindsight-api-slim/hindsight_api/engine/memory_engine.py
+++ b/hindsight-api-slim/hindsight_api/engine/memory_engine.py
@@ -9489,6 +9489,15 @@ class MemoryEngine(MemoryEngineInterface):
         invalidated_obs = 0
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
+                # Observation invalidation can update sources in another document.
+                # Serialize bank-scoped deletes before taking any document/unit locks,
+                # so two cascades cannot each hold a source the other's sweep needs.
+                # NO KEY UPDATE stays compatible with FK checks on bank children;
+                # Oracle translates it to its equivalent FOR UPDATE.
+                await conn.fetchrow(
+                    f"SELECT bank_id FROM {fq_table('banks')} WHERE bank_id = $1 FOR NO KEY UPDATE",
+                    bank_id,
+                )
                 # Get memory unit IDs before deletion (for observation cleanup). A store that
                 # keeps memories outside SQL answers by document through the store — memory_units
                 # is empty for it, so the SQL below would find nothing to clean up.
@@ -10344,6 +10353,13 @@ class MemoryEngine(MemoryEngineInterface):
             await conn.execute("SET SESSION CHARACTERISTICS AS TRANSACTION READ WRITE")
             async with conn.transaction():
                 try:
+                    # Match delete_document's bank-before-data order. Otherwise a
+                    # bank delete could hold its documents while waiting for the
+                    # bank row held by a concurrent document delete.
+                    await conn.fetchrow(
+                        f"SELECT bank_id FROM {fq_table('banks')} WHERE bank_id = $1 FOR NO KEY UPDATE",
+                        bank_id,
+                    )
                     if fact_type:
                         # For source memory types, capture ids so we can invalidate
                         # dependent observations AFTER the delete below. Running the
@@ -10604,6 +10620,12 @@ class MemoryEngine(MemoryEngineInterface):
         backend = await self._get_backend()
         async with acquire_with_retry(backend) as conn:
             async with conn.transaction():
+                # Clearing observations also updates the bank after its memories.
+                # Keep the same bank-before-data order as document/bank deletion.
+                await conn.fetchrow(
+                    f"SELECT bank_id FROM {fq_table('banks')} WHERE bank_id = $1 FOR NO KEY UPDATE",
+                    bank_id,
+                )
                 if not store.store_owned_for(bank_id):
                     # Count observations before deletion
                     count = await conn.fetchval(

--- a/hindsight-api-slim/tests/test_delete_document_concurrency.py
+++ b/hindsight-api-slim/tests/test_delete_document_concurrency.py
@@ -1,0 +1,201 @@
+"""Schedule real SQL interleavings through the engine's delete methods (#4251).
+
+The LLM cannot prescribe exact co-source IDs or transaction interleavings, so seed
+that internal state directly. Only authentication and post-commit background work
+are stubbed; acquisition, transactions, cascades and observation cleanup are real.
+"""
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from hindsight_api.engine.db.postgresql import PostgresConnection, PostgreSQLBackend
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.memory_backend_incompatible]
+
+
+@dataclass
+class DeleteRace:
+    setup: asyncpg.Connection
+    banks: list[str]
+    engines: list[MemoryEngine]
+    second_pid: int
+
+
+async def seed_sources(conn: asyncpg.Connection, bank: str) -> None:
+    await conn.execute("INSERT INTO banks(bank_id) VALUES($1)", bank)
+    sources = [uuid.uuid4(), uuid.uuid4()]
+    for document_id, unit_id in zip(["a", "b"], sources):
+        await conn.execute("INSERT INTO documents(id, bank_id) VALUES($1, $2)", document_id, bank)
+        await conn.execute(
+            "INSERT INTO memory_units(id, bank_id, document_id, text, fact_type) VALUES($1, $2, $3, 'fact', 'world')",
+            unit_id,
+            bank,
+            document_id,
+        )
+    # No entities or links: their maintenance queue locks would hide the
+    # observation-source cycle. Both documents are explicit sources of this row.
+    await conn.execute(
+        "INSERT INTO memory_units(bank_id, text, fact_type, source_memory_ids) "
+        "VALUES($1, 'shared observation', 'observation', $2)",
+        bank,
+        sources,
+    )
+
+
+@pytest_asyncio.fixture
+async def delete_race(pg0_db_url):
+    setup = await asyncpg.connect(pg0_db_url)
+    banks = [f"delete-race-{uuid.uuid4().hex}" for _ in range(2)]
+    backends = []
+    engines = []
+    try:
+        for bank in banks:
+            await seed_sources(setup, bank)
+        for _ in range(2):
+            backend = PostgreSQLBackend()
+            await backend.initialize(pg0_db_url, min_size=1, max_size=1, command_timeout=15)
+            backends.append(backend)
+            engine = MemoryEngine.__new__(MemoryEngine)
+            engine._initialized = True
+            engine._backend = backend
+            engine._operation_validator = None
+            engine._tenant_extension = None
+            engine._authenticate_tenant = AsyncMock(return_value="public")
+            engine._bank_stats_cache = SimpleNamespace(invalidate=AsyncMock())
+            engine._config_resolver = SimpleNamespace(
+                resolve_full_config=AsyncMock(return_value=SimpleNamespace(enable_auto_consolidation=False))
+            )
+            engine._submit_refreshes_for_retracted_grounding = AsyncMock()
+            engine.submit_async_graph_maintenance = AsyncMock()
+            engine._submit_vector_index_maintenance_quietly = AsyncMock()
+            engines.append(engine)
+        async with backends[1].acquire() as conn:
+            pid = await conn.fetchval("SELECT pg_backend_pid()")
+        yield DeleteRace(setup, banks, engines, pid)
+    finally:
+        for backend in backends:
+            await backend.shutdown()
+        for bank in banks:
+            await setup.execute("DELETE FROM memory_units WHERE bank_id=$1", bank)
+            await setup.execute("DELETE FROM documents WHERE bank_id=$1", bank)
+            await setup.execute("DELETE FROM banks WHERE bank_id=$1", bank)
+        await setup.close()
+
+
+async def wait_for_lock(race: DeleteRace) -> None:
+    # Observe a real wait rather than relying on a scheduler-dependent sleep.
+    async with asyncio.timeout(10):
+        while (
+            await race.setup.fetchval("SELECT wait_event_type FROM pg_stat_activity WHERE pid=$1", race.second_pid)
+            != "Lock"
+        ):
+            await asyncio.sleep(0.01)
+
+
+@pytest.mark.parametrize("rollback", [False, True])
+async def test_shared_observation_deletes_complete_after_commit_or_rollback(delete_race, request_context, rollback):
+    race = delete_race
+    first, second = race.engines
+    paused, release = asyncio.Event(), asyncio.Event()
+    original = first._delete_stale_observations_for_memories
+
+    async def pause_after_delete(conn, bank_id, fact_ids):
+        paused.set()
+        await release.wait()
+        if rollback:
+            raise RuntimeError("injected transaction rollback")
+        return await original(conn, bank_id, fact_ids)
+
+    first._delete_stale_observations_for_memories = pause_after_delete
+    tasks = [asyncio.create_task(first.delete_document("a", race.banks[0], request_context=request_context))]
+    try:
+        await asyncio.wait_for(paused.wait(), 10)
+        tasks.append(asyncio.create_task(second.delete_document("b", race.banks[0], request_context=request_context)))
+        await wait_for_lock(race)
+    finally:
+        release.set()
+        results = await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), 20)
+    assert results[1] == {"document_deleted": 1, "memory_units_deleted": 1}
+    if rollback:
+        assert isinstance(results[0], RuntimeError) and str(results[0]) == "injected transaction rollback"
+        assert await first.get_document("a", race.banks[0], request_context=request_context) is not None
+    else:
+        assert results[0] == {"document_deleted": 1, "memory_units_deleted": 1}
+        assert await first.get_document("a", race.banks[0], request_context=request_context) is None
+    assert await second.get_document("b", race.banks[0], request_context=request_context) is None
+    assert await second.delete_document("b", race.banks[0], request_context=request_context) == {
+        "document_deleted": 0,
+        "memory_units_deleted": 0,
+    }
+
+
+async def test_other_bank_can_delete_while_first_bank_is_paused(delete_race, request_context):
+    race = delete_race
+    first, second = race.engines
+    paused, release = asyncio.Event(), asyncio.Event()
+    original = first._delete_stale_observations_for_memories
+
+    async def pause_after_delete(conn, bank_id, fact_ids):
+        paused.set()
+        await release.wait()
+        return await original(conn, bank_id, fact_ids)
+
+    first._delete_stale_observations_for_memories = pause_after_delete
+    task = asyncio.create_task(first.delete_document("a", race.banks[0], request_context=request_context))
+    try:
+        await asyncio.wait_for(paused.wait(), 10)
+        result = await asyncio.wait_for(second.delete_document("b", race.banks[1], request_context=request_context), 10)
+        assert result["document_deleted"] == 1
+        assert await second.get_document("a", race.banks[1], request_context=request_context) is not None
+    finally:
+        release.set()
+        await asyncio.wait_for(task, 20)
+
+
+@pytest.mark.parametrize("clear_observations", [False, True])
+async def test_bank_cleanup_and_document_delete_use_same_lock_order(
+    delete_race, request_context, monkeypatch, clear_observations
+):
+    race = delete_race
+    first, second = race.engines
+    paused, release = asyncio.Event(), asyncio.Event()
+    execute = PostgresConnection.execute
+    pause_query = (
+        "DELETE FROM public.memory_units WHERE bank_id = $1 AND fact_type = 'observation'"
+        if clear_observations
+        else "DELETE FROM public.documents WHERE bank_id = $1"
+    )
+
+    async def pause_after_documents(conn, query, *args, **kwargs):
+        result = await execute(conn, query, *args, **kwargs)
+        if query == pause_query and args == (race.banks[0],):
+            paused.set()
+            await release.wait()
+        return result
+
+    monkeypatch.setattr(PostgresConnection, "execute", pause_after_documents)
+    # Index cleanup is after commit; the assertion concerns the SQL deletion order.
+    monkeypatch.setattr("hindsight_api.engine.retain.bank_utils.drop_bank_vector_indexes", AsyncMock())
+    cleanup = first.clear_observations if clear_observations else first.delete_bank
+    tasks = [asyncio.create_task(cleanup(race.banks[0], request_context=request_context))]
+    try:
+        await asyncio.wait_for(paused.wait(), 10)
+        tasks.append(asyncio.create_task(second.delete_document("b", race.banks[0], request_context=request_context)))
+        await wait_for_lock(race)
+    finally:
+        release.set()
+        results = await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), 20)
+    if clear_observations:
+        assert results[0] == {"deleted_count": 1}
+        assert results[1] == {"document_deleted": 1, "memory_units_deleted": 1}
+    else:
+        assert results[0]["bank_deleted"] is True
+        assert results[1] == {"document_deleted": 0, "memory_units_deleted": 0}

--- a/hindsight-system-tests/tests/test_75_delete_concurrency.py
+++ b/hindsight-system-tests/tests/test_75_delete_concurrency.py
@@ -1,0 +1,50 @@
+"""Concurrent document cleanup removes shared observations without a partial batch."""
+
+import asyncio
+
+import pytest
+from hindsight_system_tests.payloads import Consolidation, ObservationUpdate, extracted, fact, fact_ids_in, observes
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_concurrent_deletes_of_observation_sources(client, llm, bank_id, settled):
+    llm.on_step("extract_facts").returns(extracted(fact("The morning weather was mild")))
+    llm.on_step("consolidate").answers_with(observes("The weather was mild"))
+    await client.aretain(bank_id=bank_id, content="Morning weather record", document_id="morning")
+    await settled(bank_id)
+    memories = await client.memory.list_memories(bank_id, limit=100)
+    observation_id = next(m.id for m in memories.items if m.fact_type == "observation")
+
+    llm.reset()
+    llm.on_step("extract_facts").returns(extracted(fact("The evening weather was mild")))
+
+    def merge(request) -> Consolidation:
+        return Consolidation(
+            updates=[
+                ObservationUpdate(
+                    text="The weather stayed mild all day",
+                    observation_id=observation_id,
+                    source_fact_ids=fact_ids_in(request.all_text),
+                )
+            ]
+        )
+
+    llm.on_step("consolidate").answers_with(merge)
+    await client.aretain(bank_id=bank_id, content="Evening weather record", document_id="evening")
+    await settled(bank_id)
+    memories = await client.memory.list_memories(bank_id, limit=100)
+    sources = [m for m in memories.items if m.fact_type == "world"]
+    observations = [m for m in memories.items if m.fact_type == "observation"]
+    assert {m.document_id for m in sources} == {"morning", "evening"}
+    assert len(observations) == 1
+    assert set(observations[0].source_memory_ids) == {m.id for m in sources}
+
+    results = await asyncio.gather(
+        client.documents.delete_document(bank_id, "morning"),
+        client.documents.delete_document(bank_id, "evening"),
+        return_exceptions=True,
+    )
+    assert not [r for r in results if isinstance(r, Exception)], results
+    await settled(bank_id)
+    assert not (await client.memory.list_memories(bank_id, limit=100)).items


### PR DESCRIPTION
Concurrent deletion of different documents in one bank can deadlock when both invalidate an observation sourced from those documents. I reproduced `40P01` on current main by pausing one real `delete_document` transaction after its document cascade while the second waits to reset the first document’s observation source.

Acquire the tenant-qualified bank row `FOR NO KEY UPDATE` before reading or deleting document data. Bank deletion and observation clearing take the same bank-before-data order, so those cleanup paths cannot introduce an inverted lock order. Different banks remain independent, and rollback releases the lock. The existing Oracle SQL adapter rewrites this locking clause to `FOR UPDATE`.

This serializes same-bank cleanup without replaying the transaction’s attachment-blob or external-store effects. It does not claim to eliminate deadlocks involving every possible concurrent writer.

Fixes #4251.

Validation:
- Five real-PostgreSQL engine regressions cover shared observation sources, rollback, repeated deletion, cross-bank progress, full-bank deletion and observation clearing. The document/document and clear-observations/document cases fail with `DeadlockDetectedError` on the original code.
- One HTTP system story uses the published client, verifies that two documents actually share an observation, then deletes both concurrently and checks the bank is empty. Its model responses are stubbed; the server and database are real.
- 126 tests pass across the concurrency and backend-abstraction suites, including the existing Oracle locking-clause rewrite. No live Oracle deployment validation is claimed.
- `./scripts/hooks/lint.sh` passes after installing the locked Node dependencies; changed-file Ruff and diff checks pass.

AI-assisted implementation and self-review.
