### PR TITLE
fix(api): reject request bodies before clearing bank memories

### DIFF
--- a/hindsight-api-slim/hindsight_api/api/http.py
+++ b/hindsight-api-slim/hindsight_api/api/http.py
@@ -9414,11 +9414,21 @@ def _register_routes(app: FastAPI):
     @audited("clear_memories", request_param=None)
     async def api_clear_bank_memories(
         bank_id: str,
+        request: Request,
         type: str | None = Query(None, description="Optional fact type filter (world, experience, observation)"),
         request_context: RequestContext = Depends(get_request_context),
     ):
         """Clear memories for a memory bank, optionally filtered by type."""
         try:
+            # A selection body must not silently become a whole-bank delete.
+            # Inspect actual bytes (including chunked bodies) without buffering them.
+            async for chunk in request.stream():
+                if chunk:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="This endpoint clears bank memories and does not accept a request body. "
+                        "Use the type query parameter to filter by fact type.",
+                    )
             await app.state.memory.delete_bank(
                 bank_id, fact_type=type, delete_bank_profile=False, request_context=request_context
             )

--- a/hindsight-api-slim/tests/test_clear_memories_body.py
+++ b/hindsight-api-slim/tests/test_clear_memories_body.py
@@ -1,0 +1,62 @@
+"""A selection body must never turn into an unfiltered bank clear (#4337)."""
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from hindsight_api.api import create_app
+from hindsight_api.engine.memory_engine import MemoryEngine
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    memory = MagicMock(spec=MemoryEngine)
+    memory.audit_logger = None
+    memory.delete_bank = AsyncMock()
+    return create_app(memory, initialize_memory=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [b'{"ids":["one"]}', b"{}", b"[]", b"null", b" ", b"invalid", b"\xff"])
+@pytest.mark.parametrize("query", ["", "?type=world"])
+async def test_nonempty_body_never_calls_delete(app, body: bytes, query: str) -> None:
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app), base_url="http://test") as client:
+        response = await client.request("DELETE", "/v1/default/banks/bank/memories" + query, content=body)
+    assert response.status_code == 400
+    assert "does not accept a request body" in response.json()["detail"]
+    app.state.memory.delete_bank.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streamed_body_is_rejected_without_reading_the_rest(app) -> None:
+    async def chunks() -> AsyncIterator[bytes]:
+        yield b""
+        yield b'{"ids":'
+        pytest.fail("The rejected request must not be buffered or drained by the handler")
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app), base_url="http://test") as client:
+        response = await client.request("DELETE", "/v1/default/banks/bank/memories", content=chunks())
+    assert response.status_code == 400
+    app.state.memory.delete_bank.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fact_type", [None, "world", "observation"])
+async def test_empty_body_preserves_clear_semantics(app, fact_type: str | None) -> None:
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app), base_url="http://test") as client:
+        response = await client.request(
+            "DELETE",
+            "/v1/default/banks/bank/memories",
+            params={"type": fact_type} if fact_type else {},
+            content=b"",
+        )
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    app.state.memory.delete_bank.assert_awaited_once()
+    call = app.state.memory.delete_bank.await_args
+    assert call.args == ("bank",)
+    assert call.kwargs["fact_type"] == fact_type
+    assert call.kwargs["delete_bank_profile"] is False

--- a/hindsight-system-tests/tests/test_14_clear_memories_body.py
+++ b/hindsight-system-tests/tests/test_14_clear_memories_body.py
@@ -1,0 +1,60 @@
+"""A mistaken selection body must leave the bank intact, not clear it (#4337)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from hindsight_system_tests.payloads import consolidation, extracted, fact
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_selection_body_cannot_clear_the_bank(client, llm, bank_id, settled):
+    llm.on_step("extract_facts").returns(
+        extracted(
+            fact("Alice lives in Berlin", who="Alice", entities=["Alice", "Berlin"]),
+            fact("Alice plays cello", who="Alice", entities=["Alice", "cello"]),
+        )
+    )
+    llm.on_step("consolidate").returns(consolidation())
+    await client.aretain(bank_id=bank_id, content="Alice lives in Berlin and plays cello.", document_id="profile")
+    await settled(bank_id)
+
+    before = await client.memory.list_memories(bank_id, limit=100)
+    assert sorted(m.text for m in before.items) == [
+        "Alice lives in Berlin | Involving: Alice",
+        "Alice plays cello | Involving: Alice",
+    ]
+    ids = sorted(m.id for m in before.items)
+    # The generated clear method intentionally has no body argument. Use the
+    # published SDK transport to reproduce the malformed caller request.
+    api = client.memory.api_client
+    response = await api.call_api(
+        *api.param_serialize(
+            method="DELETE",
+            resource_path="/v1/default/banks/{bank_id}/memories",
+            path_params={"bank_id": bank_id},
+            header_params={"Content-Type": "application/json"},
+            body={"ids": [ids[0]]},
+        )
+    )
+    await response.read()
+    assert response.status == 400
+    assert "does not accept a request body" in json.loads(response.data)["detail"]
+
+    after = await client.memory.list_memories(bank_id, limit=100)
+    assert sorted(m.id for m in after.items) == ids
+    assert sorted(m.text for m in after.items) == sorted(m.text for m in before.items)
+    documents = await client.documents.list_documents(bank_id)
+    assert [d.id for d in documents.items] == ["profile"]
+
+    # Supported, bodyless client calls still honor the query filter and can clear.
+    result = await client.memory.clear_bank_memories(bank_id, type="observation")
+    assert result.success is True
+    assert sorted(m.id for m in (await client.memory.list_memories(bank_id)).items) == ids
+    result = await client.memory.clear_bank_memories(bank_id)
+    assert result.success is True
+    assert (await client.memory.list_memories(bank_id)).items == []
+    assert (await client.documents.list_documents(bank_id)).items == []
+    assert bank_id in [bank.bank_id for bank in (await client.banks.list_banks()).banks]


### PR DESCRIPTION
A caller sending `DELETE /banks/{bank_id}/memories` with an `ids` body currently gets 200 and clears the entire bank. Reject the first nonempty request-body chunk with 400 before calling the engine. This also covers chunked, malformed and non-JSON bodies without buffering the full payload.

Bodyless calls retain the existing `type` query filter and clear behavior. Clients sending placeholder bodies such as `{}` must omit them. This adds no bulk-delete API; #4309 and #4312 address deletion counts separately.

Fixes #4337.

Validation:
- 18 real-route cases pass; before the fix, all 15 unsafe-body cases return 200, while the three valid bodyless calls pass.
- One SDK-driven story against a real server/PostgreSQL database reproduces the original 200, then verifies 400, unchanged memory IDs/text and documents, typed clearing, full clearing and the surviving bank. LLM responses are stubbed.
- Full repository lint and documentation build pass. OpenAPI was regenerated with no changes; the SDK surface is unchanged.

AI-assisted implementation and self-review.
