### PR TITLE
fix(dsh): register tools before the first request

### DIFF
--- a/hindsight-integrations/coding-agents/src/dsh.test.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createDshHooks, dshSessionEvents, toDshParameters, type Workspace } from "./dsh";
+import { createDshHooks, dshSessionEvents, inject, toDshParameters, type Workspace } from "./dsh";
 import { readDshEvents } from "./core/transcript-dsh";
 import type { ToolSpec } from "./core/knowledge-tools";
 import { z } from "zod";
@@ -31,6 +31,12 @@ function fakeWorkspace(core: Partial<Workspace["core"]>): Workspace {
 }
 
 const enter = (messages: unknown[]) => async () => ({ kind: "enter" as const, messages }) as never;
+
+describe("dsh plugin dependencies", () => {
+  it("waits for the tool registry before mounting", () => {
+    expect(inject).toEqual(["agents", "tools"]);
+  });
+});
 
 describe("dsh pre-step injection", () => {
   it("recalls on the human prompt and appends the memory as a sourced message", async () => {

--- a/hindsight-integrations/coding-agents/src/dsh.ts
+++ b/hindsight-integrations/coding-agents/src/dsh.ts
@@ -35,8 +35,8 @@ const HARNESS = "dsh";
 /** Cordis plugin name (loader diagnostics, and the `source.plugin` on everything we inject). */
 export const name = HINDSIGHT_PLUGIN;
 
-/** The agent registry owns the lifecycle events below; without it there is nothing to bind. */
-export const inject = ["agents"];
+/** Both services must exist before mount so the first model request sees the final tool catalog. */
+export const inject = ["agents", "tools"];
 
 // ── host shapes (structural: this package must not depend on dsh's packages) ─────
 
@@ -74,6 +74,7 @@ interface PreStepPayload {
 
 /** The Cordis context surface this plugin uses. */
 interface DshContext {
+  tools: DshToolContext["tools"];
   on(
     event: "agent/session-start",
     listener: (payload: { agent: DshAgent }) => void
@@ -94,7 +95,6 @@ interface DshContext {
     event: "agent/disposed",
     listener: (payload: { agent: DshAgent }) => void
   ): (() => void) | void;
-  inject(names: string[], callback: (ctx: DshToolContext) => void): void;
 }
 
 interface DshToolContext {
@@ -408,11 +408,10 @@ export function apply(ctx: DshContext): void {
   ctx.on("agent/pre-step", hooks.preStep, { prepend: true });
   ctx.on("agent/turn-stopping", hooks.turnStopping);
   ctx.on("agent/disposed", hooks.disposed);
-  // The tools registry is optional: a composition without it (a bare headless assembly) still gets
-  // recall, injection and write-back.
-  ctx.inject(["tools"], (toolCtx) => {
-    registerTools(toolCtx, process.cwd());
-  });
+  // `tools` is a static plugin dependency, so Cordis does not mount us until the registry exists.
+  // Registering here keeps the catalog stable from the first request instead of growing it later
+  // when a nested dependency callback happens to resolve.
+  registerTools(ctx, process.cwd());
 }
 
 export default { name, inject, apply };


### PR DESCRIPTION
## Summary

- declare the DSH tool registry as a mount-time plugin dependency
- register the Hindsight tool suite directly during plugin mount
- cover the stable dependency contract with a focused regression test

This prevents the tool catalog from growing after a session has already started, which invalidates provider prompt-prefix caches.

Fixes #4317.

## Tests

- `npm test -- --run src/dsh.test.ts` (15 passed)
- `npm run build`
- `./scripts/hooks/lint.sh`
- full coding-agents unit suite: 1006 passed, 12 existing environment-sensitive git-layout tests failed because the parent home directory is itself a git repository; the focused DSH suite is green
